### PR TITLE
Core: client-seitige daten löschen, wenn session abgelaufen ist

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -114,6 +114,11 @@ if (rex::isSetup()) {
         $pages['login'] = rex_be_controller::getLoginPage();
         $page = 'login';
         rex_be_controller::setCurrentPage('login');
+
+        // clear in-browser data of a previous session with the same browser for security reasons.
+        // a possible attacker should not be able to access cached data of a previous valid session on the same computer.
+        // clearing "executionContext" or "cookies" would result in a endless loop.
+        rex_response::setHeader('Clear-Site-Data', '"cache", "storage"');
     } else {
         // Userspezifische Sprache einstellen
         $user = $login->getUser();


### PR DESCRIPTION
informationen im browser löschen, wenn jemand versucht eine url aufzurufen, die einen backend login erfordert, aber keine gültige session existiert.

auf diesem weg löschen wir die daten auf dem rechner, damit niemand aus den ggf. gecachten inhalten was raussuchen kann (z.b. in einem inet kaffee, wenn der berechtigte admin sich nicht ordentlich abgemeldet hat - aber die session mittlerweile bereits abgelaufen ist, aber noch lokale Daten auf dem Rechner vorhanden sind)

~~Ungetestet~~