### PR TITLE
set ul-classes

### DIFF
--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -303,10 +303,7 @@ class rex_navigation
         if (count($nav_obj) > 0) {
             if(!empty($this->ulclasses)){
                 $ulclasses = '';
-                foreach($this->ulclasses as $ulclass){
-                    $ulclasses .= $ulclass .' ';
-                }
-                $ulclasses = ' '.trim($ulclasses);
+                $ulclasses = ' '. implode(' '. $ulclasses);
             }
             $return .= '<ul class="rex-navi' . ($depth + 1) . $ulclasses . '">';
         }

--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -300,7 +300,6 @@ class rex_navigation
         }
 
         // $return = '';
-
         if (count($nav_obj) > 0) {
             if(!empty($this->ulclasses)){
                 $ulclasses = '';

--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -16,6 +16,7 @@
  * Navigation:
  *
  * $nav = rex_navigation::factory();
+ * $nav->setUlClasses(array('list-unstyled','list-inline'));
  * $nav->setClasses(array('lev1', 'lev2', 'lev3'));
  * $nav->setLinkClasses(array('alev1', 'alev2', 'alev3'));
  * echo $nav->get(0,2,TRUE,TRUE);
@@ -298,14 +299,14 @@ class rex_navigation
             $nav_obj = rex_category::get($category_id)->getChildren();
         }
 
-        $return = '';
+        // $return = '';
 
         if (count($nav_obj) > 0) {
             if(!empty($this->ulclasses)){
                 $ulclasses = '';
-                $ulclasses = ' '. implode(' '. $ulclasses);
+                $ulclasses = ' '. implode(' ', $ulclasses);
             }
-            $return .= '<ul class="rex-navi' . ($depth + 1) . $ulclasses . '">';
+            // $return .= '<ul class="rex-navi' . ($depth + 1) . $ulclasses . '">';
         }
 
         $lis = [];
@@ -358,7 +359,7 @@ class rex_navigation
         }
         if (count($lis) > 0) {
             if($ulclasses != ''){
-                return '<ul class="rex-navi' . $depth . $ulclasses '">' . implode('', $lis) . '</ul>';
+                return '<ul class="rex-navi' . $depth . $ulclasses .'">' . implode('', $lis) . '</ul>';
             } else {
                return '<ul class="rex-navi' . $depth . ' rex-navi-depth-' . $depth . ' rex-navi-has-' . count($lis) . '-elements">' . implode('', $lis) . '</ul>'; 
             }

--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -40,6 +40,7 @@ class rex_navigation
     private $path = [];
     private $classes = [];
     private $linkclasses = [];
+    private $ulclasses = [];
     private $filter = [];
     private $callbacks = [];
 
@@ -151,6 +152,11 @@ class rex_navigation
     public function setClasses($classes)
     {
         $this->classes = $classes;
+    }
+    
+    public function setUlClasses($classes)
+    {
+        $this->ulclasses = $classes;
     }
 
     public function setLinkClasses($classes)
@@ -295,7 +301,14 @@ class rex_navigation
         $return = '';
 
         if (count($nav_obj) > 0) {
-            $return .= '<ul class="rex-navi' . ($depth + 1) . '">';
+            if(!empty($this->ulclasses)){
+                $ulclasses = '';
+                foreach($this->ulclasses as $ulclass){
+                    $ulclasses .= $ulclass .' ';
+                }
+                $ulclasses = ' '.trim($ulclasses);
+            }
+            $return .= '<ul class="rex-navi' . ($depth + 1) . $ulclasses . '">';
         }
 
         $lis = [];
@@ -347,7 +360,12 @@ class rex_navigation
             }
         }
         if (count($lis) > 0) {
-            return '<ul class="rex-navi' . $depth . ' rex-navi-depth-' . $depth . ' rex-navi-has-' . count($lis) . '-elements">' . implode('', $lis) . '</ul>';
+            if($ulclasses != ''){
+                return '<ul class="rex-navi' . $depth . $ulclasses '">' . implode('', $lis) . '</ul>';
+            } else {
+               return '<ul class="rex-navi' . $depth . ' rex-navi-depth-' . $depth . ' rex-navi-has-' . count($lis) . '-elements">' . implode('', $lis) . '</ul>'; 
+            }
+            
         }
         return '';
     }


### PR DESCRIPTION
new method to set ul-classes
instead of str_replace 

// Ersetze REDAXO-Klassen durch eigene
$navHtml = str_replace(
    array('rex-current', 'rex-active'),
    array('my-current', 'my-active'),
    $navHtml);
