### PR TITLE
use SameSite=Strict for the rex_login session cookie

### DIFF
--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -15,6 +15,7 @@ session:
             domain: null
             secure: null
             httponly: true
+            samesite: 'Strict'
     frontend:
         cookie:
             lifetime: null
@@ -22,6 +23,7 @@ session:
             domain: null
             secure: null
             httponly: true
+            samesite: 'Strict'
 lang: de_de
 use_gzip: true
 use_etag: true

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -356,8 +356,9 @@ class rex_login
      *
      * @param "Strict"|"Lax" $sameSite
      */
-    private static function rewriteSessionCookie($sameSite) {
-        $cookiesHeaders = array();
+    private static function rewriteSessionCookie($sameSite)
+    {
+        $cookiesHeaders = [];
 
         // since header_remove() will remove all sent cookies, we need to collect all of them,
         // rewrite only the session cookie and send all cookies again.
@@ -378,7 +379,7 @@ class rex_login
         header_remove('Set-Cookie');
 
         // re-add all (inl. the rewritten session cookie)
-        foreach($cookiesHeaders as $rawHeader) {
+        foreach ($cookiesHeaders as $rawHeader) {
             header($rawHeader);
         }
     }

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -285,6 +285,11 @@ class rex_login
     {
         if ('' != session_id()) {
             session_regenerate_id(true);
+
+            $cookieParams = static::getCookieParams();
+            if ($cookieParams['samesite']) {
+                self::rewriteSessionCookie($cookieParams['samesite']);
+            }
         }
 
         // session-id is shared between frontend/backend or even redaxo instances per server because it's the same http session
@@ -297,7 +302,15 @@ class rex_login
     public static function startSession()
     {
         if (session_id() == '') {
-            static::setCookieParams();
+            $cookieParams = static::getCookieParams();
+
+            session_set_cookie_params(
+                $cookieParams['lifetime'],
+                $cookieParams['path'],
+                $cookieParams['domain'],
+                $cookieParams['secure'],
+                $cookieParams['httponly']
+            );
 
             if (!@session_start()) {
                 $error = error_get_last();
@@ -307,13 +320,19 @@ class rex_login
                     throw new rex_exception('Unable to start session!');
                 }
             }
+
+            if ($cookieParams['samesite']) {
+                self::rewriteSessionCookie($cookieParams['samesite']);
+            }
         }
     }
 
     /**
      * Einstellen der Cookie Paramter bevor die session gestartet wird.
+     *
+     * @return array
      */
-    private static function setCookieParams()
+    private static function getCookieParams()
     {
         $cookieParams = session_get_cookie_params();
 
@@ -326,13 +345,42 @@ class rex_login
             }
         }
 
-        session_set_cookie_params(
-            $cookieParams['lifetime'],
-            $cookieParams['path'],
-            $cookieParams['domain'],
-            $cookieParams['secure'],
-            $cookieParams['httponly']
-        );
+        return $cookieParams;
+    }
+
+    /**
+     * php does not natively support SameSite for cookies yet,
+     * rewrite the session cookie manually.
+     *
+     * see https://wiki.php.net/rfc/same-site-cookie
+     *
+     * @param "Strict"|"Lax" $sameSite
+     */
+    private static function rewriteSessionCookie($sameSite) {
+        $cookiesHeaders = array();
+
+        // since header_remove() will remove all sent cookies, we need to collect all of them,
+        // rewrite only the session cookie and send all cookies again.
+        $cookieHeadersPrefix = 'Set-Cookie: ';
+        $sessionCookiePrefix = 'Set-Cookie: '. session_name() .'=';
+        foreach (headers_list() as $rawHeader) {
+            // rewrite the session cookie
+            if (substr($rawHeader, 0, strlen($sessionCookiePrefix)) === $sessionCookiePrefix) {
+                $rawHeader .= '; SameSite='. $sameSite;
+            }
+            // collect all cookies
+            if (substr($rawHeader, 0, strlen($cookieHeadersPrefix)) === $cookieHeadersPrefix) {
+                $cookiesHeaders[] = $rawHeader;
+            }
+        }
+
+        // remove all cookies
+        header_remove('Set-Cookie');
+
+        // re-add all (inl. the rewritten session cookie)
+        foreach($cookiesHeaders as $rawHeader) {
+            header($rawHeader);
+        }
     }
 
     /**


### PR DESCRIPTION
this is implemented via manually rewriting of the cookie headers, as
php-src does not yet natively support the SameSite cookie attribute.

Closes #1209.