### PR TITLE
rex_sql: neue setLimit-Methode

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -307,7 +307,7 @@ class rex_sql implements Iterator
             if($this->limit) {
                 $query .= ' LIMIT :start, :results';
             }
-            $this->prepareQuery($query);a
+            $this->prepareQuery($query);
             $this->execute($params);
         } else {
             try {


### PR DESCRIPTION
Mit diesen Änderungen kann man ein Limit und ein offset einsetzen.
Die Frage wäre jetzt ob PDO::ATTR_EMULATE_PREPARES auskommentiert bleiben muss, oder nicht. Was hat das für Auswirkungen auf die Klasse?

Nur als Vorschlag, wäre sicher hilfreich sowas schon vorweg definieren zu können.

```
$sql = rex_sql::factory();
$sql->setTable('foo')->setLimit( i_Limit, i_Offset )->setWhere([])->select();
```

lg Sascha