### PR TITLE
PNG-Kompression: Default-Wert und Hinweis

### DIFF
--- a/redaxo/src/addons/media_manager/install.php
+++ b/redaxo/src/addons/media_manager/install.php
@@ -16,7 +16,7 @@ if (!$this->hasConfig('jpg_quality')) {
 }
 
 if (!$this->hasConfig('png_compression')) {
-    $this->setConfig('png_compression', 6);
+    $this->setConfig('png_compression', 5);
 }
 
 if (!$this->hasConfig('webp_quality')) {

--- a/redaxo/src/addons/media_manager/lang/de_de.lang
+++ b/redaxo/src/addons/media_manager/lang/de_de.lang
@@ -16,6 +16,7 @@ media_manager_max_resizekb = Maximale Größe einer Datei in Kilobyte, die über
 media_manager_max_resizepx = Maximale Größe einer Datei in Pixel, die über media-manager umgewandelt werden darf
 media_manager_jpg_quality = JPG-Qualität
 media_manager_png_compression = PNG-Kompression
+media_manager_png_compression_note = Werte über 6-7 verlangsamen die Bilderzeugung massiv.
 media_manager_webp_quality = WebP-Qualität
 media_manager_interlace = Interlace/Progressive-Modus
 

--- a/redaxo/src/addons/media_manager/lang/en_gb.lang
+++ b/redaxo/src/addons/media_manager/lang/en_gb.lang
@@ -16,6 +16,7 @@ media_manager_max_resizekb = Maximum size of an image in kilobyte, which media-m
 media_manager_max_resizepx = Maximum size of a image in pixel, which media-manager is allowed to process
 media_manager_jpg_quality = JPG quality
 media_manager_png_compression = PNG compression
+media_manager_png_compression_note = Values above 6-7 massively slow down the image creation.
 media_manager_webp_quality = WebP quality
 media_manager_interlace = Interlace/progressive mode
 

--- a/redaxo/src/addons/media_manager/lib/effects/effect_image_properties.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_image_properties.php
@@ -43,7 +43,7 @@ class rex_effect_image_properties extends rex_effect_abstract
             ],
             [
                 'label' => rex_i18n::msg('media_manager_png_compression'),
-                'notice' => rex_i18n::msg('media_manager_effect_image_properties_png_compression_notice'),
+                'notice' => rex_i18n::msg('media_manager_effect_image_properties_png_compression_notice').' '.rex_i18n::msg('media_manager_png_compression_note'),
                 'name' => 'png_compression',
                 'type' => 'int',
             ],

--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -198,7 +198,7 @@ class rex_managed_media
             $quality = $this->getImageProperty('jpg_quality', $addon->getConfig('jpg_quality', 85));
             imagejpeg($this->image['src'], null, $quality);
         } elseif ($format == 'png') {
-            $compression = $this->getImageProperty('png_compression', $addon->getConfig('png_compression', 6));
+            $compression = $this->getImageProperty('png_compression', $addon->getConfig('png_compression', 5));
             imagepng($this->image['src'], null, $compression);
         } elseif ($format == 'gif') {
             imagegif($this->image['src']);

--- a/redaxo/src/addons/media_manager/pages/settings.php
+++ b/redaxo/src/addons/media_manager/pages/settings.php
@@ -83,6 +83,7 @@ $inputGroup = $fragment->parse('core/form/input_group.php');
 $n = [];
 $n['label'] = '<label for="rex-js-rating-text-png-compression">' . $this->i18n('png_compression') . '</label>';
 $n['field'] = $inputGroup;
+$n['note'] = $this->i18n('png_compression_note');
 $formElements[] = $n;
 
 $select = new rex_select();

--- a/redaxo/src/addons/media_manager/pages/settings.php
+++ b/redaxo/src/addons/media_manager/pages/settings.php
@@ -72,8 +72,8 @@ $formElements[] = $n;
 $inputGroups = [];
 $n = [];
 $n['class'] = 'rex-range-input-group';
-$n['left'] = '<input id="rex-js-rating-source-png-compression" type="range" min="0" max="9" step="1" value="' . htmlspecialchars($this->getConfig('png_compression', 6)) . '" />';
-$n['field'] = '<input class="form-control" id="rex-js-rating-text-png-compression" type="text" name="settings[png_compression]" value="' . htmlspecialchars($this->getConfig('png_compression', 6)) . '" />';
+$n['left'] = '<input id="rex-js-rating-source-png-compression" type="range" min="0" max="9" step="1" value="' . htmlspecialchars($this->getConfig('png_compression')) . '" />';
+$n['field'] = '<input class="form-control" id="rex-js-rating-text-png-compression" type="text" name="settings[png_compression]" value="' . htmlspecialchars($this->getConfig('png_compression')) . '" />';
 $inputGroups[] = $n;
 
 $fragment = new rex_fragment();

--- a/redaxo/src/addons/media_manager/update.php
+++ b/redaxo/src/addons/media_manager/update.php
@@ -5,3 +5,5 @@
 if (rex_string::versionCompare($this->getVersion(), '2.3.0-dev', '<')) {
     rex_media_manager::deleteCache();
 }
+
+include $this->getPath('install.php');


### PR DESCRIPTION
closes #1192

Ich glaube, ich würde eher nicht den [Link](http://marcjschmidt.de/blog/2013/10/25/php-imagepng-performance-slow.html) aufnehmen. Vielleicht ist der mal nicht mehr erreichbar etc.