### PR TITLE
Struktur: Optimistisches caches lesen

### DIFF
--- a/redaxo/src/addons/structure/lib/structure_element.php
+++ b/redaxo/src/addons/structure/lib/structure_element.php
@@ -150,15 +150,18 @@ abstract class rex_structure_element
         $class = static::class;
         return static::getInstance([$id, $clang], function ($id, $clang) use ($class) {
             $article_path = rex_path::addonCache('structure', $id . '.' . $clang . '.article');
+
+            // load metadata from cache
+            $metadata = rex_file::getCache($article_path);
+
             // generate cache if not exists
-            if (!file_exists($article_path)) {
+            if (!$metadata) {
                 rex_article_cache::generateMeta($id, $clang);
+                $metadata = rex_file::getCache($article_path);
             }
 
             // article is valid, if cache exists after generation
-            if (file_exists($article_path)) {
-                // load metadata from cache
-                $metadata = rex_file::getCache($article_path);
+            if ($metadata) {
                 // create object with the loaded metadata
                 return new $class($metadata);
             }
@@ -200,10 +203,13 @@ abstract class rex_structure_element
             // callback to create the list of IDs
             function ($parentId, $listType) {
                 $listFile = rex_path::addonCache('structure', $parentId . '.' . $listType);
-                if (!file_exists($listFile)) {
+
+                $list = rex_file::getCache($listFile);
+                if (!$list) {
                     rex_article_cache::generateLists($parentId);
+                    $list = rex_file::getCache($listFile);
                 }
-                return rex_file::getCache($listFile);
+                return $list;
             }
         );
     }

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content.php
@@ -88,6 +88,8 @@ class rex_article_content extends rex_article_content_base
             ob_implicit_flush(0);
 
             $article_content_file = rex_path::addonCache('structure', $this->article_id . '.' . $this->clang . '.content');
+
+            $generated = true;
             if (!file_exists($article_content_file)) {
                 $generated = rex_content_service::generateArticleContent($this->article_id, $this->clang);
                 if ($generated !== true) {
@@ -96,7 +98,7 @@ class rex_article_content extends rex_article_content_base
                 }
             }
 
-            if (file_exists($article_content_file)) {
+            if ($generated === true) {
                 require $article_content_file;
             }
 


### PR DESCRIPTION
spart file operationen ein.

auf der startseite der demo sind das 38 function calls zu file_exists().
die 24% perf verbesserung sind vermutlich eine schlechte lüge von blackfire.

![image](https://user-images.githubusercontent.com/120441/50111563-53944f80-023d-11e9-88f9-28d6cb1f1117.png)

Refs #2297