### PR TITLE
Erlauben die session cookie parameter via config.yml zu setzen

### DIFF
--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -7,6 +7,21 @@ error_email: null
 fileperm: '0664'
 dirperm: '0775'
 session_duration: 7200
+session:
+    backend:
+        cookie:
+            lifetime: null
+            path: null
+            domain: null
+            secure: null
+            httponly: true
+    frontend:
+        cookie:
+            lifetime: null
+            path: null
+            domain: null
+            secure: null
+            httponly: true
 lang: de_de
 use_gzip: true
 use_etag: true

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -297,6 +297,8 @@ class rex_login
     public static function startSession()
     {
         if (session_id() == '') {
+            static::setCookieParams();
+
             if (!@session_start()) {
                 $error = error_get_last();
                 if ($error) {
@@ -306,6 +308,31 @@ class rex_login
                 }
             }
         }
+    }
+
+    /**
+     * Einstellen der Cookie Paramter bevor die session gestartet wird.
+     */
+    private static function setCookieParams()
+    {
+        $cookieParams = session_get_cookie_params();
+
+        $key = rex::isBackend() ? 'backend' : 'frontend';
+        $sessionConfig = rex::getProperty('session');
+
+        foreach ($sessionConfig[$key]['cookie'] as $name => $value) {
+            if ($value !== null) {
+                $cookieParams[$name] = $value;
+            }
+        }
+
+        session_set_cookie_params(
+            $cookieParams['lifetime'],
+            $cookieParams['path'],
+            $cookieParams['domain'],
+            $cookieParams['secure'],
+            $cookieParams['httponly']
+        );
     }
 
     /**


### PR DESCRIPTION
Session Cookie paramter können jetzt via config.yml customized werden (je frontend/backend).
Per Default wird das Session Cookie für Frontend/Backend via httponly gegen zugriffe aus javascript heraus geschützt.

Sobald das backend HTTPS only eingestellt wäre, könnte man dies auch auf den session cookie ausweiten.

SameSite ist noch nicht im php mit nativen Mitteln möglich daher ist dies hier erstmal nicht implementiert.

Refs #1209 

Zum testen muss der Cache  gelöscht werden, damit die neuen defaults greifen.

----

session cookie ist jetzt http-only - dies sollte unbedingt in den release notes auftauchen da dies ggf. bisher funktionierendes javascript beeinträchtigen könnte