### PR TITLE
"start" als Fallback Cursorname in rex_list wg Rückwärtskompatibilität

### DIFF
--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -141,7 +141,7 @@ class rex_list implements rex_url_provider_interface
         $this->linkAttributes = [];
 
         // --------- Pagination Attributes
-        $cursorName = $listName .'_start'
+        $cursorName = $listName .'_start';
         if (null === rex_request($cursorName, 'int', null) && rex_request('start', 'int')) {
             // BC: Fallback to "start"
             $cursorName = 'start';

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -142,7 +142,7 @@ class rex_list implements rex_url_provider_interface
 
         // --------- Pagination Attributes
         $cursorName = $listName .'_start'
-        if (null === rex_request($cursorName, 'int', null) && rex_request('start', 'int') {
+        if (null === rex_request($cursorName, 'int', null) && rex_request('start', 'int')) {
             // BC: Fallback to "start"
             $cursorName = 'start';
         }

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -142,7 +142,7 @@ class rex_list implements rex_url_provider_interface
 
         // --------- Pagination Attributes
         $cursorName = $listName .'_start'
-        if (null === rex_request($getCursorName, 'int', null) && rex_request('start', 'int') {
+        if (null === rex_request($cursorName, 'int', null) && rex_request('start', 'int') {
             // BC: Fallback to "start"
             $cursorName = 'start';
         }

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -142,6 +142,9 @@ class rex_list implements rex_url_provider_interface
 
         // --------- Pagination Attributes
         $this->pager = new rex_pager($rowsPerPage, $listName .'_start');
+        if (!isset($_REQUEST[$this->pager->getCursoName()] && rex_request('start', 'int')) {
+            $_REQUEST[$this->pager->getCursoName()] = rex_request('start', 'int', 0);
+        }
 
         // --------- Load Data, Row-Count
         $this->sql->setQuery($this->prepareQuery($query));

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -147,9 +147,6 @@ class rex_list implements rex_url_provider_interface
             $cursorName = 'start';
         }
         $this->pager = new rex_pager($rowsPerPage, $cursorName);
-        
-        if ()) {
-            $_REQUEST[$this->pager->getCursoName()] = rex_request('star
 
         // --------- Load Data, Row-Count
         $this->sql->setQuery($this->prepareQuery($query));

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -141,11 +141,15 @@ class rex_list implements rex_url_provider_interface
         $this->linkAttributes = [];
 
         // --------- Pagination Attributes
-        $this->pager = new rex_pager($rowsPerPage, $listName .'_start');
-        // BC: Fallback to "start"
-        if (!isset($_REQUEST[$this->pager->getCursoName()] && rex_request('start', 'int')) {
-            $_REQUEST[$this->pager->getCursoName()] = rex_request('start', 'int', 0);
+        $cursorName = $listName .'_start'
+        if (null === rex_request($getCursoName, 'int', null) && rex_request('start', 'int') {
+            // BC: Fallback to "start"
+            $cursorName = 'start';
         }
+        $this->pager = new rex_pager($rowsPerPage, $cursorName);
+        
+        if ()) {
+            $_REQUEST[$this->pager->getCursoName()] = rex_request('star
 
         // --------- Load Data, Row-Count
         $this->sql->setQuery($this->prepareQuery($query));

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -142,7 +142,7 @@ class rex_list implements rex_url_provider_interface
 
         // --------- Pagination Attributes
         $cursorName = $listName .'_start'
-        if (null === rex_request($getCursoName, 'int', null) && rex_request('start', 'int') {
+        if (null === rex_request($getCursorName, 'int', null) && rex_request('start', 'int') {
             // BC: Fallback to "start"
             $cursorName = 'start';
         }

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -142,6 +142,7 @@ class rex_list implements rex_url_provider_interface
 
         // --------- Pagination Attributes
         $this->pager = new rex_pager($rowsPerPage, $listName .'_start');
+        // BC: Fallback to "start"
         if (!isset($_REQUEST[$this->pager->getCursoName()] && rex_request('start', 'int')) {
             $_REQUEST[$this->pager->getCursoName()] = rex_request('start', 'int', 0);
         }


### PR DESCRIPTION
Closes https://github.com/redaxo/redaxo/issues/1724

Ungetestet!