### PR TITLE
faster sepia with imagefilter()

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effects/effect_filter_sepia.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_filter_sepia.php
@@ -9,9 +9,9 @@ class rex_effect_filter_sepia extends rex_effect_abstract
     {
         $this->media->asImage();
         $img = $this->media->getImage();
-        imagefilter($img,IMG_FILTER_GRAYSCALE);
-        imagefilter($img,IMG_FILTER_BRIGHTNESS,-30);
-        imagefilter($img,IMG_FILTER_COLORIZE, 90, 55, 30);
+        imagefilter($img, IMG_FILTER_GRAYSCALE);
+        imagefilter($img, IMG_FILTER_BRIGHTNESS, -30);
+        imagefilter($img, IMG_FILTER_COLORIZE, 90, 55, 30);
         $this->keepTransparent($img);
         $this->media->setImage($img);
     }

--- a/redaxo/src/addons/media_manager/lib/effects/effect_filter_sepia.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_filter_sepia.php
@@ -9,28 +9,10 @@ class rex_effect_filter_sepia extends rex_effect_abstract
     {
         $this->media->asImage();
         $img = $this->media->getImage();
-
-        if (!($t = imagecolorstotal($img))) {
-            $t = 256;
-            imagetruecolortopalette($img, true, $t);
-        }
-        $total = imagecolorstotal($img);
-        for ($i = 0; $i < $total; ++$i) {
-            $index = imagecolorsforindex($img, $i);
-            $red = ($index['red'] * 0.393 + $index['green'] * 0.769 + $index['blue'] * 0.189);
-            $green = ($index['red'] * 0.349 + $index['green'] * 0.686 + $index['blue'] * 0.168);
-            $blue = ($index['red'] * 0.272 + $index['green'] * 0.534 + $index['blue'] * 0.131);
-            if ($red > 255) {
-                $red = 255;
-            }
-            if ($green > 255) {
-                $green = 255;
-            }
-            if ($blue > 255) {
-                $blue = 255;
-            }
-            imagecolorset($img, $i, $red, $green, $blue);
-        }
+        imagefilter($img,IMG_FILTER_GRAYSCALE);
+        imagefilter($img,IMG_FILTER_BRIGHTNESS,-30);
+        imagefilter($img,IMG_FILTER_COLORIZE, 90, 55, 30);
+        $this->keepTransparent($img);
         $this->media->setImage($img);
     }
 


### PR DESCRIPTION
Pro: 
* kein BC
* schneller
* übersichtlicher code
* Alphasupport

Nachteile:
* Leichte Farbunterschiede zur vorherigen Version, sind aber saubere "Sepia" Werte.