### PR TITLE
project-Addon spät laden

### DIFF
--- a/redaxo/src/addons/project/package.yml
+++ b/redaxo/src/addons/project/package.yml
@@ -2,3 +2,5 @@ package: project
 version: dev
 author: Project Admin
 supportpage: www.redaxo.org/de/forum/
+
+load: late

--- a/redaxo/src/addons/project/package.yml
+++ b/redaxo/src/addons/project/package.yml
@@ -3,4 +3,7 @@ version: dev
 author: Project Admin
 supportpage: www.redaxo.org/de/forum/
 
+# Load project addon late to be sure that
+#   - all other addons are booted before
+#   - the fragments from project addon are always "winning" over other fragment dirs
 load: late

--- a/redaxo/src/addons/project/package.yml
+++ b/redaxo/src/addons/project/package.yml
@@ -6,4 +6,6 @@ supportpage: www.redaxo.org/de/forum/
 # Load project addon late to be sure that
 #   - all other addons are booted before
 #   - the fragments from project addon are always "winning" over other fragment dirs
+#
+# Don't use it in public addons, rely on redaxo's default order resolution (by dependencies) instead
 load: late


### PR DESCRIPTION
Ich überlege gerade, ob es sinnvoll ist, das "project"-Addon default spät zu laden.

Im Normalfall rate ich davon ab, `load: early/late` in Addons zu nutzen. Das gilt aber vor allem für veröffentlichte Addons. Dort sollte man es eher bei der von Redaxo erzeugten Ladereihenfolge gemäß Abhängigkeiten belassen.
(Nicht zu verwechseln mit dem EARLY/LATE-Parameter bei den EPs, der bei Bedarf jederzeit gerne verwendet werden kann. Es geht nur um die Gesamt-Lade-Steuerung des Addons in der `package.yml`).

Ich denke aber, das project-Addon ist etwas anderes, und da kann es ganz praktisch sein, wenn die Fragmente daraus zum Beispiel definitiv greifen. Das wäre hiermit erreicht, da der project-Fragmente-Ordner somit auch als letztes registriert werden würde, und der letzte gewinnt.

Es kann auch Vorteile im project-Addon haben, wenn alle anderen Addons schon mal gebootet wurden.