### PR TITLE
Session-ID nur neugenerieren, wenn vorhanden

### DIFF
--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -283,7 +283,10 @@ class rex_login
      */
     protected static function regenerateSessionId()
     {
-        session_regenerate_id(true);
+        if ('' != session_id()) {
+            session_regenerate_id(true);
+        }
+
         // session-id is shared between frontend/backend or even redaxo instances per server because it's the same http session
         $_SESSION['REX_SESSID'] = session_id();
     }


### PR DESCRIPTION
fixes #1054 

Ich habe die Warnung bei mir nie.
Denke aber, so sollte das gelöst sein, oder?

https://stackoverflow.com/questions/8549757/why-session-object-destruction-failed