### PR TITLE
path-provider: Bessere Vererbung und eigene Methode für bin-Ordner

### DIFF
--- a/redaxo/src/core/lib/util/path.php
+++ b/redaxo/src/core/lib/util/path.php
@@ -22,7 +22,7 @@ class rex_path
     }
 
     /**
-     * Returns a base path.
+     * Returns the base/root path.
      *
      * @param string $file File
      *
@@ -34,7 +34,7 @@ class rex_path
     }
 
     /**
-     * Returns the path to the frontend.
+     * Returns the path to the frontend (the document root).
      *
      * @param string $file File
      *
@@ -56,7 +56,7 @@ class rex_path
     }
 
     /**
-     * Returns the path to the backend.
+     * Returns the path to the backend (folder where the backend controller is placed).
      *
      * @param string $file File
      *

--- a/redaxo/src/core/lib/util/path.php
+++ b/redaxo/src/core/lib/util/path.php
@@ -145,6 +145,18 @@ class rex_path
     }
 
     /**
+     * Returns the path to the bin folder.
+     *
+     * @param string $file File
+     *
+     * @return string
+     */
+    public static function bin($file = '')
+    {
+        return self::$pathprovider->bin($file);
+    }
+
+    /**
      * Returns the path to the data folder.
      *
      * @param string $file File

--- a/redaxo/src/core/lib/util/path_default_provider.php
+++ b/redaxo/src/core/lib/util/path_default_provider.php
@@ -79,7 +79,7 @@ class rex_path_default_provider
     public function backend($file)
     {
         if ($this->provideAbsolutes) {
-            return $this->base($this->backend . '/' . $file);
+            return $this->frontend($this->backend . '/' . $file);
         }
         return $this->backend . $file;
     }
@@ -103,7 +103,7 @@ class rex_path_default_provider
      */
     public function media($file)
     {
-        return $this->base('media/' . $file);
+        return $this->frontend('media/' . $file);
     }
 
     /**
@@ -115,7 +115,7 @@ class rex_path_default_provider
      */
     public function assets($file)
     {
-        return $this->base('assets/' . $file);
+        return $this->frontend('assets/' . $file);
     }
 
     /**
@@ -159,6 +159,18 @@ class rex_path_default_provider
     public function pluginAssets($addon, $plugin, $file)
     {
         return $this->addonAssets($addon, 'plugins/' . $plugin . '/' . $file);
+    }
+
+    /**
+     * Returns the path to the bin folder.
+     *
+     * @param string $file File
+     *
+     * @return string
+     */
+    public function bin($file)
+    {
+        return $this->backend('bin/' . $file);
     }
 
     /**

--- a/redaxo/src/core/lib/util/path_default_provider.php
+++ b/redaxo/src/core/lib/util/path_default_provider.php
@@ -33,7 +33,7 @@ class rex_path_default_provider
     }
 
     /**
-     * Returns a base path.
+     * Returns the base/root path.
      *
      * @param string $file File
      *
@@ -48,7 +48,7 @@ class rex_path_default_provider
     }
 
     /**
-     * Returns the path to the frontend.
+     * Returns the path to the frontend (the document root).
      *
      * @param string $file File
      *
@@ -70,7 +70,7 @@ class rex_path_default_provider
     }
 
     /**
-     * Returns the path to the backend.
+     * Returns the path to the backend (folder where the backend controller is placed).
      *
      * @param string $file File
      *


### PR DESCRIPTION
Ich bin gerade bisschen am testen mit alternativen Path-Providern, da wir überlegen Redaxo bei unseren Yakamara-Projekten etwas umzustrukturieren (unter anderem die geschützen ordner raus aus dem doc-root).
Dabei ist mir aufgefallen, dass manche Pfade besser von `frontend()` ausgehen, als von `base()`. `frontend()` ist gedacht als Doc-Root, bei uns `/public`. `base()` ist das Basisverzeichnis, Projekt-Root.
Außerdem ist mir aufgefallen, dass noch eine Methode fehlt um zu definieren, wo der `bin`-Ordner liegt. Auch wenn die Methode aktuell gar nicht verwendet wird, halte ich sie für sinnvoll. Bisher könnte nur der Installer sie gebrauchen im Update-Skript, wo überhaupt die `bin/console` angelegt wird. Allerdings zum Ausführungszeitpunkt des Update-Skripts wird die Methode noch gar nicht vorhanden sein.