### PR TITLE
system.log bei rex_delete_cache ignorieren

### DIFF
--- a/redaxo/src/core/functions/function_rex_other.php
+++ b/redaxo/src/core/functions/function_rex_other.php
@@ -20,6 +20,7 @@ function rex_delete_cache()
         ->recursive()
         ->childFirst()
         ->ignoreFiles(['.htaccess', '.redaxo'], false)
+        ->ignoreFiles(['system.log'])
         ->ignoreSystemStuff(false);
     rex_dir::deleteIterator($finder);
 


### PR DESCRIPTION
Ich denke man sollte den system.log nicht bei Löschung des Cache löschen, da man somit wichtig Informationen verliert.
z.B. habe ich ein Import Skript geschrieben was am Ende den Cache löscht und ich logge Import-Fehler im System.log mit welche aber nie sichtbar waren da sie sofort mit delete_cache wieder entfernt wuden