### PR TITLE
PHPMAILER :: XMailer auf REXMailer gesetzt

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -23,6 +23,7 @@ class rex_mailer extends PHPMailer
         $this->CharSet = $addon->getConfig('charset');
         $this->WordWrap = $addon->getConfig('wordwrap');
         $this->Encoding = $addon->getConfig('encoding');
+        $this->XMailer = 'PHPMailer';
         if ($addon->getConfig('priority') == 0) {
             $this->Priority = null;
         } else {

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -13,7 +13,7 @@ class rex_mailer extends PHPMailer
     public function __construct($exceptions = false)
     {
         $addon = rex_addon::get('phpmailer');
-
+        $this->XMailer = 'REXMailer';
         $this->From = $addon->getConfig('from');
         $this->FromName = $addon->getConfig('fromname');
         $this->ConfirmReadingTo = $addon->getConfig('confirmto');
@@ -23,14 +23,12 @@ class rex_mailer extends PHPMailer
         $this->CharSet = $addon->getConfig('charset');
         $this->WordWrap = $addon->getConfig('wordwrap');
         $this->Encoding = $addon->getConfig('encoding');
-        $this->XMailer = 'PHPMailer';
         if ($addon->getConfig('priority') == 0) {
             $this->Priority = null;
         } else {
             $this->Priority = $addon->getConfig('priority');
         }
         $this->SMTPDebug = $addon->getConfig('smtp_debug');
-
         $this->SMTPSecure = $addon->getConfig('smtpsecure');
         $this->SMTPAuth = $addon->getConfig('smtpauth');
         $this->Username = $addon->getConfig('username');


### PR DESCRIPTION
Original wird mit Versionsnummer übertragen, das sollte vermieden werden.