### PR TITLE
travis: git-depth auf 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 sudo: false
 
 git:
-    depth: 1
+    depth: 3
 
 branches:
     only:


### PR DESCRIPTION
Wenn man mehrere PRs kurz hintereinander mergt, können manche Jobs nicht beendet werden, da der Commit nicht mehr erreichbar ist.
Dann bekomme ich eine Error-Mail von Travis. (Der letzte PR geht aber erfolgreich durch -> erneute Mail)
Daher nun doch bisschen wieder erhöht.