### PR TITLE
Sanitize input-parameters in linkmap

### DIFF
--- a/redaxo/src/addons/structure/pages/linkmap.php
+++ b/redaxo/src/addons/structure/pages/linkmap.php
@@ -9,8 +9,13 @@ $category_id = rex_category::get($category_id) ? $category_id : 0;
 $clang = rex_request('clang', 'int');
 $clang = rex_clang::exists($clang) ? $clang : rex_clang::getStartId();
 
-$opener_input_field = preg_replace('/[^a-z0-9]/i', '', $opener_input_field);
-$opener_input_field_name = preg_replace('/[^a-z0-9]/i', '', $opener_input_field_name);
+$pattern = '/[^a-z0-9_-]/i';
+if (preg_match($pattern, $opener_input_field, $match)) {
+    throw new InvalidArgumentException(sprintf('Invalid character "%s" in opener_input_field.', $match[0]));
+}
+if (preg_match($pattern, $opener_input_field_name, $match)) {
+    throw new InvalidArgumentException(sprintf('Invalid character "%s" in opener_input_field_name.', $match[0]));
+}
 
 $context = new rex_context([
     'page' => rex_be_controller::getCurrentPage(),

--- a/redaxo/src/addons/structure/pages/linkmap.php
+++ b/redaxo/src/addons/structure/pages/linkmap.php
@@ -9,6 +9,9 @@ $category_id = rex_category::get($category_id) ? $category_id : 0;
 $clang = rex_request('clang', 'int');
 $clang = rex_clang::exists($clang) ? $clang : rex_clang::getStartId();
 
+$opener_input_field = preg_replace('/[^a-z0-9]/i', '', $opener_input_field);
+$opener_input_field_name = preg_replace('/[^a-z0-9]/i', '', $opener_input_field_name);
+
 $context = new rex_context([
     'page' => rex_be_controller::getCurrentPage(),
     'opener_input_field' => $opener_input_field,


### PR DESCRIPTION
Prevents xss demonstrated in https://blog.ripstech.com/2016/redaxo-remote-code-execution-via-csrf/