### PR TITLE
Reload nach Logout

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -43,6 +43,9 @@ if (rex::isSetup()) {
         $login->setLogout(true);
         rex_csrf_token::removeAll();
         rex_response::setHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
+
+        // is necessary for login after logout
+        // and without the redirect, the csrf token would be invalid
         rex_response::sendRedirect(rex_url::backendController(['rex_logged_out' => 1]));
     }
 

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -3,7 +3,9 @@
 /**
  * @package redaxo5
  */
-
+echo '<!--';
+print_r($_SESSION);
+echo '-->';
 header('X-Robots-Tag: noindex, nofollow, noarchive');
 header('X-Frame-Options: SAMEORIGIN');
 
@@ -43,6 +45,7 @@ if (rex::isSetup()) {
         $login->setLogout(true);
         rex_csrf_token::removeAll();
         rex_response::setHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
+        rex_response::sendRedirect(rex_url::backendController());
     }
 
     $rex_user_loginmessage = '';

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -43,7 +43,7 @@ if (rex::isSetup()) {
         $login->setLogout(true);
         rex_csrf_token::removeAll();
         rex_response::setHeader('Clear-Site-Data', '"cache", "cookies", "storage", "executionContexts"');
-        rex_response::sendRedirect(rex_url::backendController());
+        rex_response::sendRedirect(rex_url::backendController(['rex_logged_out' => 1]));
     }
 
     $rex_user_loginmessage = '';
@@ -83,6 +83,10 @@ if (rex::isSetup()) {
         }
 
         rex::setProperty('user', $user);
+    }
+
+    if ($rex_user_loginmessage === '' && rex_get('rex_logged_out', 'boolean')) {
+        $rex_user_loginmessage = rex_i18n::msg('login_logged_out');
     }
 
     // Safe Mode

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -3,9 +3,7 @@
 /**
  * @package redaxo5
  */
-echo '<!--';
-print_r($_SESSION);
-echo '-->';
+
 header('X-Robots-Tag: noindex, nofollow, noarchive');
 header('X-Frame-Options: SAMEORIGIN');
 


### PR DESCRIPTION
closes #1747 

Der `Clear-Site-Data`-Header löscht im Browser die Cookies mit. Damit ist auch der neue CSRF-Token für den erneuten Login ungültig.
Ein anschließender Reload/Redirect auf die Login-Page behebt das Problem.