### PR TITLE
Secure login

### DIFF
--- a/redaxo/src/addons/tests/lib/tests_result_printer.php
+++ b/redaxo/src/addons/tests/lib/tests_result_printer.php
@@ -9,7 +9,13 @@ class rex_tests_result_printer extends PHPUnit_TextUI_ResultPrinter
 
     public function __construct($backtrace, $colors = false)
     {
-        parent::__construct(null, false, $colors);
+        $out = null;
+        if (php_sapi_name() == 'cli') {
+            // prevent headers already sent error when started from CLI
+            $out = 'php://stderr';
+        }
+
+        parent::__construct($out, false, $colors);
 
         $this->backtrace = '';
         foreach ($backtrace as $trace) {

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -28,7 +28,7 @@ class rex_backend_login extends rex_login
             AND login = :login
             AND (login_tries < ' . self::LOGIN_TRIES_1 . '
                 OR login_tries < ' . self::LOGIN_TRIES_2 . ' AND UNIX_TIMESTAMP(lasttrydate) < ' . (time() - self::RELOGIN_DELAY_1) . '
-                OR UNIX_TIMESTAMP(lasttrydate) > ' . (time() - self::RELOGIN_DELAY_2) . '
+                OR UNIX_TIMESTAMP(lasttrydate) < ' . (time() - self::RELOGIN_DELAY_2) . '
             )'
         );
         $this->tableName = $tableName;

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -24,6 +24,7 @@ class rex_backend_login extends rex_login
         $this->setSessionDuration(rex::getProperty('session_duration'));
         $qry = 'SELECT * FROM ' . $tableName . ' WHERE status=1';
         $this->setUserQuery($qry . ' AND id = :id');
+        // XXX because with concat the time into the sql query, users of this class should use checkLogin() immediately after creating the object.
         $this->setLoginQuery($qry . '
             AND login = :login
             AND (login_tries < ' . self::LOGIN_TRIES_1 . '

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -63,7 +63,7 @@ class rex_backend_login extends rex_login
         if ($check) {
             // gelungenen versuch speichern | login_tries = 0
             if ($this->userLogin != '' || !$userId) {
-                $this->regenerateSessionId();
+                self::regenerateSessionId();
                 $params = [];
                 $add = '';
                 if ($this->stayLoggedIn || $cookiekey) {

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -161,18 +161,10 @@ class rex_login
         if (!$this->logout) {
             // LoginStatus: 0 = noch checken, 1 = ok, -1 = not ok
 
-            // checkLogin schonmal ausgeführt ? gecachte ausgabe erlaubt ?
-            if ($this->cache) {                
-                // always check UID, so session fixation prevention can kick in
-                if ($this->getSessionVar('UID') != '') {
-                    if ($this->loginStatus > 0) {
-                        return true;
-                    } elseif ($this->loginStatus < 0) {
-                        return false;
-                    }
-                }
+            // gecachte ausgabe erlaubt ? checkLogin schonmal ausgeführt ?
+            if ($this->cache && $this->loginStatus != 0) {
+                return $this->loginStatus > 0;
             }
-
 
             if ($this->userLogin != '') {
                 // wenn login daten eingegeben dann checken

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -1,0 +1,36 @@
+<?php
+class rex_backend_login_test extends PHPUnit_Framework_TestCase
+{
+    private $login = 'testusr', $password = 'test1234', $cookiekey = 'mycookie';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $adduser = rex_sql::factory();
+        $adduser->setTable(rex::getTablePrefix() . 'user');
+        $adduser->setValue('name', 'test user');
+        $adduser->setValue('login', $this->login);
+        $adduser->setValue('password', rex_login::passwordHash($this->password));
+        $adduser->setValue('status', '1');
+        $adduser->setValue('login_tries', '0');
+        $adduser->setValue('cookiekey', $this->cookiekey);
+        $adduser->insert();
+    }
+
+    public function testSuccessfullLogin()
+    {
+        $login = new rex_backend_login();
+        $login->setLogin($this->login, $this->password, false);
+        $this->assertTrue($login->checkLogin());
+    }
+
+    public function tearDown()
+    {
+        $deleteuser = rex_sql::factory();
+        $deleteuser->setQuery('DELETE FROM ' . rex::getTablePrefix() . "user WHERE login = '". $this->login ."' LIMIT 1");
+
+        // make sure we don't mess up the global scope
+        // session_destroy();
+    }
+}

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -54,7 +54,7 @@ class rex_backend_login_test extends PHPUnit_Framework_TestCase
     {
         $login = new rex_backend_login();
 
-        for($i = 0; $i < rex_backend_login::LOGIN_TRIES_1; $i++) {
+        for($i = 0; $i <= 10; $i++) {
             $login->setLogin($this->login, 'somethingwhichisnotcorrect', false);
             $this->assertFalse($login->checkLogin());
         }
@@ -73,6 +73,15 @@ class rex_backend_login_test extends PHPUnit_Framework_TestCase
         $this->assertTrue($login->checkLogin());
     }
 
+
+    public function testLogout()
+    {
+        $login = new rex_backend_login();
+        $login->setLogin($this->login, $this->password, false);
+        $this->assertTrue($login->checkLogin());
+        $login->setLogout(true);
+        $this->assertFalse($login->checkLogin());
+    }
 
     public function tearDown()
     {

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -60,17 +60,18 @@ class rex_backend_login_test extends PHPUnit_Framework_TestCase
         }
 
         $login->setLogin($this->login, $this->password, false);
-        $this->assertFalse($login->checkLogin());
+        $this->assertFalse($login->checkLogin(), 'account locked after fast login attempts');
 
         sleep(1);
 
         $login->setLogin($this->login, $this->password, false);
-        $this->assertFalse($login->checkLogin());
+        $this->assertFalse($login->checkLogin(), 'even seconds later account is locked');
 
-        sleep(rex_backend_login::LOGIN_TRIES_1 - 1);
+        sleep(5);
 
         $login->setLogin($this->login, $this->password, false);
-        $this->assertTrue($login->checkLogin());
+        $this->assertTrue($login->checkLogin(), 'after waiting the account should be unlocked');
+
     }
 
 

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -54,7 +54,7 @@ class rex_backend_login_test extends PHPUnit_Framework_TestCase
     {
         $login = new rex_backend_login();
 
-        for($i = 0; $i <= 10; $i++) {
+        for($i = 0; $i < rex_backend_login::LOGIN_TRIES_1; $i++) {
             $login->setLogin($this->login, 'somethingwhichisnotcorrect', false);
             $this->assertFalse($login->checkLogin());
         }
@@ -70,12 +70,11 @@ class rex_backend_login_test extends PHPUnit_Framework_TestCase
         $login->setLogin($this->login, $this->password, false);
         $this->assertFalse($login->checkLogin(), 'even seconds later account is locked');
 
-        sleep(5);
+        sleep(rex_backend_login::RELOGIN_DELAY_1 + 2);
 
         $login = new rex_backend_login();
         $login->setLogin($this->login, $this->password, false);
         $this->assertTrue($login->checkLogin(), 'after waiting the account should be unlocked');
-
     }
 
 
@@ -94,6 +93,6 @@ class rex_backend_login_test extends PHPUnit_Framework_TestCase
         $deleteuser->setQuery('DELETE FROM ' . rex::getTablePrefix() . "user WHERE login = '". $this->login ."' LIMIT 1");
 
         // make sure we don't mess up the global scope
-        // session_destroy();
+        session_destroy();
     }
 }

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -59,16 +59,20 @@ class rex_backend_login_test extends PHPUnit_Framework_TestCase
             $this->assertFalse($login->checkLogin());
         }
 
+        // we need to re-create login-objects because the time component is static in their sql queries
+        $login = new rex_backend_login();
         $login->setLogin($this->login, $this->password, false);
         $this->assertFalse($login->checkLogin(), 'account locked after fast login attempts');
 
         sleep(1);
 
+        $login = new rex_backend_login();
         $login->setLogin($this->login, $this->password, false);
         $this->assertFalse($login->checkLogin(), 'even seconds later account is locked');
 
         sleep(5);
 
+        $login = new rex_backend_login();
         $login->setLogin($this->login, $this->password, false);
         $this->assertTrue($login->checkLogin(), 'after waiting the account should be unlocked');
 

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -25,6 +25,55 @@ class rex_backend_login_test extends PHPUnit_Framework_TestCase
         $this->assertTrue($login->checkLogin());
     }
 
+    public function testFailedLogin()
+    {
+        $login = new rex_backend_login();
+        $login->setLogin($this->login, 'somethingwhichisnotcorrect', false);
+        $this->assertFalse($login->checkLogin());
+    }
+
+    /**
+     * Test if a login is allowed after one failure before
+     */
+    public function testSuccessfullReLogin()
+    {
+        $login = new rex_backend_login();
+
+        $login->setLogin($this->login, 'somethingwhichisnotcorrect', false);
+        $this->assertFalse($login->checkLogin());
+
+        $login->setLogin($this->login, $this->password, false);
+        $this->assertTrue($login->checkLogin());
+    }
+
+
+    /**
+     * After LOGIN_TRIES_1 requests, the account should be not accessible for RELOGIN_DELAY_1 seconds
+     */
+    public function testSuccessfullReLoginAfterLoginTries1Seconds()
+    {
+        $login = new rex_backend_login();
+
+        for($i = 0; $i < rex_backend_login::LOGIN_TRIES_1; $i++) {
+            $login->setLogin($this->login, 'somethingwhichisnotcorrect', false);
+            $this->assertFalse($login->checkLogin());
+        }
+
+        $login->setLogin($this->login, $this->password, false);
+        $this->assertFalse($login->checkLogin());
+
+        sleep(1);
+
+        $login->setLogin($this->login, $this->password, false);
+        $this->assertFalse($login->checkLogin());
+
+        sleep(rex_backend_login::LOGIN_TRIES_1 - 1);
+
+        $login->setLogin($this->login, $this->password, false);
+        $this->assertTrue($login->checkLogin());
+    }
+
+
     public function tearDown()
     {
         $deleteuser = rex_sql::factory();


### PR DESCRIPTION
Session fixation und session id validierung

Zitat:

```
Current Solution

Programmer can make adoptive session with user land code as follows.

Login code fragment: Code that adds session ID as validation key.

session_destory();
session_regenerate_id();
$_SESSION['valid_id'] = session_id();
Validation code: Code other than login. Check if session is properly initilized.

if ($_SESSION['valid_id'] !== session_id()) {
  die('Invalid use of session ID');
}
Alternatively, programmers may try to delete all possible cookies by sending empty session ID cookie.
```

Siehe https://wiki.php.net/rfc/strict_sessions