### PR TITLE
Kein doppeltes Escaping der Perms

### DIFF
--- a/redaxo/src/core/lib/login/perm.php
+++ b/redaxo/src/core/lib/login/perm.php
@@ -29,7 +29,7 @@ abstract class rex_perm
      */
     public static function register($perm, $name = null, $group = self::GENERAL)
     {
-        $name = $name ?: (rex_i18n::hasMsg($key = 'perm_' . $group . '_' . $perm) ? rex_i18n::msg($key) : $perm);
+        $name = $name ?: (rex_i18n::hasMsg($key = 'perm_' . $group . '_' . $perm) ? rex_i18n::rawMsg($key) : $perm);
         self::$perms[$group][$perm] = $name;
     }
 


### PR DESCRIPTION
Die Perms werden bei der Ausgabe noch automatisch durch `rex_select` escaped.