### PR TITLE
Customizer: CodeMirror Fullscreen (F11)

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/assets/vendor/codemirror/codemirror.css
+++ b/redaxo/src/addons/be_style/plugins/customizer/assets/vendor/codemirror/codemirror.css
@@ -261,3 +261,9 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
         visibility: hidden;
     }
 }
+
+.CodeMirror-fullscreen {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  height: auto;
+}


### PR DESCRIPTION
Das CSS fehlte, um den Fullscreen aktivieren zu können.
https://codemirror.net/demo/fullscreen.html 
https://codemirror.net/addon/display/fullscreen.css