### PR TITLE
rex_view: array_unique für Assets

### DIFF
--- a/redaxo/src/core/lib/view.php
+++ b/redaxo/src/core/lib/view.php
@@ -28,7 +28,7 @@ class rex_view
      */
     public static function getCssFiles()
     {
-        return self::$cssFiles;
+        return array_unique(self::$cssFiles);;
     }
 
     /**
@@ -48,7 +48,7 @@ class rex_view
      */
     public static function getJsFiles()
     {
-        return self::$jsFiles;
+        return array_unique(self::$jsFiles);
     }
 
     /**


### PR DESCRIPTION
Damit wird verhindert, dass Assets mehrfach geladen werden können.