### PR TITLE
rex_finder: type hint für getIterator()

### DIFF
--- a/redaxo/src/core/lib/util/finder.php
+++ b/redaxo/src/core/lib/util/finder.php
@@ -185,7 +185,7 @@ class rex_finder implements IteratorAggregate, Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return Iterator|SplFileInfo[]
      */
     public function getIterator()
     {


### PR DESCRIPTION
Hilft uns aber leider noch nicht wirklich weiter, wegen:
https://youtrack.jetbrains.com/issue/WI-42084
(habe ich eben angelegt, gerne dafür voten!)

Wenn man explizit `getIterator()` verwendet, bekommt man nun Autovervollständigung.