### PR TITLE
rex_list verwendet kürzere hashes in urls

### DIFF
--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -103,7 +103,7 @@ class rex_list implements rex_url_provider_interface
         // --------- Validation
         if (!$listName) {
             // use a hopefully unique (per page) hash
-            $listName = substr(md5($query),0, 8);
+            $listName = substr(md5($query), 0, 8);
         }
 
         // --------- List Attributes

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -102,7 +102,8 @@ class rex_list implements rex_url_provider_interface
     {
         // --------- Validation
         if (!$listName) {
-            $listName = md5($query);
+            // use a hopefully unique (per page) hash
+            $listName = substr(md5($query),0, 8);
         }
 
         // --------- List Attributes


### PR DESCRIPTION
Damit die Url weniger kryptisch wirken

Closes https://github.com/redaxo/redaxo/issues/1839