### PR TITLE
Systemlog: Zeilenumbrüche darstellen

### DIFF
--- a/redaxo/src/addons/cronjob/pages/log.php
+++ b/redaxo/src/addons/cronjob/pages/log.php
@@ -39,7 +39,7 @@ if ($file = new rex_log_file($this->getDataPath('cronjob.log'))) {
                         <td class="rex-table-icon">' . $icon . '</td>
                         <td data-title="' . rex_i18n::msg('cronjob_log_date') . '">' . $entry->getTimestamp('%d.%m.%Y %H:%M:%S') . '</td>
                         <td data-title="' . rex_i18n::msg('cronjob_name') . '">' . htmlspecialchars($data[2]) . '</td>
-                        <td data-title="' . rex_i18n::msg('cronjob_log_message') . '">' . str_replace('\n', "<br />", $data[3]) . '</td>
+                        <td data-title="' . rex_i18n::msg('cronjob_log_message') . '">' . str_replace('\n', '<br />', $data[3]) . '</td>
                     </tr>';
     }
 }

--- a/redaxo/src/addons/cronjob/pages/log.php
+++ b/redaxo/src/addons/cronjob/pages/log.php
@@ -39,7 +39,7 @@ if ($file = new rex_log_file($this->getDataPath('cronjob.log'))) {
                         <td class="rex-table-icon">' . $icon . '</td>
                         <td data-title="' . rex_i18n::msg('cronjob_log_date') . '">' . $entry->getTimestamp('%d.%m.%Y %H:%M:%S') . '</td>
                         <td data-title="' . rex_i18n::msg('cronjob_name') . '">' . htmlspecialchars($data[2]) . '</td>
-                        <td data-title="' . rex_i18n::msg('cronjob_log_message') . '">' . str_replace("\n", '<br />', $data[3]) . '</td>
+                        <td data-title="' . rex_i18n::msg('cronjob_log_message') . '">' . nl2br($data[3]) . '</td>
                     </tr>';
     }
 }

--- a/redaxo/src/addons/cronjob/pages/log.php
+++ b/redaxo/src/addons/cronjob/pages/log.php
@@ -39,7 +39,7 @@ if ($file = new rex_log_file($this->getDataPath('cronjob.log'))) {
                         <td class="rex-table-icon">' . $icon . '</td>
                         <td data-title="' . rex_i18n::msg('cronjob_log_date') . '">' . $entry->getTimestamp('%d.%m.%Y %H:%M:%S') . '</td>
                         <td data-title="' . rex_i18n::msg('cronjob_name') . '">' . htmlspecialchars($data[2]) . '</td>
-                        <td data-title="' . rex_i18n::msg('cronjob_log_message') . '">' . $data[3] . '</td>
+                        <td data-title="' . rex_i18n::msg('cronjob_log_message') . '">' . str_replace('\n', "<br />", $data[3]) . '</td>
                     </tr>';
     }
 }

--- a/redaxo/src/addons/cronjob/pages/log.php
+++ b/redaxo/src/addons/cronjob/pages/log.php
@@ -39,7 +39,7 @@ if ($file = new rex_log_file($this->getDataPath('cronjob.log'))) {
                         <td class="rex-table-icon">' . $icon . '</td>
                         <td data-title="' . rex_i18n::msg('cronjob_log_date') . '">' . $entry->getTimestamp('%d.%m.%Y %H:%M:%S') . '</td>
                         <td data-title="' . rex_i18n::msg('cronjob_name') . '">' . htmlspecialchars($data[2]) . '</td>
-                        <td data-title="' . rex_i18n::msg('cronjob_log_message') . '">' . str_replace('\n', '<br />', $data[3]) . '</td>
+                        <td data-title="' . rex_i18n::msg('cronjob_log_message') . '">' . str_replace("\n", '<br />', $data[3]) . '</td>
                     </tr>';
     }
 }


### PR DESCRIPTION
Maskierte Zeilenumbrüche \n aus dem Log als HTML <br /> ausgeben