### PR TITLE
Backup: Export beschleunigen fuer datums-typen

### DIFF
--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -357,6 +357,9 @@ class rex_backup
                     $field = 'double';
                 } elseif (preg_match('#^(char|varchar|text|longtext|mediumtext|tinytext)#', $field['Type'])) {
                     $field = 'string';
+                } elseif (preg_match('#^(date|datetime|time|timestamp|year)#', $field['Type'])) {
+                    // types which can be passed tru 1:1 as escaping isn't necessary, because we know the mysql internal format.
+                    $field = 'raw';
                 }
                 // else ?
             }
@@ -386,6 +389,10 @@ class rex_backup
                         $column = $row[$idx];
 
                         switch ($type) {
+                            // prevent calling sql->escape() on values with a known format
+                            case 'raw':
+                                $record[] = "'". $column ."'";
+                                break;
                             case 'int':
                                 $record[] = (int) $column;
                                 break;


### PR DESCRIPTION
Beim exportieren ist `sql->escape` der bottleneck.

![image](https://user-images.githubusercontent.com/120441/49702221-25d45880-fbf6-11e8-8317-28da8a9aba31.png)

https://blackfire.io/profiles/592016d2-fc28-4bd3-a34b-dced62bb7002/graph

Durch die Änderungen wird unnötiges escaping vermieden, wenn das format bekannt ist in dem gespeichert wird und dort keine zu escapenden zeichen enthalten sein können