### PR TITLE
added a prototype for PrettyPageHandler rendered syslog-details

### DIFF
--- a/redaxo/src/core/pages/system.log.php
+++ b/redaxo/src/core/pages/system.log.php
@@ -23,6 +23,43 @@ if ($func == 'delLog') {
     } else {
         $error = rex_i18n::msg('syslog_delete_error');
     }
+} else if ($func == 'inspect') {
+    ob_clean();
+
+    $exception = new ErrorException(
+        'session_regenerate_id(): Session object destruction failed',
+        0,
+        E_USER_WARNING,
+        realpath(rex_path::base('./'.'redaxo\src\core\lib\login\login.php')),
+        '286'
+    );
+
+    $whoops = new \Whoops\Run();
+    $whoops->writeToOutput(false);
+    $whoops->allowQuit(false);
+
+    $handler = new \Whoops\Handler\PrettyPageHandler();
+    if (ini_get('xdebug.file_link_format')) {
+        $handler->setEditor('xdebug');
+    }
+
+    $whoops->pushHandler($handler);
+
+    $errPage = $whoops->handleException($exception);
+
+    $errPageStyle = '
+        <style>
+            /*disable details, as those show data of the current request, not those at error time. */
+            .details {
+                display: none;
+            }
+        </style>
+    ';
+
+    $errPage = str_replace('</head>', $errPageStyle . '</head>', $errPage);
+
+    echo $errPage;
+    exit();
 }
 $message = '';
 $content = '';
@@ -49,6 +86,7 @@ $content .= '
                 <tbody>';
 
 if ($file = new rex_log_file($logFile)) {
+    $first = true;
     foreach (new LimitIterator($file, 0, 30) as $entry) {
         /* @var rex_log_entry $entry */
         $data = $entry->getData();
@@ -64,6 +102,16 @@ if ($file = new rex_log_file($logFile)) {
                         <td data-title="' . rex_i18n::msg('syslog_file') . '"><div class="rex-word-break">' . (isset($data[2]) ? $data[2] : '') . '</div></td>
                         <td class="rex-table-number" data-title="' . rex_i18n::msg('syslog_line') . '">' . (isset($data[3]) ? $data[3] : '') . '</td>
                     </tr>';
+
+        if ($first) {
+            $first = false;
+
+            $content .= '
+                <tr>
+                    <td colspan="5"><iframe style="width:100%; height: 550px" src="'. rex_url::backendController(['page' => 'system/log', 'func' => 'inspect']) .'"></iframe></td>
+                </tr>
+            ';
+        }
     }
 }
 


### PR DESCRIPTION
kleiner prototype um die akzeptanz des features zu testen. aktuell ist es nur ein dummy.
closes https://github.com/redaxo/redaxo/issues/1053

Idee ist:
- man klickt im system log auf eine der system log zeilen
- dadurch wird via js ein iframe unter der zeile erzeugt der die details offenlegt
- der iframe brauch noch irgendwo ein "X" zum schließen
- es ist immer nur 1 iframe offen, d.h. durch klicken auf eine 2. syslog zeile wird der bereits offene iframe entfernt/ausgeblendet

vorschau:
![grafik](https://cloud.githubusercontent.com/assets/120441/23093336/9426cf7a-f5e0-11e6-9ee9-4988edf40905.png)
(der screenshot zeigt dummy daten, eigentlich müsste er die meldung/daten zeigen von der blauen zeile die über dem iframe zu sehen ist)