### PR TITLE
MM: Bei Benutzung von mediapath bekam man teilweise fälschlicherweise das Error-Bild

### DIFF
--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -44,13 +44,15 @@ class rex_managed_media
 
     public function setMediapath($media_path)
     {
-        if (!file_exists($media_path)) {
-            $media_path = rex_path::addon('media_manager', 'media/warning.jpg');
-        }
         $this->media_path = $media_path;
-        $this->sourcePath = $media_path;
         $this->media = basename($media_path);
         $this->asImage = false;
+
+        if (file_exists($media_path)) {
+            $this->sourcePath = $media_path;
+        } else {
+            $this->sourcePath = rex_path::addon('media_manager', 'media/warning.jpg');
+        }
     }
 
     public function getMediaFilename()


### PR DESCRIPTION
Mediapath muss original bleiben, nur der sourcePath muss aufs Error-Bild gelenkt werden.

fixes #1222