### PR TITLE
PHP-Mailer X-Priority-Fix

### DIFF
--- a/redaxo/src/addons/phpmailer/install.php
+++ b/redaxo/src/addons/phpmailer/install.php
@@ -21,7 +21,7 @@ if (!$this->hasConfig()) {
     $this->setConfig('charset', 'utf-8');
     $this->setConfig('wordwrap', 120);
     $this->setConfig('encoding', '8bit');
-    $this->setConfig('priority', 3);
+    $this->setConfig('priority', 0);
     $this->setConfig('smtpsecure', '');
     $this->setConfig('smtpauth', false);
     $this->setConfig('username', '');

--- a/redaxo/src/addons/phpmailer/lang/de_de.lang
+++ b/redaxo/src/addons/phpmailer/lang/de_de.lang
@@ -26,6 +26,7 @@ phpmailer_smtp_secure = Verschlüsselung
 phpmailer_smtp_auth = Authentifizierung
 phpmailer_config_saved_error = Fehler beim speichern der Konfiguration!
 phpmailer_config_saved_successful = Konfiguration erfolgreich gespeichert!
+phpmailer_disabled = Deaktiviert
 phpmailer_high = Hoch
 phpmailer_normal = Normal
 phpmailer_low = Niedrig

--- a/redaxo/src/addons/phpmailer/lang/en_gb.lang
+++ b/redaxo/src/addons/phpmailer/lang/en_gb.lang
@@ -26,6 +26,7 @@ phpmailer_smtp_secure = Encryption
 phpmailer_smtp_auth = Authentification
 phpmailer_config_saved_error = Configuration could not be saved
 phpmailer_config_saved_successful = Configuration saved
+phpmailer_disabled = Disabled
 phpmailer_high = High
 phpmailer_normal = Normal
 phpmailer_low = Low

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -23,8 +23,8 @@ class rex_mailer extends PHPMailer
         $this->CharSet = $addon->getConfig('charset');
         $this->WordWrap = $addon->getConfig('wordwrap');
         $this->Encoding = $addon->getConfig('encoding');
-        if ( $addon->getConfig('priority')==0){
-         $this->Priority = null;   
+        if ($addon->getConfig('priority')==0){
+            $this->Priority = null;   
         }
         else {
         $this->Priority = $addon->getConfig('priority');

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -23,7 +23,7 @@ class rex_mailer extends PHPMailer
         $this->CharSet = $addon->getConfig('charset');
         $this->WordWrap = $addon->getConfig('wordwrap');
         $this->Encoding = $addon->getConfig('encoding');
-        if ( $this->Priority = $addon->getConfig('priority')==0){
+        if ( $addon->getConfig('priority')==0){
          $this->Priority = null;   
         }
         else {

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -23,7 +23,12 @@ class rex_mailer extends PHPMailer
         $this->CharSet = $addon->getConfig('charset');
         $this->WordWrap = $addon->getConfig('wordwrap');
         $this->Encoding = $addon->getConfig('encoding');
+        if ( $this->Priority = $addon->getConfig('priority')==0){
+         $this->Priority = null;   
+        }
+        else {
         $this->Priority = $addon->getConfig('priority');
+        }
         $this->SMTPSecure = $addon->getConfig('smtpsecure');
         $this->SMTPAuth = $addon->getConfig('smtpauth');
         $this->Username = $addon->getConfig('username');

--- a/redaxo/src/addons/phpmailer/pages/config.php
+++ b/redaxo/src/addons/phpmailer/pages/config.php
@@ -80,7 +80,7 @@ $sel_priority->setName('settings[priority]');
 $sel_priority->setSize(1);
 $sel_priority->setAttribute('class', 'form-control');
 $sel_priority->setSelected($this->getConfig('priority'));
-foreach ([1 => $this->i18n('high'), 3 => $this->i18n('normal'), 5 => $this->i18n('low')] as $no => $name) {
+foreach ([0 => $this->i18n('disabled'), 1 => $this->i18n('high'), 3 => $this->i18n('normal'), 5 => $this->i18n('low')] as $no => $name) {
     $sel_priority->addOption($name, $no);
 }
 


### PR DESCRIPTION
Deaktiviert-Option hinzugefügt. 
Gerade wenn mail() oder sendmail verwendet werden, kann eine X-Priority-Einstellung zur Spamwertung führen. 
