### PR TITLE
4096 Zeichen maximale Passwortlänge per Default

### DIFF
--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -31,7 +31,7 @@ session:
             httponly: true
             samesite: 'Strict'
 password_policy:
-    length: {min: 8}
+    length: {min: 8, max: 4096}
     lowercase: {min: 0}
     uppercase: {min: 0}
     digit: {min: 0}


### PR DESCRIPTION
Siehe http://symfony.com/blog/cve-2013-5750-security-issue-in-fosuserbundle-login-form wg mögliche. Dos attacken

Closes https://github.com/redaxo/redaxo/issues/353

Ungetestet 