### PR TITLE
Datenbank UNIX_TIMESTAMP könnte andere lokale Zeit haben

### DIFF
--- a/redaxo/src/addons/cronjob/lib/manager_sql.php
+++ b/redaxo/src/addons/cronjob/lib/manager_sql.php
@@ -243,10 +243,10 @@ class rex_cronjob_manager_sql
         ');
 
         if ($this->sql->getRows() == 1) {
-            $NextTime = $this->sql->getValue('nexttime');
-            $NextDateTime = DateTime::createFromFormat(rex_sql::FORMAT_DATETIME, $NextTime);
-            if ($NextDateTime) {
-                return $NextDateTime->getTimestamp();
+            $nextTime = $this->sql->getValue('nexttime');
+            $nextDateTime = DateTime::createFromFormat(rex_sql::FORMAT_DATETIME, $nextTime);
+            if ($nextDateTime) {
+                return $nextDateTime->getTimestamp();
             }
         }
         return null;

--- a/redaxo/src/addons/cronjob/lib/manager_sql.php
+++ b/redaxo/src/addons/cronjob/lib/manager_sql.php
@@ -237,12 +237,17 @@ class rex_cronjob_manager_sql
     public function getMinNextTime()
     {
         $this->sql->setQuery('
-            SELECT  UNIX_TIMESTAMP(MIN(nexttime)) AS nexttime
+            SELECT  MIN(nexttime) AS nexttime
             FROM    ' . REX_CRONJOB_TABLE . '
             WHERE   status = 1
         ');
+
         if ($this->sql->getRows() == 1) {
-            return (int) $this->sql->getValue('nexttime');
+            $NextTime = $this->sql->getValue('nexttime');
+            $NextDateTime = DateTime::createFromFormat(rex_sql::FORMAT_DATETIME, $NextTime);
+            if ($NextDateTime) {
+                return $NextDateTime->getTimestamp();
+            }
         }
         return null;
     }

--- a/redaxo/src/addons/cronjob/lib/manager_sql.php
+++ b/redaxo/src/addons/cronjob/lib/manager_sql.php
@@ -243,7 +243,7 @@ class rex_cronjob_manager_sql
         ');
 
         if ($this->sql->getRows() == 1) {
-            return $this->sql->getDateTimeValue('nexttime');
+            return (int) $this->sql->getDateTimeValue('nexttime');
         }
         return null;
     }

--- a/redaxo/src/addons/cronjob/lib/manager_sql.php
+++ b/redaxo/src/addons/cronjob/lib/manager_sql.php
@@ -243,11 +243,7 @@ class rex_cronjob_manager_sql
         ');
 
         if ($this->sql->getRows() == 1) {
-            $nextTime = $this->sql->getValue('nexttime');
-            $nextDateTime = DateTime::createFromFormat(rex_sql::FORMAT_DATETIME, $nextTime);
-            if ($nextDateTime) {
-                return $nextDateTime->getTimestamp();
-            }
+            return $this->sql->getDateTimeValue('nexttime');
         }
         return null;
     }


### PR DESCRIPTION
Wenn die lokale Zeit nicht GM ist kann es zu einem Versatz kommen und der nächste Cronjob könnte erst verspätet ausgeführt werden.