### PR TITLE
Keine Http-Link preload header mit rex_response->sendFile() versenden

### DIFF
--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -155,7 +155,6 @@ class rex_response
         }
 
         self::sendAdditionalHeaders();
-        self::sendPreloadHeaders();
 
         readfile($file);
     }


### PR DESCRIPTION
Mir ist aufgefallen, dass preload header versendet werden wenn man Dateien mit `rex_response->sendFile()` verschickt.

es ist zu sehen dass im FF Dateien erneut heruntergeladen werden, die gar nichts damit zu tun haben.
Das liegt aktuell an
https://github.com/redaxo/redaxo/blob/79dbc75fee5acc09776f5e981947179b926ed63c/redaxo/src/addons/be_style/boot.php#L50

Ich vermute dass es keinen sinnvollen use-case gibt wenn man sendFile() verwendet um dann auch preload header verwenden zu wollen. daher hab ich das einfach mal wieder rausgeworfen.