### PR TITLE
Pjax deaktivieren

### DIFF
--- a/redaxo/src/addons/import_export/pages/export.php
+++ b/redaxo/src/addons/import_export/pages/export.php
@@ -252,7 +252,7 @@ $fragment->setVar('buttons', $buttons, false);
 $content = $fragment->parse('core/page/section.php');
 
 $content = '
-<form action="' . rex_url::currentBackendPage() . '" method="post">
+<form action="' . rex_url::currentBackendPage() . '" data-pjax="false" method="post">
     ' . $content . '
 </form>
 


### PR DESCRIPTION
Wenn das Formular mit Ajax abgeschickt wird, kann die Backup-Datei nicht heruntergeladen werden. Daher sollte es hier deaktiviert werden.