### PR TITLE
"start" als Fallback Cursorname in rex_list wg Rückwärtskompatibilität

### DIFF
--- a/redaxo/src/core/lib/util/pager.php
+++ b/redaxo/src/core/lib/util/pager.php
@@ -80,7 +80,8 @@ class rex_pager
     public function getCursor($pageNo = null)
     {
         if (null === $pageNo) {
-            $cursor = rex_request($this->cursorName, 'int', 0);
+            // BC: Fallback to "start"
+            $cursor = rex_request($this->cursorName, 'int', rex_request('start', 'int', 0));
         } else {
             $cursor = $pageNo * $this->rowsPerPage;
         }
@@ -148,7 +149,8 @@ class rex_pager
      */
     public function getCurrentPage()
     {
-        $cursor = rex_request($this->cursorName, 'int', null);
+        // BC: Fallback to "start"
+        $cursor = rex_request($this->cursorName, 'int', rex_request('start', 'int', null));
 
         if (null === $cursor) {
             return $this->getFirstPage();


### PR DESCRIPTION
Closes https://github.com/redaxo/redaxo/issues/1724

Ungetestet!