### PR TITLE
Parametertyp falsch: rex_form_widget_linkmap_element

### DIFF
--- a/redaxo/src/addons/mediapool/lib/form_element/media.php
+++ b/redaxo/src/addons/mediapool/lib/form_element/media.php
@@ -9,7 +9,7 @@ class rex_form_widget_media_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
-    public function __construct($tag = '', rex_form $table = null, array $attributes = [])
+    public function __construct($tag = '', rex_form_base $table = null, array $attributes = [])
     {
         parent::__construct('', $table, $attributes);
     }

--- a/redaxo/src/addons/mediapool/lib/form_element/medialist.php
+++ b/redaxo/src/addons/mediapool/lib/form_element/medialist.php
@@ -9,7 +9,7 @@ class rex_form_widget_medialist_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
-    public function __construct($tag = '', rex_form $table = null, array $attributes = [])
+    public function __construct($tag = '', rex_form_base $table = null, array $attributes = [])
     {
         parent::__construct('', $table, $attributes);
     }

--- a/redaxo/src/addons/structure/lib/linkmap/form_element/linklist.php
+++ b/redaxo/src/addons/structure/lib/linkmap/form_element/linklist.php
@@ -9,7 +9,7 @@ class rex_form_widget_linklist_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
-    public function __construct($tag = '', rex_form $table = null, array $attributes = [])
+    public function __construct($tag = '', rex_form_base $table = null, array $attributes = [])
     {
         parent::__construct('', $table, $attributes);
     }

--- a/redaxo/src/addons/structure/lib/linkmap/form_element/linkmap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/form_element/linkmap.php
@@ -9,7 +9,7 @@ class rex_form_widget_linkmap_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstruktorparameter
-    public function __construct($tag = '', rex_form $table = null, array $attributes = [])
+    public function __construct($tag = '', rex_form_base $table = null, array $attributes = [])
     {
         parent::__construct('', $table, $attributes);
     }

--- a/redaxo/src/core/lib/form/elements/prio.php
+++ b/redaxo/src/core/lib/form/elements/prio.php
@@ -14,7 +14,7 @@ class rex_form_prio_element extends rex_form_select_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
-    public function __construct($tag = '', rex_form $table = null, array $attributes = [])
+    public function __construct($tag = '', rex_form_base $table = null, array $attributes = [])
     {
         parent::__construct('', $table, $attributes);
 


### PR DESCRIPTION
Die neu eingeführte Klasse `rex_config_form` erzeugt ein "whoops" beim `$form->addLinkmapField`. Grund ist die Klasse `rex_form`, in der der Parameter `$table`erwartet wird. Hier muss noch auf die gemeinsame BAsisklasse `rex_form_base`geändert werden.