### PR TITLE
Passwortregeln

### DIFF
--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -130,7 +130,7 @@ if ($FUNC_ADD || $FUNC_UPDATE || $FUNC_APPLY) {
         $warnings[] = rex_i18n::msg('invalid_email');
     }
 
-    if ($userpsw && (true !== $msg = rex_password_policy::factory(rex::getProperty('password_policy', []))->check($userpsw, $user_id))) {
+    if ($userpsw && (true !== $msg = rex_backend_password_policy::factory(rex::getProperty('password_policy', []))->check($userpsw, $user_id))) {
         if (rex::getUser()->isAdmin()) {
             $msg .= ' '.rex_i18n::msg('password_admin_notice');
         }

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -130,7 +130,10 @@ if ($FUNC_ADD || $FUNC_UPDATE || $FUNC_APPLY) {
         $warnings[] = rex_i18n::msg('invalid_email');
     }
 
-    if ($userpsw && true !== $msg = rex_password_policy::factory(rex::getProperty('password_policy', []))->check($userpsw)) {
+    if ($userpsw && (true !== $msg = rex_password_policy::factory(rex::getProperty('password_policy', []))->check($userpsw, $user_id))) {
+        if (rex::getUser()->isAdmin()) {
+            $msg .= ' '.rex_i18n::msg('password_admin_notice');
+        }
         $warnings[] = $msg;
     }
 }

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -129,6 +129,10 @@ if ($FUNC_ADD || $FUNC_UPDATE || $FUNC_APPLY) {
     if ($useremail && !rex_validator::factory()->email($useremail)) {
         $warnings[] = rex_i18n::msg('invalid_email');
     }
+
+    if ($userpsw && true !== $msg = rex_password_policy::factory(rex::getProperty('password_policy', []))->check($userpsw)) {
+        $warnings[] = $msg;
+    }
 }
 
 if ($warnings) {
@@ -162,9 +166,7 @@ if ($warnings) {
     }
 
     if ($userpsw != '') {
-        // the server side encryption of pw is only required
-        // when not already encrypted by client using javascript
-        $userpsw = rex_login::passwordHash($userpsw, rex_post('javascript', 'boolean'));
+        $userpsw = rex_login::passwordHash($userpsw);
 
         $updateuser->setValue('password', $userpsw);
     }
@@ -203,9 +205,7 @@ if ($warnings) {
     $adduser->setQuery('SELECT * FROM ' . rex::getTablePrefix() . "user WHERE login = '$userlogin'");
 
     if ($adduser->getRows() == 0 && $userlogin != '' && $userpsw != '') {
-        // the server side encryption of pw is only required
-        // when not already encrypted by client using javascript
-        $userpswHash = rex_login::passwordHash($userpsw, rex_post('javascript', 'boolean'));
+        $userpswHash = rex_login::passwordHash($userpsw);
 
         $adduser = rex_sql::factory();
         $adduser->setTable(rex::getTablePrefix() . 'user');
@@ -394,7 +394,6 @@ if ($FUNC_ADD != '' || $user_id > 0) {
 
     $content .= '
             <fieldset>
-                <input type="hidden" name="javascript" value="0" id="rex-js-javascript" />
                 <input type="hidden" name="subpage" value="" />
                 <input type="hidden" name="save" value="1" />
                 ' . $add_hidden;
@@ -496,23 +495,12 @@ if ($FUNC_ADD != '' || $user_id > 0) {
         <script type="text/javascript">
         <!--
         jQuery(function($) {
-            $("#rex-form-user")
-                .submit(function(){
-                    var pwInp = $("#rex-js-user-password");
-                    if(pwInp.val() != "") {
-                        $("form#rex-form-user").append(\'<input type="hidden" name="\'+pwInp.attr("name")+\'" value="\'+Sha1.hash(pwInp.val())+\'" />\');
-                        pwInp.removeAttr("name");
-                    }
-            });
-
             $("#rex-js-user-admin").change(function() {
                  if ($(this).is(":checked"))
                      $("#rex-js-user-role").attr("disabled", "disabled");
                  else
                      $("#rex-js-user-role").removeAttr("disabled");
-        }).change();
-
-            $("#rex-js-javascript").val("1");
+            }).change();
         });
         //-->
         </script>';

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -24,6 +24,11 @@ session:
             secure: null
             httponly: true
             samesite: 'Strict'
+password_policy:
+    length: {min: 8}
+    lowercase: {min: 1}
+    uppercase: {min: 1}
+    digit: {min: 1}
 lang: de_de
 use_gzip: true
 use_etag: true

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -339,6 +339,7 @@ backend_language = Backendsprache
 user_data_updated = Benutzerdaten wurden aktualisiert!
 
 password_invalid = Das Passwort entspricht nicht den geforderten Regeln ({0})!
+password_admin_notice = Die Passwort-Regeln können über die config.yml geändert werden.
 password_rule_min = min. {0}
 password_rule_max = min. {0}
 password_rule_between = {0} bis {1}

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -338,6 +338,17 @@ profile_save_psw = Passwort speichern
 backend_language = Backendsprache
 user_data_updated = Benutzerdaten wurden aktualisiert!
 
+password_invalid = Das Passwort entspricht nicht den geforderten Regeln ({0})!
+password_rule_min = min. {0}
+password_rule_max = min. {0}
+password_rule_between = {0} bis {1}
+password_rule_length = {0} Zeichen
+password_rule_letter = {0} Buchstabe(n)
+password_rule_uppercase = {0} Großbuchstabe(n)
+password_rule_lowercase = {0} Kleinbuchstabe(n)
+password_rule_digit = {0} Ziffer(n)
+password_rule_symbol = {0} Sonderzeichen
+
 # redaxo\include\classes\class.rex_list.php
 list_previous = vorherige Seite
 list_next = nächste Seite

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -339,6 +339,7 @@ backend_language = Backend language
 user_data_updated = User data updated!
 
 password_invalid = The password does not match the required rules ({0})!
+password_admin_notice = The password rules can be changed in config.yml.
 password_rule_min = min. {0}
 password_rule_max = min. {0}
 password_rule_between = {0} to {1}

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -338,6 +338,17 @@ profile_save_psw = Save password
 backend_language = Backend language
 user_data_updated = User data updated!
 
+password_invalid = The password does not match the required rules ({0})!
+password_rule_min = min. {0}
+password_rule_max = min. {0}
+password_rule_between = {0} to {1}
+password_rule_length = {0} character(s)
+password_rule_letter = {0} letter(s)
+password_rule_uppercase = {0} uppercase letter(s)
+password_rule_lowercase = {0} lowercase letter(s)
+password_rule_digit = {0} digit(s)
+password_rule_symbol = {0} symbol(s)
+
 # redaxo\include\classes\class.rex_list.php
 list_previous = previous page
 list_next = next page

--- a/redaxo/src/core/lib/login/backend_password_policy.php
+++ b/redaxo/src/core/lib/login/backend_password_policy.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @author gharlan
+ *
+ * @package redaxo\core
+ */
+class rex_backend_password_policy extends rex_password_policy
+{
+    use rex_factory_trait;
+
+    public function __construct(array $options)
+    {
+        parent::__construct($options);
+    }
+
+    /**
+     * @return static
+     */
+    public static function factory(array $options)
+    {
+        $class = static::getFactoryClass();
+
+        return new $class($options);
+    }
+}

--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -11,7 +11,7 @@ class rex_password_policy
 
     private $options;
 
-    protected function __construct(array $options)
+    public function __construct(array $options)
     {
         $this->options = $options;
     }

--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -26,7 +26,15 @@ class rex_password_policy
         return new $class($options);
     }
 
-    public function check($password)
+    /**
+     * @param string   $password
+     * @param null|int $id
+     *
+     * @return bool|string `true` on success, otherwise an error message
+     *
+     * @throws rex_exception
+     */
+    public function check($password, $id = null)
     {
         if ($this->isValid($password)) {
             return true;
@@ -71,7 +79,7 @@ class rex_password_policy
                     $count = preg_match_all('/[a-z]/', $password);
                     break;
                 case 'digit':
-                    $count = preg_match_all('/\d/', $password);
+                    $count = preg_match_all('/[0-9]/', $password);
                     break;
                 case 'symbol':
                     $count = preg_match_all('/[^a-zA-Z0-9]/', $password);

--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -7,23 +7,11 @@
  */
 class rex_password_policy
 {
-    use rex_factory_trait;
-
     private $options;
 
     public function __construct(array $options)
     {
         $this->options = $options;
-    }
-
-    /**
-     * @return static
-     */
-    public static function factory(array $options)
-    {
-        $class = static::getFactoryClass();
-
-        return new $class($options);
     }
 
     /**

--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @author gharlan
+ *
+ * @package redaxo\core
+ */
+class rex_password_policy
+{
+    use rex_factory_trait;
+
+    private $options;
+
+    protected function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @return static
+     */
+    public static function factory(array $options)
+    {
+        $class = static::getFactoryClass();
+
+        return new $class($options);
+    }
+
+    public function check($password)
+    {
+        if ($this->isValid($password)) {
+            return true;
+        }
+
+        return rex_i18n::msg('password_invalid', $this->getRule());
+    }
+
+    protected function getRule()
+    {
+        $parts = [];
+
+        foreach ($this->options as $key => $options) {
+            if (isset($options['min'], $options['max'])) {
+                $constraint = rex_i18n::msg('password_rule_between', $options['min'], $options['max']);
+            } elseif (isset($options['max'])) {
+                $constraint = rex_i18n::msg('password_rule_max', $options['max']);
+            } else {
+                $constraint = rex_i18n::msg('password_rule_min', $options['min']);
+            }
+
+            $parts[] = rex_i18n::msg('password_rule_'.$key, $constraint);
+        }
+
+        return implode('; ', $parts);
+    }
+
+    protected function isValid($password)
+    {
+        foreach ($this->options as $key => $options) {
+            switch ($key) {
+                case 'length':
+                    $count = mb_strlen($password);
+                    break;
+                case 'letter':
+                    $count = preg_match_all('/[a-zA-Z]/', $password);
+                    break;
+                case 'uppercase':
+                    $count = preg_match_all('/[A-Z]/', $password);
+                    break;
+                case 'lowercase':
+                    $count = preg_match_all('/[a-z]/', $password);
+                    break;
+                case 'digit':
+                    $count = preg_match_all('/\d/', $password);
+                    break;
+                case 'symbol':
+                    $count = preg_match_all('/[^a-zA-Z0-9]/', $password);
+                    break;
+
+                default:
+                    throw new rex_exception(sprintf('Unknown password_policy key "%s".', $key));
+            }
+
+            if (!$this->matchesCount($count, $options)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function matchesCount($count, array $options)
+    {
+        if (isset($options['min']) && $count < $options['min']) {
+            return false;
+        }
+
+        if (isset($options['max']) && $count > $options['max']) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -80,7 +80,7 @@ if (rex_post('upd_psw_button', 'bool')) {
     if (!$userpsw || !$userpsw_new_1 || $userpsw_new_1 != $userpsw_new_2 || !rex_login::passwordVerify($userpsw, $user->getValue('password'))
     ) {
         $error = rex_i18n::msg('user_psw_error');
-    } elseif (true !== $msg = rex_password_policy::factory(rex::getProperty('password_policy', []))->check($userpsw_new_1)) {
+    } elseif (true !== $msg = rex_password_policy::factory(rex::getProperty('password_policy', []))->check($userpsw_new_1, $user_id)) {
         $error = $msg;
     } else {
         $userpsw_new_1 = rex_login::passwordHash($userpsw_new_1);

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -80,7 +80,7 @@ if (rex_post('upd_psw_button', 'bool')) {
     if (!$userpsw || !$userpsw_new_1 || $userpsw_new_1 != $userpsw_new_2 || !rex_login::passwordVerify($userpsw, $user->getValue('password'))
     ) {
         $error = rex_i18n::msg('user_psw_error');
-    } elseif (true !== $msg = rex_password_policy::factory(rex::getProperty('password_policy', []))->check($userpsw_new_1, $user_id)) {
+    } elseif (true !== $msg = rex_backend_password_policy::factory(rex::getProperty('password_policy', []))->check($userpsw_new_1, $user_id)) {
         $error = $msg;
     } else {
         $userpsw_new_1 = rex_login::passwordHash($userpsw_new_1);

--- a/redaxo/src/core/tests/login/password_policy_test.php
+++ b/redaxo/src/core/tests/login/password_policy_test.php
@@ -1,0 +1,48 @@
+<?php
+
+class rex_password_policy_test extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideCheck
+     */
+    public function testCheck(array $options, $expected, $password)
+    {
+        $policy = new rex_password_policy($options);
+
+        $result = $policy->check($password);
+
+        if ($expected) {
+            $this->assertTrue($result);
+        } else {
+            $this->assertInternalType('string', $result);
+        }
+    }
+
+    public function provideCheck()
+    {
+        yield [[], true, 'foo'];
+
+        $options = ['length' => ['min' => 3]];
+
+        yield [$options, false, '1a'];
+        yield [$options, true, '1ab'];
+        yield [$options, true, '1abcdefghijklmopqrstuvxxyz234567890'];
+
+        $options = [
+            'length' => ['min' => 8, 'max' => 15],
+            'digit' => ['max' => 3],
+            'lowercase' => ['min' => 2],
+            'uppercase' => ['min' => 1],
+            'letter' => ['min' => 3],
+            'symbol' => ['min' => 1, 'max' => 2],
+        ];
+
+        yield [$options, false, 'abcdefghi'];
+        yield [$options, false, 'abC!12'];
+        yield [$options, false, 'abcdef1234!%AB'];
+        yield [$options, true, 'abcdef123!%AB'];
+        yield [$options, true, 'AB7=E8#fg9'];
+        yield [$options, false, 'AB7=E8#fg9?'];
+        yield [$options, false, 'abcdef123!%ABuegrouwouewhifggreigeioger'];
+    }
+}


### PR DESCRIPTION
closes #1331, closes #1361 

Das mal als Ansatz. Man könnte so in der config.yml paar einfache feste Regeln festlegen. Und bei Bedarf kann man aber auch die Klasse erweitern, wenn man noch komplexere Logik reinbringen möchte (zum Beispiel ob das Passwort schon mal verwendet wurde etc.).

@staabm was meinste dazu?

Wie sieht es aus mit dem Default-Wert? Soll es default überhaupt Regeln geben, oder so wie bisher, alles frei?

- [ ] schuer daran erinnern dass er im docker erneut die config.yml aktualisieren muss, da sich die default.config.yml ändert ;-).