### PR TITLE
rex_response::sendFile() berücksichtigt das use_last_modified property

### DIFF
--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -142,7 +142,12 @@ class rex_response
         self::sendContentType($contentType);
         header('Content-Disposition: ' . $contentDisposition . '; filename="' . $filename . '"');
 
-        self::sendLastModified(filemtime($file));
+        $environment = rex::isBackend() ? 'backend' : 'frontend';
+        if (!self::$sentLastModified
+            && (rex::getProperty('use_last_modified') === true || rex::getProperty('use_last_modified') === $environment)
+        ) {
+            self::sendLastModified(filemtime($file));
+        }
 
         header('HTTP/1.1 ' . self::$httpStatus);
         if (!self::$sentCacheControl) {


### PR DESCRIPTION
vorher wurde last-modified immer geschickt, was dazu führt dass man trotz long living cache-control headers, immer ein cache-revalidate bekommt.

aufgefallen bei der Implementierung von https://github.com/redaxo/redaxo/pull/1855