### PR TITLE
rex_file: php-basierte cache files verwenden

### DIFF
--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -131,11 +131,10 @@ class rex_autoload
      */
     private static function loadCache()
     {
-        if (!self::$cacheFile || !($cache = @file_get_contents(self::$cacheFile))) {
+        if (!self::$cacheFile || !($cached = @include(self::$cacheFile))) {
             return;
         }
-
-        list(self::$classes, self::$dirs) = json_decode($cache, true);
+        list(self::$classes, self::$dirs) = $cached['value'];
     }
 
     /**

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -45,8 +45,8 @@ class rex_file
      */
     public static function getCache($file, $default = [])
     {
-        $content = self::get($file);
-        return $content === null ? $default : json_decode($content, true);
+        $content = @include($file);
+        return is_array($content) ? $content['value'] : $default;
     }
 
     /**
@@ -95,7 +95,7 @@ class rex_file
      */
     public static function putCache($file, $content)
     {
-        return self::put($file, json_encode($content));
+        return self::put($file, '<?php return ' .var_export(array('value' => $content), true) . ';');
     }
 
     /**


### PR DESCRIPTION
wenn man den PR ausgecheckt hat, muss man unter system den cache gelöscht haben, da sich das datenformat verändert hat