### PR TITLE
Aktuelle Webserver-Adresse automatisch eintragen

### DIFF
--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -167,8 +167,8 @@ if ($step >= 4) {
     );
 }
 
-if($config['server'] == "https://www.redaxo.org/") {
-    $config['server'] = "https://" . $_SERVER['HTTP_HOST'];
+if ($config['server'] == 'https://www.redaxo.org/') {
+    $config['server'] = 'https://' . $_SERVER['HTTP_HOST'];
 }
 
 if ($step > 4 && rex_post('serveraddress', 'string', '-1') != '-1') {

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -167,6 +167,10 @@ if ($step >= 4) {
     );
 }
 
+if($config['server'] == "https://www.redaxo.org/") {
+    $config['server'] = "https://" . $_SERVER['HTTP_HOST'];
+}
+
 if ($step > 4 && rex_post('serveraddress', 'string', '-1') != '-1') {
     $config['server'] = rex_post('serveraddress', 'string');
     $config['servername'] = rex_post('servername', 'string');


### PR DESCRIPTION
closes #861

Vergleicht nach `https://www.redaxo.org/`, weil es zu Problemen kommt, wenn keine Domain in der `default.config.yml` eingetragen wird.