### PR TITLE
dump() ohne Ausgabe für Non-Admins (und Non-Debug-Mode)

### DIFF
--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -88,6 +88,8 @@ if (!rex::isSetup()) {
     rex_error_handler::register();
 }
 
+rex_var_dumper::register();
+
 // ----------------- REX PERMS
 
 rex_complex_perm::register('clang', 'rex_clang_perm');

--- a/redaxo/src/core/lib/var_dumper.php
+++ b/redaxo/src/core/lib/var_dumper.php
@@ -1,0 +1,46 @@
+<?php
+
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+/**
+ * @package redaxo\core
+ */
+abstract class rex_var_dumper
+{
+    /** @var VarCloner */
+    private static $cloner;
+
+    /** @var DataDumperInterface */
+    private static $dumper;
+
+    public static function register()
+    {
+        VarDumper::setHandler(function ($var) {
+            if (rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin()) {
+                VarDumper::setHandler('self::dump');
+                self::dump($var);
+
+                return;
+            }
+
+            // register noop handler for non-admins (if not in debug mode)
+            VarDumper::setHandler(function ($var) {
+                // noop
+            });
+        });
+    }
+
+    public static function dump($var)
+    {
+        if (!self::$cloner) {
+            self::$cloner = new VarCloner();
+            self::$dumper = 'cli' === PHP_SAPI ? new CliDumper() : new HtmlDumper();
+        }
+
+        self::$dumper->dump(self::$cloner->cloneVar($var));
+    }
+}


### PR DESCRIPTION
Durch symfony/var-dumper haben wir ja jetzt auch die schicke `dump()`-Funktion integriert.

Hier ist mal ein Vorschlag von mir, sodass die Funktion für Non-Admins und Non-Debug-Mode keine Ausgabe macht.
Man kann die Funktion also auch auf Liveseiten benutzen, ohne dass die normalen User etwas davon sehen.