### PR TITLE
Core-Update in Setup wieder ermöglichen

### DIFF
--- a/redaxo/src/addons/install/lib/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api_core_update.php
@@ -152,6 +152,7 @@ class rex_api_install_core_update extends rex_api_function
             $success = true;
             rex_delete_cache();
             rex_install_webservice::deleteCache('core');
+            rex::setConfig('version', $version['version']);
         }
 
         $result = new rex_api_result($success, $message);

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -182,6 +182,8 @@ setup_510 = Backup-AddOn wurde nicht gefunden!
 setup_511 = Weiter zu Schritt 6
 setup_512 = Schritt 5 erneut durchführen
 setup_513 = System AddOn(s) konnte nicht installiert werden
+setup_514 = Aktualisierung der Datenbank
+setup_514_note = Update von vorheriger Version {0}
 setup_599 = 5 / Datenbank
 
 setup_600 = Setup: Schritt 6 von 7 / Administrator

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -182,6 +182,8 @@ setup_510 = Backup addon could not be found!
 setup_511 = Continue with step 6
 setup_512 = Repeat step 5
 setup_513 = System AddOn(s) could not be installed
+setup_514 = Update database
+setup_514_note = Update from previous version {0}
 setup_599 = 5 / Database
 
 setup_600 = Setup: Step 6 of 7 / Administrator

--- a/redaxo/src/core/lib/setup/import.php
+++ b/redaxo/src/core/lib/setup/import.php
@@ -12,9 +12,19 @@ class rex_setup_importer
         // ----- vorhandenen seite updaten
         $err_msg = '';
 
-        $import_sql = rex_path::core('install/update4_x_to_5_0.sql');
         if ($err_msg == '') {
-            $err_msg .= self::import($import_sql);
+            $version = rex::getVersion();
+            rex::setProperty('version', rex::getConfig('version'));
+
+            try {
+                include rex_path::core('update.php');
+            } catch (rex_functional_exception $e) {
+                $err_msg .= $e->getMessage();
+            } catch (rex_sql_exception $e) {
+                $err_msg .= 'SQL error: ' . $e->getMessage();
+            }
+
+            rex::setProperty('version', $version);
         }
 
         if ($err_msg == '') {

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -387,6 +387,7 @@ if ($step > 5 && $createdb > -1) {
 
     if (count($errors) == 0) {
         rex_clang_service::generateCache();
+        rex::setConfig('version', rex::getVersion());
     } else {
         $step = 5;
     }
@@ -494,6 +495,12 @@ if ($step == 5) {
         $n['note'] = rex_i18n::msg('setup_506_note');
         $formElements[] = $n;
     }
+
+    $n = [];
+    $n['label'] = '<label for="rex-form-createdb-4">' . rex_i18n::msg('setup_514') . '</label>';
+    $n['field'] = '<input type="radio" id="rex-form-createdb-4" name="createdb" value="4"' . $dbchecked[4] . ' />';
+    $n['note'] = rex_i18n::msg('setup_514_note', rex::getConfig('version'));
+    $formElements[] = $n;
 
     $fragment = new rex_fragment();
     $fragment->setVar('elements', $formElements, false);


### PR DESCRIPTION
Der PR führt quasi die aus R4 bekannte Update-Option im Setup wieder ein.
Dabei wird aber das gleiche Update-Skript verwendet, welches auch vom Installer benutzt wird.

Ohne den PR ist es sehr mühsam, DB-Änderungen zu übernehmen, wenn man per git updated.