### PR TITLE
replaceCommonVars vor replaceObjectVars, closes #570

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -435,8 +435,8 @@ class rex_article_content_base
     // ----- Modulvariablen werden ersetzt
     protected function replaceVars(rex_sql $sql, $content)
     {
-        $content = $this->replaceObjectVars($sql, $content);
         $content = $this->replaceCommonVars($content);
+        $content = $this->replaceObjectVars($sql, $content);
         $content = str_replace(
             [
                 'REX_MODULE_ID',


### PR DESCRIPTION
Werden die CommonVars vor den ObjectVars geparst, sind etwa folgende Konstrukte möglich:
`REX_LINK[id="1" widget="1" category="REX_CATEGORY_ID"]`.

Die CategoryId wird damit aufgelöst bevor das Link-Widget zusammengebaut wird.