### PR TITLE
Codestyle CI job entfernt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ branches:
 
 cache:
     directories:
-        - $HOME/.php-cs-fixer
         - $HOME/.composer/cache
 
 before_install:
@@ -23,15 +22,6 @@ jobs:
         -   php: 5.5
             env: LINTING=1
             script: if find . -name "*.php" ! -path "*/vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
-
-        -   php: 7.2
-            env: CODING_STANDARDS=1
-            install:
-                - mkdir -p "$HOME/.php-cs-fixer"
-                # CS_FIXER_VERSION defined via travisci web interface
-                - "echo '{\"require\": {\"friendsofphp/php-cs-fixer\": \"'$CS_FIXER_VERSION'\"}}' > \"$HOME/.php-cs-fixer/composer.json\""
-                - travis_retry composer update --no-interaction --working-dir "$HOME/.php-cs-fixer"
-            script: php "$HOME/.php-cs-fixer/vendor/bin/php-cs-fixer" fix --cache-file "$HOME/.php-cs-fixer/.php_cs.cache" --dry-run --diff --verbose
 
         -   &TEST
             install:


### PR DESCRIPTION
Stattdessn habe ich https://prettyci.com/ zum test installiert, was via github [checks-tab](
https://blog.github.com/2018-05-07-introducing-checks-api/) funktioniert.

Prettyci ist in wenigen Sekunden abgelaufen und blockiert auf diese art auch keinen travis job.
Somit werden die anderen travis jobs schneller fertig