### PR TITLE
Erweiterte Listenansicht für Effekte im Medien-Manager

### DIFF
--- a/redaxo/src/addons/media_manager/fragments/mmeffectslist.php
+++ b/redaxo/src/addons/media_manager/fragments/mmeffectslist.php
@@ -1,0 +1,18 @@
+<?php
+
+    // $this->class         Klasse für die Content-gruppe
+    // $this->visible      true/false
+    // $this->content       [id] = [ label, content ]
+
+    foreach( $this->content as $k=>$v )
+    {
+        echo '<div class="panel panel-default'.(isset($this->class)?(' '.$this->class):'').'">';
+        if( $v['label'] ) echo "<div class=\"panel-heading\">{$v['label']}</div>";
+        echo '<dl class="small panel-body'.(isset($this->visible)&&$this->visible?'':' hidden').'">';
+        foreach( $v['effects'] as $ek=>$ev )
+        {
+            echo "<dt>$ek</dt><dd>$ev</dd>";
+        }
+        echo '</dl>';
+        echo '</div>';
+    }

--- a/redaxo/src/addons/media_manager/pages/effects.php
+++ b/redaxo/src/addons/media_manager/pages/effects.php
@@ -62,8 +62,18 @@ $effects = [];
 foreach (rex_media_manager::getSupportedEffects() as $class => $shortName) {
     $effects[$shortName] = new $class();
 }
