### PR TITLE
CSRF-Schutz für Api-Calls

### DIFF
--- a/redaxo/src/addons/install/lib/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api_core_update.php
@@ -175,6 +175,11 @@ class rex_api_install_core_update extends rex_api_function
         return $result;
     }
 
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
+
     /**
      * @param string      $temppath
      * @param string      $version

--- a/redaxo/src/addons/install/lib/api_package_delete.php
+++ b/redaxo/src/addons/install/lib/api_package_delete.php
@@ -23,4 +23,9 @@ class rex_api_install_package_delete extends rex_api_function
         rex_install_packages::deleteCache();
         return new rex_api_result(true, rex_i18n::msg('install_info_addon_deleted', $addonkey));
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/install/lib/api_package_download.php
+++ b/redaxo/src/addons/install/lib/api_package_download.php
@@ -53,6 +53,11 @@ abstract class rex_api_install_package_download extends rex_api_function
         return new rex_api_result($success, $message);
     }
 
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
+
     protected function extractArchiveTo($dir)
     {
         if (!rex_install_archive::extract($this->archive, $dir, $this->addonkey)) {

--- a/redaxo/src/addons/install/lib/api_package_upload.php
+++ b/redaxo/src/addons/install/lib/api_package_upload.php
@@ -55,4 +55,9 @@ class rex_api_install_package_upload extends rex_api_function
         rex_install_packages::deleteCache();
         return new rex_api_result(true, rex_i18n::msg('install_info_addon_uploaded', $addonkey));
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -1,5 +1,5 @@
 package: install
-version: '2.2.1-dev'
+version: '2.3.0-dev'
 author: Gregor Harlan
 supportpage: www.redaxo.org/de/forum
 

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -1,5 +1,5 @@
 package: install
-version: '2.2.0'
+version: '2.2.1-dev'
 author: Gregor Harlan
 supportpage: www.redaxo.org/de/forum
 
@@ -22,4 +22,4 @@ page:
 requires:
     php:
         extensions: [zlib]
-    redaxo: ^5.1.0
+    redaxo: ^5.5.0-dev

--- a/redaxo/src/addons/install/pages/packages.add.php
+++ b/redaxo/src/addons/install/pages/packages.add.php
@@ -66,7 +66,7 @@ if ($addonkey && isset($addons[$addonkey]) && !rex_addon::exists($addonkey)) {
                 <td class="rex-table-icon"><i class="rex-icon rex-icon-package"></i></td>
                 <td data-title="' . $this->i18n('version') . '">' . htmlspecialchars($file['version']) . '</td>
                 <td data-title="' . $this->i18n('description') . '">' . nl2br($file['description']) . '</td>
-                <td class="rex-table-action"><a href="' . rex_url::currentBackendPage(['addonkey' => $addonkey, 'rex-api-call' => 'install_package_add', 'file' => $fileId]) . '" data-pjax="false"><i class="rex-icon rex-icon-download"></i> ' . $this->i18n('download') . '</a></td>
+                <td class="rex-table-action"><a href="' . rex_url::currentBackendPage(['addonkey' => $addonkey, 'file' => $fileId] + rex_api_install_package_add::getUrlParams()) . '" data-pjax="false"><i class="rex-icon rex-icon-download"></i> ' . $this->i18n('download') . '</a></td>
             </tr>';
     }
 

--- a/redaxo/src/addons/install/pages/packages.update.php
+++ b/redaxo/src/addons/install/pages/packages.update.php
@@ -37,7 +37,7 @@ if ($core && !empty($coreVersions)) {
                     <td class="rex-table-icon"><i class="rex-icon rex-icon-package"></i></td>
                     <td data-title="' . $this->i18n('version') . '">' . htmlspecialchars($version['version']) . '</td>
                     <td data-title="' . $this->i18n('description') . '">' . nl2br(htmlspecialchars($version['description'])) . '</td>
-                    <td class="rex-table-action"><a href="' . rex_url::currentBackendPage(['core' => 1, 'rex-api-call' => 'install_core_update', 'version_id' => $id]) . '" data-pjax="false">' . $this->i18n('update') . '</a></td>
+                    <td class="rex-table-action"><a href="' . rex_url::currentBackendPage(['core' => 1, 'version_id' => $id] + rex_api_install_core_update::getUrlParams()) . '" data-pjax="false">' . $this->i18n('update') . '</a></td>
                 </tr>';
     }
 
@@ -95,7 +95,7 @@ if ($core && !empty($coreVersions)) {
                 <td class="rex-table-icon"><i class="rex-icon rex-icon-package"></i></td>
                 <td data-title="' . $this->i18n('version') . '">' . htmlspecialchars($file['version']) . '</td>
                 <td data-title="' . $this->i18n('description') . '">' . nl2br(htmlspecialchars($file['description'])) . '</td>
-                <td class="rex-table-action"><a href="' . rex_url::currentBackendPage(['addonkey' => $addonkey, 'rex-api-call' => 'install_package_update', 'file' => $fileId]) . '" data-pjax="false">' . $this->i18n('update') . '</a></td>
+                <td class="rex-table-action"><a href="' . rex_url::currentBackendPage(['addonkey' => $addonkey, 'file' => $fileId] + rex_api_install_package_update::getUrlParams()) . '" data-pjax="false">' . $this->i18n('update') . '</a></td>
             </tr>';
     }
 

--- a/redaxo/src/addons/install/pages/packages.upload.php
+++ b/redaxo/src/addons/install/pages/packages.upload.php
@@ -97,7 +97,7 @@ if ($addonkey && isset($addons[$addonkey])) {
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-delete" value="' . $this->i18n('delete') . '" onclick="if(confirm(\'' . $this->i18n('delete') . ' ?\')) location.href=\'' . rex_url::currentBackendPage(['rex-api-call' => 'install_package_delete', 'addonkey' => $addonkey, 'file' => $file_id]) . '\';">' . $this->i18n('delete') . '</button>';
+        $n['field'] = '<button class="btn btn-delete" value="' . $this->i18n('delete') . '" onclick="if(confirm(\'' . $this->i18n('delete') . ' ?\')) location.href=\'' . rex_url::currentBackendPage(['addonkey' => $addonkey, 'file' => $file_id] + rex_api_install_package_delete::getUrlParams()) . '\';">' . $this->i18n('delete') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();
@@ -114,7 +114,7 @@ if ($addonkey && isset($addons[$addonkey])) {
         $content = $fragment->parse('core/page/section.php');
 
         $content = '
-            <form action="' . rex_url::currentBackendPage(['rex-api-call' => 'install_package_upload', 'addonkey' => $addonkey, 'file' => $file_id]) . '" method="post">
+            <form action="' . rex_url::currentBackendPage(['addonkey' => $addonkey, 'file' => $file_id] + rex_api_install_package_upload::getUrlParams()) . '" method="post">
                 ' . $content . '
             </form>';
         echo $content;

--- a/redaxo/src/addons/metainfo/lib/handler/api_default_fields.php
+++ b/redaxo/src/addons/metainfo/lib/handler/api_default_fields.php
@@ -49,4 +49,9 @@ class rex_api_metainfo_default_fields_create extends rex_api_function
 
         return new rex_api_result(true, rex_i18n::msg('minfo_default_fields_created'));
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/metainfo/package.yml
+++ b/redaxo/src/addons/metainfo/package.yml
@@ -1,5 +1,5 @@
 package: metainfo
-version: '2.2.0'
+version: '2.2.1-dev'
 author: 'Markus Staab, Jan Kristinus'
 supportpage: www.redaxo.org/de/forum/
 
@@ -17,7 +17,7 @@ pages:
     content/metainfo: { title: 'translate:metadata', icon: rex-icon rex-icon-metainfo }
 
 requires:
-    redaxo: '^5.1.0'
+    redaxo: '^5.5.0-dev'
     packages:
         structure: '^2.0.0'
         mediapool: '^2.0.0'

--- a/redaxo/src/addons/metainfo/package.yml
+++ b/redaxo/src/addons/metainfo/package.yml
@@ -1,5 +1,5 @@
 package: metainfo
-version: '2.2.1-dev'
+version: '2.3.0-dev'
 author: 'Markus Staab, Jan Kristinus'
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/metainfo/pages/field.php
+++ b/redaxo/src/addons/metainfo/pages/field.php
@@ -82,7 +82,7 @@ if ($func == '') {
     if (in_array($prefix, ['art_', 'med_'])) {
         $defaultFields = sprintf(
             '<div class="btn-group btn-group-xs"><a href="%s" class="btn btn-default">%s</a></div>',
-            rex_url::currentBackendPage(['rex-api-call' => 'metainfo_default_fields_create', 'type' => $subpage]),
+            rex_url::currentBackendPage(['type' => $subpage] + rex_api_metainfo_default_fields_create::getUrlParams()),
             rex_i18n::msg('minfo_default_fields_create')
         );
         $fragment->setVar('options', $defaultFields, false);

--- a/redaxo/src/addons/structure/lib/api_functions/api_article2category.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article2category.php
@@ -24,4 +24,9 @@ class rex_api_article2category extends rex_api_function
         }
         throw new rex_api_exception('User has no permission for this article!');
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_article2startarticle.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article2startarticle.php
@@ -25,4 +25,9 @@ class rex_api_article2startarticle extends rex_api_function
 
         throw new rex_api_exception('user has no permission for this article!');
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_add.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_add.php
@@ -24,4 +24,9 @@ class rex_api_article_add extends rex_api_function
         $result = new rex_api_result(true, rex_article_service::addArticle($data));
         return $result;
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_copy.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_copy.php
@@ -35,4 +35,9 @@ class rex_api_article_copy extends rex_api_function
 
         throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_delete.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_delete.php
@@ -19,4 +19,9 @@ class rex_api_article_delete extends rex_api_function
         $result = new rex_api_result(true, rex_article_service::deleteArticle($article_id));
         return $result;
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_edit.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_edit.php
@@ -26,4 +26,9 @@ class rex_api_article_edit extends rex_api_function
         $result = new rex_api_result(true, rex_article_service::editArticle($article_id, $clang, $data));
         return $result;
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_move.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_move.php
@@ -34,4 +34,9 @@ class rex_api_article_move extends rex_api_function
 
         throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_status.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_status.php
@@ -24,4 +24,9 @@ class rex_api_article_status extends rex_api_function
 
         throw new rex_api_exception('user has no permission for this article!');
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_category2article.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category2article.php
@@ -24,4 +24,9 @@ class rex_api_category2Article extends rex_api_function
         }
         throw new rex_api_exception('User has no permission for this article!');
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_add.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_add.php
@@ -23,4 +23,9 @@ class rex_api_category_add extends rex_api_function
         $result = new rex_api_result(true, rex_category_service::addCategory($parentId, $data));
         return $result;
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_delete.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_delete.php
@@ -19,4 +19,9 @@ class rex_api_category_delete extends rex_api_function
 
         return $result;
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_edit.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_edit.php
@@ -29,4 +29,9 @@ class rex_api_category_edit extends rex_api_function
         $result = new rex_api_result(true, rex_category_service::editCategory($catId, $clangId, $data));
         return $result;
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_move.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_move.php
@@ -32,4 +32,9 @@ class rex_api_category_move extends rex_api_function
 
         throw new rex_api_exception('user has no permission for this category!');
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_status.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_status.php
@@ -22,4 +22,9 @@ class rex_api_category_status extends rex_api_function
 
         throw new rex_api_exception('User has no permission for this category!');
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/linkmap/api_sitemap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/api_sitemap.php
@@ -31,4 +31,9 @@ class rex_api_sitemap_tree extends rex_api_function
         $result = new rex_api_result(true);
         return $result;
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/lib/linkmap/sitemap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/sitemap.php
@@ -41,7 +41,7 @@ class rex_sitemap_category_tree extends rex_linkmap_tree_renderer
 
         $li = '';
         $li .= '<li' . $liClasses . ' data-cat-id="' . $cat->getId() . '" data-parent-id="' . $cat->getParentId() . '" data-priority="' . $cat->getPriority() . '">';
-        $li .= '<a' . $linkClasses . ' href="' . $this->context->getUrl(['rex-api-call' => 'sitemap_tree', 'toggle_category_id' => $cat->getId()]) . '">&nbsp;</a>';
+        $li .= '<a' . $linkClasses . ' href="' . $this->context->getUrl(['toggle_category_id' => $cat->getId()] + rex_api_sitemap_tree::getUrlParams()) . '">&nbsp;</a>';
         $li .= '<a href="' . $this->context->getUrl(['category_id' => $cat->getId()]) . '">' . htmlspecialchars($label) . '</a>';
         $li .= $subHtml;
         $li .= '</li>';

--- a/redaxo/src/addons/structure/package.yml
+++ b/redaxo/src/addons/structure/package.yml
@@ -1,5 +1,5 @@
 package: structure
-version: '2.4.0'
+version: '2.4.1-dev'
 author: Markus Staab
 supportpage: www.redaxo.org/de/forum/
 
@@ -24,4 +24,4 @@ pages:
 system_plugins: [content]
 
 requires:
-    redaxo: ^5.3.0
+    redaxo: ^5.5.0-dev

--- a/redaxo/src/addons/structure/package.yml
+++ b/redaxo/src/addons/structure/package.yml
@@ -1,5 +1,5 @@
 package: structure
-version: '2.4.1-dev'
+version: '2.5.0-dev'
 author: Markus Staab
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/structure/pages/index.php
+++ b/redaxo/src/addons/structure/pages/index.php
@@ -176,8 +176,7 @@ if ($function == 'add_cat' && $KATPERM) {
         'id' => $category_id,
         'clang' => $clang,
     ]));
-    $add_buttons = '
-        <input type="hidden" name="rex-api-call" value="category_add" />
+    $add_buttons = rex_api_category_add::getHiddenFields().'
         <input type="hidden" name="parent-category-id" value="' . $category_id . '" />
         <button class="btn btn-save" type="submit" name="category-add-button"' . rex::getAccesskey(rex_i18n::msg('add_category'), 'save') . '>' . rex_i18n::msg('add_category') . '</button>';
 
@@ -215,7 +214,7 @@ if ($KAT->getRows() > 0) {
 
         if ($KATPERM) {
             if ($KATPERM && rex::getUser()->hasPerm('publishCategory[]')) {
-                $kat_status = '<a class="' . $status_class . '" href="' . $context->getUrl(['category-id' => $i_category_id, 'rex-api-call' => 'category_status', 'catstart' => $catstart]) . '"><i class="rex-icon ' . $status_icon . '"></i> ' . $kat_status . '</a>';
+                $kat_status = '<a class="' . $status_class . '" href="' . $context->getUrl(['category-id' => $i_category_id, 'catstart' => $catstart] + rex_api_category_status::getUrlParams()) . '"><i class="rex-icon ' . $status_icon . '"></i> ' . $kat_status . '</a>';
             } else {
                 $kat_status = '<span class="' . $status_class . ' text-muted"><i class="rex-icon ' . $status_icon . '"></i> ' . $kat_status . '</span>';
             }
@@ -229,8 +228,7 @@ if ($KAT->getRows() > 0) {
                     'clang' => $clang,
                 ]));
 
-                $add_buttons = '
-                <input type="hidden" name="rex-api-call" value="category_edit" />
+                $add_buttons = rex_api_category_edit::getHiddenFields().'
                 <input type="hidden" name="category-id" value="' . $edit_id . '" />
                 <button class="btn btn-save" type="submit" name="category-edit-button"' . rex::getAccesskey(rex_i18n::msg('save_category'), 'save') . '>' . rex_i18n::msg('save_category') . '</button>';
 
@@ -261,7 +259,7 @@ if ($KAT->getRows() > 0) {
             } else {
                 // --------------------- KATEGORIE WITH WRITE
 
-                $category_delete = '<a href="' . $context->getUrl(['category-id' => $i_category_id, 'rex-api-call' => 'category_delete', 'catstart' => $catstart]) . '" data-confirm="' . rex_i18n::msg('delete') . ' ?"><i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('delete') . '</a>';
+                $category_delete = '<a href="' . $context->getUrl(['category-id' => $i_category_id, 'catstart' => $catstart] + rex_api_category_delete::getUrlParams()) . '" data-confirm="' . rex_i18n::msg('delete') . ' ?"><i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('delete') . '</a>';
 
                 $echo .= '
                     <tr>
@@ -445,7 +443,7 @@ if ($category_id > 0 || ($category_id == 0 && !rex::getUser()->getComplexPerm('s
                     ' . $tmpl_td . '
                     <td data-title="' . rex_i18n::msg('header_date') . '">' . rex_formatter::strftime(time(), 'date') . '</td>
                     <td class="rex-table-priority" data-title="' . rex_i18n::msg('header_priority') . '"><input class="form-control" type="text" name="article-position" value="' . ($artPager->getRowCount() + 1) . '" /></td>
-                    <td class="rex-table-action" colspan="3"><input type="hidden" name="rex-api-call" value="article_add" /><button class="btn btn-save" type="submit" name="artadd_function"' . rex::getAccesskey(rex_i18n::msg('article_add'), 'save') . '>' . rex_i18n::msg('article_add') . '</button></td>
+                    <td class="rex-table-action" colspan="3">'.rex_api_article_add::getHiddenFields().'<button class="btn btn-save" type="submit" name="artadd_function"' . rex::getAccesskey(rex_i18n::msg('article_add'), 'save') . '>' . rex_i18n::msg('article_add') . '</button></td>
                 </tr>
                             ';
     }
@@ -481,7 +479,7 @@ if ($category_id > 0 || ($category_id == 0 && !rex::getUser()->getComplexPerm('s
                             ' . $tmpl_td . '
                             <td data-title="' . rex_i18n::msg('header_date') . '">' . rex_formatter::strftime($sql->getDateTimeValue('createdate'), 'date') . '</td>
                             <td class="rex-table-priority" data-title="' . rex_i18n::msg('header_priority') . '"><input class="form-control" type="text" name="article-position" value="' . htmlspecialchars($sql->getValue('priority')) . '" /></td>
-                            <td class="rex-table-action" colspan="3"><input type="hidden" name="rex-api-call" value="article_edit" /><button class="btn btn-save" type="submit" name="artedit_function"' . rex::getAccesskey(rex_i18n::msg('article_save'), 'save') . '>' . rex_i18n::msg('article_save') . '</button></td>
+                            <td class="rex-table-action" colspan="3">'.rex_api_article_edit::getHiddenFields().'<button class="btn btn-save" type="submit" name="artedit_function"' . rex::getAccesskey(rex_i18n::msg('article_save'), 'save') . '>' . rex_i18n::msg('article_save') . '</button></td>
                         </tr>';
         } elseif ($KATPERM) {
             // --------------------- ARTIKEL NORMAL VIEW | EDIT AND ENTER
@@ -496,12 +494,12 @@ if ($category_id > 0 || ($category_id == 0 && !rex::getUser()->getComplexPerm('s
                               <td class="rex-table-action"><span class="' . $article_class . ' text-muted"><i class="rex-icon ' . $article_icon . '"></i> ' . $article_status . '</span></td>';
             } else {
                 if ($KATPERM && rex::getUser()->hasPerm('publishArticle[]')) {
-                    $article_status = '<a class="' . $article_class . '" href="' . $context->getUrl(['article_id' => $sql->getValue('id'), 'rex-api-call' => 'article_status', 'artstart' => $artstart]) . '"><i class="rex-icon ' . $article_icon . '"></i> ' . $article_status . '</a>';
+                    $article_status = '<a class="' . $article_class . '" href="' . $context->getUrl(['article_id' => $sql->getValue('id'), 'artstart' => $artstart] + rex_api_article_status::getUrlParams()) . '"><i class="rex-icon ' . $article_icon . '"></i> ' . $article_status . '</a>';
                 } else {
                     $article_status = '<span class="' . $article_class . ' text-muted"><i class="rex-icon ' . $article_icon . '"></i> ' . $article_status . '</span>';
                 }
 
-                $article_delete = '<a href="' . $context->getUrl(['article_id' => $sql->getValue('id'), 'rex-api-call' => 'article_delete', 'artstart' => $artstart]) . '" data-confirm="' . rex_i18n::msg('delete') . ' ?"><i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('delete') . '</a>';
+                $article_delete = '<a href="' . $context->getUrl(['article_id' => $sql->getValue('id'), 'artstart' => $artstart] + rex_api_article_delete::getUrlParams()) . '" data-confirm="' . rex_i18n::msg('delete') . ' ?"><i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('delete') . '</a>';
 
                 $add_extra = '<td class="rex-table-action">' . $article_delete . '</td>
                               <td class="rex-table-action">' . $article_status . '</td>';

--- a/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content.php
@@ -52,4 +52,9 @@ class rex_api_content_move_slice extends rex_api_function
         $result = new rex_api_result(true, $message);
         return $result;
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_copy.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_copy.php
@@ -34,4 +34,9 @@ class rex_api_content_copy extends rex_api_function
 
         throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
@@ -165,7 +165,7 @@ class rex_article_content_editor extends rex_article_content
                 // moveup
                 $item = [];
                 $item['hidden_label'] = rex_i18n::msg('module') . ' ' . $moduleName . ' ' . rex_i18n::msg('move_slice_up');
-                $item['url'] = $context->getUrl(['upd' => time(), 'rex-api-call' => 'content_move_slice', 'direction' => 'moveup']) . $fragment;
+                $item['url'] = $context->getUrl(['upd' => time(), 'direction' => 'moveup'] + rex_api_content_move_slice::getUrlParams()) . $fragment;
                 $item['attributes']['class'][] = 'btn-move';
                 $item['attributes']['title'] = rex_i18n::msg('move_slice_up');
                 $item['icon'] = 'up';
@@ -174,7 +174,7 @@ class rex_article_content_editor extends rex_article_content
                 // movedown
                 $item = [];
                 $item['hidden_label'] = rex_i18n::msg('module') . ' ' . $moduleName . ' ' . rex_i18n::msg('move_slice_down');
-                $item['url'] = $context->getUrl(['upd' => time(), 'rex-api-call' => 'content_move_slice', 'direction' => 'movedown']) . $fragment;
+                $item['url'] = $context->getUrl(['upd' => time(), 'direction' => 'movedown'] + rex_api_content_move_slice::getUrlParams()) . $fragment;
                 $item['attributes']['class'][] = 'btn-move';
                 $item['attributes']['title'] = rex_i18n::msg('move_slice_down');
                 $item['icon'] = 'down';

--- a/redaxo/src/addons/structure/plugins/content/package.yml
+++ b/redaxo/src/addons/structure/plugins/content/package.yml
@@ -1,5 +1,5 @@
 package: structure/content
-version: '2.4.0'
+version: '2.4.1-dev'
 author: Markus Staab
 supportpage: www.redaxo.org/de/forum/
 
@@ -35,4 +35,4 @@ pages:
             actions: { title: translate:actions }
 
 requires:
-    redaxo: ^5.1.0
+    redaxo: ^5.5.0-dev

--- a/redaxo/src/addons/structure/plugins/content/package.yml
+++ b/redaxo/src/addons/structure/plugins/content/package.yml
@@ -1,5 +1,5 @@
 package: structure/content
-version: '2.4.1-dev'
+version: '2.5.0-dev'
 author: Markus Staab
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/structure/plugins/content/pages/content.functions.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.functions.php
@@ -1,11 +1,14 @@
 <?php
 
 $content .= '
-        <form id="rex-form-content-metamode" action="' . $context->getUrl() . '" method="post" enctype="multipart/form-data" id="REX_FORM" data-pjax-container="#rex-page-main">
+        <form id="rex-form-content-metamode" action="' . $context->getUrl() . '" method="post" enctype="multipart/form-data" data-pjax-container="#rex-page-main">
             <input type="hidden" name="save" value="1" />
             <input type="hidden" name="ctype" value="' . $ctype . '" />
-            <input type="hidden" name="rex-api-call" id="apiField" />
             ';
+
+$onclickApiFields = function ($hiddenFields) {
+    return 'onclick="$(this.form).append(\''.rex_escape($hiddenFields).'\')"';
+};
 
 $isStartpage = $article->getValue('startarticle') == 1;
 // --------------------------------------------------- ZUM STARTARTICLE MACHEN START
@@ -48,7 +51,7 @@ if (rex::getUser()->hasPerm('article2startarticle[]')) {
 
         $formElements = [];
         $n = [];
-        $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="article2startarticle" value="1" data-confirm="' . rex_i18n::msg('content_tostartarticle') . '?" onclick="jQuery(\'#apiField\').val(\'article2startarticle\');">' . rex_i18n::msg('content_tostartarticle') . '</button>';
+        $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="article2startarticle" value="1" data-confirm="' . rex_i18n::msg('content_tostartarticle') . '?" '.$onclickApiFields(rex_api_article2startarticle::getHiddenFields()).'>' . rex_i18n::msg('content_tostartarticle') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();
@@ -85,7 +88,7 @@ if (!$isStartpage && rex::getUser()->hasPerm('article2category[]')) {
 
     $formElements = [];
     $n = [];
-    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="article2category" value="1" data-confirm="' . rex_i18n::msg('content_tocategory') . '?" onclick="jQuery(\'#apiField\').val(\'article2category\');">' . rex_i18n::msg('content_tocategory') . '</button>';
+    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="article2category" value="1" data-confirm="' . rex_i18n::msg('content_tocategory') . '?" '.$onclickApiFields(rex_api_article2category::getHiddenFields()).'>' . rex_i18n::msg('content_tocategory') . '</button>';
     $formElements[] = $n;
 
     $fragment = new rex_fragment();
@@ -133,7 +136,7 @@ if ($isStartpage && rex::getUser()->hasPerm('article2category[]') && rex::getUse
 
         $formElements = [];
         $n = [];
-        $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="category2article" value="1" data-confirm="' . rex_i18n::msg('content_toarticle') . '?" onclick="jQuery(\'#apiField\').val(\'category2article\');">' . rex_i18n::msg('content_toarticle') . '</button>';
+        $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="category2article" value="1" data-confirm="' . rex_i18n::msg('content_toarticle') . '?" '.$onclickApiFields(rex_api_category2Article::getHiddenFields()).'>' . rex_i18n::msg('content_toarticle') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();
@@ -210,7 +213,7 @@ if ($user->hasPerm('copyContent[]') && $user->getComplexPerm('clang')->count() >
 
     $formElements = [];
     $n = [];
-    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="content_copy" onclick="jQuery(\'#apiField\').val(\'content_copy\');" value="1" data-confirm="' . rex_i18n::msg('content_submitcopycontent') . '?">' . rex_i18n::msg('content_submitcopycontent') . '</button>';
+    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="content_copy" value="1" data-confirm="' . rex_i18n::msg('content_submitcopycontent') . '?" '.$onclickApiFields(rex_api_content_copy::getHiddenFields()).'>' . rex_i18n::msg('content_submitcopycontent') . '</button>';
     $formElements[] = $n;
 
     $fragment = new rex_fragment();
@@ -251,7 +254,7 @@ if (!$isStartpage && rex::getUser()->hasPerm('moveArticle[]')) {
 
     $formElements = [];
     $n = [];
-    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="article_move" onclick="jQuery(\'#apiField\').val(\'article_move\');" value="1" data-confirm="' . rex_i18n::msg('content_submitmovearticle') . '?">' . rex_i18n::msg('content_submitmovearticle') . '</button>';
+    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="article_move" value="1" data-confirm="' . rex_i18n::msg('content_submitmovearticle') . '?" '.$onclickApiFields(rex_api_article_move::getHiddenFields()).'>' . rex_i18n::msg('content_submitmovearticle') . '</button>';
     $formElements[] = $n;
 
     $fragment = new rex_fragment();
@@ -291,7 +294,7 @@ if (rex::getUser()->hasPerm('copyArticle[]')) {
 
     $formElements = [];
     $n = [];
-    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="article_copy" onclick="jQuery(\'#apiField\').val(\'article_copy\');" value="1" data-confirm="' . rex_i18n::msg('content_submitcopyarticle') . '?">' . rex_i18n::msg('content_submitcopyarticle') . '</button>';
+    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="article_copy" value="1" data-confirm="' . rex_i18n::msg('content_submitcopyarticle') . '?" '.$onclickApiFields(rex_api_article_copy::getHiddenFields()).'>' . rex_i18n::msg('content_submitcopyarticle') . '</button>';
     $formElements[] = $n;
 
     $fragment = new rex_fragment();
@@ -331,7 +334,7 @@ if ($isStartpage && rex::getUser()->hasPerm('moveCategory[]') && rex::getUser()-
 
     $formElements = [];
     $n = [];
-    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="category_move" onclick="jQuery(\'#apiField\').val(\'category_move\');" value="1" data-confirm="' . rex_i18n::msg('content_submitmovecategory') . '?">' . rex_i18n::msg('content_submitmovecategory') . '</button>';
+    $n['field'] = '<button class="btn btn-send rex-form-aligned" type="submit" name="category_move" value="1" data-confirm="' . rex_i18n::msg('content_submitmovecategory') . '?" '.$onclickApiFields(rex_api_category_move::getHiddenFields()).'>' . rex_i18n::msg('content_submitmovecategory') . '</button>';
     $formElements[] = $n;
 
     $fragment = new rex_fragment();

--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -238,7 +238,7 @@ abstract class rex_api_function
 
     /**
      * Csrf validation is disabled by default for backwards compatiblity reasons. This default will change in a future version.
-     * Prepare all your api functions to work with csrf token by using your-api-class::getUrlParams(), otherwise they will stop work.
+     * Prepare all your api functions to work with csrf token by using your-api-class::getUrlParams()/getHiddenFields(), otherwise they will stop work.
      *
      * @return bool
      */

