### PR TITLE
Vermeidung von Data truncation Bei REX_VALUES

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_action.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_action.php
@@ -47,7 +47,7 @@ class rex_article_action
             for ($i = 1; $i <= $max; ++$i) {
                 if (isset($values[$i])) {
                     if (is_array($values[$i])) {
-                        $values[$i] = json_encode($values[$i]);
+                        $values[$i] = json_encode($values[$i], JSON_UNESCAPED_UNICODE);
                     }
                     $this->sql->setValue($key . $i, $values[$i]);
                 } else {


### PR DESCRIPTION
JSON_UNESCAPED_UNICODE
Kodiere Unicode Zeichen, welche aus mehreren Bytes bestehen, direkt (standardmäßig werden \uXXXX Escapes genutzt). Verfügbar seit PHP 5.4.0.

Hinzufügen der Konstanten JSON_UNESCAPED_UNICODE um Data truncation bei sehr lagen Texten in Fremdsprachen zu vermeiden.