### PR TITLE
hasSession() sollte keine Session starten

### DIFF
--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -130,6 +130,9 @@ class rex_backend_login extends rex_login
 
     public static function hasSession()
     {
+        if (!isset($_SESSION)) {
+            return false;
+        }
         self::startSession();
 
         $instname = rex::getProperty('instname');

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -130,7 +130,7 @@ class rex_backend_login extends rex_login
 
     public static function hasSession()
     {
-        if (!isset($_COOKIE['PHPSESSID'])) {
+        if (!isset($_COOKIE[session_name()])) {
             return false;
         }
         self::startSession();

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -130,6 +130,7 @@ class rex_backend_login extends rex_login
 
     public static function hasSession()
     {
+        // try to fast-fail, so we dont need to start a session in all cases (which would require a session lock...)
         if (!isset($_COOKIE[session_name()])) {
             return false;
         }

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -130,7 +130,7 @@ class rex_backend_login extends rex_login
 
     public static function hasSession()
     {
-        if (!isset($_SESSION)) {
+        if (!isset($_COOKIE['PHPSESSID'])) {
             return false;
         }
         self::startSession();


### PR DESCRIPTION
Wenn man im Frontend z.B: über
if(rex_backend_login::hasSession()){
...
}
nur wissen möchte ob es eine Backend Session gibt, sollte das nicht automatisch dazu führen dass generell mal eine neue Session gestartet wird, oder?