### PR TITLE
Editor-Url: Default keine "URLs" verlinken

### DIFF
--- a/redaxo/src/core/lib/util/editor.php
+++ b/redaxo/src/core/lib/util/editor.php
@@ -42,7 +42,7 @@ class rex_editor
 
         $editorUrl = null;
 
-        if (isset($this->editors[$editor])) {
+        if (isset($this->editors[$editor]) && false !== strpos($filePath, '://')) {
             $editorUrl = $this->editors[$editor];
 
             $editorUrl = str_replace('%line', $line, $editorUrl);

--- a/redaxo/src/core/lib/util/editor.php
+++ b/redaxo/src/core/lib/util/editor.php
@@ -42,6 +42,8 @@ class rex_editor
 
         $editorUrl = null;
 
+        // don't provide editor urls for paths containing "://", like "rex://..."
+        // but they can be converted into an url by the extension point below
         if (isset($this->editors[$editor]) && false !== strpos($filePath, '://')) {
             $editorUrl = $this->editors[$editor];
 


### PR DESCRIPTION
Ein `rex://`-Pfad zum Beispiel kann ja nicht von den normalen Editor-URLs geöffnet werden.
Daher das Default-Handling für Pfade mit `://` unterbinden.
Die Pfade werden also nur verlinkt, wenn Extensions dazu eine URL liefern.