### PR TITLE
rex_sql_table: Positionierung der Spalten

### DIFF
--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -417,15 +417,29 @@ class rex_sql_table
             }
         };
 
+        $currentOrder = [];
+        $after = self::FIRST;
         foreach ($columns as $name => $column) {
+            $currentOrder[$after] = $name;
+            $after = $name;
+
             if (!isset($this->positions[$name])) {
                 $handle($name);
             }
         }
+
         foreach ($this->positions as $name => $after) {
-            if (isset($columns[$name])) {
-                $handle($name, $after);
+            if (!isset($columns[$name])) {
+                continue;
             }
+
+            if (isset($currentOrder[$after]) && $currentOrder[$after] === $name) {
+                $after = null;
+            } else {
+                unset($currentOrder[$name]);
+            }
+
+            $handle($name, $after);
         }
 
         foreach ($existing as $oldName) {

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -308,6 +308,7 @@ class rex_sql_table
         }
 
         foreach ($positions as $name => $after) {
+            // unset is necessary to add new position as last array element
             unset($this->positions[$name]);
             $this->positions[$name] = $after;
         }

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -461,6 +461,7 @@ class rex_sql_table
             throw new InvalidArgumentException(sprintf('Column "%s" can not be placed after "%s", because that column does not exist.', $name, $after));
         }
 
+        // unset is necessary to add new position as last array element
         unset($this->positions[$name]);
         $this->positions[$name] = $after;
     }

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -154,11 +154,11 @@ class rex_sql_table
 
     /**
      * @param rex_sql_column $column
-     * @param null|string    $after  Column name or `rex_sql_table::FIRST`
+     * @param null|string    $afterColumn Column name or `rex_sql_table::FIRST`
      *
      * @return $this
      */
-    public function addColumn(rex_sql_column $column, $after = null)
+    public function addColumn(rex_sql_column $column, $afterColumn = null)
     {
         $name = $column->getName();
 
@@ -168,26 +168,26 @@ class rex_sql_table
 
         $this->columns[$name] = $column;
 
-        $this->setPosition($name, $after);
+        $this->setPosition($name, $afterColumn);
 
         return $this;
     }
 
     /**
      * @param rex_sql_column $column
-     * @param null|string    $after  Column name or `rex_sql_table::FIRST`
+     * @param null|string    $afterColumn Column name or `rex_sql_table::FIRST`
      *
      * @return $this
      */
-    public function ensureColumn(rex_sql_column $column, $after = null)
+    public function ensureColumn(rex_sql_column $column, $afterColumn = null)
     {
         $name = $column->getName();
 
         if (!$this->hasColumn($name)) {
-            return $this->addColumn($column, $after);
+            return $this->addColumn($column, $afterColumn);
         }
 
-        $this->setPosition($name, $after);
+        $this->setPosition($name, $afterColumn);
 
         if ($this->getColumn($name)->equals($column)) {
             return $this;
@@ -450,21 +450,21 @@ class rex_sql_table
         $this->resetModified();
     }
 
-    private function setPosition($name, $after)
+    private function setPosition($name, $afterColumn)
     {
-        if (null === $after) {
+        if (null === $afterColumn) {
             $this->implicitOrder[] = $name;
 
             return;
         }
 
-        if (self::FIRST !== $after && !$this->hasColumn($after)) {
-            throw new InvalidArgumentException(sprintf('Column "%s" can not be placed after "%s", because that column does not exist.', $name, $after));
+        if (self::FIRST !== $afterColumn && !$this->hasColumn($afterColumn)) {
+            throw new InvalidArgumentException(sprintf('Column "%s" can not be placed after "%s", because that column does not exist.', $name, $afterColumn));
         }
 
         // unset is necessary to add new position as last array element
         unset($this->positions[$name]);
-        $this->positions[$name] = $after;
+        $this->positions[$name] = $afterColumn;
     }
 
     private function getColumnDefinition(rex_sql_column $column)

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -135,8 +135,15 @@ class rex_sql_table_test extends PHPUnit_Framework_TestCase
         $this->assertEquals($title, $table->getColumn('title'));
         $this->assertEquals($description, $table->getColumn('description'));
 
-        $columns = array_keys($table->getColumns());
         $this->assertSame(['id', 'description', 'title'], array_keys($table->getColumns()));
+
+        $table
+            ->ensureColumn($title, 'id')
+            ->ensureColumn(new rex_sql_column('status', 'tinyint(1)'), 'id')
+            ->ensureColumn($title, 'status')
+            ->alter();
+
+        $this->assertSame(['id', 'status', 'title', 'description'], array_keys($table->getColumns()));
     }
 
     public function testRenameColumn()

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -140,10 +140,18 @@ class rex_sql_table_test extends PHPUnit_Framework_TestCase
         $table
             ->ensureColumn($title, 'id')
             ->ensureColumn(new rex_sql_column('status', 'tinyint(1)'), 'id')
+            ->ensureColumn(new rex_sql_column('created', 'datetime'), 'status')
             ->ensureColumn($title, 'status')
             ->alter();
 
-        $this->assertSame(['id', 'status', 'title', 'description'], array_keys($table->getColumns()));
+        $expectedOrder = ['id', 'status', 'title', 'created', 'description'];
+
+        $this->assertSame($expectedOrder, array_keys($table->getColumns()));
+
+        rex_sql_table::clearInstance(self::TABLE);
+        $table = rex_sql_table::get(self::TABLE);
+
+        $this->assertSame($expectedOrder, array_keys($table->getColumns()));
     }
 
     public function testRenameColumn()

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -98,17 +98,21 @@ class rex_sql_table_test extends PHPUnit_Framework_TestCase
     {
         $table = $this->createTable();
 
-        $column = new rex_sql_column('description', 'text', true);
+        $description = new rex_sql_column('description', 'text', true);
         $table
-            ->addColumn($column)
+            ->addColumn($description)
+            ->addColumn(new rex_sql_column('name', 'varchar(255)'), 'id')
+            ->addColumn(new rex_sql_column('pid', 'int(11)'), rex_sql_table::FIRST)
             ->alter();
 
-        $this->assertSame($column, $table->getColumn('description'));
+        $this->assertSame($description, $table->getColumn('description'));
 
         rex_sql_table::clearInstance(self::TABLE);
         $table = rex_sql_table::get(self::TABLE);
 
-        $this->assertEquals($column, $table->getColumn('description'));
+        $this->assertEquals($description, $table->getColumn('description'));
+
+        $this->assertSame(['pid', 'id', 'name', 'title', 'description'], array_keys($table->getColumns()));
     }
 
     public function testEnsureColumn()
@@ -118,8 +122,8 @@ class rex_sql_table_test extends PHPUnit_Framework_TestCase
         $title = new rex_sql_column('title', 'varchar(20)', false);
         $description = new rex_sql_column('description', 'text', true);
         $table
-            ->ensureColumn($title)
             ->ensureColumn($description)
+            ->ensureColumn($title, 'description')
             ->alter();
 
         $this->assertSame($title, $table->getColumn('title'));
@@ -130,6 +134,9 @@ class rex_sql_table_test extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($title, $table->getColumn('title'));
         $this->assertEquals($description, $table->getColumn('description'));
+
+        $columns = array_keys($table->getColumns());
+        $this->assertSame(['id', 'description', 'title'], array_keys($table->getColumns()));
     }
 
     public function testRenameColumn()
