### PR TITLE
rex_sql: Fehler bei Counter-abfrage beheben

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -871,7 +871,7 @@ class rex_sql implements Iterator
      */
     public function hasNext()
     {
-        return $this->counter != $this->rows;
+        return $this->counter < $this->rows;
     }
 
     /**

--- a/redaxo/src/core/tests/sql/sql_select_test.php
+++ b/redaxo/src/core/tests/sql/sql_select_test.php
@@ -178,6 +178,20 @@ class rex_sql_select_test extends PHPUnit_Framework_TestCase
         $this->assertEquals('mytext', $row1[5]);
     }
 
+    public function testHasNext()
+    {
+        $sql = rex_sql::factory();
+        $sql->setQuery('SELECT * FROM ' . self::TABLE);
+
+        $this->assertTrue($sql->hasNext());
+
+        $sql->next();
+        $this->assertFalse($sql->hasNext());
+
+        $sql->next();
+        $this->assertFalse($sql->hasNext());
+    }
+
     public function testError()
     {
         $sql = rex_sql::factory();


### PR DESCRIPTION
Der Counter kann mit der Methode `next()` über das Ende der vorhandenen Daten hinaus erhöht werden. Sobald dieser Fall eingetreten ist, kann mit `hasNext()` nicht mehr festgestellt werden, ob tatsächlich noch Daten vorhanden sind. 
Hiermit wird das Problem behoben