### PR TITLE
User-Verwaltung: Rollen-Select wird nicht reaktiviert

### DIFF
--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -507,9 +507,10 @@ if ($FUNC_ADD != '' || $user_id > 0) {
         jQuery(function($) {
             $("#rex-js-user-admin").change(function() {
                  if ($(this).is(":checked"))
-                     $("#rex-js-user-role").attr("disabled", "disabled");
+                     $("#rex-js-user-role").prop("disabled", true);
                  else
-                     $("#rex-js-user-role").removeAttr("disabled");
+                     $("#rex-js-user-role").prop("disabled", false);
+                 $("#rex-js-user-role").selectpicker("refresh");
             }).change();
         });
         //-->


### PR DESCRIPTION
user-verwaltung: wenn user admin ist und man deaktiviert die admin-checkbox, wird die rollen-selectbox nicht aktiviert (bug fix javascript, da jetzt mit selectpicker und nicht mehr einfache multiselectbox)