### PR TITLE
Rückwärtskompatibilität in rex_select wiederhergestellt

### DIFF
--- a/redaxo/src/core/lib/select.php
+++ b/redaxo/src/core/lib/select.php
@@ -121,7 +121,7 @@ class rex_select
                 $this->setSelected($sectvalue);
             }
         } else {
-            $this->option_selected[] = $selected;
+            $this->option_selected[] = (string) rex_escape($selected, 'html_attr');
         }
     }
 
@@ -290,6 +290,11 @@ class rex_select
 
     protected function outOption($name, $value, $level = 0, array $attributes = [])
     {
+        $name = rex_escape($name);
+        // for BC reasons, we always expect value to be a string.
+        // this also makes sure that the strict in_array() check below works.
+        $value = (string) rex_escape($value, 'html_attr');
+
         $bsps = '';
         if ($level > 0) {
             $bsps = str_repeat('&nbsp;&nbsp;&nbsp;', $level);
@@ -304,8 +309,6 @@ class rex_select
             $attr .= ' ' . $n . '="' . $v . '"';
         }
 
-        $name = rex_escape($name);
-        $value = rex_escape($value, 'html_attr');
         return '        <option value="' . $value . '"' . $attr . '>' . $bsps . $name . '</option>' . "\n";
     }
 


### PR DESCRIPTION
fixes https://github.com/redaxo/redaxo/issues/2188

hier wurde das verhalten wiederhergestellt, wie zuvor in R5.6.

entgegen der argumentation in #2188 wollte ich nicht in `rex_escape` alles nach string casten, da ich der meinung bin dass int/float etc. den typ nicht ändern sollte