### PR TITLE
Medienpool: Alle PHP-Extensions blockieren

### DIFF
--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -32,7 +32,7 @@ function rex_mediapool_filename($FILENAME, $doSubindexing = true)
     }
 
     // ---- ext checken - alle scriptendungen rausfiltern
-    if (in_array(ltrim($NFILE_EXT, '.'), rex_addon::get('mediapool')->getProperty('blocked_extensions'))) {
+    if (!rex_mediapool_isAllowedMediaType($NFILENAME)) {
         $NFILE_NAME .= $NFILE_EXT;
         $NFILE_EXT = '.txt';
     }
@@ -577,6 +577,9 @@ function rex_mediapool_isAllowedMediaType($filename, array $args = [])
         return false;
     }
     if (count($whitelist) > 0 && !in_array($file_ext, $whitelist)) {
+        return false;
+    }
+    if (preg_match('/^php\d+$/', $file_ext)) {
         return false;
     }
     return true;

--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -570,6 +570,10 @@ function rex_mediapool_isAllowedMediaType($filename, array $args = [])
         return false;
     }
 
+    if (0 === strpos($file_ext, 'php')) {
+        return false;
+    }
+
     $blacklist = rex_mediapool_getMediaTypeBlacklist();
     $whitelist = rex_mediapool_getMediaTypeWhitelist($args);
 
@@ -577,9 +581,6 @@ function rex_mediapool_isAllowedMediaType($filename, array $args = [])
         return false;
     }
     if (count($whitelist) > 0 && !in_array($file_ext, $whitelist)) {
-        return false;
-    }
-    if (preg_match('/^php\d+$/', $file_ext)) {
         return false;
     }
     return true;

--- a/redaxo/src/addons/mediapool/tests/mediapool_functions_test.php
+++ b/redaxo/src/addons/mediapool/tests/mediapool_functions_test.php
@@ -7,6 +7,8 @@ class rex_mediapool_functions_test extends PHPUnit_Framework_TestCase
      */
     public function testIsAllowedMediaType($expected, $filename, array $args = [])
     {
+        require_once rex_path::addon('mediapool', 'functions/function_rex_mediapool.php');
+
         return $this->assertSame($expected, rex_mediapool_isAllowedMediaType($filename, $args));
     }
 

--- a/redaxo/src/addons/mediapool/tests/mediapool_functions_test.php
+++ b/redaxo/src/addons/mediapool/tests/mediapool_functions_test.php
@@ -1,0 +1,29 @@
+<?php
+
+class rex_mediapool_functions_test extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideIsAllowedMediaType
+     */
+    public function testIsAllowedMediaType($expected, $filename, array $args = [])
+    {
+        return $this->assertSame($expected, rex_mediapool_isAllowedMediaType($filename, $args));
+    }
+
+    public function provideIsAllowedMediaType()
+    {
+        return [
+            [false, 'foo.bar.php'],
+            [false, 'foo.bar.php5'],
+            [false, 'foo.bar.php71'],
+            [false, 'foo.bar.php_71'],
+            [false, 'foo.bar.jsp'],
+            [false, '.htaccess'],
+            [false, '.htpasswd'],
+            [true, 'php_logo.jpg'],
+            [true, 'foo.bar.png', ['types' => 'jpg,png,gif']],
+            [false, 'foo.bar.txt', ['types' => 'jpg,png,gif']],
+            [false, 'foo.bar.php', ['types' => 'jpg,png,gif,php']],
+        ];
+    }
+}


### PR DESCRIPTION
In den blocked_extensions haben wir nur `php3` bis `php7`.
Teils werden aber auch Extensions wie `php71` ausgeführt. Daher nun ein generischer Check auf alle `phpX`-Extensions.