### PR TITLE
Passwort speichern im Chrome ermöglicht

### DIFF
--- a/redaxo/src/core/pages/login.php
+++ b/redaxo/src/core/pages/login.php
@@ -119,7 +119,6 @@ $content = '
                 var pwInp = $("#rex-id-login-password");
                 if(pwInp.val() != "") {
                     $("#rex-form-login").append(\'<input type="hidden" name="\'+pwInp.attr("name")+\'" value="\'+Sha1.hash(pwInp.val())+\'" />\');
-                    pwInp.removeAttr("name");
                 }
         });
 


### PR DESCRIPTION
fixes #1336 

@Hirbod kannst du das bestätigen?

Das Entfernen des name-Attributs ist unnötig. Das später kommende hidden-Feld gewinnt immer.
Und der Chrome bietet so aber an, das Passwort zu speichern