### PR TITLE
rex_sql_column: Bei Primary Key `null` für 'kein PK' nehmen

### DIFF
--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -197,21 +197,21 @@ class rex_sql_table
     }
 
     /**
-     * @return string[] Column names
+     * @return null|string[] Column names
      */
     public function getPrimaryKey()
     {
-        return $this->primaryKey;
+        return $this->primaryKey ?: null;
     }
 
     /**
-     * @param string|string[] $columns Column name(s)
+     * @param null|string|string[] $columns Column name(s)
      *
      * @return $this
      */
     public function setPrimaryKey($columns)
     {
-        $columns = (array) $columns;
+        $columns = null === $columns ? [] : (array) $columns;
 
         if ($this->primaryKey === $columns) {
             return $this;

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -208,9 +208,15 @@ class rex_sql_table
      * @param null|string|string[] $columns Column name(s)
      *
      * @return $this
+     *
+     * @throws rex_exception
      */
     public function setPrimaryKey($columns)
     {
+        if (is_array($columns) && !$columns) {
+            throw new rex_exception('The primary key column array can not be empty. To delete the primary key use `null` instead.');
+        }
+
         $columns = null === $columns ? [] : (array) $columns;
 
         if ($this->primaryKey === $columns) {

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -166,13 +166,13 @@ class rex_sql_table_test extends PHPUnit_Framework_TestCase
 
         $table->getColumn('id')->setExtra(null);
         $table
-            ->setPrimaryKey([])
+            ->setPrimaryKey(null)
             ->alter();
 
         rex_sql_table::clearInstance(self::TABLE);
         $table = rex_sql_table::get(self::TABLE);
 
-        $this->assertSame([], $table->getPrimaryKey());
+        $this->assertNull($table->getPrimaryKey());
     }
 
     public function testAlter()


### PR DESCRIPTION
Hier nun mal konkret als Diskussionsgrundlage..

Ich würde `null` für 'kein PK' nehmen, sowohl im Setter, als auch im Getter.
Denke das passt besser zu 'kein PK' als ein leeres Array.

Eine extra Methode `noPrimaryKey` würde ich hier nicht einführen. Wenn `getPrimaryKey` in dem Fall `null` zurück liefert, sollte man diesen Wert auch dem Setter übergeben können. Und dann finde ich die extra Methode überflüssig.
(Vermutlich reden wir hier sowieso über einen sehr theoretischen Fall, da man sehr selten PKs löscht, man ändert sie wenn eher direkt).