### PR TITLE
Update manager.php - Zeilenumbruch für logs

### DIFF
--- a/redaxo/src/addons/cronjob/lib/manager.php
+++ b/redaxo/src/addons/cronjob/lib/manager.php
@@ -98,7 +98,7 @@ class rex_cronjob_manager
             ($success ? 'SUCCESS' : 'ERROR'),
             ($this->id ?: '--'),
             $name,
-            strip_tags($message),
+            strip_tags(nl2br($message),'<br><b>'),
         ];
         $log->add($data);
     }


### PR DESCRIPTION
Zeilenumbruch in Log Message zulassen: 
strip_tags(nl2br($message),'<br><b>'),