### PR TITLE
HTTPS default nicht aktiv

### DIFF
--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -37,7 +37,7 @@ password_policy:
     digit: {min: 0}
 lang: de_de
 lang_fallback: [en_gb, de_de]
-use_https: true
+use_https: false
 use_hsts: false
 use_gzip: true
 use_etag: true

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -276,11 +276,6 @@ if ($step == 4) {
 
     $db_create_checked = rex_post('redaxo_db_create', 'boolean') ? ' checked="checked"' : '';
 
-    // set https = true only in new setups
-    if (rex_file::getConfig($configFile) === []) {
-        $config['use_https'] = true;
-    }
-
     $httpsRedirectSel = new rex_select();
     $httpsRedirectSel->setId('rex-form-https');
     $httpsRedirectSel->setStyle('class="form-control selectpicker"');

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -276,6 +276,11 @@ if ($step == 4) {
 
     $db_create_checked = rex_post('redaxo_db_create', 'boolean') ? ' checked="checked"' : '';
 
+    // set https = true only in new setups
+    if (rex_file::getConfig($configFile) === []) {
+        $config['use_https'] = true;
+    }
+
     $httpsRedirectSel = new rex_select();
     $httpsRedirectSel->setId('rex-form-https');
     $httpsRedirectSel->setStyle('class="form-control selectpicker"');


### PR DESCRIPTION
Nach dem Update auf eine neue Redaxo-Version würde in der Config `use_https` auf `true` gesetzt. Dies soll beim Update, falls der Eintrag noch nicht in der `config.yml` vorhanden ist, immer `false` sein.

Bei einer Erst-Installation soll dieser Wert weiterhin `true` vorschlagen (HTTPS für Frontend und Backend).

// cc @tbaddade @staabm 