### PR TITLE
MM: Errorbild kommt nicht bei nicht existenten Dateien

### DIFF
--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -26,7 +26,6 @@ class rex_managed_media
     public function __construct($media_path)
     {
         $this->setMediaPath($media_path);
-        $this->sourcePath = $media_path;
         $this->format = strtolower(rex_file::extension($this->getMediaPath()));
     }
 

--- a/redaxo/src/addons/media_manager/tests/managed_media_test.php
+++ b/redaxo/src/addons/media_manager/tests/managed_media_test.php
@@ -1,0 +1,25 @@
+<?php
+
+class rex_managed_media_test extends PHPUnit_Framework_TestCase
+{
+    public function testConstructor()
+    {
+        $filename = 'CHANGELOG.md';
+        $path = rex_path::addon('media_manager', $filename);
+
+        $media = new rex_managed_media($path);
+
+        $this->assertSame($path, $media->getMediaPath());
+        $this->assertSame($filename, $media->getMediaFilename());
+        $this->assertSame($path, $media->getSourcePath());
+
+        $filename = 'non_existing.jpg';
+        $path = rex_path::addon($filename);
+
+        $media = new rex_managed_media($path);
+
+        $this->assertSame($path, $media->getMediaPath());
+        $this->assertSame($filename, $media->getMediaFilename());
+        $this->assertSame(rex_path::addon('media_manager', 'media/warning.jpg'), $media->getSourcePath());
+    }
+}


### PR DESCRIPTION
Der SourcePath wird bereits in mit setMediaPath gesetzt und dort ist auch der file_exists-check mit drin. Daher muss die Zeile hier weg.