### PR TITLE
PHPMailer::Fehlermeldungen in Benutzersprache

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -17,6 +17,7 @@ class rex_mailer extends PHPMailer
     public function __construct($exceptions = false)
     {
         $addon = rex_addon::get('phpmailer');
+        $this->setLanguage(rex_i18n::getLanguage(), $addon->getPath('vendor/phpmailer/phpmailer/language/'));
         $this->XMailer = 'REXMailer';
         $this->From = $addon->getConfig('from');
         $this->FromName = $addon->getConfig('fromname');


### PR DESCRIPTION
Liefert die Fehlermeldungen entsprechend der eingestellten Sprache aus
<img width="1419" alt="bildschirmfoto 2018-12-04 um 21 37 17" src="https://user-images.githubusercontent.com/791247/49471304-cef10c80-f80c-11e8-9a9a-e192aeb5b895.png">
