### PR TITLE
In den Link-Widgets die Artikel-Ids ausgeben

### DIFF
--- a/redaxo/src/addons/structure/lib/linkmap/linkmap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/linkmap.php
@@ -56,7 +56,7 @@ class rex_linkmap_article_list extends rex_linkmap_article_list_renderer
     protected function listItem(rex_article $article, $category_id)
     {
         $liAttr = ' class="list-group-item"';
-        $url = 'javascript:insertLink(\'redaxo://' . $article->getId() . '\',\'' . addslashes(htmlspecialchars($article->getName())) . '\');';
+        $url = 'javascript:insertLink(\'redaxo://' . $article->getId() . '\',\'' . addslashes(htmlspecialchars(trim(sprintf('%s [%s]', $article->getName(), $article->getId())))) . '\');';
         return rex_linkmap_tree_renderer::formatLi($article, $category_id, $this->context, $liAttr, ' href="' . $url . '"') . '</li>' . "\n";
     }
 }

--- a/redaxo/src/addons/structure/lib/linkmap/var_link.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_link.php
@@ -51,7 +51,7 @@ class rex_var_link extends rex_var
 
         // Falls ein Artikel vorausgewählt ist, dessen Namen anzeigen und beim öffnen der Linkmap dessen Kategorie anzeigen
         if ($art instanceof rex_article) {
-            $art_name = $art->getName();
+            $art_name = trim(sprintf('%s [%s]', $art->getName(), $art->getId()));
             $category = $art->getCategoryId();
         }
 

--- a/redaxo/src/addons/structure/lib/linkmap/var_linklist.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_linklist.php
@@ -52,7 +52,7 @@ class rex_var_linklist extends rex_var
             foreach ($linklistarray as $link) {
                 if ($link != '') {
                     if ($article = rex_article::get($link)) {
-                        $options .= '<option value="' . $link . '">' . htmlspecialchars($article->getName()) . '</option>';
+                        $options .= '<option value="' . $link . '">' . htmlspecialchars(trim(sprintf('%s [%s]', $article->getName(), $article->getId()))) . '</option>';
                     }
                 }
             }


### PR DESCRIPTION
Hintergrund: In einem aktuellen Projekt leiten wir manche Artikel auf die erste Kindkategorie weiter. Die Redaktion hat jetzt zur besseren Übersicht, da kein Artikelinhalt hinterlegt ist, die Artikelnamen gelöscht. Somit erscheinen in den Widgets die Namen nicht mehr und man geht fälschlicherweise davon aus, dass in dem Widget nichts mehr zugewiesen ist. So werden zumindest noch die Ids angezeigt