### PR TITLE
Events rex:selectMedia/Link über Page Loads retten

### DIFF
--- a/redaxo/src/addons/mediapool/pages/index.php
+++ b/redaxo/src/addons/mediapool/pages/index.php
@@ -94,6 +94,8 @@ if ($error != '') {
 <script type="text/javascript">
 <!--
 
+rex_retain_popup_event_handlers('rex:selectMedia');
+
 function selectMedia(filename, alt)
 {
     var opener_input_field = "<?= $opener_input_field ?>";

--- a/redaxo/src/addons/structure/pages/linkmap.php
+++ b/redaxo/src/addons/structure/pages/linkmap.php
@@ -62,6 +62,8 @@ JS;
 
 ?>
 <script type="text/javascript">
+    rex_retain_popup_event_handlers('rex:selectLink');
+
     function insertLink(link,name){
         <?php echo $func_body . "\n" ?>
     }

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -115,6 +115,10 @@ function newWindow(name,link,width,height,type)
     winObjCounter++;
     winObj[winObjCounter] = new makeWinObj(name,link,posx,posy,width,height,extra);
 
+    if (rex.popupEvents && rex.popupEvents[name]) {
+        rex.popupEvents[name] = {};
+    }
+
     return winObj[winObjCounter].obj;
 }
 
@@ -128,6 +132,42 @@ if (opener != null)
 }else
 {
     var winObjCounter = -1;
+}
+
+function rex_retain_popup_event_handlers(eventName) {
+    if (!opener || !opener.rex || !window.name) {
+        return;
+    }
+
+    var events = opener.rex.popupEvents || {};
+
+    if (events[window.name] && events[window.name][eventName]) {
+        $.each(events[window.name][eventName], function (i, event) {
+            opener.jQuery(window).on(eventName, event);
+        });
+
+        return;
+    }
+
+    var events = opener.jQuery._data(window, 'events');
+
+    if (!events || !events[eventName]) {
+        return;
+    }
+
+    var handlers = [];
+    $.each(events[eventName], function (i, event) {
+        handlers.push(event.handler);
+    });
+
+    if (!opener.rex.popupEvents) {
+        opener.rex.popupEvents = {};
+    }
+    if (!opener.rex.popupEvents[window.name]) {
+        opener.rex.popupEvents[window.name] = {};
+    }
+
+    opener.rex.popupEvents[window.name][eventName] = handlers;
 }
 
 function setValue(id,value)


### PR DESCRIPTION
Ich habe mir nun #760 nochmal angeschaut und habe einen Workaround für das bestehende Problem gefunden, ohne etwas an der Nutzung der Events zu ändern.

Die Eventhandlers (die am Popup-window hängen) werden im opener zwischengespeichert, und nach Page (Re)loads dann wieder neu registriert.

Die Nutzung durch Addons (markitup, redactor) würde sich wie gesagt nicht ändern, nur dass es nun richtig funktioniert, und die Eventhandler bei Page Loads im Popup nicht mehr verloren gehen.

ping @staabm @phoebusryan @IngoWinter

fixes #760