### PR TITLE
Backup: Export beschleunigen

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1225,6 +1225,16 @@ class rex_sql implements Iterator
      */
     public function escape($value)
     {
+        // fast-exit for very frequent used harmless values
+        if ($value === false || $value === true || $value === null || $value === '0' || $value === '' || $value === ' ' || $value === '|' || $value === '||') {
+            return "'". $value ."'";
+        }
+
+        // fast-exit for very frequent used harmless values
+        if (\strlen($value) <= 3 && ctype_alnum($value)) {
+            return "'". $value ."'";
+        }
+
         return self::$pdo[$this->DBID]->quote($value);
     }
 


### PR DESCRIPTION
rex_sql: fast-exit in escape() um backups zu beschleunigen

![image](https://user-images.githubusercontent.com/120441/49702742-31c31900-fbfc-11e8-8b71-9bb94e87ff00.png)
