### PR TITLE
svg und mp4 im Medienpool-Upload erlauben

### DIFF
--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -18,7 +18,7 @@ page:
         sync:      { title: translate:pool_sync_files, perm: media/hasAll }
 
 blocked_extensions: [php, php3, php4, php5, php6, php7, phar, pht, phtml, hh, pl, asp, aspx, cfm, jsp, jsf, bat, sh, cgi, htaccess, htpasswd]
-allowed_doctypes: [bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, ogg, pdf, png, ppt, pptx, pps, ppsx, rar, rtf, swf, tar, tif, txt, webp, wma, xls, xlsx, zip]
+allowed_doctypes: [bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, mp4, ogg, pdf, png, ppt, pptx, pps, ppsx, rar, rtf, svg, swf, tar, tif, tiff, txt, webp, wma, xls, xlsx, zip]
 image_extensions: [bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]
 
 requires:


### PR DESCRIPTION
Siehe https://github.com/FriendsOfREDAXO/uploader/issues/4

/cc @pixelpaul @pixeldaniel