### PR TITLE
Travis Anpassungen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ branches:
     only:
         - master
 
-notifications:
-    email: false
-
 cache:
     directories:
         - $HOME/.php-cs-fixer

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,24 +32,26 @@ jobs:
             script: php "$HOME/.php-cs-fixer/vendor/bin/php-cs-fixer" fix --cache-file "$HOME/.php-cs-fixer/.php_cs.cache" --dry-run --diff --verbose
 
         -   &TEST
-            php: 5.5
             install:
                 - mysql -e 'create database redaxo_5_0;'
                 - php redaxo/src/addons/tests/bin/setup.php
             script: php redaxo/src/addons/tests/bin/run_tests.php
-        -   <<: *TEST
-            php: 5.6
-        -   <<: *TEST
-            php: 7.0
-        -   <<: *TEST
-            php: 7.1
-        -   &TEST_MARIADB
-            <<: *TEST
             php: 7.0
             env: DB=mariadb
             addons:
                 mariadb: 10.1
-        -   <<: *TEST_MARIADB
+        -   <<: *TEST
             php: 7.1
             addons:
                 mariadb: 10.2
+        -   &TEST_MYSQL
+            <<: *TEST
+            php: 5.5
+            env: DB=mysql
+            addons: ~
+        -   <<: *TEST_MYSQL
+            php: 5.6
+        -   <<: *TEST_MYSQL
+            php: 7.0
+        -   <<: *TEST_MYSQL
+            php: 7.1


### PR DESCRIPTION
- E-Mail Notifications wieder aktiv, jetzt wo der master branch geschützt ist (hatte die mal deaktiviert, da es zu oft gebimmelt hat wegen cs etc.)
- MariaDB-Builds vorgezogen, da die langsamer sind

Frage: Müssen wir wirklich 10.1 und 10.2 testen? Bei Mysql testen wir ja auch nicht mehrere Versionen?
(Ich habe keine Ahnung, was es da so für Unterschiede gibt. Frage mich aber auch, ob es dann immer mehr Builds gibt, wenn weitere Versionen rauskommen? Oder immer nur die letzten beiden unterstützen?)