### PR TITLE
JS: "rex:ready" event

### DIFF
--- a/redaxo/src/addons/be_style/assets/javascripts/main.js
+++ b/redaxo/src/addons/be_style/assets/javascripts/main.js
@@ -1,5 +1,3 @@
-(function () {
-    $(document).on('pjax:end', function(event, xhr, options) {
-        options.container.find('.selectpicker').selectpicker();
-    });
-})();
+$(document).on('rex:ready', function (event, container) {
+    container.find('.selectpicker').selectpicker();
+});

--- a/redaxo/src/addons/be_style/plugins/customizer/assets/js/main.js
+++ b/redaxo/src/addons/be_style/plugins/customizer/assets/js/main.js
@@ -1,18 +1,15 @@
-$(document).on('pjax:end',   function(){
-    Customizer.init();
-});
-$(document).ready(function(){
-    Customizer.init();
+$(document).on('rex:ready', function (event, container) {
+    Customizer.init(container);
 });
 
 var Customizer = function () {};
 
-Customizer.init = function ()
-{    
+Customizer.init = function (container)
+{
     var cm_editor = {};
     var cm = 0;
 
-	$("#rex-rex_cronjob_phpcode textarea, #rex-page-modules-actions textarea.form-control, textarea.rex-code, textarea.codemirror").each(function() {
+    container.find("#rex-rex_cronjob_phpcode textarea, #rex-page-modules-actions textarea.form-control, textarea.rex-code, textarea.codemirror").each(function() {
         var t = $(this);
         var id = t.attr("id");
 
@@ -57,11 +54,11 @@ Customizer.init = function ()
             }
         });
     });
-    
+
     if (typeof rex.customizer_labelcolor !== "undefined" && rex.customizer_labelcolor != '') {
         $('.rex-nav-top').css('border-bottom','10px solid '+rex.customizer_labelcolor)
     }
-    
+
     if (typeof rex.customizer_showlink !== "undefined" && rex.customizer_showlink != '' && !$('.be-style-customizer-title').length) {
         $('.rex-nav-top .navbar-header').append(rex.customizer_showlink);
     }

--- a/redaxo/src/addons/metainfo/assets/metainfo.js
+++ b/redaxo/src/addons/metainfo/assets/metainfo.js
@@ -44,9 +44,8 @@ function meta_checkConditionalFields(selectEl, activeIds, textIds) {
 
 };
 
-
-jQuery( function($) {
-    function disableSelect(chkbox) {
+$(document).on('rex:ready', function (event, container) {
+    var disableSelect = function (chkbox) {
         var sibling = chkbox;
         while (sibling != null) {
             if (sibling.nodeType == 1 && sibling.tagName.toLowerCase() == "select") {
@@ -54,13 +53,11 @@ jQuery( function($) {
             }
             sibling = sibling.previousSibling;
         }
-    }
-    ;
+    };
 
-    $("input[type=checkbox].rex-metainfo-checkbox").click( function() {
+    container.find("input[type=checkbox].rex-metainfo-checkbox").click(function () {
         disableSelect(this);
-    });
-    $("input[type=checkbox].rex-metainfo-checkbox").each( function() {
+    }).each(function () {
         disableSelect(this);
-    });
+    })
 });

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -544,9 +544,17 @@ jQuery(document).ready(function($) {
             })
             /*.on('pjax:success', function(e, data, status, xhr, options) {
              })*/
-            .on('pjax:start', function() { $('#rex-js-ajax-loader').addClass('rex-visible'); })
-            .on('pjax:end',   function() { $('#rex-js-ajax-loader').removeClass('rex-visible'); });
+            .on('pjax:start', function () {
+                $('#rex-js-ajax-loader').addClass('rex-visible');
+            })
+            .on('pjax:end',   function (event, xhr, options) {
+                $('#rex-js-ajax-loader').removeClass('rex-visible');
+
+                options.container.trigger('rex:ready', [options.container]);
+            });
     }
+
+    $('body').trigger('rex:ready', [$('body')]);
 
     /*
      * Replace all SVG images with inline SVG


### PR DESCRIPTION
Ziel: Initialisierung von Inhalt, egal wie er geladen wurde.
Der Nutzer soll also nix von PJAX wissen müssen, sondern nur, dass es da ein Event von Redaxo gibt, welches immer ausgelöst wird, wenn es neuen Content gibt.

@staabm Was meinst du dazu? Oder bessere Idee?

fixes #533