### PR TITLE
rex_string::buildAttributes: Doppeltes Escaping von "&" vermeiden

### DIFF
--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -228,6 +228,7 @@ class rex_string
                 if (is_array($value)) {
                     $value = implode(' ', $value);
                 }
+                $value = str_replace('&amp;', '&', $value);
                 $attr .= ' ' . rex_escape($key) . '="' . rex_escape($value) . '"';
             }
         }

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -228,6 +228,7 @@ class rex_string
                 if (is_array($value)) {
                     $value = implode(' ', $value);
                 }
+                // for bc reasons avoid double escaping of "&", especially in already escaped urls
                 $value = str_replace('&amp;', '&', $value);
                 $attr .= ' ' . rex_escape($key) . '="' . rex_escape($value) . '"';
             }

--- a/redaxo/src/core/tests/util/string_test.php
+++ b/redaxo/src/core/tests/util/string_test.php
@@ -126,13 +126,14 @@ class rex_string_test extends PHPUnit_Framework_TestCase
     public function testBuildAttributes()
     {
         $this->assertEquals(
-            ' id="rex-test" class="a b" alt="" checked data-foo="&lt;foo&gt; &amp; &quot;bar&quot;"',
+            ' id="rex-test" class="a b" alt="" checked data-foo="&lt;foo&gt; &amp; &quot;bar&quot;" href="index.php?foo=1&amp;bar=2"',
             rex_string::buildAttributes([
                 'id' => 'rex-test',
                 'class' => ['a', 'b'],
                 'alt' => '',
                 'checked',
                 'data-foo' => '<foo> & "bar"',
+                'href' => 'index.php?foo=1&amp;bar=2',
             ])
         );
     }


### PR DESCRIPTION
refs https://github.com/redaxo/redaxo/pull/1687#issuecomment-389761965

Ich hab noch mal über die BC-Break-Problematik von `rex_string::buildAttributes` mit @tbaddade gesprochen.
Das Problem ist halt, dass er die Methode oft verwendet im Frontend, und oftmals URLs da reinwirft, so wie sie aus den url-Funktionen von Redaxo kommen.

```php
$attributes = [
    'href' => $article->getUrl(),
    'data-foo' => getFoo(),
];
rex_string::buildAttributes($attributes);
```

Das Escaping aus 5.6 ist also vom Prinzip hilfreich für uns, da die Attributes bisher nicht escaped übergeben wurden.
Ausnahme sind halt die URLs, weil Redaxo da leider bereits `&amp;` nutzt. 

Damit das oben weiter funktioniert, müsste man nun also `$article->getUrl([], '&')` schreiben. Und vor allem muss man alle Stellen finden.

Daher überlege ich, ob man das Doppelescaping von `&amp;` nicht doch vermeiden sollte.
Schön finde ich das absolut nicht. Aber glaube bei den Attributes ist es schon sehr unwahrscheinlich, dass man wirklich `&amp;amp;` haben möchte, oder?
Und es würde zumindest bei uns das Updaten deutlich vereinfachen.
Aber bin mir unsicher.