### PR TITLE
rex_sql: dump() nutzen für debug/error Ausgaben

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -991,24 +991,23 @@ class rex_sql implements Iterator
     /**
      * Gibt die letzte Fehlermeldung aus.
      */
-    protected function printError($qry, $params)
+protected function printError($qry, $params)
     {
-        echo '<hr />' . "\n";
-        echo 'Query: ' . nl2br(htmlspecialchars($qry)) . "<br />\n";
-
+		$errors['debug'] = true;
+		$errors['query'] = $qry;
         if (!empty($params)) {
-            echo 'Params: ' . htmlspecialchars(print_r($params, true)) . "<br />\n";
+			$errors['params'] = $params;
         }
-
         if (strlen($this->getRows()) > 0) {
-            echo 'Affected Rows: ' . $this->getRows() . "<br />\n";
+			$errors['count'] = $this->getRows();
         }
         if (strlen($this->getError()) > 0) {
-            echo 'Error Message: ' . htmlspecialchars($this->getError()) . "<br />\n";
-            echo 'Error Code: ' . $this->getErrno() . "<br />\n";
+			$errors['error'] = $this->getError();
+			$errors['ecode'] = $this->getErrno();
         }
+		dump($errors);
     }
-
+    
     /**
      * Setzt eine Spalte auf den naechst moeglich auto_increment Wert.
      *

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -991,23 +991,23 @@ class rex_sql implements Iterator
     /**
      * Gibt die letzte Fehlermeldung aus.
      */
-protected function printError($qry, $params)
+    protected function printError($qry, $params)
     {
-		$errors['debug'] = true;
-		$errors['query'] = $qry;
+        $errors['debug'] = true;
+        $errors['query'] = $qry;
         if (!empty($params)) {
-			$errors['params'] = $params;
+            $errors['params'] = $params;
         }
         if (strlen($this->getRows()) > 0) {
-			$errors['count'] = $this->getRows();
+            $errors['count'] = $this->getRows();
         }
         if (strlen($this->getError()) > 0) {
-			$errors['error'] = $this->getError();
-			$errors['ecode'] = $this->getErrno();
+            $errors['error'] = $this->getError();
+            $errors['ecode'] = $this->getErrno();
         }
-		dump($errors);
+        dump($errors);
     }
-    
+
     /**
      * Setzt eine Spalte auf den naechst moeglich auto_increment Wert.
      *


### PR DESCRIPTION
fixed #1248

Beim letzten if-Block bin ich mir unsicher, ob dieser überhaupt noch ausgegeben wird, bei meinem Test geht bereits Whoops! dazwischen, aber ich habe mich zunächst am Original orientiert.