### PR TITLE
body-Klasse für Debug-Mode hinzugefügt

### DIFF
--- a/redaxo/src/core/layout/top.php
+++ b/redaxo/src/core/layout/top.php
@@ -31,6 +31,9 @@ $body_attr['class'] = ['rex-is-logged-out'];
 if (rex::getUser()) {
     $body_attr['class'] = ['rex-is-logged-in'];
 }
+if (rex::isDebugMode()) {
+    $body_attr['class'][] = 'rex-is-debugmode';
+}
 if (rex::isSafeMode()) {
     $body_attr['class'][] = 'rex-is-safemode';
 }


### PR DESCRIPTION
Ich fände sie nützlich, um z. B. im JS eines Addons auslesen zu können, ob der Debug-Modus aktiv ist. Für den Safemode gibt es bereits eine solche Klasse, für Debug fehlte sie noch.