### PR TITLE
MP: Pjax deaktivieren für Upload-Formulare

### DIFF
--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -527,7 +527,7 @@ function rex_mediapool_Mediaform($form_title, $button_title, $rex_file_category,
     $fragment->setVar('buttons', $buttons, false);
     $content = $fragment->parse('core/page/section.php');
 
-    $s .= ' <form action="' . rex_url::currentBackendPage() . '" method="post" enctype="multipart/form-data">
+    $s .= ' <form action="' . rex_url::currentBackendPage() . '" method="post" enctype="multipart/form-data" data-pjax="false">
                 ' . rex_csrf_token::factory('mediapool')->getHiddenField() . '
                 <fieldset>
                     <input type="hidden" name="media_method" value="add_file" />

--- a/redaxo/src/addons/mediapool/pages/media.php
+++ b/redaxo/src/addons/mediapool/pages/media.php
@@ -333,7 +333,7 @@ if ($file_id) {
             }
 
             $body = '
-                <form action="' . rex_url::currentBackendPage() . '" method="post" enctype="multipart/form-data">
+                <form action="' . rex_url::currentBackendPage() . '" method="post" enctype="multipart/form-data" data-pjax="false">
                     ' . $csrf->getHiddenField() . '
                     <input type="hidden" name="file_id" value="' . $file_id . '" />
                     ' . $arg_fields . '


### PR DESCRIPTION
Der allgemeine Fix ist problematisch (leere File-inputs löschen), da kommt es im Backend dann zu Notices, da übertragene leere File-inputs != gar nicht übertragene File-inputs.

Ich schlage vor, Pjax für die Uploadformulare einfach generell zu deaktivieren.

closes #1674

Im heute erschienenen Safari 11.1.1 ist der Fix übrigens leider noch nicht enthalten, obwohl es in der Safari Technology Preview ja bereits gefixt ist.