### PR TITLE
Methode 'getPriority' hinzugefügt

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
@@ -433,4 +433,9 @@ class rex_article_slice
     {
         return $this->_medialists[$index - 1];
     }
+    
+    public function getPriority()
+    {
+        return $this->_priority;
+    }
 }


### PR DESCRIPTION
Ich hab bei einem aktuellen Projekt das Problem, dass immer der erste Slice auf einer Seite anders dargestellt wird... und zwar Modulunabhängig. Dies habe ich nun mit dieser Methode gelöst.