### PR TITLE
Regenerieren des autoload-cache während des setups erlauben

### DIFF
--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -105,7 +105,7 @@ class rex_autoload
         // but only if an admin is logged in
         if (
             (!self::$reloaded || $force) &&
-            (rex::getConsole() || ($user = rex_backend_login::createUser()) && $user->isAdmin())
+            (rex::isSetup() || rex::getConsole() || ($user = rex_backend_login::createUser()) && $user->isAdmin())
         ) {
             self::reload($force);
             return self::autoload($class);


### PR DESCRIPTION
Zum zeitpunkt des intialen setups hat der aktuelle user noch keine admin session. daher wird im falle eines fehlers während des setups ein error dazu führen, dass man manuell den autoload.cache vom dateisystem löschen muss.
Mit diesem fix ist das im initialen setup nicht mehr nötig

hängt zum teil mit #2149 zusammen