### PR TITLE
rex_delete_cache: rex_config nicht neu laden

### DIFF
--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -215,6 +215,9 @@ class rex_backup
             // delete cache before EP to avoid obsolete caches while running extensions
             rex_delete_cache();
 
+            // refresh rex_config with new values from database
+            rex_config::refresh();
+
             // ----- EXTENSION POINT
             $msg = rex_extension::registerPoint(new rex_extension_point('BACKUP_AFTER_DB_IMPORT', $msg, [
                 'content' => $conts,

--- a/redaxo/src/core/functions/function_rex_other.php
+++ b/redaxo/src/core/functions/function_rex_other.php
@@ -25,10 +25,6 @@ function rex_delete_cache()
 
     rex_clang::reset();
 
-    if (!rex::isSetup()) {
-        rex_config::refresh();
-    }
-
     // ----- EXTENSION POINT
     return rex_extension::registerPoint(new rex_extension_point('CACHE_DELETED', rex_i18n::msg('delete_cache_message')));
 }


### PR DESCRIPTION
closes #1819 

Eingeführt hatte ich das in https://github.com/redaxo/redaxo/pull/1624, da mir aufgefallen war, dass nach einem DB-Import rex_config noch die alten Werte enthält.
Ich denke, ich würde das nun aber doch aus `rex_delete_cache` wieder ganz rausnehmen, da es eben Probleme macht. Stattdessen muss man `rex_config::refresh()` selbst aufrufen, wenn man direkt was an der `rex_config`-Tabelle ändert.