--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -90,6 +90,15 @@ abstract class rex_api_function
         return null;
     }
 
+    public static function getUrlParams()
+    {
+        $class = get_called_class();
+
+        $name = substr($class, 8);
+
+        return ['rex-api-call' => $name, rex_csrf_token::PARAM => rex_csrf_token::factory($class)->getValue()];
+    }
+
     /**
      * checks whether an api function is bound to the current requests. If so, so the api function will be executed.
      */
@@ -124,6 +133,12 @@ abstract class rex_api_function
                 $result = rex_api_result::fromJSON($urlResult);
                 $apiFunc->result = $result;
             } else {
+                if (!rex_csrf_token::factory(get_class($apiFunc))->isValid()) {
+                    $result = new rex_api_result(false, rex_i18n::msg('csrf_token_invalid'));
+                    $apiFunc->result = $result;
+                    return;
+                }
+
                 try {
                     $result = $apiFunc->execute();
 

--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -215,8 +215,8 @@ abstract class rex_api_function
     }
 
     /**
-     * This method should be overwritten in all api func classes and the return value should be changed to `true`.
-     * All links for calling the api should then be generated with `your_api_class::getUrlParams()`.
+     * Csrf validation is disabled by default for backwards compatiblity reasons. This default will change in a future version.
+     * Prepare all your api functions to work with csrf token by using your-api-class::getUrlParams(), otherwise they will stop work.
      *
      * @return bool
      */

--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -108,7 +108,29 @@ abstract class rex_api_function
         // remove the `rex_api_` prefix
         $name = substr($class, 8);
 
-        return ['rex-api-call' => $name, rex_csrf_token::PARAM => rex_csrf_token::factory($class)->getValue()];
+        return [self::REQ_CALL_PARAM => $name, rex_csrf_token::PARAM => rex_csrf_token::factory($class)->getValue()];
+    }
+
+    /**
+     * Returns the hidden fields for `rex-api-call` and `_csrf_token`.
+     *
+     * The method must be called on sub classes.
+     *
+     * @return string
+     */
+    public static function getHiddenFields()
+    {
+        $class = get_called_class();
+
+        if (__CLASS__ === $class) {
+            throw new BadMethodCallException(__FUNCTION__.' must be called on subclasses of "'.__CLASS__.'".');
+        }
+
+        // remove the `rex_api_` prefix
+        $name = substr($class, 8);
+
+        return sprintf('<input type="hidden" name="%s" value="%s"/>', self::REQ_CALL_PARAM, rex_escape($name, 'html_attr'))
+            .rex_csrf_token::factory($class)->getHiddenField();
     }
 
     /**

--- a/redaxo/src/core/lib/packages/api_package.php
+++ b/redaxo/src/core/lib/packages/api_package.php
@@ -39,4 +39,9 @@ class rex_api_package extends rex_api_function
         }
         return $result;
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }

--- a/redaxo/src/core/pages/packages.php
+++ b/redaxo/src/core/pages/packages.php
@@ -90,9 +90,8 @@ if ($subpage == '') {
         $text = rex_i18n::msg('package_' . ($key ?: $function));
         $url = rex_url::currentBackendPage([
             'package' => $package->getPackageId(),
-            'rex-api-call' => 'package',
             'function' => $function,
-        ]);
+        ] + rex_api_package::getUrlParams());
 
         $icon = ($icon != '') ? '<i class="rex-icon ' . $icon . '"></i>' : '';
         $class = ($key ?: $function);


### PR DESCRIPTION
closes #1412 

Der PR ist noch lange nicht fertig, sondern ein Diskussionsansatz.
* Wollen wir das so lösen mit den URL-Params? Muss dann alle Api-Links anpassen, und die Rex-Mindestversion in den Addons anpassen (was ich ok finde)
* Aus BC-Gründen muss der CSRF-Schutz hier wohl opt-in sein für die einzelnen Api-Funcs. Muss ich auch noch einbauen.
* Gibt grundsätzlich (ganz andere) bessere Ideen, wie wir es lösen?