### PR TITLE
CS-Fixer-Version über Travis-Env-Variable steuern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
             env: CODING_STANDARDS=1
             install:
                 - mkdir -p "$HOME/.php-cs-fixer"
-                - "echo '{\"require\": {\"friendsofphp/php-cs-fixer\": \"^2.0\"}}' > \"$HOME/.php-cs-fixer/composer.json\""
+                - "echo '{\"require\": {\"friendsofphp/php-cs-fixer\": \"'$CS_FIXER_VERSION'\"}}' > \"$HOME/.php-cs-fixer/composer.json\""
                 - travis_retry composer update --no-interaction --working-dir "$HOME/.php-cs-fixer"
             script: php "$HOME/.php-cs-fixer/vendor/bin/php-cs-fixer" fix --cache-file "$HOME/.php-cs-fixer/.php_cs.cache" --dry-run --diff --verbose
 


### PR DESCRIPTION
Die aktuelle Version enthält Bugs, weshalb die Builds zurzeit rot werden.

Habe eine Env-Variable in den Travis-Settings abgelegt, sodass wir zukünftig die Version ohne Commit/Pr steuern können.