### PR TITLE
rex_config: ID entfernt, Primary Key direkt auf (namespace, key)

### DIFF
--- a/redaxo/src/core/install.sql
+++ b/redaxo/src/core/install.sql
@@ -14,12 +14,10 @@ CREATE TABLE `rex_clang` (
 INSERT INTO `rex_clang` VALUES (1, 'de', 'deutsch', 1, 1, 0);
 
 CREATE TABLE `rex_config` (
-    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
     `namespace` varchar(75) NOT NULL,
     `key` varchar(255) NOT NULL,
     `value` text NOT NULL,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `unique_key` (`namespace`,`key`)
+    PRIMARY KEY (`namespace`, `key`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 
 CREATE TABLE `rex_user` (

--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -57,4 +57,12 @@ deny from all
 HTACCESS;
 
     rex_file::put(rex_path::backend('bin/.htaccess'), $content);
+
+    rex_sql::factory()->setQuery('
+        ALTER TABLE '.rex::getTable('config').'
+            DROP PRIMARY KEY,
+            DROP KEY `unique_key`,
+            DROP `id`,
+            ADD PRIMARY KEY (`namespace`, `key`)
+    ');
 }


### PR DESCRIPTION
Die ID wurde nirgends verwendet, sondern es wurde sowieso mit dem Unique-Key über (namespace, key) gearbeitet.
Dadurch, dass rex_config [mit `REPLACE` arbeitet](https://github.com/redaxo/redaxo/blob/master/redaxo/src/core/lib/config.php#L364), und MySQL bei Replace immer löscht und neu anlegt, hat sich die ID auch noch bei jeder Änderung einer Konfiguration geändert.

Daher mein Vorschlag, die ID zu löschen und den Primary Key direkt auf die relevanten Spalten legen.

Hauptgrund dafür ist allerdings, dass ich es dann bei ydeploy einfacher habe, da ich dort nur einzelne Konfigurationen migrieren muss: https://github.com/yakamara/ydeploy/blob/edfbda300d3081ffd15173f3383b7ef594fba2bb/package.yml#L13-L15
Und diese ständig wechselnde ID stört dabei.