### PR TITLE
Installationsanleitung

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@ REDAXO CMS
 [www.redaxo.org](http://www.redaxo.org) | [GitBook](http://doku.redaxo.sioweb.de/5.0/advanced/) | [Api Doc](http://www.redaxo.org/docs/)
 
 [![Build Status](https://secure.travis-ci.org/redaxo/redaxo.png?branch=master)](http://travis-ci.org/redaxo/redaxo)
+
+Installation
+------------
+
+Entwicklungsstand installieren:
+
+```sh
+git clone https://github.com/redaxo/redaxo.git
+git submodule init
+git submodule update
+```
+
+Oder alternativ ein [Release herunterladen](https://github.com/redaxo/redaxo/releases)
+
+Beachte: Die von Github bereit gestellten Downloads ("Download ZIP" Button) enthalten nicht die nötigen GIT Submodule, funktionieren daher nicht.


### PR DESCRIPTION
Notwendig da bereits einige Leute "Fehler gemeldet" haben, wg. des ZIP Downloads von GH