### PR TITLE
Codingstandards travis job entfernt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,6 @@ jobs:
             env: LINTING=1
             script: if find . -name "*.php" ! -path "*/vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
 
-        -   php: 7.2
-            env: CODING_STANDARDS=1
-            install:
-                - mkdir -p "$HOME/.php-cs-fixer"
-                # CS_FIXER_VERSION defined via travisci web interface
-                - "echo '{\"require\": {\"friendsofphp/php-cs-fixer\": \"'$CS_FIXER_VERSION'\"}}' > \"$HOME/.php-cs-fixer/composer.json\""
-                - travis_retry composer update --no-interaction --working-dir "$HOME/.php-cs-fixer"
-            script: php "$HOME/.php-cs-fixer/vendor/bin/php-cs-fixer" fix --cache-file "$HOME/.php-cs-fixer/.php_cs.cache" --dry-run --diff --verbose
-
         -   &TEST
             install:
                 - mysql -e 'create database redaxo_5_0;'


### PR DESCRIPTION
da er aktuell fehlschlägt und prettyci ja auch im bugfix branch läuft

beispiel siehe https://github.com/redaxo/redaxo/pull/2263