### PR TITLE
Template löschen: Hinweis welche Artikel es benutzen

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lang/de_de.lang
+++ b/redaxo/src/addons/structure/plugins/content/lang/de_de.lang
@@ -67,7 +67,8 @@ templates = Templates
 
 templates_not_found = Es wurden keine Templates gefunden
 title_templates = Templates
-cant_delete_template_because_its_in_use = Template <b>{0}</b> kann nicht gelöscht werden, da es noch von Artikeln genutzt wird oder das Default Template ist.
+cant_delete_template_because_its_in_use = Template <b>{0}</b> kann nicht gelöscht werden, da es noch von folgenden Artikeln genutzt wird:
+cant_delete_template_because_its_default_template = Template <b>{0}</b> kann nicht gelöscht werden, da es als Standardtemplate festgelegt ist.
 template_deleted = Template wurde gelöscht.
 template_added = Template wurde hinzugefügt
 template_updated = Template wurde aktualisiert

--- a/redaxo/src/addons/structure/plugins/content/lang/en_gb.lang
+++ b/redaxo/src/addons/structure/plugins/content/lang/en_gb.lang
@@ -67,7 +67,8 @@ templates = Templates
 
 templates_not_found = Templates not found
 title_templates = Templates
-cant_delete_template_because_its_in_use = Template '{0}' cannot be deleted because it is in use or the default template
+cant_delete_template_because_its_in_use = Template '{0}' cannot be deleted because it is used by following articles:
+cant_delete_template_because_its_default_template = Template '{0}' cannot be deleted because it its the default template.
 template_deleted = Template deleted.
 template_added = Template added.
 template_updated = Template updated.

--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -36,11 +36,12 @@ if ($function == 'delete') {
             while ($del->hasNext()) {
                 $aid = $del->getValue(rex::getTablePrefix().'article.id');
                 $clang_id = $del->getValue(rex::getTablePrefix() . 'article.clang_id');
-                $OOArt = rex_article::get($aid, $clang_id);
 
-                $label = $OOArt->getName() . ' [' . $aid . ']';
                 if (rex_clang::count() > 1) {
-                    $label = '(' . rex_i18n::translate(rex_clang::get($clang_id)->getName()) . ') ' . $label;
+                    $label = '(' . rex_i18n::translate(rex_clang::get($clang_id)->getName()) . ') ';
+                } else {
+                    $OOArt = rex_article::get($aid, $clang_id);
+                    $label = $OOArt->getName() . ' [' . $aid . ']';
                 }
 
                 $template_in_use_message .= '<li><a href="' . rex_url::backendPage('content', ['article_id' => $aid, 'clang' => $clang_id]) . '">' . htmlspecialchars($label) . '</a></li>';

--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -26,12 +26,39 @@ if ($function == 'delete') {
         $error = rex_i18n::msg('csrf_token_invalid');
     } else {
         $del = rex_sql::factory();
-        $del->setQuery('SELECT ' . rex::getTablePrefix() . 'article.id,' . rex::getTablePrefix() . 'template.name FROM ' . rex::getTablePrefix() . 'article
+        $del->setQuery('SELECT ' . rex::getTablePrefix() . 'article.id, rex_article.clang_id, ' . rex::getTablePrefix() . 'template.name FROM ' . rex::getTablePrefix() . 'article
         LEFT JOIN ' . rex::getTablePrefix() . 'template ON ' . rex::getTablePrefix() . 'article.template_id=' . rex::getTablePrefix() . 'template.id
         WHERE ' . rex::getTablePrefix() . 'article.template_id="' . $template_id . '" LIMIT 0,10');
 
         if ($del->getRows() > 0 || rex_template::getDefaultId() == $template_id) {
-            $error = rex_i18n::msg('cant_delete_template_because_its_in_use', rex_i18n::msg('id') . ' = ' . $template_id);
+            $template_in_use_message = '';
+            $templatename = $del->getValue(rex::getTablePrefix(). 'template.name');
+            while ($del->hasNext()) {
+                $aid = $del->getValue(rex::getTablePrefix().'article.id');
+                $clang_id = $del->getValue(rex::getTablePrefix() . 'article.clang_id');
+                $OOArt = rex_article::get($aid, $clang_id);
+
+                $label = $OOArt->getName() . ' [' . $aid . ']';
+                if (rex_clang::count() > 1) {
+                    $label = '(' . rex_i18n::translate(rex_clang::get($clang_id)->getName()) . ') ' . $label;
+                }
+
+                $template_in_use_message .= '<li><a href="' . rex_url::backendPage('content', ['article_id' => $aid, 'clang' => $clang_id]) . '">' . htmlspecialchars($label) . '</a></li>';
+                $del->next();
+            }
+
+            if ($template_in_use_message != '') {
+                $error = rex_i18n::msg('cant_delete_template_because_its_in_use', $templatename);
+                $error .= '<ul>' . $template_in_use_message . '</ul>';
+            }
+
+            if (rex_template::getDefaultId() == $template_id) {
+                if ($templatename == '') {
+                    $del->setQuery('SELECT name FROM '.rex::getTable('template'). ' WHERE id = '.$template_id);
+                    $templatename = $del->getValue('name');
+                }
+                $error .= rex_i18n::msg('cant_delete_template_because_its_default_template', $templatename);
+            }
         } else {
             $del->setQuery('DELETE FROM ' . rex::getTablePrefix() . 'template WHERE id = "' . $template_id . '" LIMIT 1'); // max. ein Datensatz darf loeschbar sein
             rex_file::delete(rex_path::addonCache('templates', $template_id . '.template'));

--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -36,12 +36,11 @@ if ($function == 'delete') {
             while ($del->hasNext()) {
                 $aid = $del->getValue(rex::getTablePrefix().'article.id');
                 $clang_id = $del->getValue(rex::getTablePrefix() . 'article.clang_id');
+                $OOArt = rex_article::get($aid, $clang_id);
 
+                $label = $OOArt->getName() . ' [' . $aid . ']';
                 if (rex_clang::count() > 1) {
-                    $label = '(' . rex_i18n::translate(rex_clang::get($clang_id)->getName()) . ') ';
-                } else {
-                    $OOArt = rex_article::get($aid, $clang_id);
-                    $label = $OOArt->getName() . ' [' . $aid . ']';
+                    $label = '(' . rex_i18n::translate(rex_clang::get($clang_id)->getName()) . ') ' . $label;
                 }
 
                 $template_in_use_message .= '<li><a href="' . rex_url::backendPage('content', ['article_id' => $aid, 'clang' => $clang_id]) . '">' . htmlspecialchars($label) . '</a></li>';

--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -48,7 +48,7 @@ if ($function == 'delete') {
             }
 
             if ($template_in_use_message != '') {
-                $error = rex_i18n::msg('cant_delete_template_because_its_in_use', $templatename);
+                $error .= rex_i18n::msg('cant_delete_template_because_its_in_use', $templatename);
                 $error .= '<ul>' . $template_in_use_message . '</ul>';
             }
 


### PR DESCRIPTION
Beim Löschen eines Templates der Hinweis in welchen Artikeln es benutzt wird.

![template_delete_warning](https://user-images.githubusercontent.com/21292755/34497707-e74a9286-effe-11e7-8fc7-f1399c6bc62d.png)

closes #1477 