### PR TITLE
Beim Core-Update die config.yml aktualisieren

### DIFF
--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -95,3 +95,9 @@ HTACCESS;
         ->setValue('language', 'sv_se')
         ->update();
 }
+
+$path = rex_path::coreData('config.yml');
+rex_file::putConfig($path, array_merge(
+    rex_file::getConfig(__DIR__.'/default.config.yml'),
+    rex_file::getConfig($path)
+));


### PR DESCRIPTION
Damit man nach dem Update in der config.yml die neuen Optionen direkt zur Verfügung hat.