### PR TITLE
PHPMailer::Debug-Medungen in korrekter Sprache

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -17,6 +17,7 @@ class rex_mailer extends PHPMailer
     public function __construct($exceptions = false)
     {
         $addon = rex_addon::get('phpmailer');
+        $this->setLanguage(rex_i18n::getLanguage(), $addon->getPath('vendor/phpmailer/phpmailer/language/'));
         $this->XMailer = 'REXMailer';
         $this->From = $addon->getConfig('from');
         $this->FromName = $addon->getConfig('fromname');


### PR DESCRIPTION
https://github.com/redaxo/redaxo/pull/2246

<img width="882" alt="bildschirmfoto 2018-12-04 um 22 05 34" src="https://user-images.githubusercontent.com/791247/49472869-d4e8ec80-f810-11e8-8a2c-34fc2ae818d2.png">

Bislang werden die Meldungen nur in englisch ausgegeben. Diese Änderung ermöglicht die Ausgabe der Debug-Meldungen in der jeweiligen Sprache. 