### PR TITLE
Systembericht: Boolesche Werte neutral als yes/no

### DIFF
--- a/redaxo/src/core/pages/system.report.html.php
+++ b/redaxo/src/core/pages/system.report.html.php
@@ -13,8 +13,7 @@ foreach ($report as $title => $group) {
 
     foreach ($group as $label => $value) {
         if (is_bool($value)) {
-            $class = $value ? 'fa-check text-success' : 'fa-times text-danger';
-            $value = '<i class="rex-icon '.$class.'"></i>';
+            $value = $value ? 'yes' : 'no';
         } else {
             $value = rex_escape($value);
         }


### PR DESCRIPTION
https://github.com/redaxo/redaxo/pull/1928#issuecomment-408586766

Mein Vorschlag ist nun erstmal die booleschen Werte neutral als yes/no auszugeben (so wie in der markdown- und cli-Variante), ohne grün/rot und so.
Wenn jemand möchte, kann er sich aber auch gerne an eine bessere Darstellung machen, bei der rüber kommt, was der aktuelle Zustand und was der Sollzustand ist, mit eventuellem Erklärtext.
Darum möchte ich mich jetzt aber gerade nicht kümmern, mir geht es ja erstmal weniger darum, das System über den Bericht zu prüfen, sondern mehr darum, anderen schnell mitteilen zu können, was für ein System man vorliegen hat. Daher hier erst mal dieser Vorschlag, um der Verwirrung vorzubeugen.