### PR TITLE
Autoloader cache nicht schreiben, wenn ein error auftritt

### DIFF
--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -147,6 +147,13 @@ class rex_autoload
             return;
         }
 
+        // dont persist a possible incomplete cache, because requests of end-users (which are not allowed to regenerate a existing cache)
+        // can error in some crazy class-not-found errors which are hard to debug.
+        $error = error_get_last();
+        if (is_array($error) && in_array($error['type'], [E_USER_ERROR, E_ERROR, E_COMPILE_ERROR, E_RECOVERABLE_ERROR, E_PARSE])) {
+            return;
+        }
+
         // remove obsolete dirs from cache
         foreach (self::$dirs as $dir => $files) {
             if (!in_array($dir, self::$addedDirs)) {


### PR DESCRIPTION
zum testen in der boot.php nach der registrierung des autoloaders und vor der registrierung des error-handlers eine exception werfen.

vor diesem patch:
es wird eine autoload.cache datei geschrieben die nur einen bruchteil aller klassen enthält.
solange diese halb-gefülle cache datei existiert laufen "einfache" http requests auf einen error seite, wenn diese den autoload cache nicht neu schreiben dürfen. dies passiert bisher z.b. im initialen setup oder wenn ein enduser das frontend besucht.

nach diesem patch:
es wird keine autoload.cache datei geschrieben. ein besuch durch einen frontend user wird eine neue autoload.cache datei erzeugen (da noch keine exisitiert). ein weiteres request im backend wird erneut versuchen den autoloader cache zu bauen.

Refs #2149