### PR TITLE
Media Manager: Revert

### DIFF
--- a/redaxo/src/addons/media_manager/CHANGELOG.md
+++ b/redaxo/src/addons/media_manager/CHANGELOG.md
@@ -8,7 +8,6 @@ Version 2.2.0 – XX.XX.2017
 
 * Neuer Effekt rotate zum Drehen der Bilder (@alexplusde)
 * Medientypen können dupliziert werden (@phoebusryan)
-* Einfachere Möglichkeit die Maße des resultierenden Bildes abzufragen
 * Ggf. geöffnete Sessions werden frühzeitig abgebrochen, um Session Locking zu mindern
 
 ### Bugfixes

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -7,104 +7,73 @@ class rex_media_manager
 {
     private $cache_path;
     private $type;
+    private $use_cache;
+
     private static $effects = [];
 
     public function __construct(rex_managed_media $media)
     {
         $this->media = $media;
+        $this->useCache(true);
     }
 
-    public static function init()
+    protected function applyEffects($type)
     {
-        $rex_media_manager_file = self::getMediaFile();
-        $rex_media_manager_type = self::getMediaType();
+        $this->type = $type;
 
-        $media = self::getMedia($rex_media_manager_file, $rex_media_manager_type);
+        if (!$this->isCached($type)) {
+            $set = $this->effectsFromType($type);
+            $set = rex_extension::registerPoint(new rex_extension_point('MEDIA_MANAGER_FILTERSET', $set, ['rex_media_type' => $type]));
 
-        if ($media) {
-            self::sendMedia($media);
-        }
-
-        return null;
-    }
-
-    public static function getMedia($rex_media_manager_file, $rex_media_manager_type)
-    {
-        $media_path = rex_path::media($rex_media_manager_file);
-        $cache_path = rex_path::addonCache('media_manager');
-
-        if ($rex_media_manager_file == '' || $rex_media_manager_type == '') {
-            return null;
-        }
-
-        $media = new rex_managed_media($media_path);
-        $media_manager = new self($media);
-        $media_manager->setCachePath($cache_path);
-        $media = $media_manager->applyEffects($rex_media_manager_type);
-
-        $headerCacheFilename = $media_manager->getHeaderCacheFilename();
-        $sourceCacheFilename = $media_manager->getSourceCacheFilename();
-
-        if (!$media_manager->isCached()) {
-            $src = $media->getSource();
-            $media->setHeader('Content-Length', rex_string::size($src));
-            $header = $media->getHeader();
-
-            $extended = '';
-            if (isset($header['Fileextension'])) {
-                $extended = '.'.$header['Fileextension'];
+            if (count($set) == 0) {
+                return $this->media;
             }
 
-            if (!isset($header['Content-Type'])) {
-                $finfo = finfo_open(FILEINFO_MIME_TYPE);
-                $content_type = finfo_file($finfo, $media->getMediapath());
-                if ($content_type != '') {
-                    $media->setHeader('Content-Type', $content_type);
+            // execute effects on image
+            foreach ($set as $effect_params) {
+                $effect_class = 'rex_effect_' . $effect_params['effect'];
+                $effect = new $effect_class();
+                $effect->setMedia($this->media);
+                $effect->setParams($effect_params['params']);
+                $effect->execute();
+            }
+        }
+    }
+
+    public function effectsFromType($type)
+    {
+        $qry = '
+            SELECT e.*
+            FROM ' . rex::getTablePrefix() . 'media_manager_type t, ' . rex::getTablePrefix() . 'media_manager_type_effect e
+            WHERE e.type_id = t.id AND t.name="' . $type . '" order by e.priority';
+
+        $sql = rex_sql::factory();
+        // $sql->setDebug();
+        $sql->setQuery($qry);
+
+        $effects = [];
+        foreach ($sql as $row) {
+            $effname = $row->getValue('effect');
+            $params = json_decode($row->getValue('parameters'), true);
+            $effparams = [];
+
+            // extract parameter out of array
+            if (isset($params['rex_effect_' . $effname])) {
+                foreach ($params['rex_effect_' . $effname] as $name => $value) {
+                    $effparams[str_replace('rex_effect_' . $effname . '_', '', $name)] = $value;
+                    unset($effparams[$name]);
                 }
             }
-            if (!isset($header['Content-Disposition'])) {
-                $media->setHeader('Content-Disposition', 'inline; filename="' . $media->getMediaFilename() . $extended . '";');
-            }
-            if (!isset($header['Last-Modified'])) {
-                $media->setHeader('Last-Modified', gmdate('D, d M Y H:i:s T'));
-            }
 
-            rex_file::putCache($headerCacheFilename, $media->getHeader());
-            rex_file::put($sourceCacheFilename . $extended, $src);
+            $effect = [
+                'effect' => $effname,
+                'params' => $effparams,
+            ];
+
+            $effects[] = $effect;
         }
 
-        $header = rex_file::getCache($headerCacheFilename);
-        $extended = '';
-        if (isset($header['Fileextension'])) {
-            $extended = '.'.$header['Fileextension'];
-        }
-        $media = new rex_managed_media($sourceCacheFilename . $extended);
-        $media->setHeaders($header);
-        $media->isImage();
-
-        return $media;
-    }
-
-    public static function sendMedia($media)
-    {
-        rex_response::cleanOutputBuffers();
-
-        // prevent session locking trough other addons
-        session_abort();
-
-        $header = $media->getHeader();
-        if (isset($header['Last-Modified'])) {
-            rex_response::sendLastModified(strtotime($header['Last-Modified']));
-            unset($header['Last-Modified']);
-        }
-        if (isset($header['Fileextension'])) {
-            unset($header['Fileextension']);
-        }
-        foreach ($header as $t => $c) {
-            header($t . ': ' . $c);
-        }
-        echo $media->getSource();
-        exit;
+        return $effects;
     }
 
     public function setCachePath($cache_path = '')
@@ -117,21 +86,16 @@ class rex_media_manager
         return $this->cache_path;
     }
 
-    public function getSourceCacheFilename()
+    protected function useCache($t = true)
     {
-        $cacheParams = $this->type . '_' . md5(serialize($this->media->getMediapath()));
-        return $this->cache_path . $this->media->getMediaFilename() . '_' . $cacheParams . '_' . $this->media->getMediaFilename();
-    }
-
-    public function getHeaderCacheFilename()
-    {
-        return $this->getSourceCacheFilename() . '.header';
+        $this->use_cache = $t;
     }
 
     public function isCached()
     {
-        $cache_file = $this->getHeaderCacheFilename();
+        $cache_file = $this->getCacheFilename();
 
+        // ----- check for cache file
         if (file_exists($cache_file)) {
             // time of cache
             $cachetime = filectime($cache_file);
@@ -147,10 +111,22 @@ class rex_media_manager
         return false;
     }
 
+    public function getCacheFilename()
+    {
+        $cacheParams = $this->type . '_' . md5(serialize($this->media->getMediapath()));
+        return $this->cache_path . $this->media->getMediaFilename() . '_' . $cacheParams;
+    }
+
+    public function getHeaderCacheFilename()
+    {
+        return $this->getCacheFilename() . '.header';
+    }
+
     public static function deleteCacheByType($type_id)
     {
         $qry = 'SELECT * FROM ' . rex::getTablePrefix() . 'media_manager_type' . ' WHERE id=' . $type_id;
         $sql = rex_sql::factory();
+        //  $sql->setDebug();
         $sql->setQuery($qry);
         $counter = 0;
         foreach ($sql as $row) {
@@ -184,61 +160,30 @@ class rex_media_manager
         return $counter;
     }
 
-    protected function applyEffects($type)
+    public function sendMedia()
     {
-        $this->type = $type;
+        $headerCacheFilename = $this->getHeaderCacheFilename();
+        $CacheFilename = $this->getCacheFilename();
 
-        if (!$this->isCached()) {
-            $set = $this->effectsFromType($type);
-            $set = rex_extension::registerPoint(new rex_extension_point('MEDIA_MANAGER_FILTERSET', $set, ['rex_media_type' => $type]));
+        rex_response::cleanOutputBuffers();
 
-            if (count($set) > 0) {
-                foreach ($set as $effect_params) {
-                    $effect_class = 'rex_effect_' . $effect_params['effect'];
-                    $effect = new $effect_class();
-                    $effect->setMedia($this->media);
-                    $effect->setParams($effect_params['params']);
-                    $effect->execute();
-                }
+        // prevent session locking trough other addons
+        session_abort();
+
+        if ($this->isCached()) {
+            $header = rex_file::getCache($headerCacheFilename);
+            if (isset($header['Last-Modified'])) {
+                rex_response::sendLastModified(strtotime($header['Last-Modified']));
+                unset($header['Last-Modified']);
             }
-        }
-
-        return $this->media;
-    }
-
-    public function effectsFromType($type)
-    {
-        $qry = '
-            SELECT e.*
-            FROM ' . rex::getTablePrefix() . 'media_manager_type t, ' . rex::getTablePrefix() . 'media_manager_type_effect e
-            WHERE e.type_id = t.id AND t.name="' . $type . '" order by e.priority';
-
-        $sql = rex_sql::factory();
-        $sql->setQuery($qry);
-
-        $effects = [];
-        foreach ($sql as $row) {
-            $effname = $row->getValue('effect');
-            $params = $row->getArrayValue('parameters');
-            $effparams = [];
-
-            // extract parameter out of array
-            if (isset($params['rex_effect_' . $effname])) {
-                foreach ($params['rex_effect_' . $effname] as $name => $value) {
-                    $effparams[str_replace('rex_effect_' . $effname . '_', '', $name)] = $value;
-                    unset($effparams[$name]);
-                }
+            foreach ($header as $t => $c) {
+                header($t . ': ' . $c);
             }
-
-            $effect = [
-                'effect' => $effname,
-                'params' => $effparams,
-            ];
-
-            $effects[] = $effect;
+            readfile($CacheFilename);
+        } else {
+            $this->media->sendMedia($CacheFilename, $headerCacheFilename, $this->use_cache);
         }
-
-        return $effects;
+        exit;
     }
 
     public static function getSupportedEffects()
@@ -272,24 +217,47 @@ class rex_media_manager
     private static function getEffectName($effectFile)
     {
         return str_replace(
-        ['effect_', '.php'],
-        '',
-        basename($effectFile)
+            ['effect_', '.php'],
+            '',
+            basename($effectFile)
         );
     }
 
     private static function getEffectClass($effectFile)
     {
         return 'rex_' . str_replace(
-        '.php',
-        '',
-        basename($effectFile)
+            '.php',
+            '',
+            basename($effectFile)
         );
     }
 
+    /*
+     * For ExtensionPoints.
+     */
     public static function mediaUpdated(rex_extension_point $ep)
     {
         self::deleteCache($ep->getParam('filename'));
+    }
+
+    public static function init()
+    {
+        //--- handle image request
+        $rex_media_manager_file = self::getMediaFile();
+        $rex_media_manager_type = self::getMediaType();
+
+        if ($rex_media_manager_file != '' && $rex_media_manager_type != '') {
+            $media_path = rex_path::media($rex_media_manager_file);
+            $cache_path = rex_path::addonCache('media_manager');
+
+            $media = new rex_managed_media($media_path);
+            $media_manager = new self($media);
+            $media_manager->setCachePath($cache_path);
+            $media_manager->applyEffects($rex_media_manager_type);
+            $media_manager->sendMedia();
+
+            exit();
+        }
     }
 
     public static function getMediaFile()
@@ -302,13 +270,5 @@ class rex_media_manager
     public static function getMediaType()
     {
         return rex_get('rex_media_type', 'string');
-    }
-
-    /*
-     * deprecated
-     */
-    public function getCacheFilename()
-    {
-        return $this->getSourceCacheFilename();
     }
 }


### PR DESCRIPTION
Der PR macht den Umbau im Media Manager komplett rückgängig, um BC wieder herzustellen.
Die anderen Änderungen (Typen kopieren, session_abort) sind aber drin geblieben.

Vorschlag ist, das so für die 5.3.0 reinzunehmen, und dann zeitnah (aber in Ruhe) ein Einzelupdate des Media Managers zu erstellen mit einer einfachen Möglichkeit, die Maße des resultierenden Bildes abzufragen etc.

closes #1025 