### PR TITLE
Git Versionsnummer bestimmung auf Windows Servern ermöglichen

### DIFF
--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -359,7 +359,7 @@ class rex
             $output = '';
             $exitCode = null;
 
-            if(strcasecmp(substr(PHP_OS, 0, 3), 'WIN') == 0){
+            if (strcasecmp(substr(PHP_OS, 0, 3), 'WIN') == 0) {
                 $command = 'where git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';
             } else {
                 $command = 'which git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -359,7 +359,12 @@ class rex
             $output = '';
             $exitCode = null;
 
-            $command = 'which git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';
+            if(strcasecmp(substr(PHP_OS, 0, 3), 'WIN') == 0){
+                $command = 'where git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';
+            } else {
+                $command = 'which git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';
+            }
+
             @exec($command, $output, $exitCode);
             if ($exitCode === 0) {
                 $output = implode('', $output);


### PR DESCRIPTION
vorher konnte der git hash nicht auf windows ermittelt werden, da bereits `which git` auf einen `unkown internal command "which"` fehler gelaufen ist 