### PR TITLE
Struktur: _DIR_ entfernt und durch  $this->getPath ersetzt

### DIFF
--- a/redaxo/src/addons/structure/pages/index.php
+++ b/redaxo/src/addons/structure/pages/index.php
@@ -74,7 +74,7 @@ echo rex_view::title(rex_i18n::msg('title_structure'));
 echo rex_view::clangSwitchAsButtons($context);
 
 // --------------------------------------------- Path
-require __DIR__ . '/../functions/function_rex_category.php';
+require $this->getPath('functions/function_rex_category.php');
 
 // -------------- STATUS_TYPE Map
 $catStatusTypes = rex_category_service::statusTypes();

--- a/redaxo/src/addons/structure/pages/index.php
+++ b/redaxo/src/addons/structure/pages/index.php
@@ -74,7 +74,7 @@ echo rex_view::title(rex_i18n::msg('title_structure'));
 echo rex_view::clangSwitchAsButtons($context);
 
 // --------------------------------------------- Path
-require $this->getPath('functions/function_rex_category.php');
+require rex_path::addon('structure', 'functions/function_rex_category.php');
 
 // -------------- STATUS_TYPE Map
 $catStatusTypes = rex_category_service::statusTypes();


### PR DESCRIPTION
Funktionen über 
`require $this->getPath('functions/function_rex_category.php');`
Dadurch kann kann die index.php z.B. in das Projekt-AddOn kopiert werden und individualisiert werden.