### PR TITLE
Customizer: Icon von "Link zur Website" klickbar machen.

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/boot.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/boot.php
@@ -28,7 +28,7 @@ if (rex::isBackend() && rex::getUser()) {
     }
 
     if ($config['showlink']) {
-        rex_view::setJsProperty('customizer_showlink', '<h1 class="be-style-customizer-title"><a href="'. rex::getServer() .'" target="_blank">' . rex::getServerName() . '</a><i class="fa fa-external-link"></i></h1>');
+        rex_view::setJsProperty('customizer_showlink', '<h1 class="be-style-customizer-title"><a href="'. rex::getServer() .'" target="_blank">' . rex::getServerName() . '<i class="fa fa-external-link"></i></a></h1>');
     }
 
     rex_view::addJsFile($this->getAssetsUrl('js/main.js'));


### PR DESCRIPTION
Das Icon war bisher außerhalb des Anker-Textes.