### PR TITLE
dritten Parameter gibt es nicht

### DIFF
--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -466,7 +466,6 @@ class rex_list extends rex_factory_base implements rex_url_provider
    *
    * @param $columnName Name der Spalte
    * @param $option Name/Id der Option
-   * @param $default Defaultrückgabewert, falls die Option nicht gesetzt ist
    *
    * @return boolean
    */


### PR DESCRIPTION
Einen dritten Parameter in der Funktion hasColumnOption gibt es nicht.
