### PR TITLE
Zusätzlicher EP für Slices im Output

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -206,17 +206,16 @@ class rex_article_content_base
      */
     protected function outputSlice(rex_sql $artDataSql, $moduleIdToAdd)
     {
-        $output = $this->replaceVars($artDataSql, $artDataSql->getValue(rex::getTablePrefix() . 'module.output'));
-
         $output = rex_extension::registerPoint(new rex_extension_point(
             'MODULE_OUTPUT',
-            $output,
+            $artDataSql->getValue(rex::getTablePrefix() . 'module.output'),
             [
                 'article_id' => $this->article_id,
                 'clang' => $this->clang,
                 'slice_data' => $artDataSql
             ]
         ));
+        $output = $this->replaceVars($artDataSql, $output);
         
         return $this->getStreamOutput('module/' . $artDataSql->getValue(rex::getTablePrefix() . 'module.id') . '/output', $output);
     }

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -208,7 +208,7 @@ class rex_article_content_base
     {
         $output = $this->replaceVars($artDataSql, $artDataSql->getValue(rex::getTablePrefix() . 'module.output'));
 
-        $customContent = rex_extension::registerPoint(new rex_extension_point(
+        $output = rex_extension::registerPoint(new rex_extension_point(
             'MODULE_OUTPUT',
             $output,
             [
@@ -217,8 +217,6 @@ class rex_article_content_base
                 'slice_data' => $artDataSql
             ]
         ));
-        if($customContent)
-            $output = $customContent;
         
         return $this->getStreamOutput('module/' . $artDataSql->getValue(rex::getTablePrefix() . 'module.id') . '/output', $output);
     }

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -208,6 +208,18 @@ class rex_article_content_base
     {
         $output = $this->replaceVars($artDataSql, $artDataSql->getValue(rex::getTablePrefix() . 'module.output'));
 
+        $customContent = rex_extension::registerPoint(new rex_extension_point(
+            'MODULE_OUTPUT',
+            $output,
+            [
+                'article_id' => $this->article_id,
+                'clang' => $this->clang,
+                'slice_data' => $artDataSql
+            ]
+        ));
+        if($customContent)
+            $output = $customContent;
+        
         return $this->getStreamOutput('module/' . $artDataSql->getValue(rex::getTablePrefix() . 'module.id') . '/output', $output);
     }
 

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -207,7 +207,7 @@ class rex_article_content_base
     protected function outputSlice(rex_sql $artDataSql, $moduleIdToAdd)
     {
         $output = rex_extension::registerPoint(new rex_extension_point(
-            'MODULE_OUTPUT',
+            'SLICE_OUTPUT',
             $artDataSql->getValue(rex::getTablePrefix() . 'module.output'),
             [
                 'article_id' => $this->article_id,


### PR DESCRIPTION
Ich habe hier noch ein extension point eingebaut. Damit wäre es mir möglich vor und nach einem Slice im Output noch Markup zu definieren. In dem EP übergebe ich das Slice SQL und kann so abfragen ob group_template gesetzt ist und entsprechend eine Gruppe bei Slice Y öffnen und bei Slice X schließen.