### PR TITLE
CSRF-Tokens löschen bei Zeitbasierter Logout

### DIFF
--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -97,6 +97,8 @@ class rex_backend_login extends rex_login
                         $this->message .= ' ' . rex_i18n::rawMsg('login_wait', '<strong data-time="' . $time . '">' . $formatted . '</strong>');
                     }
                 }
+            } else {
+                rex_csrf_token::removeAll();
             }
         }
 


### PR DESCRIPTION
Bisher wurden die Tokens nur bei explizitem Logout gelöscht. Und beim Sessionablauf php-seitig natürlich auch.
Aber nicht, wenn die Session gemäß unserer Einstellung aus der config.yml abgelaufen ist.