### PR TITLE
Debug-Mode: Optional auch bei Warnings/Notices Exceptions werfen

### DIFF
--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -1,5 +1,7 @@
 setup: true
-debug: false
+debug:
+    enabled: false
+    throw_always_exception: false
 instname: null
 server: https://www.redaxo.org/
 servername: REDAXO

--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -167,12 +167,22 @@ abstract class rex_error_handler
         if (in_array($errno, [E_USER_ERROR, E_ERROR, E_COMPILE_ERROR, E_RECOVERABLE_ERROR, E_PARSE])) {
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
         }
-        if ((error_reporting() & $errno) == $errno) {
-            if (ini_get('display_errors') && (rex::isSetup() || rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin())) {
-                echo '<div><b>' . self::getErrorType($errno) . "</b>: $errstr in <b>$errfile</b> on line <b>$errline</b></div>";
-            }
-            rex_logger::logError($errno, $errstr, $errfile, $errline);
+
+        if ((error_reporting() & $errno) !== $errno) {
+            return;
         }
+
+        $debug = rex::getDebugMode();
+
+        if (isset($debug['throw_always_exception']) && $debug['throw_always_exception']) {
+            throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+        }
+
+        if (ini_get('display_errors') && (rex::isSetup() || rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin())) {
+            echo '<div><b>' . self::getErrorType($errno) . "</b>: $errstr in <b>$errfile</b> on line <b>$errline</b></div>";
+        }
+
+        rex_logger::logError($errno, $errstr, $errfile, $errline);
     }
 
     /**

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -66,6 +66,13 @@ class rex
             throw new InvalidArgumentException('Expecting $key to be string, but ' . gettype($key) . ' given!');
         }
         switch ($key) {
+            case 'debug':
+                if (!is_array($value)) {
+                    $debug = self::getDebugMode();
+                    $debug['enabled'] = (bool) $value;
+                    $value = $debug;
+                }
+                break;
             case 'server':
                 if (!rex_validator::factory()->url($value)) {
                     throw new InvalidArgumentException('"' . $key . '" property: expecting $value to be a full URL!');
@@ -180,7 +187,19 @@ class rex
      */
     public static function isDebugMode()
     {
-        return (bool) self::getProperty('debug', false);
+        $debug = self::getDebugMode();
+
+        return isset($debug['enabled']) && $debug['enabled'];
+    }
+
+    /**
+     * Returns the debug mode.
+     *
+     * @return array
+     */
+    public static function getDebugMode()
+    {
+        return self::getProperty('debug', ['enabled' => false]);
     }
 
     /**

--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -56,7 +56,10 @@ if ($func && !$csrfToken->isValid()) {
         }
     }
 
-    $config['debug'] = isset($settings['debug']) && $settings['debug'];
+    if (!is_array($config['debug'])) {
+        $config['debug'] = [];
+    }
+    $config['debug']['enabled'] = isset($settings['debug']) && $settings['debug'];
     rex::setProperty('debug', $config['debug']);
 
     foreach (rex_system_setting::getAll() as $setting) {


### PR DESCRIPTION
closes #1637

Mein Vorschlag ist, den Debug-Modus in der config.yml aufzusplitten. So kann man eventuell zukünftig noch mal weitere Optionen ergänzen.
Des Weiteren schlage ich vor, nur einen true/false-Schalter zu ergänzen. Einzelne Error-Typen steuert man weiter über error_reporting. 