### PR TITLE
optimized media instance pool performance

### DIFF
--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -68,7 +68,7 @@ class rex_media
 
                 $media = new static();
                 foreach ($cache as $key => $value) {
-                    if (array_key_exists($key, $aliasMap)) {
+                    if (isset($aliasMap[$key])) {
                         $var_name = $aliasMap[$key];
                     } else {
                         $var_name = $key;


### PR DESCRIPTION
`null` sollte hier nicht relevant sein, daher können wir mit dem schnelleren `isset` arbeiten