### PR TITLE
Warnung ausgeben im Setup, wenn kein HTTPS verwendet wird.

### DIFF
--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -215,6 +215,7 @@ setup_799 = 7 / Heureka
 
 setup_security_msg = Der Ordner redaxo ist unsicher. Bitte schützen Sie diesen Ordner und starten das Setup erneut!
 setup_no_js_security_msg = Prüfen Sie, ob Dateien aus dem Ordner redaxo/cache, redaxo/data und redaxo/src direkt aufrufbar sind! Dies darf aus Sicherheitsgründen nicht möglich sein!
+setup_security_no_https = Das Setup wird ohne HTTPS/Verschlüsselung durchgeführt. Es wird empfohlen jegliche Frontend und Backend aufrufe nur mittels HTTPS durchzuführen, um die Privatsphäere und den Datenschutz zu gewährleisten.
 setup_security_warn_mod_security = Das Apache Modul "mod_security" ist geladen. Dies kann bei falscher Konfiguration zu Problemen führen.
 
 sql_database_name_missing = Es muss ein Datenbankname angegeben werden!

--- a/redaxo/src/core/lib/request.php
+++ b/redaxo/src/core/lib/request.php
@@ -243,4 +243,14 @@ class rex_request
 
         return isset($_SERVER['HTTP_X_PJAX_CONTAINER']) && $_SERVER['HTTP_X_PJAX_CONTAINER'] == $containerId;
     }
+
+    /**
+     * Returns whether the current request is served via https/ssl.
+     *
+     * @return bool true when https/ssl, otherwise false.
+     */
+    public static function isHttps()
+    {
+        return !empty($_SERVER['HTTPS']) && 'off' !== strtolower($_SERVER['HTTPS']);
+    }
 }

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -272,6 +272,15 @@ class rex
     }
 
     /**
+     * Returns whether the current request is served via https/ssl.
+     *
+     * @return bool true when https/ssl, otherwise false.
+     */
+    public static function isHttps() {
+        return !empty($_SERVER['HTTPS']) && 'off' !== strtolower($_SERVER['HTTPS']);
+    }
+
+    /**
      * Returns the error email.
      *
      * @return string

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -276,7 +276,8 @@ class rex
      *
      * @return bool true when https/ssl, otherwise false.
      */
-    public static function isHttps() {
+    public static function isHttps()
+    {
         return !empty($_SERVER['HTTPS']) && 'off' !== strtolower($_SERVER['HTTPS']);
     }
 

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -272,16 +272,6 @@ class rex
     }
 
     /**
-     * Returns whether the current request is served via https/ssl.
-     *
-     * @return bool true when https/ssl, otherwise false.
-     */
-    public static function isHttps()
-    {
-        return !empty($_SERVER['HTTPS']) && 'off' !== strtolower($_SERVER['HTTPS']);
-    }
-
-    /**
      * Returns the error email.
      *
      * @return string

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -136,6 +136,10 @@ if ($step == 3) {
 
     </script>';
 
+    if (!rex::isHttps()) {
+        $security .= rex_view::warning(rex_i18n::msg('setup_security_no_https'));
+    }
+
     if (function_exists('apache_get_modules') && in_array('mod_security', apache_get_modules())) {
         $security .= rex_view::warning(rex_i18n::msg('setup_security_warn_mod_security'));
     }

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -136,7 +136,7 @@ if ($step == 3) {
 
     </script>';
 
-    if (!rex::isHttps()) {
+    if (!rex_request::isHttps()) {
         $security .= rex_view::warning(rex_i18n::msg('setup_security_no_https'));
     }
 


### PR DESCRIPTION
Closes https://github.com/redaxo/redaxo/issues/1340.

Erstmal nur eine "einfache Warnung" im setup. Ein "richtiges Notificationscenter" kann später noch etabliert werden.