### PR TITLE
Cache-Path bei Nutzung von rex_media_manager::create() korrigiert

### DIFF
--- a/redaxo/src/addons/media_manager/CHANGELOG.md
+++ b/redaxo/src/addons/media_manager/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 2.5.2 – 22.12.2017
+--------------------------
+
+### Bugfixes
+
+* `rex_media_manager::create()` hat einen falschen Cache-Pfad genutzt (@gharlan)
+
+
 Version 2.5.1 – 21.12.2017
 --------------------------
 

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -6,6 +6,7 @@
 class rex_media_manager
 {
     private $media;
+    private $originalFilename;
     private $cache_path;
     private $type;
     private $use_cache;
@@ -16,6 +17,7 @@ class rex_media_manager
     public function __construct(rex_managed_media $media)
     {
         $this->media = $media;
+        $this->originalFilename = $media->getMediaFilename();
         $this->useCache(true);
     }
 
@@ -173,7 +175,7 @@ class rex_media_manager
 
     public function getCacheFilename()
     {
-        return $this->cache_path.$this->type.'/'.self::getMediaFile();
+        return $this->cache_path.$this->type.'/'.$this->originalFilename;
     }
 
     public function getHeaderCacheFilename()

--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -1,5 +1,5 @@
 package: media_manager
-version: '2.5.1'
+version: '2.5.2'
 author: 'Markus Staab, Jan Kristinus'
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/media_manager/tests/media_manager_test.php
+++ b/redaxo/src/addons/media_manager/tests/media_manager_test.php
@@ -4,17 +4,18 @@ class rex_media_manager_test extends PHPUnit_Framework_TestCase
 {
     public function testGetCacheFilename()
     {
-        $manager = new rex_media_manager(new rex_managed_media(__DIR__.'/foo.jpg'));
+        $media = new rex_managed_media(__DIR__.'/foo.jpg');
+        $manager = new rex_media_manager($media);
 
         $cachePath = rex_path::addonCache('media_manager');
         $manager->setCachePath($cachePath);
+
+        $media->setMediaPath(__DIR__.'/bar.gif');
 
         $property = new ReflectionProperty(rex_media_manager::class, 'type');
         $property->setAccessible(true);
         $property->setValue($manager, 'test');
 
-        $_GET['rex_media_file'] = 'bar.gif';
-
-        $this->assertSame($cachePath.'test/bar.gif', $manager->getCacheFilename());
+        $this->assertSame($cachePath.'test/foo.jpg', $manager->getCacheFilename());
     }
 }


### PR DESCRIPTION
Und täglich grüßt das Murmeltier.. :(
Vielleicht passt es dieses Mal dann endlich..

@isospin Kannst du bestätigen, dass der Fix bei dir auch funktioniert?