### PR TITLE
Media Manager: Fehlerhaftes Caching

### DIFF
--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -35,7 +35,7 @@ class rex_managed_media
      *
      * To get the current source path (can be changed by effects) use `getSourcePath` instead.
      *
-     * @return string
+     * @return null|string
      */
     public function getMediaPath()
     {
@@ -45,6 +45,11 @@ class rex_managed_media
     public function setMediaPath($media_path)
     {
         $this->media_path = $media_path;
+
+        if (null === $media_path) {
+            return;
+        }
+
         $this->media = basename($media_path);
         $this->asImage = false;
 
@@ -333,6 +338,7 @@ class rex_managed_media
     private function saveFiles($src, $sourceCacheFilename, $headerCacheFilename)
     {
         rex_file::putCache($headerCacheFilename, [
+            'media_path' => $this->getMediaPath(),
             'format' => $this->format,
             'headers' => $this->header,
         ]);

--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -1,5 +1,5 @@
 package: media_manager
-version: '2.4.0'
+version: '2.4.1-dev'
 author: 'Markus Staab, Jan Kristinus'
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/media_manager/update.php
+++ b/redaxo/src/addons/media_manager/update.php
@@ -2,7 +2,7 @@
 
 /** @var rex_addon $this */
 
-if (rex_string::versionCompare($this->getVersion(), '2.3.0-dev', '<')) {
+if (rex_string::versionCompare($this->getVersion(), '2.4.1-dev', '<')) {
     rex_media_manager::deleteCache();
 }
 


### PR DESCRIPTION
Das Problem tritt auf, wenn der MediaPath über Effekte angepasst wird, dass passiert zurzeit in den beiden Effekten `mediapath` und `yfeed`.

Genauer gesagt sind es zwei Probleme, die dabei auftreten:

Angenommen, wir haben einen MM-Typen der der mediapath-Effekt nutzt (also den Pfad zu den Original-Dateien ändert, nicht mehr `/media`).
Nun rufen wir eine Datei `test.jpg` über diesen Typen auf.

Problem 1:
Der MM bildet den Cache-Pfad, dieser enthält zurzeit aber den MediaPath (gehasht). Bevor die Effekte nicht ausgeführt wurden, kennt der MM aber nicht den tatsächlichen, umgebogenen MediaPath. Daher wird ein falscher Cache-Pfad gebildet. Da die Datei dort aber nicht existiert, werden die Effekte ausgeführt.
Danach prüft der MM erneut den Cache-Pfad, dieses Mal mit dem richtigen MediaPath. Dort ist der Cache vorhanden, und das Bild aus dem Cache wird geliefert.
Also wird schon das Cache-Bild ausgeliefert, es wird nicht neu gespeichert. Aber trotzdem werden bei jedem Aufruf die ganzen Effekte ausgeführt.

Problem 2:
In `isCached` wird geprüft, ob die Cache-Datei neuer ist, als die Original-Datei. Wenn nicht, wird der Cache als nicht vorhanden gewertet.
Als Original-Datei wird hier aber immer `/media/{filename}` genommen. Es kann also passieren, dass mit einer nicht existenten Datei verglichen wird (da kommen teilweise Warnungen), oder noch schlimmer mit einer falschen Datei, wenn zufällig in `/media` auch eine Datei mit dem Dateinamen liegt.

Lösung:
Der MediaPath landet nicht mehr im Cache-Pfad, sehe dafür keine Notwendigkeit.
Und zweitens wird der tatsächliche MediaPath mit in die Header-Cache-Datei geschrieben, damit der Zeitstempel-Vergleich mit der richtigen Datei erfolgt.
Dabei kann der MediaPath auf von Effekten auf `null` gesetzt werden, falls es gar keine physische Datei gibt (ist der Fall bei yfeed, dort kommen die Bilder aus der DB).

Puh, ist das viel Text.. ;)