### PR TITLE
Media Manager: setSourcePath für Effekte nutzbar machen

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php
@@ -25,12 +25,10 @@ class rex_effect_convert2img extends rex_effect_abstract
         'jpg' => [
             'ext' => 'jpg',
             'content-type' => 'image/jpeg',
-            'createfunc' => 'imagecreatefromjpeg',
         ],
         'png' => [
             'ext' => 'png',
             'content-type' => 'image/png',
-            'createfunc' => 'imagecreatefrompng',
         ],
     ];
     private static $densities = [100, 150, 200, 300, 600];
@@ -85,18 +83,15 @@ class rex_effect_convert2img extends rex_effect_abstract
             return false;
         }
 
-        $image_src = call_user_func($convert_to['createfunc'], $to_path);
-
-        if (!$image_src) {
-            return;
-        }
-
-        $this->media->setImage($image_src);
+        $this->media->setSourcePath($to_path);
         $this->media->refreshImageDimensions();
         $this->media->setFormat($convert_to['ext']);
         $this->media->setMediaFilename($filename);
         $this->media->setHeader('Content-Type', $convert_to['content-type']);
-        unlink($to_path);
+
+        register_shutdown_function(function () use ($to_path) {
+            rex_file::delete($to_path);
+        });
     }
 
     public function getParams()

--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -29,6 +29,13 @@ class rex_managed_media
         $this->format = strtolower(rex_file::extension($this->getMediapath()));
     }
 
+    /**
+     * Returns the original path of the media.
+     *
+     * To get the current source path (can be changed by effects) use `getSourcePath` instead.
+     *
+     * @return string
+     */
     public function getMediapath()
     {
         return $this->media_path;
@@ -201,6 +208,13 @@ class rex_managed_media
         }
     }
 
+    /**
+     * Returns the current source path.
+     *
+     * To get the original media path use `getMediapath()` instead.
+     *
+     * @return string
+     */
     public function getSourcePath()
     {
         return $this->sourcePath;

--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -86,13 +86,13 @@ class rex_managed_media
 
         if ($this->format == 'jpg' || $this->format == 'jpeg') {
             $this->format = 'jpeg';
-            $this->image['src'] = @imagecreatefromjpeg($this->getMediapath());
+            $this->image['src'] = @imagecreatefromjpeg($this->getSourcePath());
         } elseif ($this->format == 'gif') {
-            $this->image['src'] = @imagecreatefromgif($this->getMediapath());
+            $this->image['src'] = @imagecreatefromgif($this->getSourcePath());
         } elseif ($this->format == 'wbmp') {
-            $this->image['src'] = @imagecreatefromwbmp($this->getMediapath());
+            $this->image['src'] = @imagecreatefromwbmp($this->getSourcePath());
         } else {
-            $this->image['src'] = @imagecreatefrompng($this->getMediapath());
+            $this->image['src'] = @imagecreatefrompng($this->getSourcePath());
             if ($this->image['src']) {
                 imagealphablending($this->image['src'], false);
                 imagesavealpha($this->image['src'], true);
@@ -101,7 +101,7 @@ class rex_managed_media
         }
 
         if (!$this->image['src']) {
-            $this->setMediapath(rex_path::addon('media_manager', 'media/warning.jpg'));
+            $this->setSourcePath(rex_path::addon('media_manager', 'media/warning.jpg'));
             $this->asImage();
         } else {
             $this->refreshImageDimensions();
@@ -193,6 +193,12 @@ class rex_managed_media
     public function setSourcePath($path)
     {
         $this->sourcePath = $path;
+
+        $this->asImage = false;
+
+        if (isset($this->image['src']) && is_resource($this->image['src'])) {
+            imagedestroy($this->image['src']);
+        }
     }
 
     public function getSourcePath()


### PR DESCRIPTION
Gemäß Diskussion in Slack. Muss es aber selbst erst noch testen.