### PR TITLE
resize sollte bikubisch interpoliert werden

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effects/effect_resize.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_resize.php
@@ -96,7 +96,7 @@ class rex_effect_resize extends rex_effect_abstract
         // Transparenz erhalten
         $this->keepTransparent($des);
         imagecopyresampled($des, $gdimage, 0, 0, 0, 0, $this->params['width'], $this->params['height'], $w, $h);
-
+        imagesetinterpolation($des, IMG_BICUBIC_FIXED);
         $this->media->setImage($des);
         $this->media->refreshImageDimensions();
     }


### PR DESCRIPTION
bessere und weniger veschwommene qualität