### PR TITLE
make db:set_connection_options work

### DIFF
--- a/redaxo/src/core/lib/console/db/set_connection_options.php
+++ b/redaxo/src/core/lib/console/db/set_connection_options.php
@@ -47,7 +47,7 @@ class rex_command_db_set_connection_options extends rex_console_command
             $changed = true;
         }
 
-        if ($changed) {
+        if (!$changed) {
             throw new InvalidArgumentException('No database settings given.');
         }
 


### PR DESCRIPTION
mir scheint als wäre das ein tippfehler.. mich wundert wie der da hinkommt, da ich eigentlich das ganze getestet hatte