### PR TITLE
Optionaler Backend-Output

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lang/de_de.lang
+++ b/redaxo/src/addons/structure/plugins/content/lang/de_de.lang
@@ -104,6 +104,7 @@ articel_updated = Artikel wurden aktualisiert
 create_module = Neues Modul erstellen
 input = Eingabe
 output = Ausgabe
+output_backend = Ausgabe Backend
 module_name = Name
 save_module_and_quit = Modul speichern
 save_module_and_continue = Modul übernehmen

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -262,7 +262,7 @@ class rex_article_content_base
         $module_id = rex_request('module_id', 'int');
 
         // ---------- alle teile/slices eines artikels auswaehlen
-        $sql = 'SELECT ' . rex::getTablePrefix() . 'module.id, ' . rex::getTablePrefix() . 'module.name, ' . rex::getTablePrefix() . 'module.output, ' . rex::getTablePrefix() . 'module.input, ' . rex::getTablePrefix() . 'article_slice.*, ' . rex::getTablePrefix() . 'article.parent_id
+        $sql = 'SELECT ' . rex::getTablePrefix() . 'module.id, ' . rex::getTablePrefix() . 'module.name, ' . rex::getTablePrefix() . 'module.output, ' . rex::getTablePrefix() . 'module.output_backend, ' . rex::getTablePrefix() . 'module.input, ' . rex::getTablePrefix() . 'article_slice.*, ' . rex::getTablePrefix() . 'article.parent_id
                         FROM
                             ' . rex::getTablePrefix() . 'article_slice
                         LEFT JOIN ' . rex::getTablePrefix() . 'module ON ' . rex::getTablePrefix() . 'article_slice.module_id=' . rex::getTablePrefix() . 'module.id

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
@@ -31,8 +31,12 @@ class rex_article_content_editor extends rex_article_content
 
             $moduleInput = $artDataSql->getValue(rex::getTablePrefix() . 'module.input');
             $moduleOutput = $artDataSql->getValue(rex::getTablePrefix() . 'module.output');
+            $moduleOutputBackend = $artDataSql->getValue(rex::getTablePrefix() . 'module.output_backend');
             $moduleId = $artDataSql->getValue(rex::getTablePrefix() . 'module.id');
 
+            if($moduleOutputBackend)
+                $moduleOutput = $moduleOutputBackend;
+                
             $slice_content = '';
             // ----- add select box einbauen
             if ($this->function == 'add' && $this->slice_id == $sliceId) {

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
@@ -15,6 +15,7 @@ $iaction_id = rex_request('iaction_id', 'int'); // id der module-action relation
 $mname = rex_request('mname', 'string');
 $eingabe = rex_request('eingabe', 'string');
 $ausgabe = rex_request('ausgabe', 'string');
+$ausgabe_backend = rex_request('output_backend', 'string');
 $goon = rex_request('goon', 'string');
 $add_action = rex_request('add_action', 'string');
 
@@ -104,6 +105,7 @@ if ($function == 'add' or $function == 'edit') {
                 $IMOD->setValue('name', $mname);
                 $IMOD->setValue('input', $eingabe);
                 $IMOD->setValue('output', $ausgabe);
+                $IMOD->setValue('output_backend', $ausgabe_backend);
                 $IMOD->addGlobalCreateFields();
 
                 $IMOD->insert();
@@ -121,6 +123,7 @@ if ($function == 'add' or $function == 'edit') {
                     $UMOD->setValue('name', $mname);
                     $UMOD->setValue('input', $eingabe);
                     $UMOD->setValue('output', $ausgabe);
+                    $UMOD->setValue('output_backend', $ausgabe_backend);
                     $UMOD->addGlobalUpdateFields();
 
                     $UMOD->update();
@@ -159,6 +162,7 @@ if ($function == 'add' or $function == 'edit') {
             $hole = rex_sql::factory();
             $hole->setQuery('SELECT * FROM ' . rex::getTablePrefix() . 'module WHERE id=' . $module_id);
             $mname = $hole->getValue('name');
+            $ausgabe_backend = $hole->getValue('output_backend');
             $ausgabe = $hole->getValue('output');
             $eingabe = $hole->getValue('input');
         } else {
@@ -203,6 +207,11 @@ if ($function == 'add' or $function == 'edit') {
         $n = [];
         $n['label'] = '<label for="moutput">' . rex_i18n::msg('output') . '</label>';
         $n['field'] = '<textarea class="form-control rex-code" id="moutput" name="ausgabe">' . htmlspecialchars($ausgabe) . '</textarea>';
+        $formElements[] = $n;
+
+        $n = [];
+        $n['label'] = '<label for="moutput_backend">' . rex_i18n::msg('output_backend') . '</label>';
+        $n['field'] = '<textarea class="form-control rex-code" id="moutput_backend" name="output_backend">' . htmlspecialchars($ausgabe_backend) . '</textarea>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();


### PR DESCRIPTION
Nur als Vorschlag.

Im Backend kann es nützlich sein einen aufgeräumteren Output in die Datenbank zu speichern. In diesem Pull-Request habe ich "schnell" mal so ein Feld eingebaut. Der Vorteil wäre dass man im Output nicht prüfen muss ob man im Frontend oder Backend ist. Lässt man es leer passiert auch nichts.

Was haltet ihr davon?

**Edit:** Das Feld output_backend muss noch der Datenbank hinzugefügt werden.

Unter Umständen kann man dieses Feld auch vereinfachen. Der Entwickler erhält eine Liste mit Feldern und wählt aus, welche im Backend ausgegeben werden sollen.

- [x] VALUE[1]
- [x] VALUE[2]
- [ ] VALUE[n]
- ####
- [x] FILE[1]

Diese könnten dann etwas standardisiert ausgegeben, dass Backend würde einheitlicher / aufgeräumter dargestellt, es gäbe keine offenen HTML-Tags mehr und die Slices könnten ganz einfach auf- bzw. zugeklappt werden.

Und wie gesagt, es wäre alles optional, wer das Feld nicht nutzt bekommt einfach alles aus dem Frontend-Output wie bisher auch. Ich wüsste auf die schnelle auch nicht wie das als Addon realisierbar wäre für den Moment.

lg Sascha