### PR TITLE
Rechtschreibprüfung in Modul ein/ausgabe deaktiviert

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
@@ -221,12 +221,12 @@ if ($function == 'add' or $function == 'edit') {
 
         $n = [];
         $n['label'] = '<label for="minput">' . rex_i18n::msg('input') . '</label>';
-        $n['field'] = '<textarea class="form-control rex-code" id="minput" name="eingabe">' . htmlspecialchars($eingabe) . '</textarea>';
+        $n['field'] = '<textarea class="form-control rex-code" id="minput" name="eingabe" spellcheck="false">' . htmlspecialchars($eingabe) . '</textarea>';
         $formElements[] = $n;
 
         $n = [];
         $n['label'] = '<label for="moutput">' . rex_i18n::msg('output') . '</label>';
-        $n['field'] = '<textarea class="form-control rex-code" id="moutput" name="ausgabe">' . htmlspecialchars($ausgabe) . '</textarea>';
+        $n['field'] = '<textarea class="form-control rex-code" id="moutput" name="ausgabe" spellcheck="false">' . htmlspecialchars($ausgabe) . '</textarea>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();


### PR DESCRIPTION
In templates war es interessanterweise schon deaktiviert