### PR TITLE
Travis: Mariadb mit php 7.2 testen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
             addons:
                 mariadb: 10.1
         -   <<: *TEST
-            php: 7.1
+            php: 7.2
             addons:
                 mariadb: 10.2
         -   &TEST_MYSQL


### PR DESCRIPTION
Ich wollte nicht noch einen weiteren build dazunehmen. Mariadb mit php 7.2 sollte wohl die wichtigste variante sein