### PR TITLE
System-Log: Pfadänderung & Zeilenumbrüche

### DIFF
--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -20,6 +20,16 @@ class rex_logger extends AbstractLogger
     private static $file;
 
     /**
+     * Returns the path to the system.log file.
+     *
+     * @return string
+     */
+    public static function getPath()
+    {
+        return rex_path::coreData('system.log');
+    }
+
+    /**
      * Shorthand: Logs the given Exception.
      *
      * @param Throwable|Exception $exception The Exception to log
@@ -113,8 +123,7 @@ class rex_logger extends AbstractLogger
     {
         // check if already opened
         if (!self::$file) {
-            $file = rex_path::coreData('system.log');
-            self::$file = new rex_log_file($file, 2000000);
+            self::$file = new rex_log_file(self::getPath(), 2000000);
         }
     }
 

--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -113,7 +113,7 @@ class rex_logger extends AbstractLogger
     {
         // check if already opened
         if (!self::$file) {
-            $file = rex_path::coreCache('system.log');
+            $file = rex_path::coreData('system.log');
             self::$file = new rex_log_file($file, 2000000);
         }
     }

--- a/redaxo/src/core/pages/system.log.php
+++ b/redaxo/src/core/pages/system.log.php
@@ -60,7 +60,7 @@ if ($file = new rex_log_file($logFile)) {
                     <tr class="rex-state-' . $class . '">
                         <td data-title="' . rex_i18n::msg('syslog_timestamp') . '">' . $entry->getTimestamp('%d.%m.%Y %H:%M:%S') . '</td>
                         <td data-title="' . rex_i18n::msg('syslog_type') . '">' . htmlspecialchars($data[0]) . '</td>
-                        <td data-title="' . rex_i18n::msg('syslog_message') . '">' . htmlspecialchars($data[1]) . '</td>
+                        <td data-title="' . rex_i18n::msg('syslog_message') . '">' . nl2br(htmlspecialchars($data[1])) . '</td>
                         <td data-title="' . rex_i18n::msg('syslog_file') . '"><div class="rex-word-break">' . (isset($data[2]) ? htmlspecialchars($data[2]) : '') . '</div></td>
                         <td class="rex-table-number" data-title="' . rex_i18n::msg('syslog_line') . '">' . (isset($data[3]) ? htmlspecialchars($data[3]) : '') . '</td>
                     </tr>';

--- a/redaxo/src/core/pages/system.log.php
+++ b/redaxo/src/core/pages/system.log.php
@@ -12,7 +12,7 @@ $func = rex_request('func', 'string');
 $error = '';
 $success = '';
 
-$logFile = rex_path::coreCache('system.log');
+$logFile = rex_path::coreData('system.log');
 if ($func == 'delLog') {
     // close logger, to free remaining file-handles to syslog
     // so we can safely delete the file

--- a/redaxo/src/core/pages/system.log.php
+++ b/redaxo/src/core/pages/system.log.php
@@ -12,7 +12,7 @@ $func = rex_request('func', 'string');
 $error = '';
 $success = '';
 
-$logFile = rex_path::coreData('system.log');
+$logFile = rex_logger::getPath();
 if ($func == 'delLog') {
     // close logger, to free remaining file-handles to syslog
     // so we can safely delete the file


### PR DESCRIPTION
* In Data-Ordner statt Cache-Ordner (closes #1546)
* Zeilenumbrüche ausgeben