### PR TITLE
show current commit hash in rex-version

### DIFF
--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -291,6 +291,21 @@ class rex
     public static function getVersion($format = null)
     {
         $version = self::getProperty('version');
+
+        static $gitHash = null;
+        if (null === $gitHash && strpos($version, '-dev') !== false) {
+            $gitHash = ''; // exec only once
+
+            exec('which git 2>&1 1>/dev/null && git show --oneline -s', $output, $exitCode);
+            if ($exitCode == 0) {
+                $output = implode("",$output);
+                if (preg_match('{^[0-9a-f]+}', $output, $matches)) {
+                    $gitHash = $matches[0];
+                    $version .= '#'.$gitHash;
+                }
+            }
+        }
+
         if ($format) {
             return rex_formatter::version($version, $format);
         }

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -298,7 +298,7 @@ class rex
 
             exec('which git 2>&1 1>/dev/null && git show --oneline -s', $output, $exitCode);
             if ($exitCode == 0) {
-                $output = implode("",$output);
+                $output = implode("", $output);
                 if (preg_match('{^[0-9a-f]+}', $output, $matches)) {
                     $gitHash = $matches[0];
                     $version .= '#'.$gitHash;

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -317,7 +317,7 @@ class rex
             $command = 'which git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';
             @exec($command, $output, $exitCode);
             if ($exitCode === 0) {
-                $output = implode("", $output);
+                $output = implode('', $output);
                 if (preg_match('{^[0-9a-f]+}', $output, $matches)) {
                     $gitHash[$path] = $matches[0];
                 }

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -313,7 +313,7 @@ class rex
             $gitHash[$path] = false; // exec only once
 
             $command = 'which git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';
-            exec($command, $output, $exitCode);
+            @exec($command, $output, $exitCode);
             if ($exitCode == 0) {
                 $output = implode("", $output);
                 if (preg_match('{^[0-9a-f]+}', $output, $matches)) {

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -292,24 +292,37 @@ class rex
     {
         $version = self::getProperty('version');
 
-        static $gitHash = null;
-        if (null === $gitHash && strpos($version, '-dev') !== false) {
-            $gitHash = ''; // exec only once
-
-            exec('which git 2>&1 1>/dev/null && git show --oneline -s', $output, $exitCode);
-            if ($exitCode == 0) {
-                $output = implode("", $output);
-                if (preg_match('{^[0-9a-f]+}', $output, $matches)) {
-                    $gitHash = $matches[0];
-                    $version .= '#'.$gitHash;
-                }
-            }
-        }
-
         if ($format) {
             return rex_formatter::version($version, $format);
         }
         return $version;
+    }
+
+    /**
+     * Returns the current git version hash for the given path.
+     *
+     * @param string $path A local filesystem path
+     *
+     * @return false|string
+     */
+    public static function getVersionHash($path)
+    {
+        static $gitHash = [];
+
+        if (!isset($gitHash[$path])) {
+            $gitHash[$path] = false; // exec only once
+
+            $command = 'which git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';
+            exec($command, $output, $exitCode);
+            if ($exitCode == 0) {
+                $output = implode("", $output);
+                if (preg_match('{^[0-9a-f]+}', $output, $matches)) {
+                    $gitHash[$path] = $matches[0];
+                }
+            }
+        }
+
+        return $gitHash[$path];
     }
 
     /**

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -311,10 +311,12 @@ class rex
 
         if (!isset($gitHash[$path])) {
             $gitHash[$path] = false; // exec only once
+            $output = '';
+            $exitCode = null;
 
             $command = 'which git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';
             @exec($command, $output, $exitCode);
-            if ($exitCode == 0) {
+            if ($exitCode === 0) {
                 $output = implode("", $output);
                 if (preg_match('{^[0-9a-f]+}', $output, $matches)) {
                     $gitHash[$path] = $matches[0];

--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -100,6 +100,14 @@ $version = rex_path::src();
 if (strlen($version) > 21) {
     $version = substr($version, 0, 8) . '..' . substr($version, strlen($version) - 13);
 }
+
+$rexVersion = rex::getVersion();
+if (strpos($rexVersion, '-dev') !== false) {
+    $hash = rex::getVersionHash(rex_path::base());
+    if ($hash) {
+        $rexVersion .= '#'. $hash;
+    }
+}
 $content = [];
 $content[] = '
                         <h3>' . rex_i18n::msg('delete_cache') . '</h3>
@@ -113,7 +121,7 @@ $content[] = '
 $content[] = '
                         <h3>' . rex_i18n::msg('version') . '</h3>
                         <dl class="dl-horizontal">
-                            <dt>REDAXO</dt><dd>' . rex::getVersion() . '</dd>
+                            <dt>REDAXO</dt><dd>' . $rexVersion . '</dd>
                             <dt>PHP</dt><dd>' . PHP_VERSION . ' <a href="' . rex_url::backendPage('system/phpinfo') . '" title="phpinfo" onclick="newWindow(\'phpinfo\', this.href, 1000,800,\',status=yes,resizable=yes\');return false;"><i class="rex-icon rex-icon-phpinfo"></i></a></dd>
                         </dl>
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/120441/24578436/ae03042e-16e0-11e7-91a1-b39d66bd9c6f.png)

ggf. könnte es probleme geben falls irgendwo jemand ein bestimmtes format für die version erwartet... bin mir unsicher. alternativ könnte man extra für die system seite und error page ne andere methode machen.

allerdings betrifft es sowieso nur `-dev` versionen, daher passts vllt auch so...