### PR TITLE
fixed "options.container.trigger" is not a function

### DIFF
--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -550,7 +550,7 @@ jQuery(document).ready(function($) {
             .on('pjax:end',   function (event, xhr, options) {
                 $('#rex-js-ajax-loader').removeClass('rex-visible');
 
-                options.container.trigger('rex:ready', [options.container]);
+                options.context.trigger('rex:ready', [options.context]);
             });
     }
 


### PR DESCRIPTION
when pjax is manually invoked e.g. with `$.pjax({url: url, container: '#contentpjax'})`