### PR TITLE
rex_delete_cache(): rex_config zurücksetzen

### DIFF
--- a/redaxo/src/core/functions/function_rex_other.php
+++ b/redaxo/src/core/functions/function_rex_other.php
@@ -25,6 +25,8 @@ function rex_delete_cache()
 
     rex_clang::reset();
 
+    rex_config::refresh();
+
     // ----- EXTENSION POINT
     return rex_extension::registerPoint(new rex_extension_point('CACHE_DELETED', rex_i18n::msg('delete_cache_message')));
 }


### PR DESCRIPTION
Nach dem Cache-Löschen ist zwar die Cache-Datei von `rex_config` gelöscht, aber die alten Config-Werte sind noch php-seitig in der Klasse gecacht.