### PR TITLE
register the handleError() only for E_* levels we are interessted in

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -18,7 +18,7 @@ abstract class rex_error_handler
 
         self::$registered = true;
 
-        set_error_handler([__CLASS__, 'handleError']);
+        set_error_handler([__CLASS__, 'handleError'], error_reporting());
         set_exception_handler([__CLASS__, 'handleException']);
         register_shutdown_function([__CLASS__, 'shutdown']);
     }
@@ -114,7 +114,7 @@ abstract class rex_error_handler
 
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
 
-        } elseif ((error_reporting() & $errno) == $errno) {
+        } else {
 
             if (ini_get('display_errors') && (rex::isSetup() || rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin())) {
                 echo '<div><b>' . self::getErrorType($errno) . "</b>: $errstr in <b>$errfile</b> on line <b>$errline</b></div>";


### PR DESCRIPTION
This improves performance, because handleError() is not invoked for every E_* level, but only those we are interessted in. This removed a lot of unnecessary invocations which lead to a no-op as the error-level will be filtered nevertheless.

see
https://bugs.php.net/bug.php?id=68982
https://github.com/filp/whoops/pull/260