### PR TITLE
Build mariadb with 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
             addons:
                 mariadb: 10.1
         -   <<: *TEST
-            php: 7.2
+            php: 7.3
             addons:
                 mariadb: 10.2
         -   &TEST_MYSQL


### PR DESCRIPTION
7.3 ist in den letzten zügen und falls probleme mit mariadb und 7.3 vorhanden sind, sollten wir sie jetzt checken