### PR TITLE
optische Überlagerungen in dump() vermeiden, fixed #2311

### DIFF
--- a/redaxo/src/core/lib/var_dumper.php
+++ b/redaxo/src/core/lib/var_dumper.php
@@ -43,10 +43,10 @@ abstract class rex_var_dumper
             } else {
                 $styleAll = 'font-family: "Fira Code", Menlo, Monaco, Consolas, monospace; font-size: 14px; line-height: 1.4 !important;';
                 self::$dumper = new HtmlDumper();
-                self::$dumper->setDumpBoundaries('<pre class="rex-var-dumper sf-dump" id="%s" data-indent-pad="%s">', '</pre><script>Sfdump(%s)</script>');
+                self::$dumper->setDumpBoundaries('<pre class="rex-var-dumper sf-dump" id="%s" data-indent-pad="%s"><div class="sf-dump-rex-container">', '</div></pre><script>Sfdump(%s)</script>');
                 self::$dumper->setIndentPad('    ');
                 self::$dumper->setStyles([
-                    'default' => $styleAll . '
+                    'rex-container' => $styleAll . '
                         position: relative;
                         z-index: 99999;
                         padding: 10px;
@@ -56,6 +56,9 @@ abstract class rex_var_dumper
                         white-space: pre-wrap;
                         word-break: normal;
                         word-wrap: break-word;
+                    ',
+                    'default' => $styleAll . '
+                        background-color: transparent;
                     ',
                     'const' => $styleAll . 'color: #F78C6C; font-weight: 700;',
                     'ellipsis' => $styleAll . 'color: #eeffff;',

--- a/redaxo/src/core/lib/var_dumper.php
+++ b/redaxo/src/core/lib/var_dumper.php
@@ -59,6 +59,7 @@ abstract class rex_var_dumper
                     ',
                     'default' => $styleAll . '
                         background-color: transparent;
+                        color: #eeffff;
                     ',
                     'const' => $styleAll . 'color: #F78C6C; font-weight: 700;',
                     'ellipsis' => $styleAll . 'color: #eeffff;',


### PR DESCRIPTION
closes #2311