### PR TITLE
Media Manager: Original-Filename für Cache-Pfad nutzen

### DIFF
--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -170,7 +170,7 @@ class rex_media_manager
 
     public function getCacheFilename()
     {
-        return $this->cache_path.$this->type.'/'.$this->media->getMediaFilename();
+        return $this->cache_path.$this->type.'/'.self::getMediaFile();
     }
 
     public function getHeaderCacheFilename()

--- a/redaxo/src/addons/media_manager/tests/media_manager_test.php
+++ b/redaxo/src/addons/media_manager/tests/media_manager_test.php
@@ -1,0 +1,20 @@
+<?php
+
+class rex_media_manager_test extends PHPUnit_Framework_TestCase
+{
+    public function testGetCacheFilename()
+    {
+        $manager = new rex_media_manager(new rex_managed_media(__DIR__.'/foo.jpg'));
+
+        $cachePath = rex_path::addonCache('media_manager');
+        $manager->setCachePath($cachePath);
+
+        $property = new ReflectionProperty(rex_media_manager::class, 'type');
+        $property->setAccessible(true);
+        $property->setValue($manager, 'test');
+
+        $_GET['rex_media_file'] = 'bar.gif';
+
+        $this->assertSame($cachePath.'test/bar.gif', $manager->getCacheFilename());
+    }
+}


### PR DESCRIPTION
Das Resultat von `$this->media->getMediaFilename()` kann sich über die Effekte ändern, vor allem wenn der mediaPath neu gesetzt wird.
Gecacht werden muss aber gerade über den original übergebenen Dateinamen, damit beim zweiten Aufruf der MM die Cache-Datei findet, ohne die Effekte zu durchlaufen.

@tbaddade Bitte testen, ob damit unsere Probleme behoben sind.