### PR TITLE
fix font preload

### DIFF
--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -87,7 +87,7 @@ class rex_response
     private static function sendPreloadHeaders()
     {
         foreach (self::$preloadFiles as $preloadFile) {
-            header('Link: <' . $preloadFile['file'] . '>; rel=preload; as=' . $preloadFile['type'] . '; type="' . $preloadFile['mimeType'].'"; nopush', false);
+            header('Link: <' . $preloadFile['file'] . '>; rel=preload; as=' . $preloadFile['type'] . '; type="' . $preloadFile['mimeType'].'"; crossorigin; nopush', false);
         }
     }
 


### PR DESCRIPTION
fixes #1949 

Der Chrome kann scheinbar keine fonts preloaden ohne das "crossorigin"-Attribute. Das sorgte aktuell dafür, dass die fonts (mindestens im Chrome) doppelt geladen wurden.

siehe: [bugs.chromium.org comment 13/14](https://bugs.chromium.org/p/chromium/issues/detail?id=678429#c14)