+//dump( $effects );
 
 if ($func == '' && $type_id > 0) {
+    echo '<style>
+.rex-media-manager-effect-detail{width:20em;margin:5px 0;}
+.rex-media-manager-effect-detail .panel-body{padding:5px 15px;}
+.rex-media-manager-effect-detail dl{padding:0;margin:0}
+.rex-media-manager-effect-detail dt,dd{display:inline-block;}
+.rex-media-manager-effect-detail dt{width:65%;padding-right:3%;vertical-align:top;}
+.rex-media-manager-effect-detail dd{width:35%;}
+</style>
+';
     echo rex_view::info(rex_i18n::msg('media_manager_effect_list_header', $typeName));
 
     $query = 'SELECT * FROM ' . rex::getTablePrefix() . 'media_manager_type_effect WHERE type_id=' . $type_id . ' ORDER BY priority';
@@ -85,7 +95,26 @@ if ($func == '' && $type_id > 0) {
     $list->setColumnLabel('effect', rex_i18n::msg('media_manager_type_name'));
     $list->setColumnFormat('effect', 'custom', function ($params) use ($effects) {
         $shortName = $params['value'];
-        return isset($effects[$shortName]) ? $effects[$shortName]->getName() : $shortName;
+        $effectClass = "rex_effect_$shortName";
+        $effectParams = json_decode($params['list']->getValue('parameters'),true);
+        $instance = new $effectClass();
+        $effectLabels = [];
+        if( isset( $effectParams[$effectClass] ) )
+        {
+            $effectParams = $effectParams[$effectClass];
+            $effectLabels = array_column( $instance->getParams(),'name','label' );
+            foreach( $effectLabels as $ek=>$ev )
+            {
+                $value = "{$effectClass}_$ev";
+                $effectLabels[$ek] = isset( $effectParams[$value] ) ? $effectParams[$value] : '?';
+            }
+        }
+        $fragment = new rex_fragment();
+        $fragment->setVar( 'class', 'rex-media-manager-effect-detail' );
+        $fragment->setVar( 'visible', true, false );
+        $fragment->setVar( 'content', [['label'=>'','effects'=>$effectLabels]], false );
+        $out = $fragment->parse('mmeffectslist.php');
+        return (isset($effects[$shortName]) ? $effects[$shortName]->getName() : $shortName) . $out;
     });
 
     $list->setColumnLabel('priority', rex_i18n::msg('media_manager_type_priority'));

--- a/redaxo/src/addons/media_manager/pages/effects.php
+++ b/redaxo/src/addons/media_manager/pages/effects.php
@@ -96,23 +96,21 @@ if ($func == '' && $type_id > 0) {
     $list->setColumnFormat('effect', 'custom', function ($params) use ($effects) {
         $shortName = $params['value'];
         $effectClass = "rex_effect_$shortName";
-        $effectParams = json_decode($params['list']->getValue('parameters'),true);
+        $effectParams = json_decode($params['list']->getValue('parameters'), true);
         $instance = new $effectClass();
         $effectLabels = [];
-        if( isset( $effectParams[$effectClass] ) )
-        {
+        if (isset($effectParams[$effectClass])) {
             $effectParams = $effectParams[$effectClass];
-            $effectLabels = array_column( $instance->getParams(),'name','label' );
-            foreach( $effectLabels as $ek=>$ev )
-            {
+            $effectLabels = array_column($instance->getParams(), 'name', 'label');
+            foreach ($effectLabels as $ek => $ev) {
                 $value = "{$effectClass}_$ev";
-                $effectLabels[$ek] = isset( $effectParams[$value] ) ? $effectParams[$value] : '?';
+                $effectLabels[$ek] = isset($effectParams[$value]) ? $effectParams[$value] : '?';
             }
         }
         $fragment = new rex_fragment();
-        $fragment->setVar( 'class', 'rex-media-manager-effect-detail' );
-        $fragment->setVar( 'visible', true, false );
-        $fragment->setVar( 'content', [['label'=>'','effects'=>$effectLabels]], false );
+        $fragment->setVar('class', 'rex-media-manager-effect-detail');
+        $fragment->setVar('visible', true, false);
+        $fragment->setVar('content', [['label' => '', 'effects' => $effectLabels]], false);
         $out = $fragment->parse('mmeffectslist.php');
         return (isset($effects[$shortName]) ? $effects[$shortName]->getName() : $shortName) . $out;
     });

--- a/redaxo/src/addons/media_manager/pages/types.php
+++ b/redaxo/src/addons/media_manager/pages/types.php
@@ -185,27 +185,24 @@ function rex_mediamanager_toggleAll(dieses){
     $list->setColumnFormat('deleteType', 'custom', function ($params) {
         $list = $params['list'];
         $qry = 'SELECT effect,parameters FROM '.rex::getTable('media_manager_type_effect').' WHERE type_id=? ORDER BY priority';
-        $effects = rex_sql::factory()->getArray( $qry, [$params['list']->getValue('id')]  );
-        foreach( $effects as $k=>$v )
-        {
+        $effects = rex_sql::factory()->getArray($qry, [$params['list']->getValue('id')]);
+        foreach ($effects as $k => $v) {
             $effectClass = "rex_effect_{$v['effect']}";
-            $effectParams = json_decode($v['parameters'],true);
+            $effectParams = json_decode($v['parameters'], true);
             $instance = new $effectClass();
             $effectLabels = [];
-            if( isset( $effectParams[$effectClass] ) )
-            {
+            if (isset($effectParams[$effectClass])) {
                 $effectParams = $effectParams[$effectClass];
-                $effectLabels = array_column( $instance->getParams(),'name','label' );
-                foreach( $effectLabels as $ek=>$ev )
-                {
+                $effectLabels = array_column($instance->getParams(), 'name', 'label');
+                foreach ($effectLabels as $ek => $ev) {
                     $value = "{$effectClass}_$ev";
-                    $effectLabels[$ek] = isset( $effectParams[$value] ) ? $effectParams[$value] : '?';
+                    $effectLabels[$ek] = isset($effectParams[$value]) ? $effectParams[$value] : '?';
                 }
             }
-            $effects[$k] = ['label'=>$instance->getName(),'effects'=>$effectLabels];
+            $effects[$k] = ['label' => $instance->getName(), 'effects' => $effectLabels];
         }
         $fragment = new rex_fragment();
-        $fragment->setVar( 'content', $effects, false );
+        $fragment->setVar('content', $effects, false);
         $zusatzzeile = '</td></tr><tr class="rex-helper-line"><td></td><td colspan="6">'.
                        '<div class="hidden rex-mediamanager-list-link rex-mediamanager-list-'.$list->getValue('name').'-link">Link: <i>index.php?rex_media_type='.$list->getValue('name').'&rex_media_file=</i></div>'.
                        '<div class="rex-mediamanager-list-effect rex-mediamanager-list-'.$list->getValue('name').'-effect">'.$fragment->parse('mmeffectslist.php').'</div>';

--- a/redaxo/src/addons/media_manager/pages/types.php
+++ b/redaxo/src/addons/media_manager/pages/types.php
@@ -78,12 +78,54 @@ if ($error != '') {
 }
 
 if ($func == '') {
+    echo '<style>
+<!--[if IE ]><style>.rex-media-manager-list{table-layout: fixed;}</style><![endif]-->
+<style>
+.rex-helper-line dt,dd{display:inline-block;}
+.rex-helper-line dt{width:65%;padding-right:3%;vertical-align:top;}
+.rex-helper-line dd{width:35%;}
+.rex-helper-line td{border-top:0px!important;}
+.rex-helper-line .rex-mediamanager-list-effect{display:-ms-flexbox;display:flex;-ms-flex-flow:row wrap;flex-wrap:wrap;}
+.rex-helper-line .rex-mediamanager-list-effect > div{width:20em;margin:5px 10px 5px 0;}
+.rex-helper-line .rex-mediamanager-list-effect .panel-heading{padding:5px 15px; background-color: transparent; }
+.rex-helper-line .rex-mediamanager-list-effect .panel-body{padding:0 15px;}
+.rex-helper-line .rex-mediamanager-list-effect dl{padding:0;margin:0}
+</style>
+<script>
+function rex_mediamanager_toggle(dieses){
+    var dies = jQuery(dieses);
+    var das = jQuery(dies.data("target"));
+    console.log(das);
+    if( dies.hasClass("active") ) {
+        dies.removeClass("active");
+        das.addClass("hidden");
+    } else {
+        dies.addClass("active");
+        das.removeClass("hidden");
+    }
+}
+function rex_mediamanager_toggleAll(dieses){
+    var dies = jQuery(dieses);
+    var das = jQuery(dies.data("target"));
+    var btn = jQuery(dies.data("button"));
+
+    if( dies.hasClass("active") ) {
+        dies.removeClass("active");
+        das.addClass("hidden");
+        btn.removeClass("active");
+    } else {
+        dies.addClass("active");
+        das.removeClass("hidden");
+        btn.addClass("active");
+    }
+}
+</script>';
     // Nach Status sortieren, damit Systemtypen immer zuletzt stehen
     // (werden am seltesten bearbeitet)
     $query = 'SELECT * FROM ' . rex::getTablePrefix() . 'media_manager_type ORDER BY status, name';
 
     $list = rex_list::factory($query);
-    $list->addTableAttribute('class', 'table-striped');
+    $list->addTableAttribute('class', 'table-striped rex-media-manager-list');
     $list->setNoRowsMessage(rex_i18n::msg('media_manager_type_no_types'));
 
     $list->removeColumn('id');
@@ -94,6 +136,22 @@ if ($func == '') {
     $list->setColumnFormat('name', 'custom', function ($params) {
         $list = $params['list'];
         $name = '<b>' . $list->getValue('name') . '</b>';
+        $name .= '<div class="pull-right">
+            <button
+                onclick="rex_mediamanager_toggle(this)"
+                type="button"
+                class="btn btn btn-xs rex-mediamanager-list-effect-btn"
+                data-target=".rex-mediamanager-list-'.$list->getValue('name').'-effect .panel-body">
+                <i class="rex-icon  fa-search-plus"></i>
+            </button>&nbsp;
+            <button
+                onclick="rex_mediamanager_toggle(this)"
+                type="button"
+                class="btn btn btn-xs rex-mediamanager-list-link-btn"
+                data-target=".rex-mediamanager-list-'.$list->getValue('name').'-link">
+                <i class="rex-icon fa-link"></i>
+            </button>
+            </div>';
         $name .= ($list->getValue('description') != '') ? '<br /><span class="rex-note">' . $list->getValue('description') . '</span>' : '';
         return $name;
     });
@@ -126,16 +184,60 @@ if ($func == '') {
     $list->addLinkAttribute('deleteType', 'data-confirm', rex_i18n::msg('delete') . ' ?');
     $list->setColumnFormat('deleteType', 'custom', function ($params) {
         $list = $params['list'];
-        if ($list->getValue('status') == 1) {
-            return '<small class="text-muted">' . rex_i18n::msg('media_manager_type_system') . '</small>';
+        $qry = 'SELECT effect,parameters FROM '.rex::getTable('media_manager_type_effect').' WHERE type_id=? ORDER BY priority';
+        $effects = rex_sql::factory()->getArray( $qry, [$params['list']->getValue('id')]  );
+        foreach( $effects as $k=>$v )
+        {
+            $effectClass = "rex_effect_{$v['effect']}";
+            $effectParams = json_decode($v['parameters'],true);
+            $instance = new $effectClass();
+            $effectLabels = [];
+            if( isset( $effectParams[$effectClass] ) )
+            {
+                $effectParams = $effectParams[$effectClass];
+                $effectLabels = array_column( $instance->getParams(),'name','label' );
+                foreach( $effectLabels as $ek=>$ev )
+                {
+                    $value = "{$effectClass}_$ev";
+                    $effectLabels[$ek] = isset( $effectParams[$value] ) ? $effectParams[$value] : '?';
+                }
+            }
+            $effects[$k] = ['label'=>$instance->getName(),'effects'=>$effectLabels];
         }
-        return $list->getColumnLink('deleteType', '<i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('media_manager_type_delete'));
+        $fragment = new rex_fragment();
+        $fragment->setVar( 'content', $effects, false );
+        $zusatzzeile = '</td></tr><tr class="rex-helper-line"><td></td><td colspan="6">'.
+                       '<div class="hidden rex-mediamanager-list-link rex-mediamanager-list-'.$list->getValue('name').'-link">Link: <i>index.php?rex_media_type='.$list->getValue('name').'&rex_media_file=</i></div>'.
+                       '<div class="rex-mediamanager-list-effect rex-mediamanager-list-'.$list->getValue('name').'-effect">'.$fragment->parse('mmeffectslist.php').'</div>';
+        if ($list->getValue('status') == 1) {
+            return '<small class="text-muted">' . rex_i18n::msg('media_manager_type_system') . '</small>'.$zusatzzeile;
+        }
+        return $list->getColumnLink('deleteType', '<i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('media_manager_type_delete')).$zusatzzeile;
     });
 
     $content .= $list->get();
 
+    $button = '<div class="pull-right">
+    <button
+        onclick="rex_mediamanager_toggleAll(this)"
+        type="button"
+        class="btn btn btn-xs"
+        data-target=".rex-mediamanager-list-effect .panel-body"
+        data-button=".rex-mediamanager-list-effect-btn">
+        <i class="rex-icon fa-search-plus"></i>
+    </button>&nbsp;
+    <button
+        onclick="rex_mediamanager_toggleAll(this)"
+        type="button"
+        class="btn btn btn-xs"
+        data-target=".rex-mediamanager-list-link"
+        data-button=".rex-mediamanager-list-link-btn">
+        <i class="rex-icon fa-link"></i>
+    </button>
+    </div>';
+
     $fragment = new rex_fragment();
-    $fragment->setVar('title', rex_i18n::msg('media_manager_type_caption'), false);
+    $fragment->setVar('title', rex_i18n::msg('media_manager_type_caption').$button, false);
     $fragment->setVar('content', $content, false);
     $content = $fragment->parse('core/page/section.php');
 


### PR DESCRIPTION
Bezug: #1444

Die Typenliste ist um die Anzeige der Effekte je Typ erweitert. Die Effekte werden als Titel 
unterhalb der normalen Tabellenzeile eingeblendet.

* Hinter dem Typ-Titel (Spalte2) sind zwei Button, mit denen (a) die Effekt-Details (ursprünglicher
Issue #1444) und (b) der Bilderlink (Zusatzwunsch von @medienfeuer) eingeblendet werden. Das auf Typ-Ebene.
* Zusätzlich sind vergleichbare Button in der Titelzeile, die die Anzeige für die gesamte Tabelle
ein- bzw. ausschalten.

Das nötige JS und CSS wird über `types.php` bzw. `effects.php` mit ausgegeben. Document-Ready wird nicht benötigt, da die JS-Funktionen über onclick aktiviert werden. 

Alle Zusatzelemente innerhalb der Tabelle werden in den eh vorhandenen Callbacks eingeschleust

- $list->setColumnFormat('name', 'custom', function ($params) { ... } );
    Die Buttons je Effekt
- $list->setColumnFormat('deleteType', 'custom', function ($params) { ... } );
    die zusätzliche Zeile zum Anzeigen des Links und der Effekt-Informationen (Flexbox)

