### PR TITLE
Erklärung bzgl. debug-mode präzisiert

### DIFF
--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -131,7 +131,7 @@ system_editor_open_file = "{0}" im Editor öffnen
 system_edit_config_note = Die REDAXO Hauptkonfiguration bietet die Möglichkeit interne Systemparameter zu verändern. Die Datei sollte nur von erfahrenen Nutzern bearbeitet werden.
 lang_required = Es wird eine Sprache benötigt!
 debug_mode = Debug-Modus
-debug_mode_note = Mit dem Debug-Modus werden bei Skriptfehlern im Frontend und Backend zusätzliche Angaben zum Fehler ausgegeben. Im Live-Betrieb nicht aktivieren, da die Fehlermeldungen auch sensible Daten beinhalten können.
+debug_mode_note = Mit dem Debug-Modus werden bei PHP Skriptfehlern im Frontend und Backend zusätzliche Angaben zum Fehler ausgegeben. Im Live-Betrieb nicht aktivieren, da die Fehlermeldungen auch sensible Daten beinhalten können.
 
 # redaxo\include\pages\medienpool.php\setup.php
 setup = Setup

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -131,7 +131,7 @@ system_editor_open_file = "{0}" im Editor öffnen
 system_edit_config_note = Die REDAXO Hauptkonfiguration bietet die Möglichkeit interne Systemparameter zu verändern. Die Datei sollte nur von erfahrenen Nutzern bearbeitet werden.
 lang_required = Es wird eine Sprache benötigt!
 debug_mode = Debug-Modus
-debug_mode_note = Mit dem Debug-Modus werden bei PHP Skriptfehlern im Frontend und Backend zusätzliche Angaben zum Fehler ausgegeben. Im Live-Betrieb nicht aktivieren, da die Fehlermeldungen auch sensible Daten beinhalten können.
+debug_mode_note = Mit dem Debug-Modus werden bei PHP-Skriptfehlern im Frontend und Backend zusätzliche Angaben zum Fehler ausgegeben. Im Live-Betrieb nicht aktivieren, da die Fehlermeldungen auch sensible Daten beinhalten können.
 
 # redaxo\include\pages\medienpool.php\setup.php
 setup = Setup

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -122,7 +122,7 @@ server_invalid = The website URL is invalid, please enter a valid URL inluding p
 servername_required = Server name is required
 lang_required = Language is required
 debug_mode = Debug mode
-debug_mode_note = Activating debug mode will provide additional information concerning php script errors in the front and backend. Make sure to deactivate in production, as these error messages may contain sensible data.
+debug_mode_note = Activating debug mode will provide additional information concerning PHP script errors in the front and backend. Make sure to deactivate in production, as these error messages may contain sensible data.
 
 # redaxo\include\pages\medienpool.php\setup.php
 setup = Setup

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -122,7 +122,7 @@ server_invalid = The website URL is invalid, please enter a valid URL inluding p
 servername_required = Server name is required
 lang_required = Language is required
 debug_mode = Debug mode
-debug_mode_note = Activating debug mode will provide additional information concerning script errors in the front and backend. Make sure to deactivate in production, as these error messages may contain sensible data.
+debug_mode_note = Activating debug mode will provide additional information concerning php script errors in the front and backend. Make sure to deactivate in production, as these error messages may contain sensible data.
 
 # redaxo\include\pages\medienpool.php\setup.php
 setup = Setup


### PR DESCRIPTION
"Skriptfehler" könnte man als leser auch auf Javascript beziehen. Daher ein wenig präzisiert.