### PR TITLE
Autoloader: Cache auch im Debug-Modus bei Bedarf aktualisieren

### DIFF
--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -102,7 +102,10 @@ class rex_autoload
 
         // Class not found, so reanalyse all directories if not already done or if $force==true
         // but only if an admin is logged in
-        if ((!self::$reloaded || $force) && ($user = rex_backend_login::createUser()) && $user->isAdmin()) {
+        if (
+            (!self::$reloaded || $force) &&
+            (rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin())
+        ) {
             self::reload($force);
             return self::autoload($class);
         }


### PR DESCRIPTION
Ich denke das Verhalten sollte im Debug-Modus genauso sein, wie wenn ein Backend-Admin eingeloggt ist.