### PR TITLE
Send 'Clear-Site-Data' http header on backend logout

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -41,7 +41,7 @@ if (rex::isSetup()) {
 
     if (rex_get('rex_logout', 'boolean')) {
         $login->setLogout(true);
-        rex_response::addHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
+        rex_response::setHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
     }
 
     // the server side encryption of pw is only required

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -41,6 +41,7 @@ if (rex::isSetup()) {
 
     if (rex_get('rex_logout', 'boolean')) {
         $login->setLogout(true);
+        rex_response::addHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
     }
 
     // the server side encryption of pw is only required

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -49,12 +49,12 @@ class rex_response
     }
 
     /**
-     * Add a http response header
+     * Set a http response header. A existing header with the same name will be overridden.
      *
      * @param string $name
      * @param string $value
      */
-    public static function addHeader($name, $value) {
+    public static function setHeader($name, $value) {
         self::$additionalHeaders[$name] = $value;
     }
 

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -20,6 +20,7 @@ class rex_response
     private static $sentEtag = false;
     private static $sentContentType = false;
     private static $sentCacheControl = false;
+    private static $additionalHeaders = [];
 
     /**
      * Sets the HTTP Status code.
@@ -48,6 +49,22 @@ class rex_response
     }
 
     /**
+     * Add a http response header
+     *
+     * @param string $name
+     * @param string $value
+     */
+    public static function addHeader($name, $value) {
+        self::$additionalHeaders[$name] = $value;
+    }
+
+    private static function sendAdditionalHeaders() {
+        foreach(self::$additionalHeaders as $name => $value) {
+            header($name .': ' . $value);
+        }
+    }
+
+    /**
      * Redirects to a URL.
      *
      * NOTE: Execution will stop within this method!
@@ -63,6 +80,7 @@ class rex_response
         }
 
         self::cleanOutputBuffers();
+        self::sendAdditionalHeaders();
 
         header('HTTP/1.1 ' . self::$httpStatus);
         header('Location: ' . $url);
@@ -102,6 +120,8 @@ class rex_response
         if (!ini_get('zlib.output_compression')) {
             header('Content-Length: ' . filesize($file));
         }
+
+        self::sendAdditionalHeaders();
 
         readfile($file);
     }
@@ -201,6 +221,8 @@ class rex_response
 
         // content length schicken, damit der browser einen ladebalken anzeigen kann
         header('Content-Length: ' . rex_string::size($content));
+        
+        self::sendAdditionalHeaders();
 
         echo $content;
 

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -54,12 +54,14 @@ class rex_response
      * @param string $name
      * @param string $value
      */
-    public static function setHeader($name, $value) {
+    public static function setHeader($name, $value)
+    {
         self::$additionalHeaders[$name] = $value;
     }
 
-    private static function sendAdditionalHeaders() {
-        foreach(self::$additionalHeaders as $name => $value) {
+    private static function sendAdditionalHeaders()
+    {
+        foreach (self::$additionalHeaders as $name => $value) {
             header($name .': ' . $value);
         }
     }
@@ -221,7 +223,7 @@ class rex_response
 
         // content length schicken, damit der browser einen ladebalken anzeigen kann
         header('Content-Length: ' . rex_string::size($content));
-        
+
         self::sendAdditionalHeaders();
 
         echo $content;


### PR DESCRIPTION
This adds a Clear-Site-Data header to the logout response which will
delete all relevant data in the caches which may contain potentially
sensitive content.

See https://w3c.github.io/webappsec-clear-site-data/#header for the
definition of the types.

Durch diesen Header werden alle daten im browser von der website gelöscht um die privatsphäre des users zu schützen.

siehe u.a. https://github.com/nextcloud/server/pull/5490