### PR TITLE
Wrapper Methoden für sf yaml

### DIFF
--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -1,7 +1,5 @@
 <?php
 
-use Symfony\Component\Yaml\Yaml;
-
 /**
  * Class for handling files
  */
@@ -29,7 +27,7 @@ class rex_file
   static public function getConfig($file, $default = array())
   {
     $content = self::get($file);
-    return $content === null ? $default : Yaml::parse($content);
+    return $content === null ? $default : rex_string::yamlDecode($content);
   }
 
   /**
@@ -76,7 +74,7 @@ class rex_file
    */
   static public function putConfig($file, $content, $inline = 3)
   {
-    return self::put($file, Yaml::dump($content, $inline));
+    return self::put($file, rex_string::yamlEncode($content, $inline));
   }
 
   /**

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -86,6 +86,29 @@ class rex_string
   }
 
   /**
+   * Returns a string containing the YAML representation of $value.
+   *
+   * @param array  $value  The value being encoded
+   * @param number $inline The level where you switch to inline YAML
+   * @return string
+   */
+  static public function yamlEncode(array $value, $inline = 3)
+  {
+    return Symfony\Component\Yaml\Yaml::dump($value, $inline, 2);
+  }
+
+  /**
+   * Parses YAML into a PHP array.
+   *
+   * @param string $value YAML string
+   * @return array
+   */
+  static public function yamlDecode($value)
+  {
+    return Symfony\Component\Yaml\Yaml::parse($value);
+  }
+
+  /**
    * Highlights a string
    *
    * @param string $string


### PR DESCRIPTION
Vorschlag.. zwei Wrapper Methoden für YAML, denn YAML 2.0 nutzt zum Beispiel als Standard 4 Leerzeichen für die Einrückung, diese Wrapper-Methode stellt es um auf 2. Außerdem braucht man dann so nicht mit den Namespaces umgehen.
