### PR TITLE
Mountpoints nach Prio sortieren, wenn gleiche Oberkategorie

### DIFF
--- a/redaxo/src/addons/structure/pages/index.php
+++ b/redaxo/src/addons/structure/pages/index.php
@@ -113,9 +113,9 @@ $KAT = rex_sql::factory();
 // $KAT->setDebug();
 if (count($mountpoints) > 0 && $category_id == 0) {
     $parent_id = implode(',', $mountpoints);
-    $KAT->setQuery('SELECT COUNT(*) as rowCount FROM ' . rex::getTablePrefix() . 'article WHERE id IN (' . $parent_id . ') AND startarticle=1 AND clang_id=' . $clang . ' ORDER BY catname');
+    $KAT->setQuery('SELECT COUNT(*) as rowCount FROM ' . rex::getTablePrefix() . 'article WHERE id IN (' . $parent_id . ') AND startarticle=1 AND clang_id=' . $clang);
 } else {
-    $KAT->setQuery('SELECT COUNT(*) as rowCount FROM ' . rex::getTablePrefix() . 'article WHERE parent_id=' . $category_id . ' AND startarticle=1 AND clang_id=' . $clang . ' ORDER BY catpriority');
+    $KAT->setQuery('SELECT COUNT(*) as rowCount FROM ' . rex::getTablePrefix() . 'article WHERE parent_id=' . $category_id . ' AND startarticle=1 AND clang_id=' . $clang);
 }
 
 // --------------------- ADD PAGINATION
@@ -131,7 +131,11 @@ echo $catFragment->parse('core/navigations/pagination.php');
 
 if (count($mountpoints) > 0 && $category_id == 0) {
     $parent_id = implode(',', $mountpoints);
-    $KAT->setQuery('SELECT * FROM ' . rex::getTablePrefix() . 'article WHERE id IN (' . $parent_id . ') AND startarticle=1 AND clang_id=' . $clang . ' ORDER BY catname LIMIT ' . $catPager->getCursor() . ',' . $catPager->getRowsPerPage());
+
+    $KAT->setQuery('SELECT parent_id FROM ' . rex::getTable('article') . ' WHERE id IN (' . $parent_id . ') GROUP BY parent_id');
+    $orderBy = $KAT->getRows() > 1 ? 'catname' : 'catpriority';
+
+    $KAT->setQuery('SELECT * FROM ' . rex::getTablePrefix() . 'article WHERE id IN (' . $parent_id . ') AND startarticle=1 AND clang_id=' . $clang . ' ORDER BY ' . $orderBy . ' LIMIT ' . $catPager->getCursor() . ',' . $catPager->getRowsPerPage());
 } else {
     $KAT->setQuery('SELECT * FROM ' . rex::getTablePrefix() . 'article WHERE parent_id=' . $category_id . ' AND startarticle=1 AND clang_id=' . $clang . ' ORDER BY catpriority LIMIT ' . $catPager->getCursor() . ',' . $catPager->getRowsPerPage());
 }


### PR DESCRIPTION
refs #994
/cc @darwin26, @skerbis, @elpschulzo, @alexplusde, @DanielWeitenauer

Ist nicht als allumfassende Lösung gedacht, aber aus meiner Sicht macht es das zumindest besser, als den Status Quo.

Wenn alle Mountpoint aus der selben Oberkategorie stammen, oder alle aus dem Root, dann werden sie nun nach Prio sortiert.
Wenn sie aus unterschiedlichen Ebenen stammen, dann weiterhin nach Name, mangels schneller Alternativen.