### PR TITLE
REX und DB Version aus system/settings entfernt

### DIFF
--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -163,44 +163,6 @@ $fragment->setVar('title', rex_i18n::msg('system_features'));
 $fragment->setVar('body', $content, false);
 $sideContent[] = $fragment->parse('core/page/section.php');
 
-$content = '
-    <table class="table">
-        <tr>
-            <th class="rex-table-width-3">REDAXO</th>
-            <td>' . $rexVersion . '</td>                            
-        </tr>   
-        <tr>
-            <th>PHP</th>
-            <td>' . PHP_VERSION . ' <a href="' . rex_url::backendPage('system/phpinfo') . '" title="phpinfo" onclick="newWindow(\'phpinfo\', this.href, 1000,800,\',status=yes,resizable=yes\');return false;"><i class="rex-icon rex-icon-phpinfo"></i></a></td>                            
-        </tr>
-    </table>';
-
-$fragment = new rex_fragment();
-$fragment->setVar('title', rex_i18n::msg('version'));
-$fragment->setVar('content', $content, false);
-$sideContent[] = $fragment->parse('core/page/section.php');
-
-$content = '
-    <table class="table">
-        <tr>
-            <th class="rex-table-width-3">MySQL</th>
-            <td>' .  rex_sql::getServerVersion() . '</td>                            
-        </tr>
-        <tr>
-            <th>' . rex_i18n::msg('name') . '</th>
-            <td><span class="rex-word-break">' . $dbconfig[1]['name'] . '</span></td>                            
-        </tr>   
-        <tr>
-            <th>' . rex_i18n::msg('host') . '</th>
-            <td>' . $dbconfig[1]['host'] . '</td>                            
-        </tr>
-    </table>';
-
-$fragment = new rex_fragment();
-$fragment->setVar('title', rex_i18n::msg('database'));
-$fragment->setVar('content', $content, false);
-$sideContent[] = $fragment->parse('core/page/section.php');
-
 $content = '';
 
 $formElements = [];


### PR DESCRIPTION
closes #1900 

versions infos aus der system page entfernen da bereits in der minibar enthalten

siehe https://github.com/redaxo/redaxo/issues/1900#issuecomment-415737777


Vorher

![bildschirmfoto 2018-08-24 um 13 54 19](https://user-images.githubusercontent.com/791247/44583451-b00ec300-a7a5-11e8-9b61-d0e6a77aed14.png)

Nachher
die 2 kisten wurden rückstandslos entfernt, da die infos in der minibar enthalten

![image](https://user-images.githubusercontent.com/120441/47254654-8ef4e680-d465-11e8-9b68-404246b2e133.png)
