### PR TITLE
add progressive mode for images

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effects/effect_progressive.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_progressive.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Schaltet ein Bild in den Progressive Modus.
+ *
+ * @package redaxo\media-manager
+ */
+class rex_effect_progressive extends rex_effect_abstract
+{
+    public function execute()
+    {
+        $this->media->asImage();
+        $gdimage = $this->media->getImage();
+        imageinterlace($gdimage, 1);
+        $this->media->setImage($gdimage);
+    }
+}


### PR DESCRIPTION
Redaxo sendet alle Bilder Interlaced raus, mit diesem kleinen Effekt kann man in den progressive Modus umschalten. Ist für Ladezeiten manchmal spannend, da die Bilder anders geladen werden.