### PR TITLE
rex_i18n::msgInLocale() hinzugefügt

### DIFF
--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -87,7 +87,7 @@ class rex_response
     private static function sendPreloadHeaders()
     {
         foreach (self::$preloadFiles as $preloadFile) {
-            header('Link: <' . $preloadFile['file'] . '>; rel=preload; as=' . $preloadFile['type'] . '; type="' . $preloadFile['mimeType'].'"; nopush', false);
+            header('Link: <' . $preloadFile['file'] . '>; rel=preload; as=' . $preloadFile['type'] . '; type="' . $preloadFile['mimeType'].'"; crossorigin; nopush', false);
         }
     }
 

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -113,7 +113,10 @@ class rex_i18n
      */
     public static function msgInLocale($key, $locale)
     {
-        return self::getMsg($key, true, func_get_args(), $locale);
+        $args = func_get_args();
+        // for BC we need to strip the 1st arg
+        array_shift($args);
+        return self::getMsg($key, true, $args, $locale);
     }
 
     /**

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -79,7 +79,7 @@ class rex_i18n
     /**
      * Returns the translation htmlspecialchared for the given key.
      *
-     * @param string $key A Language-Key
+     * @param string $key             A Language-Key
      * @param string ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return string Translation for the key
@@ -92,7 +92,7 @@ class rex_i18n
     /**
      * Returns the translation for the given key.
      *
-     * @param string $key A Language-Key
+     * @param string $key             A Language-Key
      * @param string ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return string Translation for the key
@@ -105,8 +105,8 @@ class rex_i18n
     /**
      * Returns the translation htmlspecialchared for the given key and locale.
      *
-     * @param string $key    A Language-Key
-     * @param string $locale A Locale
+     * @param string $key             A Language-Key
+     * @param string $locale          A Locale
      * @param string ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return string Translation for the key

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -120,6 +120,22 @@ class rex_i18n
     }
 
     /**
+     * Returns the translation for the given key and locale.
+     *
+     * @param string $key             A Language-Key
+     * @param string $locale          A Locale
+     * @param string ...$replacements A arbritary number of strings used for interpolating within the resolved message
+     *
+     * @return string Translation for the key
+     */
+    public static function rawMsgInLocale($key, $locale)
+    {
+        $args = func_get_args();
+        // for BC we need to strip the 1st arg
+        array_shift($args);
+        return self::getMsg($key, false, $args, $locale);
+    }
+    /**
      * Returns the message fallback for a missing key in main locale.
      *
      * @param string $key

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -80,6 +80,7 @@ class rex_i18n
      * Returns the translation htmlspecialchared for the given key.
      *
      * @param string $key A Language-Key
+     * @param string ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return string Translation for the key
      */
@@ -92,6 +93,7 @@ class rex_i18n
      * Returns the translation for the given key.
      *
      * @param string $key A Language-Key
+     * @param string ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return string Translation for the key
      */
@@ -105,6 +107,7 @@ class rex_i18n
      *
      * @param string $key    A Language-Key
      * @param string $locale A Locale
+     * @param string ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return string Translation for the key
      */

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -137,6 +137,7 @@ class rex_i18n
         array_shift($args);
         return self::getMsg($key, false, $args, $locale);
     }
