### PR TITLE
self::class und static::class nutzen

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -37,6 +37,7 @@ return PhpCsFixer\Config::create()
         'blank_line_before_statement' => false,
         'braces' => ['allow_single_line_closure' => false],
         'concat_space' => false,
+        'function_to_constant' => ['functions' => ['get_class', 'get_called_class', 'php_sapi_name', 'phpversion', 'pi']],
         'heredoc_to_nowdoc' => true,
         'logical_operators' => true,
         'native_constant_invocation' => false,

--- a/redaxo/src/addons/debug/lib/api_function_debug.php
+++ b/redaxo/src/addons/debug/lib/api_function_debug.php
@@ -10,7 +10,7 @@ abstract class rex_api_function_debug extends rex_api_function
         $apiFunc = self::factory();
 
         if ($apiFunc != null) {
-            ChromePhp::group(__CLASS__);
+            ChromePhp::group(self::class);
             ChromePhp::log('called api function "' . get_class(self::factory()) . '"');
             ChromePhp::groupEnd();
         }

--- a/redaxo/src/addons/debug/lib/sql_debug.php
+++ b/redaxo/src/addons/debug/lib/sql_debug.php
@@ -82,7 +82,7 @@ class rex_sql_debug extends rex_sql
                 ++$i;
             }
 
-            ChromePhp::log(__CLASS__ . ' (' . count(self::$queries) . ' queries, ' . self::$errors . ' errors)');
+            ChromePhp::log(self::class . ' (' . count(self::$queries) . ' queries, ' . self::$errors . ' errors)');
             ChromePhp::table($tbl);
         }
     }

--- a/redaxo/src/addons/structure/lib/structure_element.php
+++ b/redaxo/src/addons/structure/lib/structure_element.php
@@ -147,7 +147,7 @@ abstract class rex_structure_element
             $clang = rex_clang::getCurrentId();
         }
 
-        $class = get_called_class();
+        $class = static::class;
         return static::getInstance([$id, $clang], function ($id, $clang) use ($class) {
             $article_path = rex_path::addonCache('structure', $id . '.' . $clang . '.article');
             // generate cache if not exists
@@ -186,7 +186,7 @@ abstract class rex_structure_element
             $clang = rex_clang::getCurrentId();
         }
 
-        $class = get_called_class();
+        $class = static::class;
         return static::getInstanceList(
             // list key
             [$parentId, $listType],

--- a/redaxo/src/addons/structure/lib/var_article.php
+++ b/redaxo/src/addons/structure/lib/var_article.php
@@ -35,7 +35,7 @@ class rex_var_article extends rex_var
         }
 
         if ($field) {
-            return __CLASS__ . '::getArticleValue(' . $id . ', ' . $field . ', ' . $clang . ')';
+            return self::class . '::getArticleValue(' . $id . ', ' . $field . ', ' . $clang . ')';
         }
         if (!$noId || !in_array($this->getContext(), ['module', 'action'])) {
             // aktueller Artikel darf nur in Templates, nicht in Modulen eingebunden werden
@@ -43,7 +43,7 @@ class rex_var_article extends rex_var
             if ($noId && $clang == 'null') {
                 return '$this->getArticle(' . $ctype . ')';
             }
-            return __CLASS__ . '::getArticle(' . $id . ', ' . $ctype . ', ' . $clang . ')';
+            return self::class . '::getArticle(' . $id . ', ' . $ctype . ', ' . $clang . ')';
         }
 
         return false;

--- a/redaxo/src/addons/structure/lib/var_category.php
+++ b/redaxo/src/addons/structure/lib/var_category.php
@@ -27,7 +27,7 @@ class rex_var_category extends rex_var
         $category_id = $this->getParsedArg('id', '$this->getValue(\'category_id\')');
         $clang = $this->getParsedArg('clang', 'null');
 
-        return __CLASS__ . '::getCategoryValue(' . $category_id . ', ' . $field . ', ' . $clang . ')';
+        return self::class . '::getCategoryValue(' . $category_id . ', ' . $field . ', ' . $clang . ')';
     }
 
     public static function getCategoryValue($id, $field, $clang = null)

