### PR TITLE
Warnung beheben wenn lang_fallback nicht definiert ist

### DIFF
--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -166,7 +166,7 @@ class rex_i18n
             return $msg;
         }
 
-        foreach (rex::getProperty('lang_fallback', array()) as $locale) {
+        foreach (rex::getProperty('lang_fallback', []) as $locale) {
             if (self::$locale === $locale) {
                 continue;
             }

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -166,7 +166,7 @@ class rex_i18n
             return $msg;
         }
 
-        foreach (rex::getProperty('lang_fallback') as $locale) {
+        foreach (rex::getProperty('lang_fallback', array()) as $locale) {
             if (self::$locale === $locale) {
                 continue;
             }


### PR DESCRIPTION
behebt eine Warnung `Warning: Invalid argument supplied for foreach() in C:\xampp7.1.4\htdocs\redaxo\redaxo\src\core\lib\util\i18n.php on line 169`.

Ursache ist vermutlich dass meine `config.yml` noch nicht auf dem aktuellsten Stand ist, d.h. es könnte sein dass diese Warnung nur in Entwicklungssystemen auftritt.

Da der Fix einfach ist, hab ich es mal hier reingestellt, ob man das wirklich so übernehmen sollte können wir diskutieren.