### PR TITLE
MP-Funktionen auch im Frontend einbinden

### DIFF
--- a/redaxo/src/addons/mediapool/boot.php
+++ b/redaxo/src/addons/mediapool/boot.php
@@ -14,9 +14,9 @@ $mypage = 'mediapool';
 
 rex_complex_perm::register('media', 'rex_media_perm');
 
-if (rex::isBackend() && rex::getUser()) {
-    require_once __DIR__ . '/functions/function_rex_mediapool.php';
+require_once __DIR__ . '/functions/function_rex_mediapool.php';
 
+if (rex::isBackend() && rex::getUser()) {
     rex_view::addJsFile($this->getAssetsUrl('mediapool.js'));
     rex_view::setJsProperty('imageExtensions', $this->getProperty('image_extensions'));
 }


### PR DESCRIPTION
Gerade in letzter Zeit kam vermehrt die Frage auf, wie man die Funktionen denn im Frontend nutzen kann.
Ich denke, wir sollten sie daher auch im Frontend immer einbinden, damit sie direkt zur Verfügung stehen.

refs #1614