### PR TITLE
rex_autoload in Kombination mit anderen Autoloadern

### DIFF
--- a/redaxo/src/addons/be_dashboard/plugins/rss_reader/package.yml
+++ b/redaxo/src/addons/be_dashboard/plugins/rss_reader/package.yml
@@ -5,7 +5,3 @@ supportpage: www.redaxo.org/de/forum/
 requires:
   php:
     extensions: [xml]
-
-autoload:
-  classes:
-    - vendor/

--- a/redaxo/src/addons/debug/package.yml
+++ b/redaxo/src/addons/debug/package.yml
@@ -3,7 +3,3 @@ author: Markus Staab
 supportpage: www.redaxo.org/de/forum/
 
 load: early
-
-autoload:
-  classes:
-    - vendor/

--- a/redaxo/src/addons/import_export/package.yml
+++ b/redaxo/src/addons/import_export/package.yml
@@ -8,7 +8,3 @@ navigation:
   subpages:
     export: {title: 'translate:im_export_export'}
     import: {title: 'translate:im_export_import', perm: 'import_export[import]'}
-
-autoload:
-  classes:
-    - vendor/

--- a/redaxo/src/addons/phpmailer/package.yml
+++ b/redaxo/src/addons/phpmailer/package.yml
@@ -12,7 +12,3 @@ navigation:
 requires:
   redaxo:
     min-version: '5.0.alpha3'
-
-autoload:
-  classes:
-    - vendor/

--- a/redaxo/src/addons/tests/lib/test_runner.php
+++ b/redaxo/src/addons/tests/lib/test_runner.php
@@ -7,8 +7,6 @@ class rex_test_runner
     // load all required PEAR libs from vendor folder
     $path = __DIR__ . '/../vendor/';
     set_include_path($path . PATH_SEPARATOR . get_include_path());
-
-    require_once 'PHPUnit/Autoload.php';
   }
 
   public function run(rex_test_locator $locator, $colors = false)

--- a/redaxo/src/addons/textile/package.yml
+++ b/redaxo/src/addons/textile/package.yml
@@ -5,7 +5,3 @@ supportpage: www.redaxo.org/de/forum/
 navigation:
   title: 'Textile'
   perm: admin[]
-
-autoload:
-  classes:
-    - vendor/

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -96,6 +96,7 @@ abstract class rex_package_manager extends rex_factory_base
     // check if install.inc.php exists
     if ($state === true && is_readable($install_file)) {
       rex_autoload::addDirectory($this->package->getBasePath('lib'));
+      rex_autoload::addDirectory($this->package->getBasePath('vendor'));
       try {
         static::includeFile($this->package, self::INSTALL_FILE);
         // Wurde das "install" Flag gesetzt?
@@ -236,6 +237,7 @@ abstract class rex_package_manager extends rex_factory_base
           if (!rex::isSetup()) {
             if (is_readable($this->package->getBasePath(self::CONFIG_FILE))) {
               rex_autoload::addDirectory($this->package->getBasePath('lib'));
+              rex_autoload::addDirectory($this->package->getBasePath('vendor'));
               static::includeFile($this->package, self::CONFIG_FILE);
             }
           }

--- a/redaxo/src/core/packages.inc.php
+++ b/redaxo/src/core/packages.inc.php
@@ -31,6 +31,9 @@ foreach ($packageOrder as $packageId) {
   if (is_readable($folder . 'lib')) {
     rex_autoload::addDirectory($folder . 'lib');
   }
+  if (is_readable($folder . 'vendor')) {
+    rex_autoload::addDirectory($folder . 'vendor');
+  }
   $autoload = $package->getProperty('autoload');
   if (is_array($autoload) && isset($autoload['classes']) && is_array($autoload['classes'])) {
     foreach ($autoload['classes'] as $dir) {


### PR DESCRIPTION
@staabm Du hattest im sfFinder-Branch es mal so geändert, dass das vendor-Verzeichnis im core nicht mehr von unserem Autoloader erfasst wird und stattdessen den Composer-Autoloader zusätzlich eingebunden. Da wir den Branch nicht übernommen haben, ist das im master nicht so. Ich habe jetzt aber auch bemerkt, dass das problematisch wäre. PHPUnit im tests-Addon zum Beispiel nutzt aber schon einen eigenen Autoloader, da haben wir somit auch die Problematik, daher dieses Issue..

Zunächst noch mal der aktuelle Ablauf unseres Autoloaders:
- Wird ein noch unbekannter Ordner erstmalig hinzugefügt, werden alle Dateien darin ausgelesen und nach Klassen durchsucht. Die neuen Zuordnungen Klasse=>Datei werden dem Cache hinzugefügt. 
- Wird eine Klasse nicht gefunden, werden pro Request einmalig alle Ordner neu durchsucht (also alle Dateien per Tokenizer analysiert), um eventuelle Verschiebungen oder neue Klassen zu finden.

Der zweite Punkt greift somit im Normalfall nur während der Entwicklungsphase (beim Verschieben oder Hinzufügen von Klassen). Gibt es aber nun Klassen, die über andere Autoloader eingebunden werden, wird bei jedem Request, bei dem die Klasse verwendet wird, zunächst unser Autoloader die Klasse nicht finden, und daher alle Dateien neu analysieren. Danach erst wird dann der andere Autoloader an die Reihe kommen. Das ist natürlich sehr ineffizient (so eine komplette Analyse dauert bei mir etwa 0,8s bis 1,0s)..

Mein Vorschlag ist daher, doch alle vendor-Verzeichnisse automatisch unserem Autoloader hinzuzufügen, und die anderen Autoloader nicht einzubinden (werden sie zusätzlich eingebunden, schade sie aber auch nicht, sind nur überflüssig). Ich sehe da auch keine wirklichen Nachteile, denn unser Autoloader kommt ja mit jeder Struktur klar und bei ganz normalen Seitenaufrufen ist er auch sehr effizient, da er für jede Klasse den genauen Pfad gecacht hat. Die zusätzlichen Arbeiten, wie Ordner auslesen und Dateien analysieren passieren ja immer nur einmalig beim Hinzufügen von neuen Ordnern (und dann auch nur der eine Ordner). Und nach dem Cache löschen, Verschieben von Klassen oder Hinzufügen neuer Klassen innerhalb eines eigentlich bekannten Ordners ist halt eine komplette neue Analyse notwendig.

@staabm Was meinst du dazu?
