### PR TITLE
rex_socket: Error-Handler immer zurücksetzen

### DIFF
--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -263,9 +263,11 @@ class rex_socket
             }
         });
 
-        $this->stream = @fsockopen($host, $this->port, $errno, $errstr);
-
-        restore_error_handler();
+        try {
+            $this->stream = @fsockopen($host, $this->port, $errno, $errstr);
+        } finally {
+            restore_error_handler();
+        }
 
         if ($this->stream) {
             stream_set_timeout($this->stream, $this->timeout);


### PR DESCRIPTION
Ich glaube, zurzeit kommt zwar niemals bei `fsockopen` eine Exception, aber sauberer ist es so trotzdem. Und könnte sich in der Zukunft ja auch mal ändern, dass es doch Exceptions geben kann.