### PR TITLE
Fixed bug mit winObjCounter permission denied

### DIFF
--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -121,10 +121,14 @@ function newWindow(name,link,width,height,type)
 var winObj = new Array();
 if (opener != null)
 {
-    if (typeof(opener.winObjCounter) == "number")
-    {
-        var winObjCounter = opener.winObjCounter;
-    }
+	try{
+	    if (typeof(opener.winObjCounter) == "number")
+	    {
+	        var winObjCounter = opener.winObjCounter;
+	    }
+	} catch(e) {
+	    var winObjCounter = -1;
+	}
 }else
 {
     var winObjCounter = -1;

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -127,6 +127,7 @@ if (opener != null)
 	        var winObjCounter = opener.winObjCounter;
 	    }
 	} catch(e) {
+	    // in x-origin cases opener.winObjCounter would not be readable
 	    var winObjCounter = -1;
 	}
 }else


### PR DESCRIPTION
try/catch hinzugefügt um foldenden Fehler zu vermeiden
Error: Permission denied to access property „winObjCounter“ 

Ist mehr ein Workaround, imo ist das Ganze komisch gelöst. Evtl. zukünftig mit Modals arbeiten statt Popups?
