### PR TITLE
Console: Fatal Error auch abfangen

### DIFF
--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -1,6 +1,9 @@
 <?php
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 /**
  * @package redaxo\core
@@ -10,5 +13,16 @@ class rex_console_application extends Application
     public function __construct()
     {
         parent::__construct('REDAXO', rex::getVersion());
+    }
+
+    public function doRun(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            return parent::doRun($input, $output);
+        } catch (\Exception $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            throw new FatalThrowableError($e);
+        }
     }
 }

--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -20,6 +20,7 @@ class rex_console_application extends Application
         try {
             return parent::doRun($input, $output);
         } catch (\Exception $e) {
+            // catch and rethrow \Exceptions first to only catch fatal errors below (\Exception implements \Throwable)
             throw $e;
         } catch (\Throwable $e) {
             throw new FatalThrowableError($e);


### PR DESCRIPTION
So werden Fatal Error auch durch Symfony behandelt. Insbesondere greift so auch die Unterscheidung, ob man `-v` nutzt oder nicht.

Die beiden oberen Aufrufe waren vor der Änderung, die unteren danach:

![screenshot 2017-09-15 11 54 22](https://user-images.githubusercontent.com/330436/30477287-e7a4e74c-9a0c-11e7-897c-a4d1d7d2fb82.png)
