### PR TITLE
Kommentar zu rex_sql::getRow() korrigiert (#1572)

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -622,8 +622,9 @@ class rex_sql implements Iterator
     }
 
     /**
-     * Gibt den Wert der aktuellen Zeile im ResultSet zurueck und
-     * bewegt den internen Zeiger auf die naechste Zeile.
+     * Gibt den Wert der aktuellen Zeile im ResultSet zurueck
+     * Falls es noch keine erste Zeile (lastRow) gibt, wird der Satzzeiger 
+     * initialisiert. Weitere Satzwechsel mittels next().
      */
     public function getRow($fetch_type = PDO::FETCH_ASSOC)
     {

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -623,7 +623,7 @@ class rex_sql implements Iterator
 
     /**
      * Gibt den Wert der aktuellen Zeile im ResultSet zurueck
-     * Falls es noch keine erste Zeile (lastRow) gibt, wird der Satzzeiger 
+     * Falls es noch keine erste Zeile (lastRow) gibt, wird der Satzzeiger
      * initialisiert. Weitere Satzwechsel mittels next().
      */
     public function getRow($fetch_type = PDO::FETCH_ASSOC)


### PR DESCRIPTION
Bezug auf Issue "rex_sql->getRow: Docs missverständlich (#1572)". Der Text legt nahe, dass nach dem Auslesen des Satzes mit getRow() und dem nächsten Auslesen mei getRow() der Satzzeiger weiterbewegt wird. Passiert aber nicht, sondern nur beim ersten getRow()-Aufruf zur Initialisierung. Dokumentationstext angepasst mit Hinweis auf notwendigen Aufruf von next()

closes #1572