### PR TITLE
rex-form: Keine führenden/nachfolgenden whitespaces speichern

### DIFF
--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -1322,7 +1322,7 @@ class rex_form
                 // Callback, um die Values vor dem Speichern noch beeinflussen zu können
                 $fieldValue = $this->preSave($fieldsetName, $fieldName, $fieldValue, $sql);
 
-                $values[$fieldName] = $fieldValue;
+                $values[$fieldName] = trim($fieldValue);
             }
         }
 

--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -1322,7 +1322,10 @@ class rex_form
                 // Callback, um die Values vor dem Speichern noch beeinflussen zu können
                 $fieldValue = $this->preSave($fieldsetName, $fieldName, $fieldValue, $sql);
 
-                $values[$fieldName] = trim($fieldValue);
+                if (is_string($fieldValue)) {
+                    $fieldValue = trim($fieldValue);
+                }
+                $values[$fieldName] = $fieldValue;
             }
         }
 


### PR DESCRIPTION
closes https://github.com/redaxo/redaxo/issues/1700