### PR TITLE
setter-func um active/current class zu verändern

### DIFF
--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -165,16 +165,6 @@ class rex_navigation
         $this->linkclasses = $classes;
     }
 
-    public function setActiveClass($class)
-    {
-        $this->activeClass = $class;
-    }
-
-    public function setCurrentClass($class)
-    {
-        $this->currentClass = $class;
-    }
-
     public function setNormalClass($class)
     {
         $this->normalClass = $class;

--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -43,10 +43,7 @@ class rex_navigation
     private $activeClass = 'rex-active';
     private $currentClass = 'rex-current';
     private $normalClass = 'rex-normal';
-    private $activeLiClass = $this->activeClass;
-    private $activeAClass = $this->activeClass;
-    private $currentLiClass = $this->activeClass;
-    private $currentAClass = $this->activeClass;
+    private $ulClass = '';
     private $filter = [];
     private $callbacks = [];
 
@@ -55,7 +52,10 @@ class rex_navigation
 
     private function __construct()
     {
-        // nichts zu tun
+        $this->activeLiClass = $this->activeClass;
+        $this->activeAClass = $this->activeClass;
+        $this->currentLiClass = $this->activeClass;
+        $this->currentAClass = $this->activeClass;
     }
 
     public static function factory()
@@ -198,6 +198,11 @@ class rex_navigation
     public function setCurrentAClass($class)
     {
         $this->currentAClass = $class;
+    }
+
+    public function setUlClass($class)
+    {
+        $this->ulClass = $class;
     }
 
     /**
@@ -389,7 +394,7 @@ class rex_navigation
             }
         }
         if (count($lis) > 0) {
-            return '<ul class="rex-navi' . $depth . ' rex-navi-depth-' . $depth . ' rex-navi-has-' . count($lis) . '-elements">' . implode('', $lis) . '</ul>';
+            return '<ul class="rex-navi' . $depth . ' rex-navi-depth-' . $depth . ' rex-navi-has-' . count($lis) . '-elements' . $this->ulClass .'">' . implode('', $lis) . '</ul>';
         }
         return '';
     }

--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -54,8 +54,8 @@ class rex_navigation
     {
         $this->activeLiClass = $this->activeClass;
         $this->activeAClass = $this->activeClass;
-        $this->currentLiClass = $this->activeClass;
-        $this->currentAClass = $this->activeClass;
+        $this->currentLiClass = $this->currentClass;
+        $this->currentAClass = $this->currentClass;
     }
 
     public static function factory()

--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -40,6 +40,13 @@ class rex_navigation
     private $path = [];
     private $classes = [];
     private $linkclasses = [];
+    private $activeClass = 'rex-active';
+    private $currentClass = 'rex-current';
+    private $normalClass = 'rex-normal';
+    private $activeLiClass = $this->$activeClass;
+    private $activeAClass = $this->$activeClass;
+    private $currentLiClass = $this->$activeClass;
+    private $currentAClass = $this->$activeClass;
     private $filter = [];
     private $callbacks = [];
 
@@ -51,9 +58,6 @@ class rex_navigation
         // nichts zu tun
     }
 
-    /**
-     * @return static
-     */
     public static function factory()
     {
         $class = self::getFactoryClass();
@@ -123,16 +127,7 @@ class rex_navigation
             }
         }
 
-        $show = !$category_id;
         foreach ($path as $pathItem) {
-            if (!$show) {
-                if ($pathItem == $category_id) {
-                    $show = true;
-                } else {
-                    continue;
-                }
-            }
-
             $cat = rex_category::get($pathItem);
             $lis .= '<li class="rex-lvl' . $i . '"><a href="' . $cat->getUrl() . '">' . htmlspecialchars($cat->getName()) . '</a></li>';
             ++$i;
@@ -155,9 +150,9 @@ class rex_navigation
     /**
      * @see getBreadcrumb()
      */
-    public function showBreadcrumb($startPageLabel = false, $includeCurrent = false, $category_id = 0)
+    public function showBreadcrumb($includeCurrent = false, $category_id = 0)
     {
-        echo $this->getBreadcrumb($startPageLabel, $includeCurrent, $category_id);
+        echo $this->getBreadcrumb($includeCurrent, $category_id);
     }
 
     public function setClasses($classes)
@@ -170,6 +165,40 @@ class rex_navigation
         $this->linkclasses = $classes;
     }
 
