### PR TITLE
Sidebar Metadaten verschieben

### DIFF
--- a/redaxo/src/addons/metainfo/extensions/extension_content_sidebar.php
+++ b/redaxo/src/addons/metainfo/extensions/extension_content_sidebar.php
@@ -1,37 +1,41 @@
 <?php
+/**
+ * @deprecated Moved to structure/content plugin, since the respective fields are not dependent on the metainfo addon
+ */
+if (rex_string::versionCompare(rex_plugin::get('structure', 'content')->getVersion(), '2.6.0', '<=')) {
+    rex_extension::register('STRUCTURE_CONTENT_SIDEBAR', function (rex_extension_point $ep) {
+        $params = $ep->getParams();
+        $subject = $ep->getSubject();
 
-rex_extension::register('STRUCTURE_CONTENT_SIDEBAR', function (rex_extension_point $ep) {
-    $params = $ep->getParams();
-    $subject = $ep->getSubject();
+        $article = rex_article::get($params['article_id'], $params['clang']);
+        $articleStatusTypes = rex_article_service::statusTypes();
 
-    $article = rex_article::get($params['article_id'], $params['clang']);
-    $articleStatusTypes = rex_article_service::statusTypes();
+        $panel = '';
+        $panel .= '<dl class="dl-horizontal text-left">';
 
-    $panel = '';
-    $panel .= '<dl class="dl-horizontal text-left">';
+        $panel .= '<dt>' . rex_i18n::msg('created_by') . '</dt>';
+        $panel .= '<dd>' . $article->getValue('createuser') . '</dd>';
 
-    $panel .= '<dt>' . rex_i18n::msg('created_by') . '</dt>';
-    $panel .= '<dd>' . $article->getValue('createuser') . '</dd>';
+        $panel .= '<dt>' . rex_i18n::msg('created_on') . '</dt>';
+        $panel .= '<dd>' . rex_formatter::strftime($article->getValue('createdate'), 'date') . '</dd>';
 
-    $panel .= '<dt>' . rex_i18n::msg('created_on') . '</dt>';
-    $panel .= '<dd>' . rex_formatter::strftime($article->getValue('createdate'), 'date') . '</dd>';
+        $panel .= '<dt>' . rex_i18n::msg('updated_by') . '</dt>';
+        $panel .= '<dd>' . $article->getValue('updateuser') . '</dd>';
 
-    $panel .= '<dt>' . rex_i18n::msg('updated_by') . '</dt>';
-    $panel .= '<dd>' . $article->getValue('updateuser') . '</dd>';
+        $panel .= '<dt>' . rex_i18n::msg('updated_on') . '</dt>';
+        $panel .= '<dd>' . rex_formatter::strftime($article->getValue('updatedate'), 'date') . '</dd>';
 
-    $panel .= '<dt>' . rex_i18n::msg('updated_on') . '</dt>';
-    $panel .= '<dd>' . rex_formatter::strftime($article->getValue('updatedate'), 'date') . '</dd>';
+        $panel .= '<dt>' . rex_i18n::msg('status') . '</dt>';
+        $panel .= '<dd class="' . $articleStatusTypes[$article->getValue('status')][1] . '">' . $articleStatusTypes[$article->getValue('status')][0] . '</dd>';
 
-    $panel .= '<dt>' . rex_i18n::msg('status') . '</dt>';
-    $panel .= '<dd class="' . $articleStatusTypes[$article->getValue('status')][1] . '">' . $articleStatusTypes[$article->getValue('status')][0] . '</dd>';
+        $panel .= '</dl>';
+        $fragment = new rex_fragment();
+        $fragment->setVar('title', '<i class="rex-icon rex-icon-info"></i> ' . rex_i18n::msg('metadata'), false);
+        $fragment->setVar('body', $panel, false);
+        $fragment->setVar('collapse', true);
+        $fragment->setVar('collapsed', true);
+        $content = $fragment->parse('core/page/section.php');
 
-    $panel .= '</dl>';
-    $fragment = new rex_fragment();
-    $fragment->setVar('title', '<i class="rex-icon rex-icon-info"></i> ' . rex_i18n::msg('metadata'), false);
-    $fragment->setVar('body', $panel, false);
-    $fragment->setVar('collapse', true);
-    $fragment->setVar('collapsed', true);
-    $content = $fragment->parse('core/page/section.php');
-
-    return $content.$subject;
-});
+        return $content.$subject;
+    });
+}

