### PR TITLE
/bin-Ordner schützen

### DIFF
--- a/bin/.htaccess
+++ b/bin/.htaccess
@@ -1,0 +1,2 @@
+order deny,allow
+deny from all

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -449,6 +449,7 @@ jQuery(function($){
         time = new Date();
         time.setTime(time.getTime() + 1000 * 60 * 60 * 24);
         setCookie('htaccess_check', '1', time.toGMTString());
+        checkHtaccess('../bin', 'release');
         checkHtaccess('cache', '.redaxo');
         checkHtaccess('data', '.redaxo');
         checkHtaccess('src', 'core/boot.php');

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -114,8 +114,14 @@ if ($step == 3) {
     $security .= '<script>
 
     jQuery(function($){
-
-        $.each(["' . rex_url::backend('data/.redaxo') . '", "' . rex_url::backend('src/core/boot.php') . '", "' . rex_url::backend('cache/.redaxo') . '"], function (i, url) {
+        var urls = [
+            "' . rex_url::frontend('bin/release') . '", 
+            "' . rex_url::backend('data/.redaxo') . '", 
+            "' . rex_url::backend('src/core/boot.php') . '", 
+            "' . rex_url::backend('cache/.redaxo') . '"
+        ];
+        
+        $.each(urls, function (i, url) {
             $.ajax({
                 url: url,
                 cache: false,


### PR DESCRIPTION
In den Releases ist der Ordner nicht drin. Aber wenn man die GitHub-Version nutzt, dann schon.
(Ist mir auf traduko.redaxo.org aufgefallen, wo ich das Repository gecloned habe.)

Ich überlege, ob wir auch noch eine `.gitattributes` hinzufügen sollten, die den bin-Ordner excluded.
Dann wäre er beim Zip-Download über Github auch nicht mehr enthalten, nur noch bei `git clone`.