### PR TITLE
CSRF-Tokens unterscheiden nach http/https

### DIFF
--- a/redaxo/src/core/lib/csrf_token.php
+++ b/redaxo/src/core/lib/csrf_token.php
@@ -128,7 +128,9 @@ class rex_csrf_token
 
     private static function getSessionKey()
     {
-        return 'csrf_tokens_'.rex::getEnvironment();
+        $suffix = !empty($_SERVER['HTTPS']) && 'off' !== strtolower($_SERVER['HTTPS']) ? '_https' : '';
+
+        return 'csrf_tokens_'.rex::getEnvironment().$suffixs;
     }
 
     private static function generateToken()

--- a/redaxo/src/core/lib/csrf_token.php
+++ b/redaxo/src/core/lib/csrf_token.php
@@ -130,7 +130,7 @@ class rex_csrf_token
     {
         $suffix = !empty($_SERVER['HTTPS']) && 'off' !== strtolower($_SERVER['HTTPS']) ? '_https' : '';
 
-        return 'csrf_tokens_'.rex::getEnvironment().$suffixs;
+        return 'csrf_tokens_'.rex::getEnvironment().$suffix;
     }
 
     private static function generateToken()

--- a/redaxo/src/core/lib/csrf_token.php
+++ b/redaxo/src/core/lib/csrf_token.php
@@ -128,6 +128,8 @@ class rex_csrf_token
 
     private static function getSessionKey()
     {
+        // use separate tokens for http/https
+        // http://symfony.com/blog/cve-2017-16653-csrf-protection-does-not-use-different-tokens-for-http-and-https
         $suffix = !empty($_SERVER['HTTPS']) && 'off' !== strtolower($_SERVER['HTTPS']) ? '_https' : '';
 
         return 'csrf_tokens_'.rex::getEnvironment().$suffix;


### PR DESCRIPTION
http://symfony.com/blog/cve-2017-16653-csrf-protection-does-not-use-different-tokens-for-http-and-https

Ich verstehe es nicht hundertprozentig, aber vermute, dass es uns auch betrifft. Jedenfalls sollte es nicht schaden, die Tokens zwischen http/https zu trennen.