### PR TITLE
Prüfungsmöglichkeit für Rückbezüge zwischen Addons (#1869)

### DIFF
--- a/redaxo/src/core/lib/packages/api_package.php
+++ b/redaxo/src/core/lib/packages/api_package.php
@@ -31,7 +31,10 @@ class rex_api_package extends rex_api_function
         }
         $reinstall = 'install' === $function && $package->isInstalled();
         $manager = rex_package_manager::factory($package);
-        $success = $manager->$function();
+        $success = $manager->precheck( $function, $reinstall );
+        if( $success ) {
+            $success = $manager->$function();
+        }
         $message = $manager->getMessage();
         $result = new rex_api_result($success, $message);
         if ($success && !$reinstall) {

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -768,4 +768,37 @@ abstract class rex_package_manager
 
         return $packages;
     }
+
+
+    /**
+     * Extended Pre-Check upfront to AddOn-management-actions
+     *
+     * @param string $function Requested AddOn-management-action: (un)install, (de)activate, delete
+     *
+     * @throws rex_functional_exception
+     * @throws rex_sql_exception
+     *
+     * @return bool TRUE on success, FALSE on error
+     */
+    public function precheck( $function, $reinstall )
+    {
+        try {
+            // include precheck.php
+            if (is_readable($this->package->getPath(rex_package::FILE_PRECHECK))) {
+                if( $function == 'install' && $reinstall===true ) $function = 'reinstall';
+                $this->package->includeFile(rex_package::FILE_PRECHECK, [ 'request' => $function ]);
+
+                if (($instmsg = $this->package->getProperty('installmsg', '')) != '') {
+                    $this->message =$instmsg;
+                    return false;
+                }
+            }
+
+        } catch (rex_functional_exception $e) {
+            $this->message = $e->getMessage();
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/redaxo/src/core/lib/packages/package.php
+++ b/redaxo/src/core/lib/packages/package.php
@@ -16,6 +16,7 @@ abstract class rex_package implements rex_package_interface
     const FILE_UNINSTALL = 'uninstall.php';
     const FILE_UNINSTALL_SQL = 'uninstall.sql';
     const FILE_UPDATE = 'update.php';
+    const FILE_PRECHECK = 'precheck.php';
 
     /**
      * Name of the package.


### PR DESCRIPTION
Das Thema wurde im Issue #1869 diskutiert. Der Lösungsvorschlag ist nun, eine weitere Package-Datei `precheck.php` einzuführen.  
Auf das "warum" gehe ich hier nicht mehr ein; siehe Issue.

Der Ablauf ist nunmehr dieser:

- auf der Seite zur Addon-Verwaltung wird ain Aktion angeklickt, z.B. deavtivate oder deinstall, oder ...
- Die Aktion wird regulär über `rex_api_package::execute()` abgewickelt.
- Bevor die eigentliche Aktion mit `$success = $manager->$function()` ausgeführt wird, wird vorgeschaltet `$success = $manager->precheck($function,$reinstall)` aufgerufen.
- Nur bei positiver Rückmeldung wir die eigentliche $function ausgeführt.

## Charme der Lösung

- Die Lösung ist analog zu `install.php` etc. Nur das Addon stellt den Code zur Verfügung. Eine EP-Lösung hätte Addons ermöglicht, auch anderen Addons (unzulässig?) in die Verwaltungsaktionen einzugreifen.   
- Die Prüfung wird vorgelagert ausgeführt. Das vermeidet Umbauten in den Aktions-Methoden z.B. für Rückabwicklungen im Falls eines Abbruchs (wurde im Issue im Detail diskutiert). Der Eingriff ist also minimal; die Ablauflogik wird pratisch nicht beeinflusst.

## Änderungen im Detail:

### redaxo/src/core/lib/package.php

Neue Konstante `FILE_PRECHECK = 'precheck.php';` für den Script-Namen. Das Script steht wie `install.php` etc. im Addon-Root. 

### redaxo/src/core/lib/manager.php

Hier steht die neue Methode `precheck($function,$reinstall)`, die das Script `precheck.php` aufruft und das Ergebnis an `rex_api_package::execute` zurückmeldet, zu finden am Ende der Datei.

### redaxo/src/core/lib/api_package.php

Ruft '$manager->precheck($function,$reinstall)`auf und je nach Rückmeldung wird die eigentliche Aktions ausgeführt ode reben nicht.

## Beispiel für eine `precheck.php`

```
<?php
/**
 *  This file is part of the REDAXO-AddOn ".....".
 *
 *  @package     ...
 *  @version     ...
 *  @author      FriendsOfREDAXO @ GitHub <https://github.com/FriendsOfREDAXO/focuspoint>
 *  @copyright   FriendsOfREDAXO <https://friendsofredaxo.github.io/>
 *
 *  For the full copyright and license information, please view the LICENSE
 *  file that was distributed with this source code.
 *
 *  ------------------------------------------------------------------------------------------------
 *
 *  Perform extended cross-checks upfront to management-actions for addons called from
 *  page=packages. Management-actions are
 *      - install
 *      - reinstall     technically a re-install is identical to install
 *      - uninstall
 *      - activate
 *      - deactivate
 *      - delete        delete is uninstall plus removing all files
 *
 *  This script is called upfront to the management-action in question to perform extended
 *  integration checks not coverable by package-dependency-rules from package.yml
 *
 *  Example:
 *      an addon provides an effect for the media-manager-addon. If the effect is actively
 *      used be a media-manager-type, this addon cannot be removed or deactivated without risking a
 *      fatal error in case the media-manager (re-)builds an image.
 *
 *      precheck.php is intended to check espacially these backward-dependency and prevent the
 *      management-action before touching the system.
 *
 *  Input:
 *      As checks can be different for different managemant-actions, the requested action is
 *      provided in the variable $request
 *
 *  Output - checks passed:
 *      just end the script
 *
 *  Output - checks NOT passed:
 *      just end the script, but set an installmsg
 *          $this->setProperty('installmsg','«detailed error message»');
 *      or throw a functional exception
 *          throw new rex_functional_exception('«detailed error message»');
 *
 *  Note:
 *      in case of an install (not re-install) the addon´s addon/lib and other configurations
 *      are not loaded yet. Be carefull and assure e.g. "includes" as necessary.
 *      But in generall: special prechecks should never be necessary for "install".
 */

switch ( $request )
{
    case 'install':
        //noop
        break;
    case 'reinstall':
        //noop
        break;
    case 'activate':
        //noop
        break;
    case 'deactivate':
        //noop
        break;
    case 'uninstall':
        //noop
        break;
    case 'delete':
        //noop
        break;
}
```
