### PR TITLE
Zentrale rex_markup Klasse

### DIFF
--- a/redaxo/src/core/lib/util/markup.php
+++ b/redaxo/src/core/lib/util/markup.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Markup parser class
+ *
+ * @author gharlan
+ * @package redaxo\core
+ */
+class rex_markup
+{
+    /**
+     * @var callable[]
+     */
+    private static $parsers = [];
+
+    /**
+     * @var int[]
+     */
+    private static $fileExtensions = [];
+
+    /**
+     * Parses a file, the markup type is select by the file extension
+     *
+     * @param string $file
+     * @param array  $options
+     * @return string
+     * @throws InvalidArgumentException
+     */
+    public static function parseFile($file, array $options = [])
+    {
+        if (!file_exists($file)) {
+            throw new InvalidArgumentException(sprintf('File "%s" does not exist!', $file));
+        }
+        return self::parse(rex_file::get($file), rex_file::extension($file), $options);
+    }
+
+    /**
+     * Parses content by the given markup type
+     *
+     * @param string $content
+     * @param string $markup
+     * @param array  $options
+     * @return string
+     */
+    public static function parse($content, $markup, array $options = [])
+    {
+        $markup = strtolower($markup);
+        if (isset(self::$fileExtensions[$markup])) {
+            return call_user_func(self::$parsers[self::$fileExtensions[$markup]], $content, $options);
+        }
+        return $content;
+    }
+
+    /**
+     * Registers a markup type
+     *
+     * @param string[] $fileExtensions
+     * @param callable $parser
+     */
+    public static function register(array $fileExtensions, callable $parser)
+    {
+        $id = count(self::$fileExtensions);
+        self::$parsers[$id] = $parser;
+        foreach ($fileExtensions as $extension) {
+            self::$fileExtensions[strtolower($extension)] = $id;
+        }
+    }
+
+    /**
+     * Checks whether the given markup type is registered
+     *
+     * @param string $markup
+     * @return bool
+     */
+    public function isRegistered($markup)
+    {
+        return isset(self::$fileExtensions[strtolower($markup)]);
+    }
+}


### PR DESCRIPTION
## Basis

Ich habe die Idee, eine zentrale Klasse für das Parsen von Markupsprachen (Textile, Markdown etc.) einzuführen. Für die Klasse selbst habe ich schon mal einen ersten Vorschlag erstellt, so wird glaube ich am besten deutlich, wie ich mir das vorstelle.

Wenn ich jetzt zum Beispiel Markdown parsen möchte, rufe ich das auf:

```php
echo rex_markup::parse('**Fetter Markdown Text**', 'markdown');
```

Wurde ein Parser für Markdown registriert, wird der Text geparst. Ansonsten muss man eben mit dem ungeparsten Text leben. (Mit `rex_markup::isRegistered` kann man auch checken, ob ein Parser registriert wurde.)

Ein neuer Parser wird zum Beispiel so registriert:

```php
rex_markup::register(['md', 'markdown'], 'rex_markdown::parse');
```

Ein Vorteil dieser Klasse ist, dass man eine zentrale Anlaufstelle hat, um Markup zu parsen. So kann zum Beispiel jemand ein alternatives Textile-Addon erstellen, mit ganz anderer interner Klassenstruktur, und anderem Addonnamen. Bisher wird ja in der Regel direkt geprüft, ob das Addon "textile" verfügbar ist, und dann deren Api verwendet.

## REX_VALUE mit Markup-Parsing

Dadurch, dass die Klasse direkt im Core ist, kann man auch für REX_VALUE ein Markup-Argument hinzufügen:

```
REX_VALUE[id=1 markup=textile]
```

Vorteil davon ist zum Beispiel, dass der bereits geparste Inhalt gecacht wird. Bisher wird ja bei jedem Aufruf geparst.

## Markdown-Dateien in Packages

Die help.php wird in Packages sehr wenig genutzt. Durch GitHub haben aber immer mehr Addons eine README-Datei.
Daher würde ich vorschlagen, dass falls keine help.php vorhanden ist, nach einer Readme geschaut wird, und die stattdessen angezeigt wird. Die Datei wird dann an `rex_markup::parseFile` überreicht, sodass eben zum Beispiel Markdown oder Textile geparst wird, falls der entsprechende Parser vorhanden ist.
Meist wird für die Readme Markdown verwendet, was ich für solche Dateien auch deutlich geeigneter halte als Textile. Daher sollten wir dann am besten noch ein Markdown-Addon anbieten, oder vielleicht sogar analog zu YAML als festen Bestandteil in den Core aufnehmen, um die Verwendung noch mehr zu forcieren.

Es scheint außerdem immer mehr Standard zu werden, dass es zusätzlich noch eine CHANGELOG(.md/.textile)-Datei gibt. Daher könnte man die dann auch noch (falls vorhanden) auf der Help-Page des Addons anzeigen, unterhalb der Readme oder so.

------

Was meint ihr zu dem Ganzen?

PS: Ist ein bisschen viel für ein Issue, wusste aber nicht, wie ich es anders machen soll, weil ja alles aufeinander aufbaut.