### PR TITLE
verständlichere CSRF-Meldung

### DIFF
--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -27,7 +27,7 @@ function = Funktion
 no_editing_rights = Keine Editiererlaubnis
 check_rights_in_directory = Bitte überprüfen Sie die Rechte im Ordner
 error_undefined = Ein undefinierter Fehler ist aufgetreten
-csrf_token_invalid = Der CSRF-Token ist nicht gültig.
+csrf_token_invalid = Bitte das Formular erneut absenden. (Fehler: CSRF-Token ungültig)
 
 # redaxo/redaxo/index.php
 system = System

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -27,7 +27,6 @@ function = Function
 no_editing_rights = permission denied
 check_rights_in_directory = Please review permissions in directory
 error_undefined = An undefinied error occurred
-csrf_token_invalid = The csrf token is invalid.
 
 # redaxo/redaxo/index.php
 system = System

--- a/redaxo/src/core/lang/es_es.lang
+++ b/redaxo/src/core/lang/es_es.lang
@@ -27,7 +27,6 @@ function = Función
 no_editing_rights = Permiso denegado
 check_rights_in_directory = Compruebe los permisos de carpeta.
 error_undefined = Se ha producido un error indefinido
-csrf_token_invalid = El token csrf no es válido.
 
 # redaxo/redaxo/index.php
 system = Sistema

--- a/redaxo/src/core/lang/sv_se.lang
+++ b/redaxo/src/core/lang/sv_se.lang
@@ -27,7 +27,6 @@ function = Funktion
 no_editing_rights = Du har inte rätt att ändra
 check_rights_in_directory = Vänligen kolla rättigheterna i mappen
 error_undefined = Okänt fel
-csrf_token_invalid = CSRF-token är inte giltig.
 
 # redaxo/redaxo/index.php
 system = System


### PR DESCRIPTION
Mit der technischen Meldung kann ein Nutzer im Frontend nichts anfangen. Auch ungeübte Entwickler scheitern daran, zu verstehen, was nötig ist. Mit dieser einfachen Instruktion soll die Usability verbessert werden.