@@ -250,28 +257,38 @@ class rex_sql_table_test extends PHPUnit_Framework_TestCase
     {
         $table = rex_sql_table::get(self::TABLE);
         $table
-            ->ensureColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment'))
             ->ensureColumn(new rex_sql_column('title', 'varchar(255)', false, 'Default title'))
-            ->ensureColumn(new rex_sql_column('description', 'text', true))
+            ->ensureColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment'), rex_sql_table::FIRST)
+            ->ensureColumn(new rex_sql_column('status', 'tinyint(1)'))
+            ->ensureColumn(new rex_sql_column('timestamp', 'datetime', true))
+            ->ensureColumn(new rex_sql_column('description', 'text', true), 'title')
             ->setPrimaryKey('id')
             ->ensure();
 
         $this->assertTrue($table->exists());
+        $this->assertSame(['id', 'title', 'description', 'status', 'timestamp'], array_keys($table->getColumns()));
 
         rex_sql_table::clearInstance(self::TABLE);
         $table = rex_sql_table::get(self::TABLE);
 
         $table
+            ->ensureColumn(new rex_sql_column('timestamp', 'datetime', true))
             ->ensureColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment'))
-            ->ensureColumn(new rex_sql_column('title', 'varchar(20)', false))
+            ->ensureColumn(new rex_sql_column('status', 'tinyint(1)'))
+            ->ensureColumn(new rex_sql_column('title', 'varchar(20)', false), 'timestamp')
             ->setPrimaryKey(['id', 'title'])
             ->ensure();
+
+        $expectedOrder = ['timestamp', 'title', 'id', 'status', 'description'];
+
+        $this->assertSame($expectedOrder, array_keys($table->getColumns()));
 
         rex_sql_table::clearInstance(self::TABLE);
         $table = rex_sql_table::get(self::TABLE);
 
-        $this->assertSame(['id', 'title'], $table->getPrimaryKey());
+        $this->assertSame(['title', 'id'], $table->getPrimaryKey());
         $this->assertTrue($table->hasColumn('description'));
         $this->assertNull($table->getColumn('title')->getDefault());
+        $this->assertSame($expectedOrder, array_keys($table->getColumns()));
     }
 }


### PR DESCRIPTION
Auch wenn die Reihenfolge der Spalten eigentlich nicht wichtig ist, fände ich es trotzdem cool, wenn man die Position angeben könnte.

Bevor ich aber die eigentliche Implementierung umsetze, erstmal die Frage, ob wir das überhaupt drin haben wollen.
Habe hier im PR mal die Api angedeutet, wie ich es mir vorstelle.