### PR TITLE
rex_redirect: Korrektur Validierung & rex_response nutzen

### DIFF
--- a/redaxo/src/addons/structure/functions/function_rex_url.php
+++ b/redaxo/src/addons/structure/functions/function_rex_url.php
@@ -66,12 +66,11 @@ function rex_getUrl($id = null, $clang = null, array $params = [], $separator = 
  */
 function rex_redirect($article_id, $clang = null, array $params = [])
 {
-    if ((int) $article_id == $article_id) {
+    if (null !== $article_id && '' !== $article_id && !is_int($article_id) && $article_id !== (string) (int) $article_id) {
         throw new InvalidArgumentException(sprintf('"%s" is not a valid article_id!', $article_id));
     }
 
-    // Alle OBs schließen
-    while (@ob_end_clean());
+    rex_response::cleanOutputBuffers();
 
     header('Location: ' . rex_getUrl($article_id, $clang, $params, '&'));
     exit();

--- a/redaxo/src/addons/structure/functions/function_rex_url.php
+++ b/redaxo/src/addons/structure/functions/function_rex_url.php
@@ -70,8 +70,5 @@ function rex_redirect($article_id, $clang = null, array $params = [])
         throw new InvalidArgumentException(sprintf('"%s" is not a valid article_id!', $article_id));
     }
 
-    rex_response::cleanOutputBuffers();
-
-    header('Location: ' . rex_getUrl($article_id, $clang, $params, '&'));
-    exit();
+    rex_response::sendRedirect(rex_getUrl($article_id, $clang, $params, '&'));
 }

--- a/redaxo/src/addons/structure/plugins/content/pages/content.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.php
@@ -370,7 +370,6 @@ if ($article->getRows() == 1) {
             if (rex::getUser()->hasPerm('moveArticle[]') && rex::getUser()->getComplexPerm('structure')->hasCategoryPerm($category_id_new)) {
                 if (rex_article_service::moveArticle($article_id, $category_id, $category_id_new)) {
                     $info = rex_i18n::msg('content_articlemoved');
-                    ob_end_clean();
                     rex_response::sendRedirect($context->getUrl(['info' => $info], false));
                 } else {
                     $warning = rex_i18n::msg('content_errormovearticle');
@@ -387,7 +386,6 @@ if ($article->getRows() == 1) {
             if (rex::getUser()->hasPerm('copyArticle[]') && rex::getUser()->getComplexPerm('structure')->hasCategoryPerm($category_copy_id_new)) {
                 if (($new_id = rex_article_service::copyArticle($article_id, $category_copy_id_new)) !== false) {
                     $info = rex_i18n::msg('content_articlecopied');
-                    ob_end_clean();
                     rex_response::sendRedirect($context->getUrl(['article_id' => $new_id, 'info' => $info], false));
                 } else {
                     $warning = rex_i18n::msg('content_errorcopyarticle');
@@ -404,7 +402,6 @@ if ($article->getRows() == 1) {
             if (rex::getUser()->hasPerm('moveCategory[]') && rex::getUser()->getComplexPerm('structure')->hasCategoryPerm($article->getValue('parent_id')) && rex::getUser()->getComplexPerm('structure')->hasCategoryPerm($category_id_new)) {
                 if ($category_id != $category_id_new && rex_category_service::moveCategory($category_id, $category_id_new)) {
                     $info = rex_i18n::msg('category_moved');
-                    ob_end_clean();
                     rex_response::sendRedirect($context->getUrl(['info' => $info], false));
                 } else {
                     $warning = rex_i18n::msg('content_error_movecategory');

--- a/redaxo/src/addons/structure/tests/function_rex_url_test.php
+++ b/redaxo/src/addons/structure/tests/function_rex_url_test.php
@@ -1,0 +1,21 @@
+<?php
+
+class rex_structure_function_url_test extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideRedirectException
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRedirectException($article_id)
+    {
+        rex_redirect($article_id);
+    }
+
+    public function provideRedirectException()
+    {
+        return [
+            ['http://www.example.com'],
+            ['1 Foo'],
+        ];
+    }
+}

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -62,6 +62,8 @@ class rex_response
             throw new InvalidArgumentException('Illegal redirect url "' . $url . '", contains newlines');
         }
 
+        self::cleanOutputBuffers();
+
         header('HTTP/1.1 ' . self::$httpStatus);
         header('Location: ' . $url);
         exit;


### PR DESCRIPTION
ping @joachimdoerr @staabm 

`==` war in der Tat falsch, müsste wenn `!=` sein.

Allerdings passte die Art des Vergleichs auch allgemein nicht.
Beispiel `'foo'`: bei `(int) 'foo' == 'foo'` kommt `true` raus.

#1293 