### PR TITLE
Adds Errormailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,159 @@
-REDAXO CMS
-==========
+# PHPMailer
 
-*Einfach, flexibel, sinnvoll!*
+- [Allgemeines](#allgemeines)
+- [Beispiele](#beispiele)
+- [Systemlog-Fehlermeldungen senden](#syslog)
+- [Tipps](#tipps)
+    - [Spam-Blocker](#spam-blocker)
+    - [Verwendung bei selbstsignierten Zertifikaten](#zertifikate)
 
-![Screenshot](https://raw.githubusercontent.com/redaxo/redaxo/assets/redaxo_01.png)
+<a name="ueber"></a>
 
-[REDAXO](https://www.redaxo.org) ist ein freies Content-Management-System (CMS). Ziel des Systems ist es ein Framwork für die Entwicklung und Pflege von Websites zu bieten. Der modulare Aufbau sorgt für eine flexible Erweiterbarkeit durch AddOns und Module. 
+## Allgemeines
+Das PHPMailer-AddOn ermöglicht den Versand von E-Mails.
 
-[Changelog](https://github.com/redaxo/redaxo/blob/master/redaxo/src/core/CHANGELOG.md) | [Dokumentation](https://redaxo.org/doku/master) | [Api Doc](https://redaxo.org/api/master/) | [www.redaxo.org](https://www.redaxo.org) 
+Der Aufruf erfolgt über die Klasse `rex_mailer`. Dabei werden die nachfolgend beschriebenen und in der Konfiguration hinterlegten Einstellungen berücksichtigt.
 
-[![Build Status](https://secure.travis-ci.org/redaxo/redaxo.svg?branch=master)](https://travis-ci.org/redaxo/redaxo)
+Die Werte der Konfiguration können in AddOns oder Modulen leicht überschrieben werden, siehe [Beispiele](#beispiele).
+
+Weitere Informationen zur Verwendung von PHPMailer unter: [https://github.com/PHPMailer/PHPMailer/wiki/Tutorial](https://github.com/PHPMailer/PHPMailer/wiki/Tutorial)
+
+> **Hinweis:** Eine Test-Mail kann nach dem Speichern der Einstellungen verschickt werden. Hierzu müssen unbedingt Absender- und Test-Adresse festgelegt werden.
+
+<a name="beispiele"></a>
+## PHPMailer Code-Beispiele
 
 
-Installation
-------------
+### 1. Beispiel
 
-*Entwicklungsstand* installieren:
+E-Mail an einen bestimmten Empfänger senden.
 
-```sh
-git clone https://github.com/redaxo/redaxo.git
-cd redaxo
-git submodule init
-git submodule update
+```php
+<?php
+  // PHPMailer-Instanz
+  $mail = new rex_mailer();
+
+  //Absenderadresse überschreiben
+ // $mail->From = "absender@domain.tld";
+
+  //Absendername überschreiben
+  // $mail->FromName = "Vorname Nachname";
+
+  // Antwortadresse festlegen
+  // $mail->addReplyTo("username@domain.com", "Software Simian");
+
+  // Empfänger
+  $mail->addAddress("empfaenger@domain.tld");
+
+  // Empfänger als CC hinzufügen - Weitere anlegen wenn mehrere erwünscht
+  // $mail->addCC("empfaenger2@domain.tld);
+
+  // Empfänger als BCC hinzufügen - Weitere anlegen wenn mehrere erwünscht
+  // $mail->addBCC("empfaenger3@domain.tld");
+
+  //Betreff der E-Mail
+  $mail->Subject = "PHPMailer-Test";
+
+  //Text der EMail setzen
+  $mail->Body = "Hi \n\n this mail was sent by PHPMailer!";
+
+  //Überprüfen ob E-Mail gesendet wurde
+  if(!$mail->send())
+  {
+     echo "An error occurred";
+     echo "Error: " . $mail->ErrorInfo;
+  }
+  else
+  {
+     echo "E-Mail has been sent";
+  }
 ```
 
-*Beachte:*
-- Die von Github bereit gestellten Downloads ("Download ZIP" Button) enthalten *nicht* die nötigen GIT Submodule, funktionieren daher nicht.
-- Die auf Github angebotenen REDAXO versionen sollten *nicht* im Produkiveinsatz verwendet werden!
 
-[Download der offiziellen REDAXO Releases](https://github.com/redaxo/redaxo/releases)
+### 2. Beispiel
+
+E-Mail an einen Empfängerkreis senden, der aus der Datenbank ausgelesen wird.
+
+
+```php
+
+<?php
+
+$mail = new rex_mailer();
+$sql = rex_sql::factory();
+
+$query = "SELECT full_name, email, photo FROM employee WHERE id= ?";
+$sql->setQuery($query, array($id));
+
+foreach($sql as $row)
+{
+    // HTML body
+    $body  = "Hello <font size=\"4\">" . $row->getValue("full_name") . "</font>, <p>";
+    $body .= "<i>Your</i> personal photograph to this message.<p>";
+    $body .= "Sincerely, <br />";
+    $body .= "phpmailer List manager";
+
+    // Plain text body (for mail clients that cannot read HTML)
+    $text_body  = "Hello " . $row->getValue("full_name") . ", \n\n";
+    $text_body .= "Your personal photograph to this message.\n\n";
+    $text_body .= "Sincerely, \n";
+    $text_body .= "phpmailer List manager";
+
+    $mail->Body    = $body;
+    $mail->Subject = "PHPMailer-Test";
+    $mail->AltBody = $text_body;
+    $mail->AddAddress($row->getValue("email"), $row->getValue("full_name"));
+    $mail->AddStringAttachment($sql->getValue("photo"), "YourPhoto.jpg");
+
+    if(!$mail->Send())
+        echo "There has been a mail error sending to " . $row->getValue("email") . "<br>";
+
+    // Clear all addresses and attachments for next loop
+    $mail->ClearAddresses();
+    $mail->ClearAttachments();
+}
+
+```
+
+<a name="syslog"></a>
+
+## Systemlog-Fehlermeldungen senden
+
+Durch Aktivieren der Checkbox *Systemlog-Fehler per E-Mail senden*, wird das Systemlog im 15 Minuten-Abstand per Email an die im System hinterlegte *E-Mail-Adresse bei Fehlern* verschickt. Um unnötige Sendungen zu vermeiden, sollte das error_reporting für PHP korrekt konfiguriert sein. 
+
+<a name="tipps"></a>
+
+## Tipps
+
+<a name="spam-blocker"></a>
+### Spam-Blocker
+
+- Der Server, der die E-Mails versendet, sollte möglichst per SPF-Eintrag für die verwendete E-Mail-Domain als autorisierter Server im DNS hinterlegt sein.
+
+- Prioritäts-Einstellungen können zu einem Spam-Blocking führen.
+
+- Große E-Mail-Verteiler sollten möglichst in kleiner Zahl und nicht als CC verschickt werden.
+
+<a name="zertifikate"></a>
+### Verwendung bei selbstsignierten Zertifikaten
+
+Per Default wird der Peer verifiziert. Dies kann ggf. zu Problemen führen. Die nachfolgenden Einstellungen helfen, dieses Problem zu umgehen.
+
+```php
+<?php
+
+$mail = new rex_mailer();
+$mail->SMTPOptions = array(
+    'ssl' => array(
+        'verify_peer' => false,
+        'verify_peer_name' => false,
+        'allow_self_signed' => true
+    ),
+    'tls' => array(
+        'verify_peer' => false,
+        'verify_peer_name' => false,
+        'allow_self_signed' => true
+    ),
+);
+```
+

--- a/README.md
+++ b/README.md
@@ -1,159 +1,31 @@
-# PHPMailer
+REDAXO CMS
+==========
 
-- [Allgemeines](#allgemeines)
-- [Beispiele](#beispiele)
-- [Systemlog-Fehlermeldungen senden](#syslog)
-- [Tipps](#tipps)
-    - [Spam-Blocker](#spam-blocker)
-    - [Verwendung bei selbstsignierten Zertifikaten](#zertifikate)
+*Einfach, flexibel, sinnvoll!*
 
-<a name="ueber"></a>
+![Screenshot](https://raw.githubusercontent.com/redaxo/redaxo/assets/redaxo_01.png)
 
-## Allgemeines
-Das PHPMailer-AddOn ermöglicht den Versand von E-Mails.
+[REDAXO](https://www.redaxo.org) ist ein freies Content-Management-System (CMS). Ziel des Systems ist es ein Framwork für die Entwicklung und Pflege von Websites zu bieten. Der modulare Aufbau sorgt für eine flexible Erweiterbarkeit durch AddOns und Module. 
 
-Der Aufruf erfolgt über die Klasse `rex_mailer`. Dabei werden die nachfolgend beschriebenen und in der Konfiguration hinterlegten Einstellungen berücksichtigt.
+[Changelog](https://github.com/redaxo/redaxo/blob/master/redaxo/src/core/CHANGELOG.md) | [Dokumentation](https://redaxo.org/doku/master) | [Api Doc](https://redaxo.org/api/master/) | [www.redaxo.org](https://www.redaxo.org) 
 
-Die Werte der Konfiguration können in AddOns oder Modulen leicht überschrieben werden, siehe [Beispiele](#beispiele).
-
-Weitere Informationen zur Verwendung von PHPMailer unter: [https://github.com/PHPMailer/PHPMailer/wiki/Tutorial](https://github.com/PHPMailer/PHPMailer/wiki/Tutorial)
-
-> **Hinweis:** Eine Test-Mail kann nach dem Speichern der Einstellungen verschickt werden. Hierzu müssen unbedingt Absender- und Test-Adresse festgelegt werden.
-
-<a name="beispiele"></a>
-## PHPMailer Code-Beispiele
+[![Build Status](https://secure.travis-ci.org/redaxo/redaxo.svg?branch=master)](https://travis-ci.org/redaxo/redaxo)
 
 
-### 1. Beispiel
+Installation
+------------
 
-E-Mail an einen bestimmten Empfänger senden.
+*Entwicklungsstand* installieren:
 
-```php
-<?php
-  // PHPMailer-Instanz
-  $mail = new rex_mailer();
-
-  //Absenderadresse überschreiben
- // $mail->From = "absender@domain.tld";
-
-  //Absendername überschreiben
-  // $mail->FromName = "Vorname Nachname";
-
-  // Antwortadresse festlegen
-  // $mail->addReplyTo("username@domain.com", "Software Simian");
-
-  // Empfänger
-  $mail->addAddress("empfaenger@domain.tld");
-
-  // Empfänger als CC hinzufügen - Weitere anlegen wenn mehrere erwünscht
-  // $mail->addCC("empfaenger2@domain.tld);
-
-  // Empfänger als BCC hinzufügen - Weitere anlegen wenn mehrere erwünscht
-  // $mail->addBCC("empfaenger3@domain.tld");
-
-  //Betreff der E-Mail
-  $mail->Subject = "PHPMailer-Test";
-
-  //Text der EMail setzen
-  $mail->Body = "Hi \n\n this mail was sent by PHPMailer!";
-
-  //Überprüfen ob E-Mail gesendet wurde
-  if(!$mail->send())
-  {
-     echo "An error occurred";
-     echo "Error: " . $mail->ErrorInfo;
-  }
-  else
-  {
-     echo "E-Mail has been sent";
-  }
+```sh
+git clone https://github.com/redaxo/redaxo.git
+cd redaxo
+git submodule init
+git submodule update
 ```
 
+*Beachte:*
+- Die von Github bereit gestellten Downloads ("Download ZIP" Button) enthalten *nicht* die nötigen GIT Submodule, funktionieren daher nicht.
+- Die auf Github angebotenen REDAXO versionen sollten *nicht* im Produkiveinsatz verwendet werden!
 
-### 2. Beispiel
-
-E-Mail an einen Empfängerkreis senden, der aus der Datenbank ausgelesen wird.
-
-
-```php
-
-<?php
-
-$mail = new rex_mailer();
-$sql = rex_sql::factory();
-
-$query = "SELECT full_name, email, photo FROM employee WHERE id= ?";
-$sql->setQuery($query, array($id));
-
-foreach($sql as $row)
-{
-    // HTML body
-    $body  = "Hello <font size=\"4\">" . $row->getValue("full_name") . "</font>, <p>";
-    $body .= "<i>Your</i> personal photograph to this message.<p>";
-    $body .= "Sincerely, <br />";
-    $body .= "phpmailer List manager";
-
-    // Plain text body (for mail clients that cannot read HTML)
-    $text_body  = "Hello " . $row->getValue("full_name") . ", \n\n";
-    $text_body .= "Your personal photograph to this message.\n\n";
-    $text_body .= "Sincerely, \n";
-    $text_body .= "phpmailer List manager";
-
-    $mail->Body    = $body;
-    $mail->Subject = "PHPMailer-Test";
-    $mail->AltBody = $text_body;
-    $mail->AddAddress($row->getValue("email"), $row->getValue("full_name"));
-    $mail->AddStringAttachment($sql->getValue("photo"), "YourPhoto.jpg");
-
-    if(!$mail->Send())
-        echo "There has been a mail error sending to " . $row->getValue("email") . "<br>";
-
-    // Clear all addresses and attachments for next loop
-    $mail->ClearAddresses();
-    $mail->ClearAttachments();
-}
-
-```
-
-<a name="syslog"></a>
-
-## Systemlog-Fehlermeldungen senden
-
-Durch Aktivieren der Checkbox *Systemlog-Fehler per E-Mail senden*, wird das Systemlog im 15 Minuten-Abstand per Email an die im System hinterlegte *E-Mail-Adresse bei Fehlern* verschickt. Um unnötige Sendungen zu vermeiden, sollte das error_reporting für PHP korrekt konfiguriert sein. 
-
-<a name="tipps"></a>
-
-## Tipps
-
-<a name="spam-blocker"></a>
-### Spam-Blocker
-
-- Der Server, der die E-Mails versendet, sollte möglichst per SPF-Eintrag für die verwendete E-Mail-Domain als autorisierter Server im DNS hinterlegt sein.
-
-- Prioritäts-Einstellungen können zu einem Spam-Blocking führen.
-
-- Große E-Mail-Verteiler sollten möglichst in kleiner Zahl und nicht als CC verschickt werden.
-
-<a name="zertifikate"></a>
-### Verwendung bei selbstsignierten Zertifikaten
-
-Per Default wird der Peer verifiziert. Dies kann ggf. zu Problemen führen. Die nachfolgenden Einstellungen helfen, dieses Problem zu umgehen.
-
-```php
-<?php
-
-$mail = new rex_mailer();
-$mail->SMTPOptions = array(
-    'ssl' => array(
-        'verify_peer' => false,
-        'verify_peer_name' => false,
-        'allow_self_signed' => true
-    ),
-    'tls' => array(
-        'verify_peer' => false,
-        'verify_peer_name' => false,
-        'allow_self_signed' => true
-    ),
-);
-```
-
+[Download der offiziellen REDAXO Releases](https://github.com/redaxo/redaxo/releases)

--- a/redaxo/src/addons/phpmailer/README.md
+++ b/redaxo/src/addons/phpmailer/README.md
@@ -2,7 +2,7 @@
 
 - [Allgemeines](#allgemeines)
 - [Beispiele](#beispiele)
-- [Systemlog-Fehlermeldungen senden](#syslog)
+- [Systemlog senden](#syslog)
 - [Tipps](#tipps)
     - [Spam-Blocker](#spam-blocker)
     - [Verwendung bei selbstsignierten Zertifikaten](#zertifikate)
@@ -117,9 +117,9 @@ foreach($sql as $row)
 
 <a name="syslog"></a>
 
-## Systemlog-Fehlermeldungen senden
+## Systemlog senden
 
-Durch Aktivieren der Checkbox *Systemlog-Fehler per E-Mail senden*, wird das Systemlog im 15 Minuten-Abstand per Email an die im System hinterlegte *E-Mail-Adresse bei Fehlern* verschickt. Um unnötige Sendungen zu vermeiden, sollte das error_reporting für PHP korrekt konfiguriert sein. 
+Durch Aktivieren der Checkbox *Systemlog per E-Mail senden*, wird das Systemlog im 15 Minuten-Abstand per Email an die im System hinterlegte *E-Mail-Adresse bei Fehlern* verschickt. Um unnötige Sendungen zu vermeiden, sollte das error_reporting für PHP korrekt konfiguriert sein. 
 
 <a name="tipps"></a>
 

--- a/redaxo/src/addons/phpmailer/README.md
+++ b/redaxo/src/addons/phpmailer/README.md
@@ -2,6 +2,7 @@
 
 - [Allgemeines](#allgemeines)
 - [Beispiele](#beispiele)
+- [Systemlog-Fehlermeldungen senden](#syslog)
 - [Tipps](#tipps)
     - [Spam-Blocker](#spam-blocker)
     - [Verwendung bei selbstsignierten Zertifikaten](#zertifikate)
@@ -114,6 +115,12 @@ foreach($sql as $row)
 
 ```
 
+<a name="syslog"></a>
+
+## Systemlog-Fehlermeldungen senden
+
+Durch Aktivieren der Checkbox *Systemlog-Fehler per E-Mail senden*, wird das Systemlog im 15 Minuten-Abstand per Email an die im System hinterlegte *E-Mail-Adresse bei Fehlern* verschickt. Um unnötige Sendungen zu vermeiden, sollte das error_reporting für PHP korrekt konfiguriert sein. 
+
 <a name="tipps"></a>
 
 ## Tipps
@@ -149,5 +156,4 @@ $mail->SMTPOptions = array(
     ),
 );
 ```
-
 

--- a/redaxo/src/addons/phpmailer/README.md
+++ b/redaxo/src/addons/phpmailer/README.md
@@ -2,7 +2,7 @@
 
 - [Allgemeines](#allgemeines)
 - [Beispiele](#beispiele)
-- [Systemlog senden](#syslog)
+- [Systemlog via E-Mail senden](#syslog)
 - [Tipps](#tipps)
     - [Spam-Blocker](#spam-blocker)
     - [Verwendung bei selbstsignierten Zertifikaten](#zertifikate)

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -1,0 +1,58 @@
+<?php
+if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
+    
+    rex_extension::register('RESPONSE_SHUTDOWN', function(rex_extension_point $ep)
+    {
+        $logFile  = rex_path::coreData('system.log');
+        $fileTime = filemtime($logFile);
+        $sendTime = $this->getConfig('last_log_file_send_time', 0);
+        $timediff = $fileTime - $sendTime;
+        if (filesize($logFile) > 0 && $timediff > 9 && $file = new rex_log_file($logFile)) {
+            //Start - generate mailbody
+            $mailBody = '';
+            $mailBody .= '<table>';
+            $mailBody .= '    <thead>';
+            $mailBody .= '        <tr>';
+            $mailBody .= '            <th>' . rex_i18n::msg('syslog_timestamp') . '</th>';
+            $mailBody .= '            <th>' . rex_i18n::msg('syslog_type') . '</th>';
+            $mailBody .= '            <th>' . rex_i18n::msg('syslog_message') . '</th>';
+            $mailBody .= '            <th>' . rex_i18n::msg('syslog_file') . '</th>';
+            $mailBody .= '            <th>' . rex_i18n::msg('syslog_line') . '</th>';
+            $mailBody .= '        </tr>';
+            $mailBody .= '    </thead>';
+            $mailBody .= '    <tbody>';
+            
+            foreach (new LimitIterator($file, 0, 30) as $entry) {
+                /* @var rex_log_entry $entry */
+                $data = $entry->getData();
+                $mailBody .= '        <tr>';
+                $mailBody .= '            <td>' . $entry->getTimestamp('%d.%m.%Y %H:%M:%S') . '</td>';
+                $mailBody .= '            <td>' . $data[0] . '</td>';
+                $mailBody .= '            <td>' . $data[1] . '</td>';
+                $mailBody .= '            <td>' . (isset($data[2]) ? $data[2] : '') . '</td>';
+                $mailBody .= '            <td>' . (isset($data[3]) ? $data[3] : '') . '</td>';
+                $mailBody .= '        </tr>';
+            }
+            
+            $mailBody .= '    </tbody>';
+            $mailBody .= '</table>';
+            //End - generate mailbody
+            
+            //Start  send mail
+            $mail          = new rex_mailer();
+            $mail->Subject = rex::getServerName() . ' | system.log';
+            $mail->Body    = $mailBody;
+            $mail->AltBody = strip_tags($mailBody);
+            $mail->setFrom(rex::getErrorEmail(), 'REDAXO Errormail');
+            $mail->addAddress(rex::getErrorEmail());
+            $this->setConfig('last_log_file_send_time', $fileTime);
+            
+            if ($mail->Send()) {
+                // close logger, to free remaining file-handles to syslog
+                rex_logger::close();
+            }
+            //End  send mail
+        }
+    });
+}
+?>

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -9,16 +9,15 @@
  */
 
 if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
-    
+
     rex_extension::register('RESPONSE_SHUTDOWN', function(rex_extension_point $ep)
     {
         $logFile  = rex_path::coreData('system.log');
-        $fileTime = filemtime($logFile);
         $sendTime = $this->getConfig('last_log_file_send_time', 0);
-        $timediff = $fileTime - $sendTime;
+        $timediff = time() - $sendTime;
         if (filesize($logFile) > 0 && $timediff > 900 && $file = new rex_log_file($logFile)) {
             //Start - generate mailbody
-            $mailBody = '';
+            $mailBody = '$timediff';
             $mailBody .= '<table>';
             $mailBody .= '    <thead>';
             $mailBody .= '        <tr>';
@@ -55,11 +54,11 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
             $mail->setFrom(rex::getErrorEmail(), 'REDAXO Errormailer');
             $mail->addAddress(rex::getErrorEmail());
             $this->setConfig('last_log_file_send_time', $fileTime);
-            
+
             if ($mail->Send()) {
                 // close logger, to free remaining file-handles to syslog
-                rex_logger::close();
             }
+            rex_logger::close();
             //End  send mail
         }
     });

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -1,4 +1,13 @@
 <?php
+
+/**
+ * PHPMailer Addon.
+ *
+ * @author markus[dot]staab[at]redaxo[dot]de Markus Staab
+ *
+ * @package redaxo\phpmailer
+ */
+
 if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
     
     rex_extension::register('RESPONSE_SHUTDOWN', function(rex_extension_point $ep)

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -18,6 +18,7 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
         if ($timediff > 900 && filesize($logFile) > 0 && $file = new rex_log_file($logFile)) {
             //Start - generate mailbody
             $mailBody = '';
+            $mailBody .= '<style>  td, th {padding: 5px;} table {width: 100%; border: 1px solid #ccc; } th {background: #b00; color: #fff;} td { border: 0; border-bottom: 1px solid #b00;} </style> ';
             $mailBody .= '<table>';
             $mailBody .= '    <thead>';
             $mailBody .= '        <tr>';
@@ -35,7 +36,7 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
                 $mailBody .= '        <tr>';
                 $mailBody .= '            <td>' . $entry->getTimestamp('%d.%m.%Y %H:%M:%S') . '</td>';
                 $mailBody .= '            <td>' . $data[0] . '</td>';
-                $mailBody .= '            <td>' . $data[1] . '</td>';
+                $mailBody .= '            <td>' . substr($data[1],0,128) . '</td>';
                 $mailBody .= '            <td>' . (isset($data[2]) ? $data[2] : '') . '</td>';
                 $mailBody .= '            <td>' . (isset($data[3]) ? $data[3] : '') . '</td>';
                 $mailBody .= '        </tr>';

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -13,8 +13,9 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
     {
         $logFile  = rex_path::coreData('system.log');
         $sendTime = $this->getConfig('last_log_file_send_time', 0);
+        $timediff = '';
         $timediff = time() - $sendTime;
-        if (filesize($logFile) > 0 && $timediff > 900 && $file = new rex_log_file($logFile)) {
+        if ($timediff > 900 && filesize($logFile) > 0 && $file = new rex_log_file($logFile)) {
             //Start - generate mailbody
             $mailBody = '';
             $mailBody .= '<table>';

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -9,7 +9,6 @@
  */
 
 if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
-
     rex_extension::register('RESPONSE_SHUTDOWN', function(rex_extension_point $ep)
     {
         $logFile  = rex_path::coreData('system.log');
@@ -29,7 +28,6 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
             $mailBody .= '        </tr>';
             $mailBody .= '    </thead>';
             $mailBody .= '    <tbody>';
-            
             foreach (new LimitIterator($file, 0, 30) as $entry) {
                 /* @var rex_log_entry $entry */
                 $data = $entry->getData();
@@ -41,11 +39,9 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
                 $mailBody .= '            <td>' . (isset($data[3]) ? $data[3] : '') . '</td>';
                 $mailBody .= '        </tr>';
             }
-            
             $mailBody .= '    </tbody>';
             $mailBody .= '</table>';
             //End - generate mailbody
-            
             //Start  send mail
             $mail          = new rex_mailer();
             $mail->Subject = rex::getServerName() . ' | system.log';
@@ -54,10 +50,10 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
             $mail->setFrom(rex::getErrorEmail(), 'REDAXO Errormailer');
             $mail->addAddress(rex::getErrorEmail());
             $this->setConfig('last_log_file_send_time', $fileTime);
-
             if ($mail->Send()) {
-                // close logger, to free remaining file-handles to syslog
+               // mail has been sent
             }
+             // close logger, to free remaining file-handles to syslog
             rex_logger::close();
             //End  send mail
         }

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -16,7 +16,7 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
         $fileTime = filemtime($logFile);
         $sendTime = $this->getConfig('last_log_file_send_time', 0);
         $timediff = $fileTime - $sendTime;
-        if (filesize($logFile) > 0 && $timediff > 9 && $file = new rex_log_file($logFile)) {
+        if (filesize($logFile) > 0 && $timediff > 900 && $file = new rex_log_file($logFile)) {
             //Start - generate mailbody
             $mailBody = '';
             $mailBody .= '<table>';

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -52,7 +52,7 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
             $mail->Subject = rex::getServerName() . ' | system.log';
             $mail->Body    = $mailBody;
             $mail->AltBody = strip_tags($mailBody);
-            $mail->setFrom(rex::getErrorEmail(), 'REDAXO Errormail');
+            $mail->setFrom(rex::getErrorEmail(), 'REDAXO Errormailer');
             $mail->addAddress(rex::getErrorEmail());
             $this->setConfig('last_log_file_send_time', $fileTime);
             

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -17,7 +17,7 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
         $timediff = time() - $sendTime;
         if (filesize($logFile) > 0 && $timediff > 900 && $file = new rex_log_file($logFile)) {
             //Start - generate mailbody
-            $mailBody = '$timediff';
+            $mailBody = '';
             $mailBody .= '<table>';
             $mailBody .= '    <thead>';
             $mailBody .= '        <tr>';

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -64,4 +64,3 @@ if (!rex::isBackend() && $this->getConfig('errormailer') == true) {
         }
     });
 }
-?>

--- a/redaxo/src/addons/phpmailer/install.php
+++ b/redaxo/src/addons/phpmailer/install.php
@@ -29,9 +29,13 @@ if (!$this->hasConfig()) {
     $this->setConfig('password', '');
     $this->setConfig('smtp_debug', '0');
     $this->setConfig('log', 0);
+    $this->setConfig('smtpauth', false);
 } else {
     if (!$this->hasConfig('log')) {
         $this->setConfig('log', 0);
+    }
+     if (!$this->hasConfig('errormailer')) {
+        $this->setConfig('errormailer', false);
     }
 }
 
@@ -40,3 +44,4 @@ $logFolder = rex_path::addonData('phpmailer', 'mail_log');
 if (file_exists($oldBackUpFolder) && !file_exists($logFolder)) {
     rename($oldBackUpFolder, $logFolder);
 }
+

--- a/redaxo/src/addons/phpmailer/install.php
+++ b/redaxo/src/addons/phpmailer/install.php
@@ -29,7 +29,7 @@ if (!$this->hasConfig()) {
     $this->setConfig('password', '');
     $this->setConfig('smtp_debug', '0');
     $this->setConfig('log', 0);
-    $this->setConfig('smtpauth', false);
+    $this->setConfig('errormailer', false);
 } else {
     if (!$this->hasConfig('log')) {
         $this->setConfig('log', 0);

--- a/redaxo/src/addons/phpmailer/lang/de_de.lang
+++ b/redaxo/src/addons/phpmailer/lang/de_de.lang
@@ -52,4 +52,4 @@ phpmailer_log = E-Mail Log
 phpmailer_log_info = Log-Ordner: <span title="{0}">{1}</span>
 phpmailer_log_yes = Ja
 phpmailer_log_no = Nein
-phpmailer_errormailer = System-Log-Fehler per E-Mail senden
+phpmailer_errormailer = Systemlog per E-Mail senden

--- a/redaxo/src/addons/phpmailer/lang/de_de.lang
+++ b/redaxo/src/addons/phpmailer/lang/de_de.lang
@@ -52,3 +52,4 @@ phpmailer_log = E-Mail Log
 phpmailer_log_info = Log-Ordner: <span title="{0}">{1}</span>
 phpmailer_log_yes = Ja
 phpmailer_log_no = Nein
+phpmailer_errormailer = System-Log-Fehler per E-Mail senden

--- a/redaxo/src/addons/phpmailer/lang/en_gb.lang
+++ b/redaxo/src/addons/phpmailer/lang/en_gb.lang
@@ -52,3 +52,4 @@ phpmailer_log = E-Mail Log
 phpmailer_log_info = Log-Folder: <span title="{0}">{1}</span>
 phpmailer_log_yes = Yes
 phpmailer_log_no = No
+phpmailer_errormailer = Send Systemlog errors via mail

--- a/redaxo/src/addons/phpmailer/lang/en_gb.lang
+++ b/redaxo/src/addons/phpmailer/lang/en_gb.lang
@@ -52,4 +52,4 @@ phpmailer_log = E-Mail Log
 phpmailer_log_info = Log-Folder: <span title="{0}">{1}</span>
 phpmailer_log_yes = Yes
 phpmailer_log_no = No
-phpmailer_errormailer = Send Systemlog errors via mail
+phpmailer_errormailer = Send Systemlog via mail

--- a/redaxo/src/addons/phpmailer/pages/config.php
+++ b/redaxo/src/addons/phpmailer/pages/config.php
@@ -32,6 +32,7 @@ if (rex_post('btn_save', 'string') != '') {
         ['smtp_debug', 'int'],
         ['test_address', 'string'],
         ['log', 'int', 1],
+        ['errormailer', 'boolean'],
     ]));
 
     $message = $this->i18n('config_saved_successful');
@@ -118,6 +119,9 @@ $content = '';
 
 $content .= '<fieldset class="col-sm-6"><legend>' . $this->i18n('email_options') . '</legend>';
 
+
+
+
 $formElements = [];
 $n = [];
 $n['label'] = '<label for="phpmailer-fromname">' . $this->i18n('sender_name') . '</label>';
@@ -187,6 +191,12 @@ $n['label'] = '<label for="phpmailer-priority">' . $this->i18n('priority') . '</
 $n['field'] = $sel_priority->get();
 $formElements[] = $n;
 
+
+
+
+
+
+
 $n = [];
 $n['label'] = '<label for="phpmailer-log">' . $this->i18n('log') . '</label>';
 $n['field'] = $sel_log->get();
@@ -196,6 +206,18 @@ $formElements[] = $n;
 $fragment = new rex_fragment();
 $fragment->setVar('elements', $formElements, false);
 $content .= $fragment->parse('core/form/form.php');
+
+
+$n = [];
+$n['label'] = '<label for="phpmailer-errormailer">' . $this->i18n('errormailer') . '</label>';
+$n['field'] = '<input type="checkbox" id="phpmailer-errormailer" name="settings[errormailer]"' . (!empty($this->getConfig('errormailer')) && $this->getConfig('errormailer') == true ? ' checked="checked"' : false) . ' value="1" />';
+$formElements_e[] = $n;
+$n = [];
+$fragment_e = new rex_fragment();
+$fragment->setVar('elements', $formElements_e, false);
+$content .= $fragment->parse('core/form/checkbox.php');
+
+
 
 $content .= '</fieldset><fieldset class="col-sm-6"><legend>' . $this->i18n('smtp_options') . '</legend>';
 


### PR DESCRIPTION
Sends Syslog to Error-Mail-Adress. 
Can be activated via Checkbox
thx to @phoebusryan 
<img width="1166" alt="bildschirmfoto 2018-05-30 um 22 35 16" src="https://user-images.githubusercontent.com/791247/40746122-ce7dc8ac-6459-11e8-9225-ff517aaa9cc8.png">


<img width="951" alt="bildschirmfoto 2018-05-31 um 00 00 21" src="https://user-images.githubusercontent.com/791247/40749863-b3900f6c-6465-11e8-84e4-e7fa6b822010.png">

closes #1693