### PR TITLE
PHPMailer: Passwort nicht im Klartext anzeigen - config.php

### DIFF
--- a/redaxo/src/addons/phpmailer/pages/config.php
+++ b/redaxo/src/addons/phpmailer/pages/config.php
@@ -217,7 +217,7 @@ $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="phpmailer-password">' . $this->i18n('smtp_password') . '</label>';
-$n['field'] = '<input class="form-control" id="phpmailer-password" type="text" name="settings[password]" value="' . $this->getConfig('password') . '" autocomplete="new-password" />';
+$n['field'] = '<input class="form-control" id="phpmailer-password" type="password" name="settings[password]" value="' . $this->getConfig('password') . '" autocomplete="new-password" />';
 $formElements[] = $n;
 
 $n = [];


### PR DESCRIPTION
... id="phpmailer-password" type="password" ...