### PR TITLE
Commands als internal classes markieren

### DIFF
--- a/redaxo/src/addons/cronjob/lib/command/run.php
+++ b/redaxo/src/addons/cronjob/lib/command/run.php
@@ -4,7 +4,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @package redaxo\core
+ * @package redaxo\cronjob
+ *
+ * @internal
  */
 class rex_command_cronjob_run extends rex_console_command
 {

--- a/redaxo/src/core/lib/console/cache/clear.php
+++ b/redaxo/src/core/lib/console/cache/clear.php
@@ -5,6 +5,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @package redaxo\core
+ *
+ * @internal
  */
 class rex_command_cache_clear extends rex_console_command
 {

--- a/redaxo/src/core/lib/console/package/activate.php
+++ b/redaxo/src/core/lib/console/package/activate.php
@@ -6,6 +6,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @package redaxo\core
+ *
+ * @internal
  */
 class rex_command_package_activate extends rex_console_command
 {

--- a/redaxo/src/core/lib/console/package/deactivate.php
+++ b/redaxo/src/core/lib/console/package/deactivate.php
@@ -6,6 +6,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @package redaxo\core
+ *
+ * @internal
  */
 class rex_command_package_deactivate extends rex_console_command
 {

--- a/redaxo/src/core/lib/console/package/install.php
+++ b/redaxo/src/core/lib/console/package/install.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @package redaxo\core
+ *
+ * @internal
  */
 class rex_command_package_install extends rex_console_command
 {

--- a/redaxo/src/core/lib/console/package/uninstall.php
+++ b/redaxo/src/core/lib/console/package/uninstall.php
@@ -6,6 +6,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @package redaxo\core
+ *
+ * @internal
  */
 class rex_command_package_uninstall extends rex_console_command
 {


### PR DESCRIPTION
Die Klassen gehören meiner Meinung nach nicht zur public Api, darauf soll man sich nicht verlassen können, dass die Klassen so existieren.
(Nur die Kommandos selbst gehören zur Public Api).