### PR TITLE
autocomplete=new-password nutzen

### DIFF
--- a/redaxo/src/addons/phpmailer/pages/config.php
+++ b/redaxo/src/addons/phpmailer/pages/config.php
@@ -200,7 +200,7 @@ $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="phpmailer-password">' . $this->i18n('smtp_password') . '</label>';
-$n['field'] = '<input class="form-control" id="phpmailer-password" type="text" name="settings[password]" value="' . $this->getConfig('password') . '" />';
+$n['field'] = '<input class="form-control" id="phpmailer-password" type="text" name="settings[password]" value="' . $this->getConfig('password') . '" autocomplete="new-password" />';
 $formElements[] = $n;
 
 $n = [];

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -387,7 +387,7 @@ if ($FUNC_ADD != '' || $user_id > 0) {
 
     $n = [];
     $n['label'] = '<label for="rex-js-user-password">' . rex_i18n::msg('password') . '</label>';
-    $n['field'] = '<input class="form-control" type="password" id="rex-js-user-password" name="userpsw" autocomplete="off" />';
+    $n['field'] = '<input class="form-control" type="password" id="rex-js-user-password" name="userpsw" autocomplete="new-password"/>';
 
     if (rex::getProperty('pswfunc') != '') {
         $n['note'] = rex_i18n::msg('psw_encrypted');


### PR DESCRIPTION
closes #1245
closes #1270

Im PHPMailer konnte ich es bei mir gar nicht reproduzieren, dass das Passwort-Feld vorausgefüllt wird. Daher die Frage an @alexplusde: Ist das so für dich gelöst?

Auch ping an @skerbis: Bei dir löst es das Problem definitiv noch nicht im Edge?