### PR TITLE
'textarea.rex_code' zu den default CodeMirror selektoren hinzugefügt

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/boot.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/boot.php
@@ -113,7 +113,7 @@ if (rex::isBackend() && rex::getUser()) {
         // JsProperty CodeMirror-Theme
         rex_view::setJsProperty('customizer_codemirror_defaulttheme', $config['codemirror_theme']);
         // JsProperty CodeMirror-Selectors
-        $selectors = 'textarea.rex-js-code, textarea.codemirror';
+        $selectors = 'textarea.rex-code, textarea.rex-js-code, textarea.codemirror';
         if ($config['codemirror-selectors'] != '') {
             $selectors = $selectors . ', ' . $config['codemirror-selectors'];
         }


### PR DESCRIPTION
Sodass Templates/Module etc. per default auch gehighlighted werden