### PR TITLE
faster greyscale using imagefilter()

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effects/effect_filter_greyscale.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_filter_greyscale.php
@@ -8,39 +8,16 @@ class rex_effect_filter_greyscale extends rex_effect_abstract
     public function execute()
     {
         $this->media->asImage();
+        $img = $this->media->getImage();
 
-        $gdimage = $this->media->getImage();
-        $w = $this->media->getWidth();
-        $h = $this->media->getHeight();
+        imagefilter($img, IMG_FILTER_GRAYSCALE);
 
-        $src_x = ceil($w);
-        $src_y = ceil($h);
-        $dst_x = $src_x;
-        $dst_y = $src_y;
-        $dst_im = imagecreatetruecolor($dst_x, $dst_y);
-
-        imagecopyresampled($dst_im, $gdimage, 0, 0, 0, 0, $dst_x, $dst_y, $src_x, $src_y);
-
-        for ($c = 0; $c < 256; ++$c) {
-            $palette[$c] = imagecolorallocate($dst_im, $c, $c, $c);
-        }
-
-        for ($y = 0; $y < $src_y; ++$y) {
-            for ($x = 0; $x < $src_x; ++$x) {
-                $rgb = imagecolorat($dst_im, $x, $y);
-                $r = ($rgb >> 16) & 0xFF;
-                $g = ($rgb >> 8) & 0xFF;
-                $b = $rgb & 0xFF;
-                $gs = $r * 0.299 + $g * 0.587 + $b * 0.114;
-                imagesetpixel($dst_im, $x, $y, $palette[$gs]);
-            }
-        }
-
-        $this->media->setImage($dst_im);
+        $this->media->setImage($img);
     }
 
     public function getParams()
     {
-        return [];
+        return [
+        ];
     }
 }


### PR DESCRIPTION
Auch hier Umbau zum nativen imagefilter()

* ist wesentlich schneller
* übersichtlicher im Code
* Alphasupport

Hier würde ich überlegen, noch IMG_FILTER_BRIGHTNESS mit einzubauen, da man darüber feinere S/W Einstellungen hinbekommt. Aber vermutlich wäre ein eigener Brightness Effekt angebracht