### PR TITLE
addGlobalCreate/UpdateFields: Auch in Frontend funktional gemacht

### DIFF
--- a/redaxo/src/addons/structure/lib/service_article.php
+++ b/redaxo/src/addons/structure/lib/service_article.php
@@ -54,6 +54,7 @@ class rex_article_service
 
         $AART = rex_sql::factory();
         unset($id);
+        $user = rex::isBackend() ? null : 'frontend';
         foreach (rex_clang::getAllIds() as $key) {
             // ------- Kategorienamen holen
             $category = rex_category::get($data['category_id'], $key);
@@ -78,8 +79,8 @@ class rex_article_service
             $AART->setValue('startarticle', 0);
             $AART->setValue('status', 0);
             $AART->setValue('template_id', $data['template_id']);
-            $AART->addGlobalCreateFields();
-            $AART->addGlobalUpdateFields();
+            $AART->addGlobalCreateFields($user);
+            $AART->addGlobalUpdateFields($user);
 
             try {
                 $AART->insert();
@@ -170,7 +171,7 @@ class rex_article_service
         $EA->setValue('name', $data['name']);
         $EA->setValue('template_id', $data['template_id']);
         $EA->setValue('priority', $data['priority']);
-        $EA->addGlobalUpdateFields();
+        $EA->addGlobalUpdateFields(rex::isBackend() ? null : 'frontend');
 
         try {
             $EA->update();
@@ -181,7 +182,7 @@ class rex_article_service
                 ->setTable(rex::getTable('article'))
                 ->setWhere('id = :id AND clang_id != :clang', ['id' => $article_id, 'clang' => $clang])
                 ->setValue('priority', $data['priority'])
-                ->addGlobalUpdateFields()
+                ->addGlobalUpdateFields(rex::isBackend() ? null : 'frontend')
                 ->update();
 
             foreach (rex_clang::getAllIds() as $clangId) {
@@ -682,7 +683,7 @@ class rex_article_service
             // $uc->setDebug();
             $uc->setTable(rex::getTablePrefix() . 'article');
             $uc->setWhere("clang_id='$to_clang' and id='$to_id'");
-            $uc->addGlobalUpdateFields();
+            $uc->addGlobalUpdateFields(rex::isBackend() ? null : 'frontend');
 
             foreach ($params as $key => $value) {
                 $uc->setValue($value, $gc->getValue($value));
@@ -709,6 +710,8 @@ class rex_article_service
         $id = (int) $id;
         $to_cat_id = (int) $to_cat_id;
         $new_id = '';
+
+        $user = rex::isBackend() ? null : 'frontend';
 
         // Artikel in jeder Sprache kopieren
         foreach (rex_clang::getAllIds() as $clang) {
@@ -746,8 +749,8 @@ class rex_article_service
                     $art_sql->setValue('priority', 99999); // Artikel als letzten Artikel in die neue Kat einfügen
                     $art_sql->setValue('status', 0); // Kopierter Artikel offline setzen
                     $art_sql->setValue('startarticle', 0);
-                    $art_sql->addGlobalUpdateFields();
-                    $art_sql->addGlobalCreateFields();
+                    $art_sql->addGlobalUpdateFields($user);
+                    $art_sql->addGlobalCreateFields($user);
 
                     // schon gesetzte Felder nicht wieder überschreiben
                     $dont_copy = ['id', 'pid', 'parent_id', 'catname', 'name', 'catpriority', 'path', 'priority', 'status', 'updatedate', 'updateuser', 'createdate', 'createuser', 'startarticle'];
@@ -839,7 +842,7 @@ class rex_article_service
                     $art_sql->setValue('priority', '99999');
                     // Kopierter Artikel offline setzen
                     $art_sql->setValue('status', $from_sql->getValue('status'));
-                    $art_sql->addGlobalUpdateFields();
+                    $art_sql->addGlobalUpdateFields(rex::isBackend() ? null : 'frontend');
 
                     $art_sql->setWhere('clang_id="' . $clang . '" and startarticle<>1 and id="' . $id . '" and parent_id="' . $from_cat_id . '"');
                     $art_sql->update();

--- a/redaxo/src/addons/structure/lib/service_category.php
+++ b/redaxo/src/addons/structure/lib/service_category.php
@@ -65,6 +65,8 @@ class rex_category_service
             // Alle Templates der Kategorie
             $templates = rex_template::getTemplatesForCategory($category_id);
         }
+        
+        $user = rex::isBackend() ? null : 'frontend';
 
         // Kategorie in allen Sprachen anlegen
         $AART = rex_sql::factory();
@@ -102,8 +104,8 @@ class rex_category_service
             $AART->setValue('path', $path);
             $AART->setValue('startarticle', 1);
             $AART->setValue('status', $data['status']);
-            $AART->addGlobalUpdateFields();
-            $AART->addGlobalCreateFields();
+            $AART->addGlobalUpdateFields($user);
+            $AART->addGlobalCreateFields($user);
 
             try {
                 $AART->insert();
@@ -172,7 +174,9 @@ class rex_category_service
             $EKAT->setValue('catpriority', $data['catpriority']);
         }
 
-        $EKAT->addGlobalUpdateFields();
+        $user = rex::isBackend() ? null : 'frontend';
+        
+        $EKAT->addGlobalUpdateFields($user);
 
         try {
             $EKAT->update();
@@ -187,7 +191,7 @@ class rex_category_service
                     $EART->setTable(rex::getTablePrefix() . 'article');
                     $EART->setWhere(['id' => $ArtSql->getValue('id'), 'startarticle' => '0', 'clang_id' => $clang]);
                     $EART->setValue('catname', $data['catname']);
-                    $EART->addGlobalUpdateFields();
+                    $EART->addGlobalUpdateFields($user);
 
                     $EART->update();
                     rex_article_cache::delete($ArtSql->getValue('id'), $clang);
@@ -209,7 +213,7 @@ class rex_category_service
                     ->setTable(rex::getTable('article'))
                     ->setWhere('id = :id AND clang_id != :clang', ['id' => $category_id, 'clang' => $clang])
                     ->setValue('catpriority', $data['catpriority'])
-                    ->addGlobalUpdateFields()
+                    ->addGlobalUpdateFields($user)
                     ->update();
 
                 foreach (rex_clang::getAllIds() as $clangId) {
@@ -337,7 +341,7 @@ class rex_category_service
             $EKAT->setTable(rex::getTablePrefix() . 'article');
             $EKAT->setWhere(['id' => $category_id,  'clang_id' => $clang, 'startarticle' => 1]);
             $EKAT->setValue('status', $newstatus);
-            $EKAT->addGlobalCreateFields();
+            $EKAT->addGlobalCreateFields(rex::isBackend() ? null : 'frontend');
 
             try {
                 $EKAT->update();

--- a/redaxo/src/addons/structure/plugins/content/lib/content_service.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/content_service.php
@@ -57,7 +57,7 @@ class rex_content_service
                     $upd->setValue('priority', $CM->getValue('priority') + 1);
                     $updSort = 'ASC';
                 }
-                $upd->addGlobalUpdateFields();
+                $upd->addGlobalUpdateFields(rex::isBackend() ? null : 'frontend');
                 $upd->update();
 
                 rex_sql_util::organizePriorities(
@@ -159,6 +159,8 @@ class rex_content_service
             $cols = rex_sql::factory();
             //$cols->setDebug();
             $cols->setquery('SHOW COLUMNS FROM ' . rex::getTablePrefix() . 'article_slice');
+            
+            $user = rex::isBackend() ? null : 'frontend';
 
             foreach ($gc as $slice) {
                 foreach ($cols as $col) {
@@ -181,8 +183,8 @@ class rex_content_service
                     }
                 }
 
-                $ins->addGlobalUpdateFields();
-                $ins->addGlobalCreateFields();
+                $ins->addGlobalUpdateFields($user);
+                $ins->addGlobalCreateFields($user);
                 $ins->setTable(rex::getTablePrefix() . 'article_slice');
                 $ins->insert();
             }


### PR DESCRIPTION
Die Methoden in `rex_article_service`,  `rex_category_service`,  `rex_content_service` etc. lassen sich im Frontend nicht nutzen, da überall die Methoden `rex_sql::addGlobalCreate/UpdateFields` aufgerufen werden.
Einzig bei `rex_article_service::articleStatus` gab es einen Workaround, da wurde im Frontend als User "frontend" übergeben (siehe Changes in diesem PR).

Aufgefallen ist das Problem, da @phoebusryan im Frontend Artikel kopieren möchte.

Ich bin mir unsicher, wie wir das Problem am besten lösen sollten. Aber auf jeden Fall sollten die Methoden meiner Meinung nach auch im Frontend nutzbar sein.
Sehe diese drei Variante:

1. Den Workaround von `rex_article_service::articleStatus` an allen relevanten Stellen integrieren
2. Den Workaround so direkt in die `rex_sql::addGlobalCreate/UpdateFields` Methoden aufnehmen, also im Frontend den User auf "frontend" setzen
3. In den Methoden abfangen, wenn kein User existiert, und dann das Feld leeren

Zurzeit setzt der PR Variante 3 um.