### PR TITLE
Mediapool security fixes

### DIFF
--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -18,6 +18,11 @@ function rex_mediapool_filename($FILENAME, $doSubindexing = true)
 {
     // ----- neuer filename und extension holen
     $NFILENAME = rex_string::normalize($FILENAME, '_', '.-');
+
+    if ('.' === $NFILENAME[0]) {
+        $NFILENAME[0] = '_';
+    }
+
     if (strrpos($NFILENAME, '.') != '') {
         $NFILE_NAME = substr($NFILENAME, 0, strlen($NFILENAME) - (strlen($NFILENAME) - strrpos($NFILENAME, '.')));
         $NFILE_EXT = substr($NFILENAME, strrpos($NFILENAME, '.'), strlen($NFILENAME) - strrpos($NFILENAME, '.'));

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -17,7 +17,7 @@ page:
         structure: { title: translate:pool_cat_list,   perm: media/hasAll }
         sync:      { title: translate:pool_sync_files, perm: media/hasAll }
 
-blocked_extensions: [php, php3, php4, php5, php6, php7, pht, phtml, pl, asp, aspx, cfm, jsp, jsf, bat, sh, cgi, htaccess, htpasswd]
+blocked_extensions: [php, php3, php4, php5, php6, php7, phar, pht, phtml, hh, pl, asp, aspx, cfm, jsp, jsf, bat, sh, cgi, htaccess, htpasswd]
 allowed_doctypes: [bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, ogg, pdf, png, ppt, pptx, pps, ppsx, rar, rtf, swf, tar, tif, txt, webp, wma, xls, xlsx, zip]
 image_extensions: [bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]
 

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -17,7 +17,7 @@ page:
         structure: { title: translate:pool_cat_list,   perm: media/hasAll }
         sync:      { title: translate:pool_sync_files, perm: media/hasAll }
 
-blocked_extensions: [php, php3, php4, php5, php6, php7, phtml, pl, asp, aspx, cfm, jsp, jsf, bat, sh, cgi]
+blocked_extensions: [php, php3, php4, php5, php6, php7, pht, phtml, pl, asp, aspx, cfm, jsp, jsf, bat, sh, cgi, htaccess, htpasswd]
 allowed_doctypes: [bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, ogg, pdf, png, ppt, pptx, pps, ppsx, rar, rtf, swf, tar, tif, txt, webp, wma, xls, xlsx, zip]
 image_extensions: [bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]
 


### PR DESCRIPTION
* blocked_extensions erweitert um pht, htaccess und htpasswd
* Zusätzlich wenn Dateiname mit Punkt beginnt, durch _ ersetzen