### PR TITLE
Non-Zero exit-code verwenden bei unbehandelten Exceptions

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -157,13 +157,13 @@ abstract class rex_error_handler
     </button>', $errPage);
 
             rex_response::sendContent($errPage, $handler->contentType());
-            exit;
+            exit(1);
         }
 
         // TODO small error page, without debug infos
         $buf = 'Oooops, an internal error occured!';
         rex_response::sendContent($buf);
-        exit;
+        exit(1);
     }
 
     /**


### PR DESCRIPTION
In https://github.com/redaxo/redaxo/pull/1948 ist zu sehen dass bei uncaught exceptions dennoch ein travis build als erfolgreich gewertet wird. Dies wird hier behoben.