### PR TITLE
Basis-Klasse für Commands

### DIFF
--- a/redaxo/src/core/lib/console/command.php
+++ b/redaxo/src/core/lib/console/command.php
@@ -1,0 +1,17 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @package redaxo\core
+ */
+abstract class rex_console_command extends Command
+{
+    protected function getStyle(InputInterface $input, OutputInterface $output)
+    {
+        return new SymfonyStyle($input, $output);
+    }
+}


### PR DESCRIPTION
So können wir ggf. den Style mal allgemein für alle Commands anpassen.
(Alle, die diese Basis-Klasse nutzen.)

Auch können wir bei Bedarf irgendwelche Hilfsmethoden anbieten.