--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -23,7 +23,7 @@ if (rex::isBackend()) {
     }
 
     if (rex_be_controller::getCurrentPagePart(1) == 'content') {
-        rex_extension::register('STRUCTURE_CONTENT_SIDEBAR', function(rex_extension_point $ep) {
+        rex_extension::register('STRUCTURE_CONTENT_SIDEBAR', function (rex_extension_point $ep) {
             $params = $ep->getParams();
             $subject = $ep->getSubject();
 

--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -22,6 +22,44 @@ if (rex::isBackend()) {
         rex_system_setting::register(new rex_system_setting_default_template_id());
     }
 
+    if (rex_be_controller::getCurrentPagePart(1) == 'content') {
+        rex_extension::register('STRUCTURE_CONTENT_SIDEBAR', function(rex_extension_point $ep) {
+            $params = $ep->getParams();
+            $subject = $ep->getSubject();
+
+            $article = rex_article::get($params['article_id'], $params['clang']);
+            $articleStatusTypes = rex_article_service::statusTypes();
+
+            $panel = '';
+            $panel .= '<dl class="dl-horizontal text-left">';
+
+            $panel .= '<dt>'.rex_i18n::msg('created_by').'</dt>';
+            $panel .= '<dd>'.$article->getValue('createuser').'</dd>';
+
+            $panel .= '<dt>'.rex_i18n::msg('created_on').'</dt>';
+            $panel .= '<dd>'.rex_formatter::strftime($article->getValue('createdate'), 'date').'</dd>';
+
+            $panel .= '<dt>'.rex_i18n::msg('updated_by').'</dt>';
+            $panel .= '<dd>'.$article->getValue('updateuser').'</dd>';
+
+            $panel .= '<dt>'.rex_i18n::msg('updated_on').'</dt>';
+            $panel .= '<dd>'.rex_formatter::strftime($article->getValue('updatedate'), 'date').'</dd>';
+
+            $panel .= '<dt>'.rex_i18n::msg('status').'</dt>';
+            $panel .= '<dd class="'.$articleStatusTypes[$article->getValue('status')][1].'">'.$articleStatusTypes[$article->getValue('status')][0].'</dd>';
+
+            $panel .= '</dl>';
+            $fragment = new rex_fragment();
+            $fragment->setVar('title', '<i class="rex-icon rex-icon-info"></i> '.rex_i18n::msg('metadata'), false);
+            $fragment->setVar('body', $panel, false);
+            $fragment->setVar('collapse', true);
+            $fragment->setVar('collapsed', true);
+            $content = $fragment->parse('core/page/section.php');
+
+            return $content.$subject;
+        });
+    }
+
     rex_extension::register('CLANG_DELETED', function (rex_extension_point $ep) {
         $del = rex_sql::factory();
         $del->setQuery('delete from ' . rex::getTablePrefix() . "article_slice where clang_id='" . $ep->getParam('clang')->getId() . "'");

--- a/redaxo/src/addons/structure/plugins/content/package.yml
+++ b/redaxo/src/addons/structure/plugins/content/package.yml
@@ -1,5 +1,5 @@
 package: structure/content
-version: '2.6.0'
+version: '2.6.1'
 author: Markus Staab
 supportpage: www.redaxo.org/de/forum/
 


### PR DESCRIPTION
Da die Metadaten nicht vom Addon Metainfo abhängen.
Als Vorbereitung für Anpassungen auf dem Weg zu Structure 3.