### PR TITLE
cs fix

### DIFF
--- a/redaxo/src/addons/backup/pages/export.php
+++ b/redaxo/src/addons/backup/pages/export.php
@@ -68,7 +68,6 @@ if ($export && !$csrfToken->isValid()) {
             $header = 'plain/text';
 
             $hasContent = rex_backup::exportDb($export_path . $filename . $ext, $EXPTABLES);
-            // ------------------------------ /FUNC EXPORT SQL
         } elseif ($exporttype == 'files') {
             // ------------------------------ FUNC EXPORT FILES
             $header = 'tar/gzip';
@@ -79,7 +78,6 @@ if ($export && !$csrfToken->isValid()) {
                 $content = rex_backup::exportFiles($EXPDIR);
                 $hasContent = rex_file::put($export_path . $filename . $ext, $content);
             }
-            // ------------------------------ /FUNC EXPORT FILES
         }
 
         if ($hasContent) {

--- a/redaxo/src/addons/metainfo/lib/handler/media_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/media_handler.php
@@ -184,8 +184,6 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
         if ($ep->getName() == 'MEDIA_FORM_EDIT') {
             $params['activeItem'] = $params['media'];
             unset($params['media']);
-            // Hier die category_id setzen, damit keine Warnung entsteht (REX_LINK_BUTTON)
-            // $params['activeItem']->setValue('category_id', 0);
         } elseif ($ep->getName() == 'MEDIA_ADDED') {
             $sql = rex_sql::factory();
             $qry = 'SELECT id FROM ' . rex::getTablePrefix() . 'media WHERE filename="' . $params['filename'] . '"';

--- a/redaxo/src/addons/structure/plugins/content/pages/content.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.php
@@ -135,11 +135,10 @@ if ($article->getRows() == 1) {
             }
 
             if ($CM->getRows() != 1) {
-                // ------------- START: MODUL IST NICHT VORHANDEN
+                // ------------- MODUL IST NICHT VORHANDEN
                 $global_warning = rex_i18n::msg('module_not_found');
                 $slice_id = '';
                 $function = '';
-                // ------------- END: MODUL IST NICHT VORHANDEN
             } else {
                 // ------------- MODUL IST VORHANDEN
 


### PR DESCRIPTION
Damit wir wieder die neuste CS-Fixer-Version nutzen können (ist bereits in Travis eingestellt).
(Seitdem werden Kommentare am Ende eines Blocks anders eingerückt, daher habe ich die Kommentare ganz entfernt)