### PR TITLE
Update media_manager.php

### DIFF
--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -190,7 +190,7 @@ class rex_media_manager
             return $this->cache;
         }
 
-        return $this->cache = rex_file::getCache($this->getHeaderCacheFilename(), null);
+        return $this->cache = rex_file::getCache($this->getHeaderCacheFilename());
     }
 
     public static function deleteCacheByType($type_id)


### PR DESCRIPTION
`null` als Default Rückgabewert für `rex_file::getCache` macht keinen Sinn, da die Funktion ein Array zurückgeben soll.