### PR TITLE
rex_socket Beispiel verallgemeinert

### DIFF
--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -7,7 +7,7 @@
  * <code>
  *     try {
  *         $socket = rex_socket::factory('www.example.com');
- *         $socket->setPath('/path/index.php?param=1');
+ *         $socket->setPath('/url/to/my/resource?param=1');
  *         $response = $socket->doGet();
  *         if($response->isOk()) {
  *             $body = $response->getBody();


### PR DESCRIPTION
Beispiel verallgemeinert, da ein unbedarfter programmierer ggf. den Eindruck bekommt dass der rex_socket nur urls zu php-dateien öffnen kann