### PR TITLE
ignore: history_user hinzugefügt

### DIFF
--- a/redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php
+++ b/redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php
@@ -75,7 +75,7 @@ class rex_article_slice_history
             $sql = rex_sql::factory();
             $sql->setTable(rex::getTable('article_slice'));
 
-            $ignore_fields = ['id', 'slice_id', 'history_date', 'history_type', 'history_user];
+            $ignore_fields = ['id', 'slice_id', 'history_date', 'history_type', 'history_user'];
             foreach ($slice as $k => $v) {
                 if (in_array($k, $ignore_fields)) {
                 } else {

--- a/redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php
+++ b/redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php
@@ -75,7 +75,7 @@ class rex_article_slice_history
             $sql = rex_sql::factory();
             $sql->setTable(rex::getTable('article_slice'));
 
-            $ignore_fields = ['id', 'slice_id', 'history_date', 'history_type'];
+            $ignore_fields = ['id', 'slice_id', 'history_date', 'history_type', 'history_user];
             foreach ($slice as $k => $v) {
                 if (in_array($k, $ignore_fields)) {
                 } else {


### PR DESCRIPTION
History kann wieder verwendet werden. Achtung! Bei Verwendung von Blöcks werden ggf. einige Slices in der Gegenüberstellung nicht angezeigt. Sie werden aber wiederhergestellt
https://github.com/redaxo/redaxo/issues/1171