+
     /**
      * Returns the message fallback for a missing key in main locale.
      *

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -114,6 +114,7 @@ class rex_i18n
     public static function msgInLocale($key, $locale)
     {
         $args = func_get_args();
+        $args[1] = $key;
         // for BC we need to strip the 1st arg
         array_shift($args);
         return self::getMsg($key, true, $args, $locale);
@@ -131,6 +132,7 @@ class rex_i18n
     public static function rawMsgInLocale($key, $locale)
     {
         $args = func_get_args();
+        $args[1] = $key;
         // for BC we need to strip the 1st arg
         array_shift($args);
         return self::getMsg($key, false, $args, $locale);

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -39,10 +39,9 @@ $sel_be_sprache->setSelected($userperm_be_sprache);
 $locales = rex_i18n::getLocales();
 asort($locales);
 foreach ($locales as $locale) {
-    rex_i18n::setLocale($locale, false); // Locale nicht neu setzen
-    $sel_be_sprache->addOption(rex_i18n::msg('lang'), $locale);
+    $sel_be_sprache->addOption(rex_i18n::msgInLocale('lang', $locale), $locale);
 }
-rex_i18n::setLocale($userperm_be_sprache, false);
+rex_i18n::setLocale($userperm_be_sprache);
 
 // --------------------------------- FUNCTIONS
 

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -41,7 +41,6 @@ asort($locales);
 foreach ($locales as $locale) {
     $sel_be_sprache->addOption(rex_i18n::msgInLocale('lang', $locale), $locale);
 }
-rex_i18n::setLocale($userperm_be_sprache);
 
 // --------------------------------- FUNCTIONS
 

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -16,14 +16,11 @@ $lang = rex_request('lang', 'string');
 if ($step == 1) {
     rex_setup::init();
 
-    $saveLocale = rex_i18n::getLocale();
     $langs = [];
     foreach (rex_i18n::getLocales() as $locale) {
-        rex_i18n::setLocale($locale, false); // Locale nicht neu setzen
-        $label = rex_i18n::msg('lang');
+        $label = rex_i18n::msgInLocale('lang', $locale);
         $langs[$locale] = '<a class="list-group-item" href="' . rex_url::backendPage('setup', ['step' => 2, 'lang' => $locale]) . '">' . $label . '</a>';
     }
-    rex_i18n::setLocale($saveLocale, false);
 
     echo rex_view::title(rex_i18n::msg('setup_100'));
     $content = '<div class="list-group">' . implode('', $langs) . '</div>';

--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -101,14 +101,11 @@ $sel_lang->setId('rex-id-lang');
 $sel_lang->setAttribute('class', 'form-control selectpicker');
 $sel_lang->setSize(1);
 $sel_lang->setSelected(rex::getProperty('lang'));
-$savedlocale = rex_i18n::getLocale();
 $locales = rex_i18n::getLocales();
 asort($locales);
 foreach ($locales as $locale) {
-    rex_i18n::setLocale($locale, false);
-    $sel_lang->addOption(rex_i18n::msg('lang').' ('.$locale.')', $locale);
+    $sel_lang->addOption(rex_i18n::msgInLocale('lang', $locale).' ('.$locale.')', $locale);
 }
-rex_i18n::setLocale($savedlocale, false);
 
 $sel_editor = new rex_select();
 $sel_editor->setStyle('class="form-control"');

--- a/redaxo/src/core/tests/util/i18n_test.php
+++ b/redaxo/src/core/tests/util/i18n_test.php
@@ -17,11 +17,11 @@ rex_i18n_test_4=abc=def
 LANG;
         $content .= "rex_i18n_test_5   =   abc def   \n";
 
-        rex_file::put($this->getPath().'/de_de.lang', $content);
+        rex_file::put($this->getPath().'/de_de.lang', $content ."\nmy=DE");
 
         $content .= "\nrex_i18n_test_6 = test6\n";
 
-        rex_file::put($this->getPath().'/en_gb.lang', $content);
+        rex_file::put($this->getPath().'/en_gb.lang', $content."\nmy=EN");
     }
 
     public function tearDown()
@@ -70,5 +70,13 @@ LANG;
 
         $this->assertSame('test6', rex_i18n::msg('rex_i18n_test_6'));
         $this->assertSame('[translate:rex_i18n_test_7]', rex_i18n::msg('rex_i18n_test_7'));
+    }
+
+    public function testGetMsgInLocaleFallback()
+    {
+        rex_i18n::addDirectory($this->getPath());
+
+        $this->assertSame('DE', rex_i18n::msgInLocale('my', 'de_de'));
+        $this->assertSame('EN', rex_i18n::msgInLocale('my', 'en_gb'));
     }
 }

--- a/redaxo/src/core/tests/util/i18n_test.php
+++ b/redaxo/src/core/tests/util/i18n_test.php
@@ -87,7 +87,7 @@ LANG;
         $this->assertSame('DE', rex_i18n::msgInLocale('my', 'de_de'));
         $this->assertSame('EN', rex_i18n::msgInLocale('my', 'en_gb'));
     }
-  
+
     public function testTranslateCallable()
     {
         $this->assertSame('translated', rex_i18n::translate('translate:my_cb', false, 'rex_i18n_trans_cb::mytranslate'));


### PR DESCRIPTION
Erlaubt es anderssprachige Übersetzungen zu ermitteln, ohne die "default-locale" umstellen zu müssen.

damit man in situationen wie
https://github.com/redaxo/redaxo/blob/fc666da432c9be44ceef57b917ef81a01131fa12/redaxo/src/core/pages/profile.php#L40-L43

nicht die system locale-umstellen und wieder re-storen muss.