### PR TITLE
session lock verhindern

### DIFF
--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -11,6 +11,10 @@ class rex_media_manager
 
     public function __construct(rex_managed_media $media)
     {
+        // prevent session locking trough other addons
+        // will not have any side effects and will even work without a started session
+        session_abort();
+        
         $this->media = $media;
     }
 


### PR DESCRIPTION
indem eine ggf. gestartete session abgebrochen wird. Hat keine weiteren Auswirkungen.
In meinen Testumgebungen konnten mehrere Sekunden Ladezeit eingespart werden, wenn es viele Bilder auf einer Seite gegeben hat. So lange keine Session aktiv ist, hat dieser Fix keine Auswirkungen (weder schneller noch langsamer). Da es aber diverse Addons geben kann, die eine Session im Frontend starten, sollte das einfach als "genereller Schutz" eingebaut werden.