### PR TITLE
added getUrl() function for rex_media_manager

### DIFF
--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -321,13 +321,13 @@ class rex_media_manager
     
     public static function getUrl($filename = '', $type = '', $rewrite = true)
     {
+        
         if($rewrite) {
             $url = '/images/' . $type . '/' . $filename;
         } else {
             $url = 'index.php?rex_media_type=' . $type . '&rex_media_file=' . $filename;
         }
-
+        
         return $url;
     }
-    
 }

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -318,10 +318,9 @@ class rex_media_manager
     {
         return rex_get('rex_media_type', 'string');
     }
-    
+
     public static function getUrl($filename = '', $type = '', $rewrite = true)
     {
-        
         if($rewrite) {
             $url = '/images/' . $type . '/' . $filename;
         } else {

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -318,4 +318,16 @@ class rex_media_manager
     {
         return rex_get('rex_media_type', 'string');
     }
+    
+    public static function getUrl($filename = '', $type = '', $rewrite = true)
+    {
+        if($rewrite) {
+            $rewrite = '/images/'.$type.'/'.$filename;
+        } else {
+            $rewrite = 'index.php?rex_media_type=' . $type . '&rex_media_file='. $filename;
+        }
+
+        return $rewrite;
+    }
+    
 }

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -322,9 +322,9 @@ class rex_media_manager
     public static function getUrl($filename = '', $type = '', $rewrite = true)
     {
         if($rewrite) {
-            $rewrite = '/images/'.$type.'/'.$filename;
+            $rewrite = '/images/' . $type . '/' . $filename;
         } else {
-            $rewrite = 'index.php?rex_media_type=' . $type . '&rex_media_file='. $filename;
+            $rewrite = 'index.php?rex_media_type=' . $type . '&rex_media_file=' . $filename;
         }
 
         return $rewrite;

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -322,12 +322,12 @@ class rex_media_manager
     public static function getUrl($filename = '', $type = '', $rewrite = true)
     {
         if($rewrite) {
-            $rewrite = '/images/' . $type . '/' . $filename;
+            $url = '/images/' . $type . '/' . $filename;
         } else {
-            $rewrite = 'index.php?rex_media_type=' . $type . '&rex_media_file=' . $filename;
+            $url = 'index.php?rex_media_type=' . $type . '&rex_media_file=' . $filename;
         }
 
-        return $rewrite;
+        return $url;
     }
     
 }


### PR DESCRIPTION
Es kann Dateiname & Parameter übergeben werden.

```php
rex_media_manager::getUrl('file.jpg', 'image-typ', $rewrite = true)
// Er gibt dann /images/image-typ/file.jpg
```

Steht rewrite auf false, wird die index.php? Variante ausgegeben.

Es bleibt zu diskutieren, ob das in den Media Manager oder in YRewrite reingehört (da YRewrite die Setting dazu in der .htaccess liefert)

Ich hab es jetzt hier eingebaut, da es um Medien geht. Ich habe mich bewusst für Paramater entschieden, da wir über das Objekt zwar den Dateinamen herausfinden könnten (praktisch in einem Chain), jedoch nicht den Typ. Außerdem kann man dadurch darauf verzichten, vorher ein Image-Objekt zu instanziieren. 

Über die Bennenung getUrl() kann natürlich auch noch diskutiert werden.

#1030