### PR TITLE
History: Bugfix für Flexbox-Probleme

### DIFF
--- a/redaxo/src/addons/structure/plugins/history/assets/history.js
+++ b/redaxo/src/addons/structure/plugins/history/assets/history.js
@@ -224,6 +224,20 @@
             this.targetFrame = $('#content-history-iframe-2', this.el);
             this.submit = $('[data-history-layer="snap"]', this.el);
             this.cancel = $('[data-history-layer="cancel"]', this.el);
+
+            // fix layout for browsers having flexbox issues (Safari < 11 most notably)
+            // they require a px based flex container to properly calculate childs’ height
+            // unfortunately, this results in removing the responsiveness ¯\_(ツ)_/¯
+            // see: https://github.com/philipwalton/flexbugs#14-flex-containers-with-wrapping-the-container-is-not-sized-to-contain-its-items
+            // use timeout to run late!
+            window.setTimeout(function () {
+                this.wrapper = $('.history-layer-panel-3', this.el);
+                this.target = $('.history-responsive-container', this.el);
+
+                if (this.target.height() < 1) {
+                    this.wrapper.css('height', this.wrapper.height());
+                }
+            }.bind(this), 1);
         },
 
         /**


### PR DESCRIPTION
Das ist ein sehr nerviges [Flexbox-Issue](https://github.com/philipwalton/flexbugs#14-flex-containers-with-wrapping-the-container-is-not-sized-to-contain-its-items), speziell im Safari <11. Ich habe lange rumprobiert, denke aber, dass man es nicht behoben kriegt, ohne das Flexbox-Layout grundlegend umzustruktieren und damit vermutlich Einschränkungen hinnehmen zu müssen. Denn aktuell funktioniert das Layout ziemlich gut, und ohne Flexbox wäre manches nicht so einfach machbar.

Mir ist nur ein Bugfix eingefallen, der gut anwendbar ist, ohne die anderen Browser zu beeinträchtigen: Per JS wird gemessen, ob die Kindelemente 0 px hoch sind (Ergebnis des Flexbox-Issues). Ist das der Fall, wird der umliegende Container gemessen, der die richtige Höhe vorgibt, und diese wird ihm nochmal dediziert als Inline-Style drangeklebt. Das sieht dann etwa so aus: `<div class="history-layer-panel-3" style="height: 476px;">`. Als Ergebnis berechnet dann auch der olle Safari die Kindelemente richtig.
Nachteil: Das Layout ist nicht mehr flexibel, sondern basiert auf der initialen Fenstergröße. Wird diese nachträglich verändert, passt sich der Container nicht an. Ich finde das okay als Bugfix und habe bewusst drauf verzichtet, im JS auch noch auf Window-Resize zu hören.

Falls sich noch jemand daran probieren möchte, eine CSS-only-Lösung zu finden: Gerne! Ich bin aber recht sicher, dass es keine gibt. Also vielleicht lieber die Mühe sparen :)

fixes #1349