### PR TITLE
Altes IE todo entfernt

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/pages/content.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.php
@@ -324,8 +324,6 @@ if ($article->getRows() == 1) {
                         // ----- / POST SAVE ACTION
 
                         // Update Button wurde gedrückt?
-                        // TODO: Workaround, da IE keine Button Namen beim
-                        // drücken der Entertaste übermittelt
                         if (rex_post('btn_save', 'string')) {
                             $function = '';
                         }


### PR DESCRIPTION
Wird nicht mehr ungesetzt. Hat niemanden bisher gestört.