### PR TITLE
$this->getFileName() existiert

### DIFF
--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -312,7 +312,7 @@ function rex_mediapool_deleteMedia($filename)
 
     rex_file::delete(rex_path::media($filename));
 
-    rex_media_cache::delete($this->getFileName());
+    rex_media_cache::delete($filename);
 
     return ['ok' => true, 'msg' => rex_i18n::msg('pool_file_deleted')];
 }


### PR DESCRIPTION
Die Variable muss übergeben werden, damit auch der cache gelöscht werden kann.
