### PR TITLE
Media Manager: imagepalettecopy für alle Bilder aufrufen, nicht nur für gifs

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effect_abstract.php
+++ b/redaxo/src/addons/media_manager/lib/effect_abstract.php
@@ -32,13 +32,15 @@ abstract class rex_effect_abstract
     protected function keepTransparent($des)
     {
         $image = $this->media;
+        $gdimage = $image->getImage();
+
+        imagepalettecopy($gdimage, $des);
+
         if ($image->getFormat() == 'png') {
             imagealphablending($des, false);
             imagesavealpha($des, true);
         } elseif ($image->getFormat() == 'gif') {
-            $gdimage = $image->getImage();
             $colorTransparent = imagecolortransparent($gdimage);
-            imagepalettecopy($gdimage, $des);
             if ($colorTransparent > 0) {
                 imagefill($des, 0, 0, $colorTransparent);
                 imagecolortransparent($des, $colorTransparent);


### PR DESCRIPTION
Das scheint #1086 zu fixen. Leider weiß ich aber überhaupt nicht, ob das irgendwelche negativen Folgen hat.
Aktuell wird die Funktion insbesondere nicht nur zusätzlich bei PNGs aufgerufen, sondern zum Beispiel auch bei JPGs. Konnte spontan keine negativen Auswirkungen sehen, was aber nichts heißen muss.
Vorher wurde sie nur bei GIFs genutzt.

/cc @isospin