### PR TITLE
Fix #1614

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1100,12 +1100,14 @@ class rex_sql implements Iterator
      */
     public function addGlobalUpdateFields($user = null)
     {
-        if (!$user) {
+        if (!$user && rex::isBackend()) {
             $user = rex::getUser()->getValue('login');
         }
 
         $this->setDateTimeValue('updatedate', time());
-        $this->setValue('updateuser', $user);
+        if($user instanceof rex_user) {
+            $this->setValue('updateuser', $user);
+        }
 
         return $this;
     }
@@ -1117,12 +1119,14 @@ class rex_sql implements Iterator
      */
     public function addGlobalCreateFields($user = null)
     {
-        if (!$user) {
+        if (!$user && rex::isBackend()) {
             $user = rex::getUser()->getValue('login');
         }
 
         $this->setDateTimeValue('createdate', time());
-        $this->setValue('createuser', $user);
+        if($user instanceof rex_user) {
+            $this->setValue('createuser', $user);
+        }
 
         return $this;
     }

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1105,7 +1105,7 @@ class rex_sql implements Iterator
         }
 
         $this->setDateTimeValue('updatedate', time());
-        if($user instanceof rex_user) {
+        if($user instanceof rex_user || $user != "") {
             $this->setValue('updateuser', $user);
         }
 
@@ -1124,7 +1124,7 @@ class rex_sql implements Iterator
         }
 
         $this->setDateTimeValue('createdate', time());
-        if($user instanceof rex_user) {
+        if($user instanceof rex_user || $user != "") {
             $this->setValue('createuser', $user);
         }
 


### PR DESCRIPTION
Dieser Fix würde die addGlobal...Fields Funktionen auch in nicht eingeloggtem Zustand funktionieren lassen.

Beispiel: Ein CronJob soll jede Nacht Stellenangebote aus einem XML auslesen und automatisch in die Datenbank speichern. Da der CronJob ohne eingeloggtem User arbeitet können die addGlobal...Fields Methoden nicht genutzt werden.

Siehe hier: https://github.com/redaxo/redaxo/issues/1614