### PR TITLE
rex_string::buildAttributes: Werte wurden nicht escaped

### DIFF
--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -223,12 +223,12 @@ class rex_string
 
         foreach ($attributes as $key => $value) {
             if (is_int($key)) {
-                $attr .= ' ' . $value;
+                $attr .= ' ' . rex_escape($value);
             } else {
                 if (is_array($value)) {
                     $value = implode(' ', $value);
                 }
-                $attr .= ' ' . $key . '="' . $value . '"';
+                $attr .= ' ' . rex_escape($key) . '="' . rex_escape($value) . '"';
             }
         }
 

--- a/redaxo/src/core/tests/util/string_test.php
+++ b/redaxo/src/core/tests/util/string_test.php
@@ -132,7 +132,8 @@ class rex_string_test extends PHPUnit_Framework_TestCase
                 'class' => ['a', 'b'],
                 'alt' => '',
                 'checked',
-                'data-foo' => '<foo> & "bar"'])
+                'data-foo' => '<foo> & "bar"',
+            ])
         );
     }
 }

--- a/redaxo/src/core/tests/util/string_test.php
+++ b/redaxo/src/core/tests/util/string_test.php
@@ -126,8 +126,13 @@ class rex_string_test extends PHPUnit_Framework_TestCase
     public function testBuildAttributes()
     {
         $this->assertEquals(
-            ' id="rex-test" class="a b" alt="" checked',
-            rex_string::buildAttributes(['id' => 'rex-test', 'class' => ['a', 'b'], 'alt' => '', 'checked'])
+            ' id="rex-test" class="a b" alt="" checked data-foo="&lt;foo&gt; &amp; &quot;bar&quot;"',
+            rex_string::buildAttributes([
+                'id' => 'rex-test',
+                'class' => ['a', 'b'],
+                'alt' => '',
+                'checked',
+                'data-foo' => '<foo> & "bar"'])
         );
     }
 }


### PR DESCRIPTION
Überall wo die Methode bisher verwendet wird, werden die Attribute als HTML-Attribute ausgegeben.
Somit sehe die Änderung als Bugfix an, nicht als bc break.