### PR TITLE
rex_complex_perm: Bessere Exception-Message

### DIFF
--- a/redaxo/src/core/lib/login/complex_perm.php
+++ b/redaxo/src/core/lib/login/complex_perm.php
@@ -77,7 +77,7 @@ abstract class rex_complex_perm
     public static function register($key, $class)
     {
         if (!is_subclass_of($class, __CLASS__)) {
-            throw new InvalidArgumentException(sprintf('$class must be a subclass of %s!', __CLASS__));
+            throw new InvalidArgumentException(sprintf('Class "%s" must be a subclass of "%s"!', $class, __CLASS__));
         }
         self::$classes[$key] = $class;
     }


### PR DESCRIPTION
Siehe Slack (@Hirbod), aktuell sieht man in der Message nicht, bei welcher Klasse die Registrierung scheitert.