+    public function setActiveClass($class)
+    {
+        $this->$activeClass = $class;
+    }
+
+    public function setCurrentClass($class)
+    {
+        $this->$currentClass = $class;
+    }
+
+    public function setNormalClass($class)
+    {
+        $this->$normalClass = $class;
+    }
+
+    public function setActiveAClass($class)
+    {
+        $this->$activeAClass = $class;
+    }
+
+    public function setActiveLiClass($class)
+    {
+        $this->$activeLiClass = $class;
+    }
+
+    public function setCurrentLiClass($class)
+    {
+        $this->$currentLiClass = $class;
+    }
+
+    public function setCurrentAClass($class)
+    {
+        $this->$currentAClass = $class;
+    }
     /**
      * Fügt einen Filter hinzu.
      *
@@ -182,7 +211,6 @@ class rex_navigation
     {
         $this->filter[] = ['metafield' => $metafield, 'value' => $value, 'type' => $type, 'depth' => $depth];
     }
-
     /**
      * Fügt einen Callback hinzu.
      *
@@ -322,13 +350,13 @@ class rex_navigation
                 $li['class'][] = 'rex-article-' . $nav->getId();
                 // classes abhaengig vom pfad
                 if ($nav->getId() == $this->current_category_id) {
-                    $li['class'][] = 'rex-current';
-                    $a['class'][] = 'rex-current';
+                    $li['class'][] = $this->currentLiClass;
+                    $a['class'][] = $this->currentAClass;
                 } elseif (in_array($nav->getId(), $this->path)) {
-                    $li['class'][] = 'rex-active';
-                    $a['class'][] = 'rex-active';
+                    $li['class'][] = $this->activeLiClass;
+                    $a['class'][] = $this->activeAClass;
                 } else {
-                    $li['class'][] = 'rex-normal';
+                    $li['class'][] = $this->normalClass;
                 }
                 if (isset($this->linkclasses[($depth - 1)])) {
                     $a['class'][] = $this->linkclasses[($depth - 1)];

--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -394,7 +394,7 @@ class rex_navigation
             }
         }
         if (count($lis) > 0) {
-            return '<ul class="rex-navi' . $depth . ' rex-navi-depth-' . $depth . ' rex-navi-has-' . count($lis) . '-elements' . $this->ulClass .'">' . implode('', $lis) . '</ul>';
+            return '<ul class="rex-navi' . $depth . ' rex-navi-depth-' . $depth . ' rex-navi-has-' . count($lis) . '-elements ' . $this->ulClass .'">' . implode('', $lis) . '</ul>';
         }
         return '';
     }

--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -43,10 +43,10 @@ class rex_navigation
     private $activeClass = 'rex-active';
     private $currentClass = 'rex-current';
     private $normalClass = 'rex-normal';
-    private $activeLiClass = $this->$activeClass;
-    private $activeAClass = $this->$activeClass;
-    private $currentLiClass = $this->$activeClass;
-    private $currentAClass = $this->$activeClass;
+    private $activeLiClass = $this->activeClass;
+    private $activeAClass = $this->activeClass;
+    private $currentLiClass = $this->activeClass;
+    private $currentAClass = $this->activeClass;
     private $filter = [];
     private $callbacks = [];
 
@@ -167,38 +167,39 @@ class rex_navigation
 
     public function setActiveClass($class)
     {
-        $this->$activeClass = $class;
+        $this->activeClass = $class;
     }
 
     public function setCurrentClass($class)
     {
-        $this->$currentClass = $class;
+        $this->currentClass = $class;
     }
 
     public function setNormalClass($class)
     {
-        $this->$normalClass = $class;
+        $this->normalClass = $class;
     }
 
     public function setActiveAClass($class)
     {
-        $this->$activeAClass = $class;
+        $this->activeAClass = $class;
     }
 
     public function setActiveLiClass($class)
     {
-        $this->$activeLiClass = $class;
+        $this->activeLiClass = $class;
     }
 
     public function setCurrentLiClass($class)
     {
-        $this->$currentLiClass = $class;
+        $this->currentLiClass = $class;
     }
 
     public function setCurrentAClass($class)
     {
-        $this->$currentAClass = $class;
+        $this->currentAClass = $class;
     }
+
     /**
      * Fügt einen Filter hinzu.
      *


### PR DESCRIPTION
Ich habe die Class bisschen erweitert, damit man eigene Classes für active und current setzen kann. Aktuell waren rex-current und rex-active fix. Das ist nicht schön und macht es teilweise schwierig, mit Fremdcode oder diversen libs, die Navigationen umzusetzen.

```php
    public function setActiveClass($class)
    {
        $this->activeClass = $class;
    }

    public function setCurrentClass($class)
    {
        $this->currentClass = $class;
    }

    public function setNormalClass($class)
    {
        $this->normalClass = $class;
    }

    public function setActiveAClass($class)
    {
        $this->activeAClass = $class;
    }

    public function setActiveLiClass($class)
    {
        $this->activeLiClass = $class;
    }

    public function setCurrentLiClass($class)
    {
        $this->currentLiClass = $class;
    }

    public function setCurrentAClass($class)
    {
        $this->currentAClass = $class;
    }

    public function setUlClass($class)
    {
        $this->ulClass = $class;
    }
```

Wird nichts gesetzt, werden die Defaults genommen. Diese habe ich als private deklariert. Möchte man diese einfach ändern, nutzt man eine der drei ersten oben genannten. Ich fand es aber auch wichtig, das unabhängig für a und li steuern zu können (und jeweils für current und active). Deswegen sind es ein paar mehr "setter" geworden, aber ich hoffe, da stört sich niemand daran.

Geht das klar @staabm @gharlan ?