### PR TITLE
rex_context: separated GET and POST params

### DIFF
--- a/redaxo/src/addons/structure/pages/index.php
+++ b/redaxo/src/addons/structure/pages/index.php
@@ -171,16 +171,10 @@ if ($function == 'add_cat' || $function == 'edit_cat') {
 
   $echo .= '
   <div class="rex-form" id="rex-form-structure-category">
-  <form action="index.php" method="post">
+  <form action="' . $context->getUrl(array('catstart' => $catstart)) . '" method="post">
     <fieldset>';
 
-  $params = array();
-  $params['catstart'] = $catstart;
-  if ($function == 'edit_cat') {
-    $params['edit_id'] = $edit_id;
-  }
-
-  $echo .= $context->getHiddenInputFields($params);
+  $echo .= $context->getHiddenInputFields(array('edit_id' => $edit_id));
 }
 
 
@@ -457,12 +451,10 @@ if ($category_id > 0 || ($category_id == 0 && !rex::getUser()->getComplexPerm('s
 
     $echo .= '
     <div class="rex-form" id="rex-form-structure-article">
-    <form action="index.php" method="post">
+    <form action="' . $context->getUrl(array('artstart' => $artstart)) . '" method="post">
       <fieldset>';
 
-    $params = array();
-    $params['artstart'] = $artstart;
-    $echo .= $context->getHiddenInputFields($params);
+    $echo .= $context->getHiddenInputFields();
   }
 
   // ----------- PRINT OUT THE ARTICLES

--- a/redaxo/src/core/tests/context_test.php
+++ b/redaxo/src/core/tests/context_test.php
@@ -6,8 +6,9 @@ class rex_context_test extends PHPUnit_Framework_TestCase
 
   public function setUp()
   {
-    $globalParams = array('int' => '25', 'str' => '<a b$c&?>');
-    $this->context = new rex_context($globalParams);
+    $getParams = array('int' => '25', 'str' => '<a b$c&?>');
+    $postParams = array('int' => '26', 'str' => '<d e$f&?>');
+    $this->context = new rex_context($getParams, $postParams);
 
     parent::setUp();
   }
@@ -31,31 +32,31 @@ class rex_context_test extends PHPUnit_Framework_TestCase
   public function testGetHiddenInputFields()
   {
     $this->assertEquals(
-      '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a b$c&amp;?&gt;" />',
+      '<input type="hidden" name="int" value="26" /><input type="hidden" name="str" value="&lt;d e$f&amp;?&gt;" />',
       $this->context->getHiddenInputFields(),
       'parameters get properly encoded'
     );
 
     $this->assertEquals(
-      '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="xyz" />',
+      '<input type="hidden" name="int" value="26" /><input type="hidden" name="str" value="xyz" />',
       $this->context->getHiddenInputFields(array('str' => 'xyz')),
       'local params override global params'
     );
 
     $this->assertEquals(
-      '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a b$c&amp;?&gt;" /><input type="hidden" name="str2" value="xyz" />',
+      '<input type="hidden" name="int" value="26" /><input type="hidden" name="str" value="&lt;d e$f&amp;?&gt;" /><input type="hidden" name="str2" value="xyz" />',
       $this->context->getHiddenInputFields(array('str2' => 'xyz')),
       'new params are appended'
     );
 
     $this->assertEquals(
-      '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a b$c&amp;?&gt;" /><input type="hidden" name="myarr[0]" value="xyz" /><input type="hidden" name="myarr[1]" value="123" />',
+      '<input type="hidden" name="int" value="26" /><input type="hidden" name="str" value="&lt;d e$f&amp;?&gt;" /><input type="hidden" name="myarr[0]" value="xyz" /><input type="hidden" name="myarr[1]" value="123" />',
       $this->context->getHiddenInputFields(array('myarr' => array('xyz', 123))),
       'numeric arrays are handled'
     );
 
     $this->assertEquals(
-      '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a b$c&amp;?&gt;" /><input type="hidden" name="myarr[a]" value="xyz" /><input type="hidden" name="myarr[b]" value="123" />',
+      '<input type="hidden" name="int" value="26" /><input type="hidden" name="str" value="&lt;d e$f&amp;?&gt;" /><input type="hidden" name="myarr[a]" value="xyz" /><input type="hidden" name="myarr[b]" value="123" />',
       $this->context->getHiddenInputFields(array('myarr' => array('a' => 'xyz', 'b' => 123))),
       'assoc arrays are handled'
     );


### PR DESCRIPTION
Ich möchte gerne erreichen, dass man von den Formularen nie nur auf "index.php" landet (mit allen Parametern inkl. page als POST-Parameter). Ich habe inzwischen alle Formulare angepasst, bis auf zwei, die rex_context verwenden.

rex_context kann bisher nur entweder alle Parameter als Url ausgeben, oder als Hidden Inputs. Ich möchte aber auch dort manche Parameter als GET-Parameter haben, und andere als POST. Das würde dieser PR ermöglichen.

@staabm Was meinst du dazu?