--- a/redaxo/src/addons/structure/plugins/content/lib/var_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/var_template.php
@@ -12,7 +12,7 @@ class rex_var_template extends rex_var
         $template_id = $this->getParsedArg('id', 0, true);
 
         if ($template_id > 0) {
-            return __CLASS__ . '::getTemplateOutput(require ' . __CLASS__ . '::getTemplateStream(' . $template_id . ', $this))';
+            return self::class . '::getTemplateOutput(require ' . self::class . '::getTemplateStream(' . $template_id . ', $this))';
         }
 
         return false;

--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -99,10 +99,10 @@ abstract class rex_api_function
      */
     public static function getUrlParams()
     {
-        $class = get_called_class();
+        $class = static::class;
 
-        if (__CLASS__ === $class) {
-            throw new BadMethodCallException(__FUNCTION__.' must be called on subclasses of "'.__CLASS__.'".');
+        if (self::class === $class) {
+            throw new BadMethodCallException(__FUNCTION__.' must be called on subclasses of "'.self::class.'".');
         }
 
         // remove the `rex_api_` prefix
@@ -120,10 +120,10 @@ abstract class rex_api_function
      */
     public static function getHiddenFields()
     {
-        $class = get_called_class();
+        $class = static::class;
 
-        if (__CLASS__ === $class) {
-            throw new BadMethodCallException(__FUNCTION__.' must be called on subclasses of "'.__CLASS__.'".');
+        if (self::class === $class) {
+            throw new BadMethodCallException(__FUNCTION__.' must be called on subclasses of "'.self::class.'".');
         }
 
         // remove the `rex_api_` prefix

--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -44,13 +44,13 @@ class rex_autoload
             self::$composerLoader->setClassMapAuthoritative(true);
         }
 
-        if (false === spl_autoload_register([__CLASS__, 'autoload'])) {
-            throw new Exception(sprintf('Unable to register %s::autoload as an autoloading method.', __CLASS__));
+        if (false === spl_autoload_register([self::class, 'autoload'])) {
+            throw new Exception(sprintf('Unable to register %s::autoload as an autoloading method.', self::class));
         }
 
         self::$cacheFile = rex_path::coreCache('autoload.cache');
         self::loadCache();
-        register_shutdown_function([__CLASS__, 'saveCache']);
+        register_shutdown_function([self::class, 'saveCache']);
 
         self::$registered = true;
     }
@@ -60,7 +60,7 @@ class rex_autoload
      */
     public static function unregister()
     {
-        spl_autoload_unregister([__CLASS__, 'autoload']);
+        spl_autoload_unregister([self::class, 'autoload']);
         self::$registered = false;
     }
 

--- a/redaxo/src/core/lib/base/factory_trait.php
+++ b/redaxo/src/core/lib/base/factory_trait.php
@@ -45,7 +45,7 @@ trait rex_factory_trait
         if (!is_string($subclass)) {
             throw new InvalidArgumentException('Expecting $subclass to be a string, ' . gettype($subclass) . ' given!');
         }
-        $calledClass = get_called_class();
+        $calledClass = static::class;
         if ($subclass != $calledClass && !is_subclass_of($subclass, $calledClass)) {
             throw new InvalidArgumentException('$class "' . $subclass . '" is expected to define a subclass of ' . $calledClass . '!');
         }
@@ -59,7 +59,7 @@ trait rex_factory_trait
      */
     public static function getFactoryClass()
     {
-        $calledClass = get_called_class();
+        $calledClass = static::class;
         return isset(self::$factoryClasses[$calledClass]) ? self::$factoryClasses[$calledClass] : $calledClass;
     }
 
@@ -70,7 +70,7 @@ trait rex_factory_trait
      */
     public static function hasFactoryClass()
     {
-        $calledClass = get_called_class();
+        $calledClass = static::class;
         return isset(self::$factoryClasses[$calledClass]) && self::$factoryClasses[$calledClass] != $calledClass;
     }
 

--- a/redaxo/src/core/lib/base/instance_pool_trait.php
+++ b/redaxo/src/core/lib/base/instance_pool_trait.php
@@ -31,7 +31,7 @@ trait rex_instance_pool_trait
     protected static function addInstance($key, self $instance)
     {
         $key = self::getInstancePoolKey($key);
-        $class = get_called_class();
+        $class = static::class;
         self::$instances[$class][$key] = $instance;
     }
 
@@ -45,7 +45,7 @@ trait rex_instance_pool_trait
     protected static function hasInstance($key)
     {
         $key = self::getInstancePoolKey($key);
-        $class = get_called_class();
+        $class = static::class;
         return isset(self::$instances[$class][$key]);
     }
 
@@ -63,7 +63,7 @@ trait rex_instance_pool_trait
     {
         $args = (array) $key;
         $key = self::getInstancePoolKey($args);
-        $class = get_called_class();
+        $class = static::class;
         if (!isset(self::$instances[$class][$key]) && $createCallback) {
             $instance = call_user_func_array($createCallback, $args);
             self::$instances[$class][$key] = $instance instanceof static ? $instance : null;
@@ -82,7 +82,7 @@ trait rex_instance_pool_trait
     public static function clearInstance($key)
     {
         $key = self::getInstancePoolKey($key);
-        $class = get_called_class();
+        $class = static::class;
         unset(self::$instances[$class][$key]);
     }
 
@@ -91,7 +91,7 @@ trait rex_instance_pool_trait
      */
     public static function clearInstancePool()
     {
-        $calledClass = get_called_class();
+        $calledClass = static::class;
         // unset instances of calledClass and of all subclasses of calledClass
         foreach (self::$instances as $class => $_) {
             if ($class === $calledClass || is_subclass_of($class, $calledClass)) {

--- a/redaxo/src/core/lib/base/singleton_trait.php
+++ b/redaxo/src/core/lib/base/singleton_trait.php
@@ -23,7 +23,7 @@ trait rex_singleton_trait
      */
     public static function getInstance()
     {
-        $class = get_called_class();
+        $class = static::class;
         if (!isset(self::$instances[$class])) {
             self::$instances[$class] = new static();
         }

--- a/redaxo/src/core/lib/config.php
+++ b/redaxo/src/core/lib/config.php
@@ -272,7 +272,7 @@ class rex_config
         }
 
         // save cache on shutdown
-        register_shutdown_function([__CLASS__, 'save']);
+        register_shutdown_function([self::class, 'save']);
 
         self::load();
         self::$initialized = true;

--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -18,9 +18,9 @@ abstract class rex_error_handler
 
         self::$registered = true;
 
-        set_error_handler([__CLASS__, 'handleError']);
-        set_exception_handler([__CLASS__, 'handleException']);
-        register_shutdown_function([__CLASS__, 'shutdown']);
+        set_error_handler([self::class, 'handleError']);
+        set_exception_handler([self::class, 'handleException']);
+        register_shutdown_function([self::class, 'shutdown']);
     }
 
     /**

--- a/redaxo/src/core/lib/login/complex_perm.php
+++ b/redaxo/src/core/lib/login/complex_perm.php
@@ -76,8 +76,8 @@ abstract class rex_complex_perm
      */
     public static function register($key, $class)
     {
-        if (!is_subclass_of($class, __CLASS__)) {
-            throw new InvalidArgumentException(sprintf('Class "%s" must be a subclass of "%s"!', $class, __CLASS__));
+        if (!is_subclass_of($class, self::class)) {
+            throw new InvalidArgumentException(sprintf('Class "%s" must be a subclass of "%s"!', $class, self::class));
         }
         self::$classes[$key] = $class;
     }

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -41,7 +41,7 @@ abstract class rex_package_manager
      */
     public static function factory(rex_package $package)
     {
-        if (get_called_class() == __CLASS__) {
+        if (static::class == self::class) {
             $class = $package instanceof rex_plugin ? 'rex_plugin_manager' : 'rex_addon_manager';
             return $class::factory($package);
         }

--- a/redaxo/src/core/lib/packages/plugins/plugin.php
+++ b/redaxo/src/core/lib/packages/plugins/plugin.php
@@ -41,7 +41,7 @@ class rex_plugin extends rex_package implements rex_plugin_interface
     public static function get($addon, $plugin = null)
     {
         if ($plugin === null) {
-            throw new InvalidArgumentException('Missing Argument 2 for ' . __CLASS__ . '::' . __METHOD__ . '()');
+            throw new InvalidArgumentException('Missing Argument 2 for ' . self::class . '::' . __METHOD__ . '()');
         }
         if (!is_string($addon)) {
             throw new InvalidArgumentException('Expecting $addon to be string, but ' . gettype($addon) . ' given!');

--- a/redaxo/src/core/lib/util/formatter.php
+++ b/redaxo/src/core/lib/util/formatter.php
@@ -27,7 +27,7 @@ abstract class rex_formatter
      */
     public static function format($value, $formatType, $format)
     {
-        if (!is_callable([__CLASS__, $formatType])) {
+        if (!is_callable([self::class, $formatType])) {
             throw new InvalidArgumentException('Unknown $formatType: "' . $formatType . '"!');
         }
         return self::$formatType($value, $format);

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -63,7 +63,7 @@ class rex_socket
      */
     public static function factory($host, $port = 80, $ssl = false)
     {
-        if (get_called_class() === __CLASS__ && ($proxy = rex::getProperty('socket_proxy'))) {
+        if (static::class === self::class && ($proxy = rex::getProperty('socket_proxy'))) {
             return rex_socket_proxy::factoryUrl($proxy)->setDestination($host, $port, $ssl);
         }
 

--- a/redaxo/src/core/lib/util/stream.php
+++ b/redaxo/src/core/lib/util/stream.php
@@ -62,7 +62,7 @@ class rex_stream
         }
 
         if (!self::$registered) {
-            stream_wrapper_register('rex', __CLASS__);
+            stream_wrapper_register('rex', self::class);
             self::$registered = true;
         }
 

--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -127,7 +127,7 @@ abstract class rex_var
     {
         if (!isset(self::$vars[$var])) {
             $class = 'rex_var_' . strtolower(substr($var, 4));
-            if (!class_exists($class) || !is_subclass_of($class, __CLASS__)) {
+            if (!class_exists($class) || !is_subclass_of($class, self::class)) {
                 return false;
             }
             self::$vars[$var] = $class;

--- a/redaxo/src/core/vendor/filp/whoops/src/Whoops/Exception/FrameCollection.php
+++ b/redaxo/src/core/vendor/filp/whoops/src/Whoops/Exception/FrameCollection.php
@@ -118,7 +118,7 @@ class FrameCollection implements ArrayAccess, IteratorAggregate, Serializable, C
      */
     public function offsetSet($offset, $value)
     {
-        throw new \Exception(__CLASS__ . ' is read only');
+        throw new \Exception(self::class . ' is read only');
     }
 
     /**
@@ -127,7 +127,7 @@ class FrameCollection implements ArrayAccess, IteratorAggregate, Serializable, C
      */
     public function offsetUnset($offset)
     {
-        throw new \Exception(__CLASS__ . ' is read only');
+        throw new \Exception(self::class . ' is read only');
     }
 
     /**

--- a/redaxo/src/core/vendor/symfony/debug/ErrorHandler.php
+++ b/redaxo/src/core/vendor/symfony/debug/ErrorHandler.php
@@ -116,7 +116,7 @@ class ErrorHandler
     {
         if (null === self::$reservedMemory) {
             self::$reservedMemory = str_repeat('x', 10240);
-            register_shutdown_function(__CLASS__.'::handleFatalError');
+            register_shutdown_function(self::class.'::handleFatalError');
         }
 
         if ($handlerIsNew = null === $handler) {

--- a/redaxo/src/core/vendor/symfony/debug/Exception/ContextErrorException.php
+++ b/redaxo/src/core/vendor/symfony/debug/Exception/ContextErrorException.php
@@ -33,7 +33,7 @@ class ContextErrorException extends \ErrorException
      */
     public function getContext()
     {
-        @trigger_error(sprintf('The %s class is deprecated since Symfony 3.3 and will be removed in 4.0.', __CLASS__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s class is deprecated since Symfony 3.3 and will be removed in 4.0.', self::class), E_USER_DEPRECATED);
 
         return $this->context;
     }


### PR DESCRIPTION
Als früher Vorgriff auf https://wiki.php.net/rfc/deprecations_php_7_4.
(Auch wenn da noch nichts entschieden ist)