### PR TITLE
mpool: finfo php extension soll optional sein

### DIFF
--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -302,8 +302,17 @@ class rex_managed_media
 
         $header = $this->getHeader();
         if (!isset($header['Content-Type'])) {
-            $finfo = finfo_open(FILEINFO_MIME_TYPE);
-            $content_type = finfo_file($finfo, $this->getSourcePath());
+            $content_type = '';
+            
+            if (!$content_type && function_exists('mime_content_type')) {
+                $content_type = mime_content_type($this->getSourcePath());
+            }            
+                
+            if (!$content_type && function_exists('finfo_open')) {
+               $finfo = finfo_open(FILEINFO_MIME_TYPE);
+               $content_type = finfo_file($finfo, $this->getSourcePath());
+            }
+            
             if ($content_type != '') {
                 $this->setHeader('Content-Type', $content_type);
             }

--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -303,16 +303,16 @@ class rex_managed_media
         $header = $this->getHeader();
         if (!isset($header['Content-Type'])) {
             $content_type = '';
-            
+
             if (!$content_type && function_exists('mime_content_type')) {
                 $content_type = mime_content_type($this->getSourcePath());
-            }            
-                
-            if (!$content_type && function_exists('finfo_open')) {
-               $finfo = finfo_open(FILEINFO_MIME_TYPE);
-               $content_type = finfo_file($finfo, $this->getSourcePath());
             }
-            
+
+            if (!$content_type && function_exists('finfo_open')) {
+                $finfo = finfo_open(FILEINFO_MIME_TYPE);
+                $content_type = finfo_file($finfo, $this->getSourcePath());
+            }
+
             if ($content_type != '') {
                 $this->setHeader('Content-Type', $content_type);
             }

--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -16,5 +16,5 @@ page:
 
 requires:
     php:
-        extensions: [gd, fileinfo]
+        extensions: [gd]
     redaxo: ^5.1.0


### PR DESCRIPTION
detect content type in managed_media like we do in function_rex_mediapool.php

https://github.com/redaxo/redaxo/blob/a6db3cd0a94fd9bb4aea65a59aaf42457834be6f/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php#L290-L297