### PR TITLE
Console: Alle Packages immer listen, aber ggf. nur ydeploy booten

### DIFF
--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -7,11 +7,15 @@ require __DIR__.'/boot.php';
 // force debug mode to enable output of notices/warnings and dump() function
 rex::setProperty('debug', true);
 
+rex_addon::initialize();
+
+foreach (rex::getConfig('package-order') as $packageId) {
+    rex_package::get($packageId)->enlist();
+}
+
 $application = new rex_console_application();
 
 rex::setProperty('console', $application);
-
-rex_addon::initialize();
 
 $application->setCommandLoader(new rex_console_command_loader());
 

--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -48,5 +48,7 @@ class rex_console_application extends Application
         foreach (rex::getConfig('package-order') as $packageId) {
             rex_package::get($packageId)->boot();
         }
+
+        rex_extension::registerPoint(new rex_extension_point('PACKAGES_INCLUDED'));
     }
 }

--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -39,14 +39,14 @@ class rex_console_application extends Application
 
     private function loadPackages(rex_console_command $command)
     {
-        if ('ydeploy:migrate' !== $command->getName()) {
-            require rex_path::core('packages.php');
+        if ('ydeploy:migrate' === $command->getName()) {
+            $command->getPackage()->boot();
 
             return;
         }
 
-        $package = $command->getPackage();
-        $package->enlist();
-        $package->boot();
+        foreach (rex::getConfig('package-order') as $packageId) {
+            rex_package::get($packageId)->boot();
+        }
     }
 }


### PR DESCRIPTION
Mir ist aufgefallen, dass wenn der Autoload-Cache noch nicht da ist, die Commands nicht gefunden werden, da die Addons ja jetzt erst direkt vor Ausführung des Commands geladen wurden.

Daher habe ich es jetzt so geändert, dass immer (frühzeitig) alle Addons gelistet werden. Und nur das Booten geschieht später, und halt ggf. begrenzt auf ydeploy.