### PR TITLE
rex_socket: Bessere Fehlermeldungen

### DIFF
--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -263,13 +263,15 @@ class rex_socket
             }
         });
 
-        if ($this->stream = @fsockopen($host, $this->port, $errno, $errstr)) {
+        $this->stream = @fsockopen($host, $this->port, $errno, $errstr);
+
+        restore_error_handler();
+
+        if ($this->stream) {
             stream_set_timeout($this->stream, $this->timeout);
 
             return;
         }
-
-        restore_error_handler();
 
         if ($errstr) {
             throw new rex_socket_exception($errstr . ' (' . $errno . ')');


### PR DESCRIPTION
fixes #784

Mit `error_get_last` bin ich nicht zum Ziel gekommen, war leer.
Auch ist es so, dass die letzte Warning nicht zum eigentlichen Fehler führt, es werden öfters gleich drei geworfen (siehe Issue), und dabei ist die erste die interessanteste. 
Daher fange ich die nun ab.