### PR TITLE
Be-Navi: Kein doppeltes Escaping der URLs

### DIFF
--- a/redaxo/src/core/lib/be/navigation.php
+++ b/redaxo/src/core/lib/be/navigation.php
@@ -112,7 +112,7 @@ class rex_be_navigation
                 $n['linkAttr'][$name] = trim($value);
             }
 
-            $n['href'] = str_replace('&', '&amp;', $page->getHref());
+            $n['href'] = $page->getHref();
             $n['title'] = $page->getTitle();
             $n['active'] = $page->isActive();
 


### PR DESCRIPTION
Wegen https://github.com/redaxo/redaxo/pull/1687 wurden die URLs nun doppelt escaped.