### PR TITLE
Schönere Statusmeldung wenn nur 1 Backup gelöscht wird

### DIFF
--- a/redaxo/src/addons/backup/lib/cronjob.php
+++ b/redaxo/src/addons/backup/lib/cronjob.php
@@ -63,7 +63,7 @@ class rex_cronjob_export extends rex_cronjob
                 }
 
                 if ($countDeleted) {
-                    $message .= ', '.$countDeleted.' old backups deleted';
+                    $message .= ', '.$countDeleted.' old backup(s) deleted';
                 }
             }
 


### PR DESCRIPTION
vorher: `1 old backups deleted`
jetzt: `1 old backup(s) deleted`

siehe https://github.com/redaxo/redaxo/issues/1765#issuecomment-397955248