### PR TITLE
Cronjob: Besseres Handling von nexttime und execution_start

### DIFF
--- a/redaxo/src/addons/cronjob/lib/manager_sql.php
+++ b/redaxo/src/addons/cronjob/lib/manager_sql.php
@@ -127,12 +127,16 @@ class rex_cronjob_manager_sql
                 AND   nexttime <= ?
             ORDER BY  nexttime ASC, execution_moment DESC, name ASC
         ';
-        if (!$script) {
+
+        if ($script) {
+            $minExecutionStartDiff = 6 * 60 * 60;
+        } else {
             $query .= ' LIMIT 1';
+
+            $minExecutionStartDiff = 2 * (ini_get('max_execution_time') ?: 60 * 60);
         }
 
-        $maxExecutionTime = ini_get('max_execution_time') ?: 60 * 60;
-        $jobs = $sql->getArray($query, [rex_sql::datetime(time() - 2 * $maxExecutionTime), '%|' .$env. '|%', rex_sql::datetime()]);
+        $jobs = $sql->getArray($query, [rex_sql::datetime(time() - $minExecutionStartDiff), '%|' .$env. '|%', rex_sql::datetime()]);
 
         if (!$jobs) {
             $this->saveNextTime();

--- a/redaxo/src/addons/cronjob/lib/manager_sql.php
+++ b/redaxo/src/addons/cronjob/lib/manager_sql.php
@@ -204,9 +204,9 @@ class rex_cronjob_manager_sql
         $params = json_decode($job['parameters'], true);
         $cronjob = rex_cronjob::factory($job['type']);
 
-        $success = $this->getManager()->tryExecute($cronjob, $job['name'], $params, $log, $job['id']);
-
         $this->setNextTime($job['id'], $job['interval'], $resetExecutionStart);
+
+        $success = $this->getManager()->tryExecute($cronjob, $job['name'], $params, $log, $job['id']);
 
         return $success;
     }


### PR DESCRIPTION
fixes #990 replaces #1001

Es wird nun direkt vor Ausführung eines Jobs deren nexttime gesetzt, statt erst danach. So wird sichergestellt, dass die Jobs garantiert erst zum nächsten Zeitpunkt erneut starten.

Der Ablauf ist so:
- Alle Jobs abrufen, die dran sind
- Bei all jenen execution_start setzen
- Anschließend die Jobs nacheinander ausführen. Vor jeder Ausführung nexttime neu setzen

Bei Punkt 1 werden die rausgelassen, die bereits als zur Ausführung bereitstehend (execution_start) markiert wurden, auch wenn sie noch nicht tatsächlich gestartet wurden (nexttime wurde also noch nicht angepasst).
Nach doppelter max_execution_time, bzw. 6 Stunden in Skript-Umgebung, wird davon ausgegangen, dass grundsätzlich etwas schief gegangen ist, und der Job wohl doch nicht ausgeführt wurde.

Bei einem Abbruch wird über eine Shutdown-Function bei allen angedachten Jobs geschaut, ob sie denn tatsächlich gestartet wurden, und wenn nicht, execution_start wieder zurückgesetzt. So wird sichergestellt, dass sie dann baldmöglichst ausgeführt werden.