### PR TITLE
Fallback-Übersetzungen korrigiert

### DIFF
--- a/redaxo/src/core/lib/packages/addons/addon.php
+++ b/redaxo/src/core/lib/packages/addons/addon.php
@@ -134,7 +134,7 @@ class rex_addon extends rex_package implements rex_addon_interface
     {
         $args = func_get_args();
         $key = $this->getName() . '_' . $key;
-        if (rex_i18n::hasMsg($key)) {
+        if (rex_i18n::hasMsgOrFallback($key)) {
             $args[0] = $key;
         }
         return call_user_func_array('rex_i18n::msg', $args);

--- a/redaxo/src/core/lib/packages/plugins/plugin.php
+++ b/redaxo/src/core/lib/packages/plugins/plugin.php
@@ -152,7 +152,7 @@ class rex_plugin extends rex_package implements rex_plugin_interface
     {
         $args = func_get_args();
         $key = $this->getAddon()->getName() . '_' . $this->getName() . '_' . $key;
-        if (rex_i18n::hasMsg($key)) {
+        if (rex_i18n::hasMsgOrFallback($key)) {
             $args[0] = $key;
             return call_user_func_array('rex_i18n::msg', $args);
         }

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -196,6 +196,36 @@ class rex_i18n
     }
 
     /**
+     * Checks if there is a translation for the given key in current language or any fallback language.
+     *
+     * @param string $key Key
+     *
+     * @return bool TRUE on success, else FALSE
+     */
+    public static function hasMsgOrFallback($key)
+    {
+        if (isset(self::$msg[self::$locale][$key])) {
+            return true;
+        }
+
+        foreach (rex::getProperty('lang_fallback', []) as $locale) {
+            if (self::$locale === $locale) {
+                continue;
+            }
+
+            if (empty(self::$loaded[$locale])) {
+                self::loadAll($locale);
+            }
+
+            if (isset(self::$msg[$locale][$key])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Adds a new translation to the catalogue.
      *
      * @param string $key Key
@@ -297,7 +327,7 @@ class rex_i18n
 
         if (
             ($content = rex_file::get($file)) &&
-            preg_match_all('/^([^=\s]+)\h*=\h*(.*)(?<=\S)/m', $content, $matches, PREG_SET_ORDER)
+            preg_match_all('/^([^=\s]+)\h*=\h*(\S.*)(?<=\S)/m', $content, $matches, PREG_SET_ORDER)
         ) {
             foreach ($matches as $match) {
                 self::$msg[$locale][$match[1]] = $match[2];

--- a/redaxo/src/core/tests/util/i18n_test.php
+++ b/redaxo/src/core/tests/util/i18n_test.php
@@ -40,10 +40,28 @@ LANG;
         rex_i18n::addDirectory($this->getPath());
 
         $this->assertSame('abc def', rex_i18n::msg('rex_i18n_test_foo'));
-        $this->assertSame('', rex_i18n::msg('rex_i18n_test_bar'));
+        $this->assertSame('[translate:rex_i18n_test_bar]', rex_i18n::msg('rex_i18n_test_bar'));
         $this->assertSame('ghi', rex_i18n::msg('rex_i18n_test_baz'));
         $this->assertSame('abc=def', rex_i18n::msg('rex_i18n_test_4'));
         $this->assertSame('abc def', rex_i18n::msg('rex_i18n_test_5'));
+    }
+
+    public function testHasMsg()
+    {
+        rex_i18n::addDirectory($this->getPath());
+
+        $this->assertTrue(rex_i18n::hasMsg('rex_i18n_test_foo'));
+        $this->assertFalse(rex_i18n::hasMsg('rex_i18n_test_bar'));
+        $this->assertFalse(rex_i18n::hasMsg('rex_i18n_test_6'));
+    }
+
+    public function testHasMsgOrFallback()
+    {
+        rex_i18n::addDirectory($this->getPath());
+
+        $this->assertTrue(rex_i18n::hasMsgOrFallback('rex_i18n_test_foo'));
+        $this->assertFalse(rex_i18n::hasMsgOrFallback('rex_i18n_test_bar'));
+        $this->assertTrue(rex_i18n::hasMsgOrFallback('rex_i18n_test_6'));
     }
 
     public function testGetMsgFallback()


### PR DESCRIPTION
closes #1802 

Waren gleich zwei Probleme:
- Zum Einen haben wir leere Übersetzungen als vorhanden angesehen (also `key = ` mit leerem Value)
- Zum Anderen funktionierten die Fallbacks nicht bei diesen Kurzformen innerhalb der Packages, wo man den Package-Präfix weglassen kann

/cc @schuer 