### PR TITLE
Toggle-Button in Passwortfeldern ohne Tabindex

### DIFF
--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -529,7 +529,7 @@ jQuery(document).ready(function($) {
             $el.after($eye);
             $eye
                 .wrap('<span class="input-group-btn"></span>')
-                .wrap('<button type="button" class="btn btn-view"></button>');
+                .wrap('<button type="button" class="btn btn-view" tabindex="-1"></button>');
 
             $el.next('span.input-group-btn').find('button.btn').click(function(event) {
                 $eye.toggleClass("rex-icon-view rex-icon-hide");


### PR DESCRIPTION
Finde das störend, wenn man das Formular ausfüllt, und per Tab von Feld zu Feld springt, dass man beim Passwortfeld doppelt Tab drücken muss, um das nächste Feld zu erreichen.
Mir ist gerade passiert, dass ich ohne zu schauen, Tab einfach gedrückt habe, dann losgetippt, und gewundert, warum das Feld leer blieb (da Focus auf Toggle-Button).