### PR TITLE
Konsolenkommandos: Optionaler Single-Package-Modus

### DIFF
--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -11,7 +11,7 @@ $application = new rex_console_application();
 
 rex::setProperty('console', $application);
 
-require rex_path::core('packages.php');
+rex_addon::initialize();
 
 $application->setCommandLoader(new rex_console_command_loader());
 

--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -39,7 +39,7 @@ class rex_console_application extends Application
 
     private function loadPackages(rex_console_command $command)
     {
-        if ($command->requiresOtherPackages()) {
+        if ('ydeploy:migrate' !== $command->getName()) {
             require rex_path::core('packages.php');
 
             return;

--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -46,7 +46,7 @@ class rex_console_application extends Application
         }
 
         $package = $command->getPackage();
-        $package->register();
+        $package->enlist();
         $package->boot();
     }
 }

--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -1,6 +1,7 @@
 <?php
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
@@ -25,5 +26,27 @@ class rex_console_application extends Application
         } catch (\Throwable $e) {
             throw new FatalThrowableError($e);
         }
+    }
+
+    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
+    {
+        if ($command instanceof rex_console_command) {
+            $this->loadPackages($command);
+        }
+
+        return parent::doRunCommand($command, $input, $output);
+    }
+
+    private function loadPackages(rex_console_command $command)
+    {
+        if ($command->requiresOtherPackages()) {
+            require rex_path::core('packages.php');
+
+            return;
+        }
+
+        $package = $command->getPackage();
+        $package->register();
+        $package->boot();
     }
 }

--- a/redaxo/src/core/lib/console/command.php
+++ b/redaxo/src/core/lib/console/command.php
@@ -25,6 +25,11 @@ abstract class rex_console_command extends Command
         return $this->package;
     }
 
+    public function requiresOtherPackages()
+    {
+        return true;
+    }
+
     protected function getStyle(InputInterface $input, OutputInterface $output)
     {
         return new SymfonyStyle($input, $output);

--- a/redaxo/src/core/lib/console/command.php
+++ b/redaxo/src/core/lib/console/command.php
@@ -25,11 +25,6 @@ abstract class rex_console_command extends Command
         return $this->package;
     }
 
