### PR TITLE
db:connection-options: auch mysqldump unterstützen

### DIFF
--- a/redaxo/src/core/lib/console/db/connection_options.php
+++ b/redaxo/src/core/lib/console/db/connection_options.php
@@ -34,7 +34,7 @@ EOF
             '--host='.escapeshellarg($db['host']),
             '--user='.escapeshellarg($db['login']),
             '--password='.escapeshellarg($db['password']),
-            '--database='.escapeshellarg($db['name']),
+            escapeshellarg($db['name']),
         ]);
     }
 }


### PR DESCRIPTION
Mir ist aufgefallen, dass `mysqldump` keine `--database`-Option hat.
Daher nun die Datenbank ohne Optionsname, das wird so von `mysql` und `mysqldump` unterstützt.

Beispiele:

```
// import
redaxo/bin/console db:conn | xargs mysql < dump.sql

// export
redaxo/bin/console db:conn | xargs mysqldump > dump.sql
```