### PR TITLE
Setter für type hinzugefügt

### DIFF
--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -182,7 +182,7 @@ class rex_media_manager
         }
         exit;
     }
-    
+
     public static function getSupportedEffects()
     {
         $dirs = [

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -17,7 +17,7 @@ class rex_media_manager
         $this->useCache(true);
     }
 
-    protected function applyEffects($type)
+    public function applyEffects($type)
     {
         $this->type = $type;
 
@@ -181,11 +181,6 @@ class rex_media_manager
             $this->media->sendMedia($CacheFilename, $headerCacheFilename, $this->use_cache);
         }
         exit;
-    }
-    
-    public function setType($type)
-    {
-    	$this->type = $type;
     }
     
     public static function getSupportedEffects()

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -182,7 +182,12 @@ class rex_media_manager
         }
         exit;
     }
-
+    
+    public function setType($type)
+    {
+    	$this->type = $type;
+    }
+    
     public static function getSupportedEffects()
     {
         $dirs = [


### PR DESCRIPTION
Setter bietet die Möglichkeit extern zu prüfen, ob die Cache Datei schon erstellt wurde oder überhaupt erst den Dateinamen der gecachten Datei zu erfahren. Grund siehe: http://www.redaxo.org/de/forum/allgemeines-f39/bildcache-manuell-erzeugen-t21457.html

Bitte mit aufnehmen!
