### PR TITLE
Neuer EP EXTEND_MODULE_FUNCTIONS

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
@@ -381,6 +381,20 @@ if ($OUT) {
     $list->addLinkAttribute(rex_i18n::msg('delete_module'), 'data-confirm', rex_i18n::msg('confirm_delete_module'));
 
     $list->setNoRowsMessage(rex_i18n::msg('modules_not_found'));
+    
+    rex_extension::registerPoint(new rex_extension_point('EXTEND_MODULE_FUNCTIONS', $list, [
+        $function,
+        $function_action,
+        $save,
+        $module_id,
+        $action_id,
+        $iaction_id,
+        $mname,
+        $eingabe,
+        $ausgabe,
+        $goon,
+        $add_action,
+    ]));
 
     $content .= $list->get();
 


### PR DESCRIPTION
EXTEND_MODULE_FUNCTIONS würde es Entwicklern ermöglichen, die Optionen für Module zu erweitern. Unter Anderem könnte damit dieses Problem gelöst werden: https://github.com/redaxo/redaxo/issues/498

Dann könnte Redaxo schlank bleiben und ein Addon - evt Rex++ - würde dann Zusatz-UI liefern, so wie das Addon Slice UI

Namen und Variablen müssen wir noch besprechen wenn dass okay ist für euch. Wenn ja würde ich auch das Formular mit EXTEND_MODULE_FORM erweitern. 

Beispiel: Editieren mit EP hinzufügen:

```
rex_extension::register('EXTEND_MODULE_FUNCTIONS',function(rex_extension_point $ep){
  $list = $ep->getSubject();
  
  $list->addColumn(rex_i18n::msg('module_functions'), '<i class="rex-icon rex-icon-edit"></i> ' . rex_i18n::msg('edit'));
  $list->setColumnLayout(rex_i18n::msg('module_functions'), ['<th class="rex-table-action" colspan="2">###VALUE###</th>', '<td class="rex-table-action">###VALUE###</td>']);
  $list->setColumnParams(rex_i18n::msg('module_functions'), ['function' => 'edit', 'module_id' => '###id###']);
});
```

Generell würde ich sogar soweit gehen, dass Templates, Modules, Settings usw. durch solche EPs erweitert werden. Dann müssten wir noch überlegen, wie diese EP lauten sollen:

`EXTEND_modulname_bereich` 

Modulname wäre Modules / Templates / Settings
Bereich könnte sein Liste, Formular, What ever.