-    public function requiresOtherPackages()
-    {
-        return true;
-    }
-
     protected function getStyle(InputInterface $input, OutputInterface $output)
     {
         return new SymfonyStyle($input, $output);

--- a/redaxo/src/core/lib/console/command_loader.php
+++ b/redaxo/src/core/lib/console/command_loader.php
@@ -5,6 +5,8 @@ use Symfony\Component\Console\Exception\CommandNotFoundException;
 
 /**
  * @package redaxo\core
+ *
+ * @internal
  */
 class rex_console_command_loader implements CommandLoaderInterface
 {

--- a/redaxo/src/core/lib/packages/package.php
+++ b/redaxo/src/core/lib/packages/package.php
@@ -295,6 +295,43 @@ abstract class rex_package implements rex_package_interface
         $this->propertiesLoaded = true;
     }
 
+    public function register()
+    {
+        $folder = $this->getPath();
+
+        // add addon path for i18n
+        if (is_readable($folder . 'lang')) {
+            rex_i18n::addDirectory($folder . 'lang');
+        }
+        // add package path for fragment loading
+        if (is_readable($folder . 'fragments')) {
+            rex_fragment::addDirectory($folder . 'fragments' . DIRECTORY_SEPARATOR);
+        }
+        // add addon path for class-loading
+        if (is_readable($folder . 'lib')) {
+            rex_autoload::addDirectory($folder . 'lib');
+        }
+        if (is_readable($folder . 'vendor')) {
+            rex_autoload::addDirectory($folder . 'vendor');
+        }
+        $autoload = $this->getProperty('autoload');
+        if (is_array($autoload) && isset($autoload['classes']) && is_array($autoload['classes'])) {
+            foreach ($autoload['classes'] as $dir) {
+                $dir = $this->getPath($dir);
+                if (is_readable($dir)) {
+                    rex_autoload::addDirectory($dir);
+                }
+            }
+        }
+    }
+
+    public function boot()
+    {
+        if (is_readable($this->getPath(self::FILE_BOOT))) {
+            $this->includeFile(self::FILE_BOOT);
+        }
+    }
+
     /**
      * Returns the registered packages.
      *

--- a/redaxo/src/core/lib/packages/package.php
+++ b/redaxo/src/core/lib/packages/package.php
@@ -295,7 +295,7 @@ abstract class rex_package implements rex_package_interface
         $this->propertiesLoaded = true;
     }
 
-    public function register()
+    public function enlist()
     {
         $folder = $this->getPath();
 

--- a/redaxo/src/core/packages.php
+++ b/redaxo/src/core/packages.php
@@ -17,43 +17,12 @@ if (rex::isSetup() || rex::isSafeMode()) {
 // in the first run, we register all folders for class- and fragment-loading,
 // so it is transparent in which order the addons are included afterwards.
 foreach ($packageOrder as $packageId) {
-    $package = rex_package::get($packageId);
-    $folder = $package->getPath();
-
-    // add addon path for i18n
-    if (is_readable($folder . 'lang')) {
-        rex_i18n::addDirectory($folder . 'lang');
-    }
-    // add package path for fragment loading
-    if (is_readable($folder . 'fragments')) {
-        rex_fragment::addDirectory($folder . 'fragments' . DIRECTORY_SEPARATOR);
-    }
-    // add addon path for class-loading
-    if (is_readable($folder . 'lib')) {
-        rex_autoload::addDirectory($folder . 'lib');
-    }
-    if (is_readable($folder . 'vendor')) {
-        rex_autoload::addDirectory($folder . 'vendor');
-    }
-    $autoload = $package->getProperty('autoload');
-    if (is_array($autoload) && isset($autoload['classes']) && is_array($autoload['classes'])) {
-        foreach ($autoload['classes'] as $dir) {
-            $dir = $package->getPath($dir);
-            if (is_readable($dir)) {
-                rex_autoload::addDirectory($dir);
-            }
-        }
-    }
+    rex_package::get($packageId)->register();
 }
 
 // now we actually include the addons logic
 foreach ($packageOrder as $packageId) {
-    $package = rex_package::get($packageId);
-
-    // include the addon itself
-    if (is_readable($package->getPath(rex_package::FILE_BOOT))) {
-        $package->includeFile(rex_package::FILE_BOOT);
-    }
+    rex_package::get($packageId)->boot();
 }
 
 // ----- all addons configs included

--- a/redaxo/src/core/packages.php
+++ b/redaxo/src/core/packages.php
@@ -17,7 +17,7 @@ if (rex::isSetup() || rex::isSafeMode()) {
 // in the first run, we register all folders for class- and fragment-loading,
 // so it is transparent in which order the addons are included afterwards.
 foreach ($packageOrder as $packageId) {
-    rex_package::get($packageId)->register();
+    rex_package::get($packageId)->enlist();
 }
 
 // now we actually include the addons logic


### PR DESCRIPTION
Gestern bin ich über ein größeres Problem bei YDeploy gestolpert, welches ich bisher leider irgendwie gar nicht bedacht habe.

Thomas hat ein Addon geupdated, `ydeploy:diff` ausgeführt, und commitet.
Ich habe anschließend gepullt, und wollte die Änderungen migrieren.
Während der Ausführung von `ydeploy:migrate` wird Redaxo aber ja auch geladen, inklusive Addons.
Somit wurde von dem geupdateten Addon die neue `boot.php` geladen, die DB war aber ja noch alt, da ich sie ja gerade erst updaten wollte. Daher schlug die Migration fehl.

Daher ist nun meine Idee, dass Konsolenkommandos optional im Single-Package-Modus laufen können, dann wird nur der Core und das Package, dass den Command bereitstellt, geladen.

Um das zu ermöglichen, müssen die Kommandos doch über die `package.yml` registriert werden, statt über die `boot.php` wie [bisher](https://github.com/yakamara/ydeploy/blob/master/boot.php#L3-L6). Sieht dann so aus:

```yaml
console_commands:
    ydeploy:diff: rex_ydeploy_command_diff
    ydeploy:migrate: rex_ydeploy_command_migrate
```

Außerdem benötigen wir leider symfony/console 3.4-dev, da erst da die CommandLoader reinkommen.

Auch muss man wissen, dass nun das jeweilige Command-Objekt erzeugt wird, bevor die Addons geladen werden. Ich denke, in der Regel wird das aber gar nicht auffallen.