### PR TITLE
Media Manager: Maße etc. des Cache-Bildes

### DIFF
--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -1,5 +1,5 @@
 package: media_manager
-version: '2.2.0'
+version: '2.3.0-dev'
 author: 'Markus Staab, Jan Kristinus'
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/media_manager/update.php
+++ b/redaxo/src/addons/media_manager/update.php
@@ -1,0 +1,7 @@
+<?php
+
+/** @var rex_addon $this */
+
+if (rex_string::versionCompare($this->getVersion(), '2.3.0-dev', '<')) {
+    rex_media_manager::deleteCache();
+}


### PR DESCRIPTION
closes #707 

Aufruf wäre nun:
```php
$media = rex_media_manager::create($type, $file)->getMedia();
$media->getFormat();
$media->getWidth();
$media->getHeight();
```