### PR TITLE
Import Backup: Cache löschen vor EP

### DIFF
--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -212,6 +212,8 @@ class rex_backup
 
         // generated neu erstellen, wenn kein Fehler aufgetreten ist
         if ($error == '') {
+            rex_delete_cache();
+
             // ----- EXTENSION POINT
             $msg = rex_extension::registerPoint(new rex_extension_point('BACKUP_AFTER_DB_IMPORT', $msg, [
                 'content' => $conts,

--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -212,6 +212,7 @@ class rex_backup
 
         // generated neu erstellen, wenn kein Fehler aufgetreten ist
         if ($error == '') {
+            // delete cache before EP to avoid obsolete caches while running extensions
             rex_delete_cache();
 
             // ----- EXTENSION POINT
@@ -224,6 +225,7 @@ class rex_backup
             // require import skript to do some userside-magic
             self::importScript(str_replace('.sql', '.php', $filename), self::IMPORT_DB, self::IMPORT_EVENT_POST);
 
+            // delete cache again because the extensions and the php script could have changed data again
             $msg .= rex_delete_cache();
             $return['state'] = true;
         }


### PR DESCRIPTION
Ich denke, es ist hier sinnvoll, vor dem EP den Cache zu löschen, damit im EP nicht mit alten Cache-Dateien gearbeitet wird.
Bisher wird nur weiter unten der Cache gelöscht, nach dem Import der zum Backup gehörenden PHP-Datei. Denke dort muss es auch bleiben.
Daher als zusätzlicher Aufruf.