### PR TITLE
utf8mb4 für die sql-connection nutzen

### DIFF
--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -223,6 +223,7 @@ setup_security_warn_mod_security = Das Apache Modul "mod_security" ist geladen. 
 
 sql_database_name_missing = Es muss ein Datenbankname angegeben werden!
 sql_database_already_exists = Datenbank existiert schon.
+sql_database_min_version = Die MySQL-Version {0} ist veraltet, es wird mindestens Version {1} benötigt!
 sql_unable_to_connect_database = Es konnte keine Verbindung zur Datenbank hergestellt werden!
 sql_unable_to_connect_server = Es konnte keine Verbindung zum Datenbankserver hergestellt werden!
 sql_unable_to_create_database = Die angegebene Datenbank konnte nicht angelegt werden!

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -218,6 +218,7 @@ setup_no_js_security_msg = Please make sure that files in the folder redaxo/incl
 
 sql_database_name_missing = Enter a database name!
 sql_database_already_exists = Database already exists!
+sql_database_min_version = The MySQL version {0} is too old, you need at least version {1}!
 sql_unable_to_connect_database = Unable to establish a connection to the database!
 sql_unable_to_connect_server = Unable to establish a connection to the database server!
 sql_unable_to_create_database = Unable to create the database!

--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -126,7 +126,7 @@ class rex_setup
 
         $serverVersion = rex_sql::getServerVersion();
         if (rex_string::versionCompare($serverVersion, self::MIN_MYSQL_VERSION, '<') == 1) {
-            return rex_i18n::msg('setup_404', $serverVersion, self::MIN_MYSQL_VERSION);
+            return rex_i18n::msg('sql_database_min_version', $serverVersion, self::MIN_MYSQL_VERSION);
         }
         return '';
     }

--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -8,7 +8,7 @@
 class rex_setup
 {
     const MIN_PHP_VERSION = REX_MIN_PHP_VERSION;
-    const MIN_MYSQL_VERSION = '5.0';
+    const MIN_MYSQL_VERSION = '5.5.3';
 
     private static $MIN_PHP_EXTENSIONS = ['session', 'pdo', 'pdo_mysql', 'pcre', 'tokenizer'];
 

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -76,7 +76,7 @@ class rex_sql implements Iterator
                 self::$pdo[$DBID] = $conn;
 
                 // ggf. Strict Mode abschalten
-                $this->setQuery('SET SESSION SQL_MODE="", NAMES utf8');
+                $this->setQuery('SET SESSION SQL_MODE="", NAMES utf8mb4');
             }
         } catch (PDOException $e) {
             throw new rex_sql_exception('Could not connect to database', $e, $this);

--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -1,7 +1,21 @@
 <?php
 
+// don't use REX_MIN_PHP_VERSION and rex_setup::MIN_MYSQL_VERSION here!
+// while updating the core, the constants contain the old min versions from previous core version
+
 if (PHP_VERSION_ID < 50509) {
     throw new rex_functional_exception(rex_i18n::msg('setup_301', PHP_VERSION, '5.5.9'));
+}
+
+$mysqlVersion = rex_sql::getServerVersion();
+$minMysqlVersion = '5.5.3';
+if (rex_string::versionCompare($mysqlVersion, $minMysqlVersion, '<')) {
+    // The message was added in 5.6.0, so it does not exist while updating from previous versions
+    $message = rex_i18n::hasMsg('sql_database_min_version')
+        ? rex_i18n::msg('sql_database_min_version', $mysqlVersion, $minMysqlVersion)
+        : "The MySQL version $mysqlVersion is too old, you need at least version $minMysqlVersion!";
+
+    throw new rex_functional_exception($message);
 }
 
 // Installer >= 2.1.2 required because of https://github.com/redaxo/redaxo/issues/1018

--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -10,7 +10,7 @@ if (PHP_VERSION_ID < 50509) {
 $mysqlVersion = rex_sql::getServerVersion();
 $minMysqlVersion = '5.5.3';
 if (rex_string::versionCompare($mysqlVersion, $minMysqlVersion, '<')) {
-    // The message was added in 5.6.0, so it does not exist while updating from previous versions
+    // The message was added in REDAXO 5.6.0, so it does not exist while updating from previous versions
     $message = rex_i18n::hasMsg('sql_database_min_version')
         ? rex_i18n::msg('sql_database_min_version', $mysqlVersion, $minMysqlVersion)
         : "The MySQL version $mysqlVersion is too old, you need at least version $minMysqlVersion!";


### PR DESCRIPTION
Mein Vorschlag für einen allerersten Schritt in Richtung utf8mb4.
So wird für die Connection schon mal utf8mb4 genutzt, sodass überhaupt theoretisch 4-byte-zeichen gespeichert werden können.
Ich denke, das sollte eigentlich komplett kompatibel sein.

Im Issue gab es viel Zustimmung für die allgemeine Anhebung der Mindest-Mysql-Version, um utf8mb4 zu ermöglichen. Somit würde ich hier auch nicht zweigleisig fahren, sondern zumindest für die Connection einheitlich utf8mb4 nutzen.

Falls wir den Weg so gehen wollen, würde ich noch in der update.php des Cores einen Check einbauen und ein Update mit einer älteren Mysql-Version verhindern.

ref #638