### PR TITLE
Console: Besseres Dekodieren der i18n-Messages

### DIFF
--- a/redaxo/src/core/lib/console/cache/clear.php
+++ b/redaxo/src/core/lib/console/cache/clear.php
@@ -19,7 +19,7 @@ class rex_command_cache_clear extends rex_console_command
         $successMsg = rex_delete_cache();
         $io = $this->getStyle($input, $output);
 
-        $io->success($successMsg);
+        $io->success($this->decodeMessage($successMsg));
         return 0;
     }
 }

--- a/redaxo/src/core/lib/console/command.php
+++ b/redaxo/src/core/lib/console/command.php
@@ -36,9 +36,9 @@ abstract class rex_console_command extends Command
     /**
      * Decodes a html message for use in the CLI, e.g. provided by rex_i18n.
      *
-     * @param string $message
+     * @param string $message A html message
      *
-     * @return string
+     * @return string A cli optimzed message
      */
     protected function decodeMessage($message)
     {

--- a/redaxo/src/core/lib/console/command.php
+++ b/redaxo/src/core/lib/console/command.php
@@ -32,4 +32,19 @@ abstract class rex_console_command extends Command
     {
         return new SymfonyStyle($input, $output);
     }
+
+    /**
+     * Decodes messages coming from rex_i18n.
+     *
+     * @param string $message
+     *
+     * @return string
+     */
+    protected function decodeMessage($message)
+    {
+        $message = preg_replace('/<br ?\/?>\r?\n?/', "\n", $message);
+        $message = strip_tags($message);
+
+        return htmlspecialchars_decode($message);
+    }
 }

--- a/redaxo/src/core/lib/console/command.php
+++ b/redaxo/src/core/lib/console/command.php
@@ -34,7 +34,7 @@ abstract class rex_console_command extends Command
     }
 
     /**
-     * Decodes messages coming from rex_i18n.
+     * Decodes a html message for use in the CLI, e.g. provided by rex_i18n.
      *
      * @param string $message
      *

--- a/redaxo/src/core/lib/console/package/activate.php
+++ b/redaxo/src/core/lib/console/package/activate.php
@@ -29,11 +29,13 @@ class rex_command_package_activate extends rex_console_command
 
         $manager = rex_package_manager::factory($package);
         $success = $manager->activate();
-        $message = strip_tags($manager->getMessage());
+        $message = $this->decodeMessage($manager->getMessage());
+
         if ($success) {
             $io->success($message);
             return 0;
         }
+
         $io->error($message);
         return 1;
     }

--- a/redaxo/src/core/lib/console/package/deactivate.php
+++ b/redaxo/src/core/lib/console/package/deactivate.php
@@ -29,11 +29,13 @@ class rex_command_package_deactivate extends rex_console_command
 
         $manager = rex_package_manager::factory($package);
         $success = $manager->deactivate();
-        $message = strip_tags($manager->getMessage());
+        $message = $this->decodeMessage($manager->getMessage());
+
         if ($success) {
             $io->success($message);
             return 0;
         }
+
         $io->error($message);
         return 1;
     }

--- a/redaxo/src/core/lib/console/package/install.php
+++ b/redaxo/src/core/lib/console/package/install.php
@@ -39,17 +39,14 @@ class rex_command_package_install extends rex_console_command
         }
 
         $manager = rex_package_manager::factory($package);
-        try {
-            $success = $manager->install();
-        } catch (rex_functional_exception $e) {
-            $io->error($e->getMessage());
-            return 1;
-        }
-        $message = strip_tags($manager->getMessage());
+        $success = $manager->install();
+        $message = $this->decodeMessage($manager->getMessage());
+
         if ($success) {
             $io->success($message);
             return 0;
         }
+
         $io->error($message);
         return 1;
     }

--- a/redaxo/src/core/lib/console/package/uninstall.php
+++ b/redaxo/src/core/lib/console/package/uninstall.php
@@ -28,17 +28,14 @@ class rex_command_package_uninstall extends rex_console_command
         }
 
         $manager = rex_package_manager::factory($package);
-        try {
-            $success = $manager->uninstall();
-        } catch (rex_functional_exception $e) {
-            $io->error($e->getMessage());
-            return 1;
-        }
-        $message = strip_tags($manager->getMessage());
+        $success = $manager->uninstall();
+        $message = $this->decodeMessage($manager->getMessage());
+
         if ($success) {
             $io->success($message);
             return 0;
         }
+
         $io->error($message);
         return 1;
     }

--- a/redaxo/src/core/tests/console/command_test.php
+++ b/redaxo/src/core/tests/console/command_test.php
@@ -1,0 +1,14 @@
+<?php
+
+class rex_console_command_test extends PHPUnit_Framework_TestCase
+{
+    public function testDecodeMessage()
+    {
+        $method = new ReflectionMethod(rex_console_command::class, 'decodeMessage');
+        $method->setAccessible(true);
+
+        $command = $this->getMockForAbstractClass(rex_console_command::class);
+
+        $this->assertSame("\"Foo\"\nbar\nbaz", $method->invoke($command, "&quot;Foo&quot;<br><b>bar</b><br />\nbaz"));
+    }
+}

--- a/redaxo/src/core/tests/console/command_test.php
+++ b/redaxo/src/core/tests/console/command_test.php
@@ -9,6 +9,6 @@ class rex_console_command_test extends PHPUnit_Framework_TestCase
 
         $command = $this->getMockForAbstractClass(rex_console_command::class);
 
-        $this->assertSame("\"Foo\"\nbar\nbaz", $method->invoke($command, "&quot;Foo&quot;<br><b>bar</b><br />\nbaz"));
+        $this->assertSame("\"Foo\"\nbar\nbaz\nabc\ndef", $method->invoke($command, "&quot;Foo&quot;<br><b>bar</b><br />\nbaz<br/>\rabc<br>\r\ndef"));
     }
 }


### PR DESCRIPTION
Hier der "Vorher (oben) / Nachher (unten)"-Vergleich:

![screenshot 2017-12-14 14 48 54](https://user-images.githubusercontent.com/330436/33995401-2c014094-e0de-11e7-9f07-4a6cc3b03ee7.png)

Da ich denke, dass man das auch noch in anderen Commands gebrauchen kann (zum Beispiel eben in cache:clear), habe ich es als allgemeine Methode in der Command-Klasse angelegt.