### PR TITLE
Fehler vermeiden, wenn kein Editor ausgewählt

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -66,15 +66,7 @@ abstract class rex_error_handler
             $handler = new \Whoops\Handler\PrettyPageHandler();
             $handler->setApplicationRootPath(rtrim(rex_path::base(), '/\\'));
 
-            $editor = rex::getProperty('editor');
-            if (!empty($editor)) {
-                $handler->setEditor(function ($file, $line) {
-                    $editor = rex_editor::factory();
-                    return $editor->getUrl($file, $line);
-                });
-            } elseif (ini_get('xdebug.file_link_format')) {
-                $handler->setEditor('xdebug');
-            }
+            $handler->setEditor([rex_editor::factory(), 'getUrl']);
 
             $whoops->pushHandler($handler);
 

--- a/redaxo/src/core/lib/util/editor.php
+++ b/redaxo/src/core/lib/util/editor.php
@@ -39,10 +39,15 @@ class rex_editor
     public function getUrl($filePath, $line)
     {
         $editor = rex::getProperty('editor');
-        $editorUrl = $this->editors[$editor];
 
-        $editorUrl = str_replace('%line', $line, $editorUrl);
-        $editorUrl = str_replace('%file', $filePath, $editorUrl);
+        $editorUrl = null;
+
+        if (isset($this->editors[$editor])) {
+            $editorUrl = $this->editors[$editor];
+
+            $editorUrl = str_replace('%line', $line, $editorUrl);
+            $editorUrl = str_replace('%file', $filePath, $editorUrl);
+        }
 
         $editorUrl = rex_extension::registerPoint(new rex_extension_point('EDITOR_URL', $editorUrl, [
             'file' => $filePath,


### PR DESCRIPTION
Aktuell bekommt man Fehler, wenn kein Editor ausgewählt wurde.

Außerdem schlage ich vor, den Editor immer an whoops weiterzugeben, denn auch wenn kein Editor ausgewählt wurde, können die `rex://`-Pfade ja trotzdem verlinkt werden.
Dafür brauchen wir aber noch diesen Fix upstream: https://github.com/filp/whoops/pull/582