### PR TITLE
Core: Weniger file-operationen im bootstrap

### DIFF
--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -84,7 +84,9 @@ rex::setProperty('version', '5.7.0-beta1');
 
 $cacheFile = rex_path::coreCache('config.yml.cache');
 $configFile = rex_path::coreData('config.yml');
-if (@filemtime($cacheFile) >= @filemtime($configFile)) {
+
+$cacheMtime = @filemtime($cacheFile);
+if ($cacheMtime && $cacheMtime >= @filemtime($configFile)) {
     $config = rex_file::getCache($cacheFile);
 } else {
     $config = array_merge(

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -84,7 +84,7 @@ rex::setProperty('version', '5.7.0-beta1');
 
 $cacheFile = rex_path::coreCache('config.yml.cache');
 $configFile = rex_path::coreData('config.yml');
-if (file_exists($cacheFile) && file_exists($configFile) && filemtime($cacheFile) >= filemtime($configFile)) {
+if (@filemtime($cacheFile) >= @filemtime($configFile)) {
     $config = rex_file::getCache($cacheFile);
 } else {
     $config = array_merge(


### PR DESCRIPTION
In der boot-phase ist jegliches IO zuviel.
daher hier besser mit `@` operator arbeiten und dafür 2x `file_exists` einsparen.