### PR TITLE
clear_cache button ziel url update

### DIFF
--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -12,7 +12,7 @@ page:
         types: { title: 'translate:media_manager_subpage_types' }
         overview: { title: 'translate:media_manager_subpage_desc' }
         settings: { title: 'translate:media_manager_subpage_config' }
-        clear_cache: { title: 'translate:media_manager_subpage_clear_cache', itemclass: 'pull-right', linkclass: 'btn btn-delete', href: { page: media_manager/overview, func: clear_cache } }
+        clear_cache: { title: 'translate:media_manager_subpage_clear_cache', itemclass: 'pull-right', linkclass: 'btn btn-delete', href: { page: media_manager/types, func: clear_cache } }
 
 requires:
     php:


### PR DESCRIPTION
Zur Zeit wird man nach Klick auf den Button zur "overview" Seite geleitet, was momentan fälschlicherweise die Anleitung ist. Besser wäre, man würde auf die Übersicht der Typen gelangen, sprich zu "types". Noch besser wäre, man würde auf der jeweiligen Seite bleiben, wo man den Knopf gedrückt hat, dazu müsste man aber wahrscheinlich den Cache-Löschen Knopf anders einbinden.
