### PR TITLE
Medienpool: Optionale MimeType-Whitelist

### DIFF
--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -592,6 +592,32 @@ function rex_mediapool_isAllowedMediaType($filename, array $args = [])
 }
 
 /**
+ * Checks file against optional whitelist from property `allowed_mime_types`.
+ *
+ * @param string $path
+ *
+ * @return bool
+ */
+function rex_mediapool_isAllowedMimeType($path)
+{
+    $whitelist = rex_addon::get('mediapool')->getProperty('allowed_mime_types');
+
+    if (!$whitelist) {
+        return true;
+    }
+
+    $extension = mb_strtolower(rex_file::extension($path));
+
+    if (!isset($whitelist[$extension])) {
+        return false;
+    }
+
+    $mime_type = mime_content_type($path);
+
+    return in_array($mime_type, $whitelist[$extension]);
+}
+
+/**
  * get whitelist of mediatypes(extensions) given via media widget "types" param.
  *
  * @param array $args widget params

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -18,14 +18,16 @@ page:
         sync:      { title: translate:pool_sync_files, perm: media/hasAll }
 
 blocked_extensions: [php, php3, php4, php5, php6, php7, phar, pht, phtml, hh, pl, asp, aspx, cfm, jsp, jsf, bat, sh, cgi, htaccess, htpasswd]
+
+# optional mime type whitelist. the list is checked after the blocked_extensions check from above has passed.
+# exmaple:
+#   allowed_mime_types:
+#       gif: [image/gif]
+#       jpg: [image/jpeg, image/pjpeg]
+allowed_mime_types: ~
+
 allowed_doctypes: [bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, mp4, ogg, pdf, png, ppt, pptx, pps, ppsx, rar, rtf, svg, swf, tar, tif, tiff, txt, webp, wma, xls, xlsx, zip]
 image_extensions: [bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]
-
-# optional mime type whitelist, example:
-# allowed_mime_types:
-#     gif: [image/gif]
-#     jpg: [image/jpeg, image/pjpeg]
-allowed_mime_types: ~
 
 requires:
     redaxo: ^5.4.0

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -21,5 +21,11 @@ blocked_extensions: [php, php3, php4, php5, php6, php7, phar, pht, phtml, hh, pl
 allowed_doctypes: [bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, mp4, ogg, pdf, png, ppt, pptx, pps, ppsx, rar, rtf, svg, swf, tar, tif, tiff, txt, webp, wma, xls, xlsx, zip]
 image_extensions: [bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]
 
+# optional mime type whitelist, example:
+# allowed_mime_types:
+#     gif: [image/gif]
+#     jpg: [image/jpeg, image/pjpeg]
+allowed_mime_types: ~
+
 requires:
     redaxo: ^5.4.0

--- a/redaxo/src/addons/mediapool/pages/upload.php
+++ b/redaxo/src/addons/mediapool/pages/upload.php
@@ -19,6 +19,8 @@ if ($media_method == 'add_file') {
                     $warning .= count($whitelist) > 0
                         ? '<br />' . rex_i18n::msg('pool_file_allowed_mediatypes') . ' <code>' . rtrim(implode('</code>, <code>', $whitelist), ', ') . '</code>'
                         : '<br />' . rex_i18n::msg('pool_file_banned_mediatypes') . ' <code>' . rtrim(implode('</code>, <code>', rex_mediapool_getMediaTypeBlacklist()), ', ') . '</code>';
+                } elseif (!rex_mediapool_isAllowedMimeType($_FILES['file_new']['tmp_name'])) {
+                    $warning = rex_i18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . rex_file::extension($_FILES['file_new']['name']) . '</code> (<code>' . mime_content_type($_FILES['file_new']['tmp_name']) . '</code>)';
                 } else {
                     $FILEINFOS['title'] = rex_request('ftitle', 'string');
 


### PR DESCRIPTION
closes #1483

Wir brauchen das zwingend in einem Projekt, bisher muss es @dergel dort immer händisch reinmanipulieren.