### PR TITLE
Add colorpicker class

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/pages/system.customizer.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/pages/system.customizer.php
@@ -119,7 +119,7 @@ $formElements = [];
 
 $n = [];
 $n['label'] = '<label for="customizer-labelcolor">' . rex_i18n::msg('customizer_labelcolor') . '</label>';
-$n['field'] = '<input class="form-control minicolors" id="customizer-labelcolor" type="text" name="settings[labelcolor]" value="' . htmlspecialchars($config['labelcolor']) . '" />';
+$n['field'] = '<input class="form-control" id="customizer-labelcolor" type="text" name="settings[labelcolor]" value="' . htmlspecialchars($config['labelcolor']) . '" />';
 $formElements[] = $n;
 
 $n = [];

--- a/redaxo/src/addons/be_style/plugins/customizer/pages/system.customizer.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/pages/system.customizer.php
@@ -25,7 +25,7 @@ if (rex_post('btn_save', 'string') != '') {
     $labelcolor = $newConfig['labelcolor'];
     if ($labelcolor == '') {
         $tempConfig['labelcolor'] = '';
-    } elseif (preg_match('/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/', $labelcolor)) {
+    } elseif (preg_match('^(#(?:[0-9a-f]{2}){2,4}|#[0-9a-f]{3}|(?:rgba?|hsla?)\((?:\d+%?(?:deg|rad|grad|turn)?(?:,|\s)+){2,3}[\s\/]*[\d\.]+%?\))$^', $labelcolor)) {
         $tempConfig['labelcolor'] = htmlspecialchars($labelcolor);
     } else {
         $error[] = rex_i18n::msg('customizer_labelcolor_error');
@@ -119,7 +119,7 @@ $formElements = [];
 
 $n = [];
 $n['label'] = '<label for="customizer-labelcolor">' . rex_i18n::msg('customizer_labelcolor') . '</label>';
-$n['field'] = '<input class="form-control" id="customizer-labelcolor" type="text" name="settings[labelcolor]" value="' . htmlspecialchars($config['labelcolor']) . '" />';
+$n['field'] = '<input class="form-control minicolors" id="customizer-labelcolor" type="text" name="settings[labelcolor]" value="' . htmlspecialchars($config['labelcolor']) . '" />';
 $formElements[] = $n;
 
 $n = [];


### PR DESCRIPTION
Bereitet das input-feld für das FOR-addon "UI tools" vor, indem es die Klasse und ein erweitertes REGEX-Pattern ( https://stackoverflow.com/questions/43706082/validation-hex-and-rgba-colors-using-regex-in-php ) ergänzt.