### PR TITLE
Neuer EP: EDITOR_URL

### DIFF
--- a/redaxo/src/addons/metainfo/boot.php
+++ b/redaxo/src/addons/metainfo/boot.php
@@ -44,3 +44,28 @@ if (rex::isBackend()) {
 
     rex_extension::register('PAGE_CHECKED', 'rex_metainfo_extensions_handler');
 }
+
+rex_extension::register('EDITOR_URL', function (rex_extension_point $ep) {
+    if (!preg_match('@^rex:///metainfo/(\d+)@', $ep->getParam('file'), $match)) {
+        return;
+    }
+
+    $id = $match[1];
+    $sql = rex_sql::factory();
+    $sql->setQuery('SELECT `name` FROM '.rex::getTable('metainfo_field').' WHERE id = ? LIMIT 1', [$id]);
+
+    if (!$sql->getRows()) {
+        return;
+    }
+
+    static $pages = [
+        'art_' => 'articles',
+        'cat_' => 'categories',
+        'med_' => 'media',
+        'clang_' => 'clangs',
+    ];
+
+    $prefix = rex_metainfo_meta_prefix($sql->getValue('name'));
+
+    return rex_url::backendPage('metainfo/'.$pages[$prefix], ['func' => 'edit', 'field_id' => $id]);
+});

--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -93,3 +93,15 @@ if (rex::isBackend()) {
         rex_response::sendPage($content, $article->getValue('updatedate'));
     });
 }
+
+rex_extension::register('EDITOR_URL', function (rex_extension_point $ep) {
+    static $urls = [
+        'template' => ['templates', 'template_id'],
+        'module' => ['modules/modules', 'module_id'],
+        'action' => ['modules/actions', 'action_id'],
+    ];
+
+    if (preg_match('@^rex:///(template|module|action)/(\d+)@', $ep->getParam('file'), $match)) {
+        return rex_url::backendPage($urls[$match[1]][0], ['function' => 'edit', $urls[$match[1]][1] => $match[2]]);
+    }
+});

--- a/redaxo/src/core/lib/util/editor.php
+++ b/redaxo/src/core/lib/util/editor.php
@@ -38,27 +38,17 @@ class rex_editor
 
     public function getUrl($filePath, $line)
     {
-        // make internal urls work with parse_url()
-        $filePath = str_replace('rex:///', 'rex://', $filePath);
-
-        $parsedUrl = parse_url($filePath);
-        // rex:// internal url mapping to backend form-edit urls
-        if (isset($parsedUrl['scheme']) && $parsedUrl['scheme'] === 'rex') {
-            if ($parsedUrl['host'] === 'template') {
-                $templateId = ltrim($parsedUrl['path'], '/');
-                return rex_url::backendPage('templates', ['function' => 'edit', 'template_id' => $templateId]);
-            }
-            if ($parsedUrl['host'] === 'module') {
-                $moduleId = (int) ltrim($parsedUrl['path'], '/');
-                return rex_url::backendPage('modules/modules', ['function' => 'edit', 'module_id' => $moduleId]);
-            }
-        }
-
         $editor = rex::getProperty('editor');
         $editorUrl = $this->editors[$editor];
 
         $editorUrl = str_replace('%line', $line, $editorUrl);
         $editorUrl = str_replace('%file', $filePath, $editorUrl);
+
+        $editorUrl = rex_extension::registerPoint(new rex_extension_point('EDITOR_URL', $editorUrl, [
+            'file' => $filePath,
+            'line' => $line,
+            'editor' => $this,
+        ]));
 
         return $editorUrl;
     }


### PR DESCRIPTION
Bin mir noch nicht ganz sicher in der Umsetzung, aber hier mal mein aktueller Stand/Vorschlag.

Ich würde schon über einen EP gehen, wenn wirklich ein `rex://`-Pfad ausgeführt würde bevor alle Addons geladen sind, und dann ein Fehler kommt, wäre es halt Pech, denke ich.
Bisher ist mir aber kein solcher Fall bekannt.

Überlegt habe ich, ob der EP nur für `rex://`-Pfade greifen sollte, habe mich dann aber doch dafür entschieden, alle Pfade durch den EP zu jagen.

Das developer-Addon muss aus den `rex://`-Pfaden ja dann normale Editor-Urls machen, es würde also in der Extension rekursiv erneut `$editor->getUrl()` aufrufen. Ist aber ja eigentlich auch ok, oder?
Also sähe es im developer-Addon grob so aus:

```php
rex_extension::register('EDITOR_URL', function (rex_extension_point $ep) {
    if (preg_match('@^rex:///(template|module|action)/(\d+)@', $ep->getParam('file'), $match)) {
        return $ep->getParam('editor')->getUrl('<developer-path>', $ep->getParam('line'));
    }
}, rex_extension::LATE);
```