### PR TITLE
MediaManager: Bilder werden immer mit Status 200 geliefert.

### DIFF
--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -88,10 +88,11 @@ class rex_media_manager
     public static function sendMedia($media)
     {
         rex_response::cleanOutputBuffers();
-        
+
         // prevent session locking trough other addons
         session_abort();
 
+        $header = $media->getHeader();
         if (isset($header['Last-Modified'])) {
             rex_response::sendLastModified(strtotime($header['Last-Modified']));
             unset($header['Last-Modified']);
@@ -99,7 +100,7 @@ class rex_media_manager
         if (isset($header['Fileextension'])) {
             unset($header['Fileextension']);
         }
-        foreach ($media->getHeader() as $t => $c) {
+        foreach ($header as $t => $c) {
             header($t . ': ' . $c);
         }
         echo $media->getSource();


### PR DESCRIPTION
Wollte mir eigentlich mal ansehen, wie man den Expires-Header setzt, weil wir kürzlich viele Probleme mit generierten Bildern haben. Bin in der 5.3-Beta1 dann darauf gestoßen, dass die Bilder immer generiert und mit Status 200 ausgeliefert werden.
Beim genaueren untersuchen ist mir aufgefallen, dass es die Varable $header in der Funktion rex_media_manager::sendMedia gar nicht gibt.

Das dürfte das Problem aus #1025 sehr wahrscheinlich lösen.