### PR TITLE
rex_content_service::copyContent(): Fehler bei mehreren Slices

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/content_service.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/content_service.php
@@ -139,7 +139,6 @@ class rex_content_service
             $cols->setquery('SHOW COLUMNS FROM ' . rex::getTablePrefix() . 'article_slice');
 
             foreach ($gc as $slice) {
-                $ins->setTable(rex::getTablePrefix() . 'article_slice');
                 foreach ($cols as $col) {
                     $colname = $col->getValue('Field');
                     if ($colname == 'clang_id') {
@@ -162,6 +161,7 @@ class rex_content_service
 
                 $ins->addGlobalUpdateFields();
                 $ins->addGlobalCreateFields();
+                $ins->setTable(rex::getTablePrefix() . 'article_slice');
                 $ins->insert();
             }
 

--- a/redaxo/src/addons/structure/plugins/content/lib/content_service.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/content_service.php
@@ -131,13 +131,15 @@ class rex_content_service
 
         if ($gc->getRows() > 0) {
             $ins = rex_sql::factory();
-            $ins->setTable(rex::getTablePrefix() . 'article_slice');
+            //$ins->setDebug();
             $ctypes = [];
 
             $cols = rex_sql::factory();
-            // $cols->setDebug();
+            //$cols->setDebug();
             $cols->setquery('SHOW COLUMNS FROM ' . rex::getTablePrefix() . 'article_slice');
+
             foreach ($gc as $slice) {
+                $ins->setTable(rex::getTablePrefix() . 'article_slice');
                 foreach ($cols as $col) {
                     $colname = $col->getValue('Field');
                     if ($colname == 'clang_id') {


### PR DESCRIPTION
Wenn mehr als ein Slice kopiert wird, dann wirft der zweite Slice Fehler, weil die Tabelle nicht gesetzt ist. Die Tabelle muss für jedes Insert neu definiert werden.