### PR TITLE
Kommentare in generated rex-code ergänzen

### DIFF
--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -171,9 +171,9 @@ abstract class rex_var
                     $output .= str_repeat("\n", max(0, substr_count($match[0], "\n") - substr_count($output, "\n") - substr_count($format, "\n")));
                     if ($useVariables) {
                         $replace = '$__rex_var_content_' . ++self::$variableIndex;
-                        $variables[] = $replace . ' = ' . $output;
+                        $variables[] = '/* '. $match[0] .' */ ' . $replace . ' = ' . $output;
                     } else {
-                        $replace = $output;
+                        $replace = '/* '. $match[0] .' */ ' . $output;
                     }
                     $content = str_replace($match[0], sprintf($format, $replace), $content);
                     $replaced = true;


### PR DESCRIPTION
Um dem User beim lesen des generierten PHP codes zu unterstützen.

Dies zum Beispiel in whoops-stack frames

![image](https://user-images.githubusercontent.com/120441/47935275-1d438080-deda-11e8-9e0f-699743fd6fe3.png)


closes https://github.com/redaxo/redaxo/issues/2152