### PR TITLE
fix rex_form

### DIFF
--- a/redaxo/src/core/lib/form/config_form.php
+++ b/redaxo/src/core/lib/form/config_form.php
@@ -16,6 +16,11 @@ class rex_config_form extends rex_form_base
         parent::__construct($fieldset, md5($this->namespace.$fieldset), 'post', $debug);
 
         $this->namespace = $namespace;
+
+        // --------- Load Env
+        if (rex::isBackend()) {
+            $this->loadBackendConfig();
+        }
     }
 
     /**

--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -46,6 +46,8 @@ class rex_form extends rex_form_base
         $this->sql->setDebug($this->debug);
         $this->sql->setQuery('SELECT * FROM ' . $tableName . ' WHERE ' . $this->whereCondition . ' LIMIT 2');
 
+        $this->setFormId('rex-addon-editmode');
+
         // --------- validate where-condition and determine editMode
         $numRows = $this->sql->getRows();
         if ($numRows == 0) {

--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -57,6 +57,11 @@ class rex_form extends rex_form_base
         } else {
             throw new rex_exception('rex_form: Die gegebene Where-Bedingung führt nicht zu einem eindeutigen Datensatz!');
         }
+
+        // --------- Load Env
+        if (rex::isBackend()) {
+            $this->loadBackendConfig();
+        }
     }
 
     /**

--- a/redaxo/src/core/lib/form/form_base.php
+++ b/redaxo/src/core/lib/form/form_base.php
@@ -35,8 +35,8 @@ abstract class rex_form_base
     /** @var string */
     protected $warning;
 
-    /** @var string */
-    protected $divId;
+    /** @var null|string */
+    protected $formId;
 
     /** @var rex_csrf_token */
     private $csrfToken;
@@ -55,10 +55,9 @@ abstract class rex_form_base
         $this->elements = [];
         $this->params = [];
         $this->addFieldset($fieldset ?: $this->name);
-        $this->divId = 'rex-addon-editmode';
         $this->setMessage('');
 
-        $this->debug = &$debug;
+        $this->debug = $debug;
 
         $this->csrfToken = rex_csrf_token::factory('rex_form_'.$this->getName());
     }
@@ -77,6 +76,11 @@ abstract class rex_form_base
     protected function loadBackendConfig()
     {
         $this->addParam('page', rex_be_controller::getCurrentPage());
+    }
+
+    public function setFormId($id)
+    {
+        $this->formId = $id;
     }
 
     /**
@@ -1218,7 +1222,12 @@ abstract class rex_form_base
         $fieldsets = $this->getFieldsetElements();
         $last = count($fieldsets);
 
-        $s .= '<form id="' . $this->divId . '" action="' . rex_url::backendController($actionParams) . '" method="' . $this->method . '">' . "\n";
+        $id = '';
+        if ($this->formId) {
+            $id = ' id="'.$this->formId.'"';
+        }
+
+        $s .= '<form' . $id . ' action="' . rex_url::backendController($actionParams) . '" method="' . $this->method . '">' . "\n";
         foreach ($fieldsets as $fieldsetName => $fieldsetElements) {
             $s .= '<fieldset>' . "\n";
 

--- a/redaxo/src/core/lib/form/form_base.php
+++ b/redaxo/src/core/lib/form/form_base.php
@@ -1224,7 +1224,7 @@ abstract class rex_form_base
 
         $id = '';
         if ($this->formId) {
-            $id = ' id="'.$this->formId.'"';
+            $id = ' id="'.rex_escape($this->formId).'"';
         }
 
         $s .= '<form' . $id . ' action="' . rex_url::backendController($actionParams) . '" method="' . $this->method . '">' . "\n";

--- a/redaxo/src/core/lib/form/form_base.php
+++ b/redaxo/src/core/lib/form/form_base.php
@@ -60,11 +60,6 @@ abstract class rex_form_base
 
         $this->debug = &$debug;
 
-        // --------- Load Env
-        if (rex::isBackend()) {
-            $this->loadBackendConfig();
-        }
-
         $this->csrfToken = rex_csrf_token::factory('rex_form_'.$this->getName());
     }
 


### PR DESCRIPTION
Durch die neue Basisklasse hatte sich die Reihenfolge im Konstruktor bisschen geändert, loadBackendConfig wurde früher aufgerufen. Darin wird aber ein EP aufgerufen, der unter anderem vom MM genutzt wird. Und durch den frühereren Aufruf fehlte nun die Initialisierung des SQL-Objekts in rex_form.
Dadurch kam es zu einer Exception beim Hinzufügen eines MM-Types.

Daher lasse ich nun die Kindklassen die Methoden aufrufen am Ende des Konstruktors.

closes #1801