### PR TITLE
Im Setup warnen, wenn eine veraltete PHP Version verwendet wird

### DIFF
--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -240,6 +240,7 @@ setup_security_msg = Der Ordner redaxo ist unsicher. Bitte schützen Sie diesen 
 setup_no_js_security_msg = Prüfen Sie, ob Dateien aus dem Ordner redaxo/cache, redaxo/data und redaxo/src direkt aufrufbar sind! Dies darf aus Sicherheitsgründen nicht möglich sein!
 setup_security_no_https = Das Setup wird ohne HTTPS/Verschlüsselung durchgeführt. Es wird empfohlen jegliche Frontend und Backend aufrufe nur mittels HTTPS durchzuführen, um die Privatsphäre und den Datenschutz zu gewährleisten.
 setup_security_warn_mod_security = Das Apache Modul "mod_security" ist geladen. Dies kann bei falscher Konfiguration zu Problemen führen.
+setup_security_deprecated_php = Die verwendete PHP Version {0} wird nicht mehr vom Hersteller gepflegt und sollte aktualisiert werden.
 
 sql_database_name_missing = Es muss ein Datenbankname angegeben werden!
 sql_database_already_exists = Datenbank existiert schon.

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -227,6 +227,7 @@ setup_security_msg = The folder redaxo/include is not secure. Please protect thi
 setup_no_js_security_msg = Please make sure that files in the folder redaxo/include are not directly accessible! Due to security concerns accessing these files should not be possible!
 setup_security_no_https = The setup will continue without SSL encryption. It is recommended to use SSL encryption for each call to the front- and backend in order to ensure privacy and data protection.
 setup_security_warn_mod_security = The Apache module "mod_security" is loaded. This can cause problems if not configured correctly.
+setup_security_deprecated_php = The used PHP Version {0} version will no longer receive updates. You should consider upgrading to a newer version.
 
 sql_database_name_missing = Enter a database name!
 sql_database_already_exists = Database already exists!

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -140,6 +140,12 @@ if ($step == 3) {
         $security .= rex_view::warning(rex_i18n::msg('setup_security_warn_mod_security'));
     }
 
+    if (version_compare(PHP_VERSION, '5.6', '<') == 1) {
+        $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION));
+    } elseif (version_compare(PHP_VERSION, '7.0', '<=') == 1 && time() > strtotime('1 Jan 2019')) {
+        $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION));
+    }
+
     echo rex_view::title(rex_i18n::msg('setup_300'));
 
     $fragment = new rex_fragment();


### PR DESCRIPTION
nur eine warnung als hinweis an den user. kein blocker o.ä. sodass das setup weiterhin normal durchgeführt werden kann, mit den gleichen php versionen wir auch unter R5.6