### PR TITLE
Einfache Validatorklasse

### DIFF
--- a/redaxo/src/addons/cronjob/lib/form.php
+++ b/redaxo/src/addons/cronjob/lib/form.php
@@ -26,15 +26,6 @@ class rex_cronjob_form extends rex_form
         return $field;
     }
 
-    protected function validate()
-    {
-        $el = $this->getElement($this->mainFieldset, 'name');
-        if ($el->getValue() == '') {
-            return rex_i18n::msg('cronjob_error_no_name');
-        }
-        return true;
-    }
-
     protected function save()
     {
         if ($this->isEditMode()) {

--- a/redaxo/src/addons/cronjob/pages/cronjobs.php
+++ b/redaxo/src/addons/cronjob/pages/cronjobs.php
@@ -144,6 +144,7 @@ if ($func == '') {
 
     $field = $form->addTextField('name');
     $field->setLabel($this->i18n('name'));
+    $field->getValidator()->add('notEmpty', $this->i18n('cronjob_error_no_name'));
     $nameFieldId = $field->getAttribute('id');
 
     $field = $form->addTextAreaField('description');

--- a/redaxo/src/core/lib/form/elements/element.php
+++ b/redaxo/src/core/lib/form/elements/element.php
@@ -18,6 +18,8 @@ class rex_form_element
     protected $prefix;
     protected $suffix;
     protected $notice;
+    /** @var rex_validator */
+    protected $validator;
 
     public function __construct($tag, rex_form $table = null, array $attributes = [], $separateEnding = false)
     {
@@ -32,6 +34,7 @@ class rex_form_element
         $this->setPrefix('');
         $this->setSuffix('');
         $this->fieldName = '';
+        $this->validator = rex_validator::factory();
     }
 
     // --------- Attribute setter/getters
@@ -179,6 +182,11 @@ class rex_form_element
     public function hasSeparateEnding()
     {
         return $this->separateEnding;
+    }
+
+    public function getValidator()
+    {
+        return $this->validator;
     }
 
     // --------- Element Methods

--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -1134,7 +1134,22 @@ class rex_form
      */
     protected function validate()
     {
-        return true;
+        $messages = [];
+        foreach ($this->getSaveElements() as $fieldsetName => $fieldsetElements) {
+            foreach ($fieldsetElements as $element) {
+                /** @var rex_form_element $element */
+                // read-only-fields
+                if (strpos($element->getAttribute('class'), 'rex-form-read') !== false) {
+                    continue;
+                }
+
+                $validator = $element->getValidator();
+                if (!$validator->isValid($element->getSaveValue())) {
+                    $messages[] = $validator->getMessage();
+                }
+            }
+        }
+        return empty($messages) ? true : implode('<br />', $messages);
     }
 
     /**

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -64,13 +64,13 @@ class rex
         }
         switch ($key) {
             case 'server':
-                if (!preg_match('@^\w+://(?:[\w-]+\.)*[\w-]+(?::\d+)?(?:/.*)?$@u', $value)) {
+                if (!rex_validator::factory()->url($value)) {
                     throw new InvalidArgumentException('"server" property: expecting $value to be a full URL!');
                 }
                 $value = rtrim($value, '/') . '/';
                 break;
             case 'error_email':
-                if (null !== $value && !preg_match('/^[\w.-]+@[\w.-]+\.[a-z]{2,}$/ui', $value)) {
+                if (null !== $value && !rex_validator::factory()->email($value)) {
                     throw new InvalidArgumentException('"error_email" property: expecting $value to be an email address!');
                 }
                 break;

--- a/redaxo/src/core/lib/util/validator.php
+++ b/redaxo/src/core/lib/util/validator.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * Validator class
+ *
+ * @author gharlan
+ * @package redaxo\core
+ */
+class rex_validator
+{
+    use rex_factory_trait;
+
+    private $types = [];
+    private $message;
+
+    /**
+     * Constructor
+     */
+    protected function __construct()
+    {
+        // noop
+    }
+
+    /**
+     * Factory method
+     *
+     * @return static
+     */
+    public static function factory()
+    {
+        $class = static::getFactoryClass();
+        return new $class;
+    }
+
+    /**
+     * Adds a validator
+     *
+     * @param string      $type    Validator type (any static method name of this class)
+     * @param null|string $message Message which is used if this validator type does not match
+     * @param mixed       $option  Type specific option
+     * @throws InvalidArgumentException
+     */
+    public function add($type, $message = null, $option = null)
+    {
+        if (!method_exists($this, $type)) {
+            throw new InvalidArgumentException('Unknown validator type: ' . $type);
+        }
+        $this->types[] = [$type, $message, $option];
+    }
+
+    /**
+     * Checks whether the given value matches all added validators
+     *
+     * @param string $value
+     * @return bool
+     */
+    public function isValid($value)
+    {
+        $this->message = null;
+        foreach ($this->types as $type) {
+            list($type, $message, $option) = $type;
+            if (!$this->$type($value, $option)) {
+                $this->message = $message;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the message
+     *
+     * @return string[]
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * Checks whether the value is not empty
+     *
+     * @param string $value
+     * @return bool
+     */
+    public function notEmpty($value)
+    {
+        return 0 !== strlen($value);
+    }
+
+    /**
+     * Checks whether the value is from the given type
+     *
+     * @param string $value
+     * @param string $type
+     * @throws InvalidArgumentException
+     * @return bool
+     */
+    public function type($value, $type)
+    {
+        switch ($type) {
+            case 'int':
+            case 'integer':
+                return self::match($value, '/^\d+$/');
+
+            case 'float':
+            case 'real':
+                return is_numeric($value);
+
+            default:
+                throw new InvalidArgumentException('Unknown $type:' . $type);
+        }
+    }
+
+    /**
+     * Checks whether the value has the given min length
+     *
+     * @param string $value
+     * @param int    $minLength
+     * @return bool
+     */
+    public function minLength($value, $minLength)
+    {
+        return mb_strlen($value) >= $minLength;
+    }
+
+    /**
+     * Checks whether the value has the given max value
+     *
+     * @param string $value
+     * @param int    $maxLength
+     * @return bool
+     */
+    public function maxLength($value, $maxLength)
+    {
+        return mb_strlen($value) <= $maxLength;
+    }
+
+    /**
+     * Checks whether the value is equal or greater than the given min value
+     *
+     * @param string $value
+     * @param int    $min
+     * @return bool
+     */
+    public function min($value, $min)
+    {
+        return $value >= $min;
+    }
+
+    /**
+     * Checks whether the value is equal or lower than the given max value
+     *
+     * @param string $value
+     * @param int    $max
+     * @return bool
+     */
+    public function max($value, $max)
+    {
+        return $value <= $max;
+    }
+
+    /**
+     * Checks whether the value is an URL
+     *
+     * @param string $value
+     * @return bool
+     */
+    public function url($value)
+    {
+        return $this->match($value, '@^\w+://(?:[\w-]+\.)*[\w-]+(?::\d+)?(?:/.*)?$@u');
+    }
+
+    /**
+     * Checks whether the value is an email address
+     *
+     * @param string $value
+     * @return bool
+     */
+    public function email($value)
+    {
+        return $this->match($value, '/^[\w.-]+@[\w.-]+\.[a-z]{2,}$/ui');
+    }
+
+    /**
+     * Checks whether the value matches the given regex
+     *
+     * @param string $value
+     * @param string $regex
+     * @return bool
+     */
+    public function match($value, $regex)
+    {
+        return (bool) preg_match($regex, $value);
+    }
+
+    /**
+     * Checks whether the value does not match the given regex
+     *
+     * @param string $value
+     * @param string $regex
+     * @return bool
+     */
+    public function notMatch($value, $regex)
+    {
+        return !$this->match($value, $regex);
+    }
+
+    /**
+     * Checks whether the value is one of the given valid values
+     *
+     * @param string $value
+     * @param array  $validValues
+     * @return bool
+     */
+    public function values($value, array $validValues)
+    {
+        return in_array($value, $validValues);
+    }
+
+    /**
+     * Checks the value by using the given callable
+     *
+     * @param string   $value
+     * @param callable $callback
+     * @return bool
+     */
+    public function custom($value, callable $callback)
+    {
+        return $callback($value);
+    }
+}

--- a/redaxo/src/core/tests/util/validator_test.php
+++ b/redaxo/src/core/tests/util/validator_test.php
@@ -1,0 +1,165 @@
+<?php
+
+class rex_validator_test extends PHPUnit_Framework_TestCase
+{
+    public function testNotEmpty()
+    {
+        $validator = rex_validator::factory();
+        $this->assertFalse($validator->notEmpty(''));
+        $this->assertTrue($validator->notEmpty('0'));
+        $this->assertTrue($validator->notEmpty('aaa'));
+    }
+
+    public function dataType()
+    {
+        return [
+            ['',      'int', false],
+            ['a',     'int', false],
+            ['0',     'int', true],
+            ['1234',  'int', true],
+            ['34.54', 'int', false],
+            ['',      'float', false],
+            ['a',     'float', false],
+            ['0',     'float', true],
+            ['1234',  'float', true],
+            ['34.54', 'float', true]
+        ];
+    }
+
+    /**
+     * @dataProvider dataType
+     */
+    public function testType($value, $type, $expected)
+    {
+        $this->assertEquals($expected, rex_validator::factory()->type($value, $type));
+    }
+
+    public function testMinLength()
+    {
+        $validator = rex_validator::factory();
+        $this->assertFalse($validator->minLength('ab', 3));
+        $this->assertTrue($validator->minLength('abc', 3));
+    }
+
+    public function testMaxLength()
+    {
+        $validator = rex_validator::factory();
+        $this->assertFalse($validator->maxLength('abc', 2));
+        $this->assertTrue($validator->maxLength('ab', 2));
+    }
+
+    public function testMin()
+    {
+        $validator = rex_validator::factory();
+        $this->assertFalse($validator->min('4', 5));
+        $this->assertTrue($validator->min('5', 5));
+    }
+
+    public function testMax()
+    {
+        $validator = rex_validator::factory();
+        $this->assertFalse($validator->max('5', 4));
+        $this->assertTrue($validator->max('4', 4));
+    }
+
+    public function dataUrl()
+    {
+        return [
+            ['', false],
+            ['abc', false],
+            ['www.example.com', false],
+            ['http://localhost', true],
+            ['http://www.example.com/path/to/file.php?page=2&x=3', true],
+            ['http://www.example.com:8080/', true]
+        ];
+    }
+
+    /**
+     * @dataProvider dataUrl
+     */
+    public function testUrl($value, $isValid)
+    {
+        $this->assertEquals($isValid, rex_validator::factory()->url($value));
+    }
+
+    public function dataEmail()
+    {
+        return [
+            ['', false],
+            ['abc', false],
+            ['@example.com', false],
+            ['info@example.com', true],
+            ['abc.def@sub.example.com', true]
+        ];
+    }
+
+    /**
+     * @dataProvider dataEmail
+     */
+    public function testEmail($value, $isValid)
+    {
+        $this->assertEquals($isValid, rex_validator::factory()->email($value));
+    }
+
+    public function testMatch()
+    {
+        $validator = rex_validator::factory();
+        $this->assertFalse($validator->match('aa', '/^.$/'));
+        $this->assertTrue($validator->match('a', '/^.$/'));
+    }
+
+    public function testNotMatch()
+    {
+        $validator = rex_validator::factory();
+        $this->assertTrue($validator->notMatch('aa', '/^.$/'));
+        $this->assertFalse($validator->notMatch('a', '/^.$/'));
+    }
+
+    public function testValues()
+    {
+        $validator = rex_validator::factory();
+        $this->assertFalse($validator->values('abc', ['def', 'ghi']));
+        $this->assertTrue($validator->values('ghi', ['def', 'ghi']));
+    }
+
+    public function testCustom()
+    {
+        $validator = rex_validator::factory();
+
+        $callback = function ($v) use (&$value, &$isCalled) {
+            $isCalled = true;
+            $this->assertEquals($value, $v);
+            return $value === 'abc';
+        };
+
+        $isCalled = false;
+        $value = 'abc';
+        $this->assertTrue($validator->custom($value, $callback));
+        $this->assertTrue($isCalled, 'Custom callback is called');
+
+        $isCalled = false;
+        $value = 'def';
+        $this->assertFalse($validator->custom($value, $callback));
+        $this->assertTrue($isCalled, 'Custom callback is called');
+    }
+
+    public function testIsValid()
+    {
+        $validator = rex_validator::factory();
+
+        $this->assertTrue($validator->isValid(''));
+        $this->assertNull($validator->getMessage());
+
+        $validator->add('notEmpty', 'not-empty');
+        $validator->add('minLength', 'min-length', 3);
+
+        $this->assertFalse($validator->isValid(''));
+        $this->assertEquals('not-empty', $validator->getMessage());
+
+        $this->assertFalse($validator->isValid('ab'));
+        $this->assertEquals('min-length', $validator->getMessage());
+
+        $this->assertTrue($validator->isValid('abc'));
+        $this->assertNull($validator->getMessage());
+    }
+}


### PR DESCRIPTION
Analog zu `rex_formatter` eine Klasse `rex_validator` für öfters gebrauchte Validierungen wie E-Mai, URL etc.
In `rex_form` könnte man die dann auch integrieren, sodass man die Felder leichter validieren lassen kann.

Siehe auch https://github.com/redaxo/redaxo/commit/e9aacd90a3c1f0e802e95773e8d4f79d073c750a#commitcomment-2730054
