### PR TITLE
MM: Unnötige Cache-Dateien vermeiden

### DIFF
--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -50,7 +50,7 @@ class rex_media_manager
             foreach ($cache['headers'] as $key => $value) {
                 $media->setHeader($key, $value);
             }
-        } else {
+        } elseif ($manager->use_cache) {
             $media->save($manager->getCacheFilename(), $manager->getHeaderCacheFilename());
         }
 
@@ -76,6 +76,7 @@ class rex_media_manager
             $set = rex_extension::registerPoint(new rex_extension_point('MEDIA_MANAGER_FILTERSET', $set, ['rex_media_type' => $type]));
 
             if (count($set) == 0) {
+                $this->use_cache = false;
                 return $this->media;
             }
 


### PR DESCRIPTION
Wenn ein MM-Typ keinerlei Effekte hat, wird die Originaldatei ausgeliefert. Die braucht eigentlich dann auch nicht gecacht werden.

Genauso wenn man einen "virtuellen" MM-Typ aufruft, und der EP `MEDIA_MANAGER_FILTERSET` keine Effekte liefert.