### PR TITLE
Struktur: install.php in update.php einbinden

### DIFF
--- a/redaxo/src/addons/structure/update.php
+++ b/redaxo/src/addons/structure/update.php
@@ -2,19 +2,13 @@
 
 /** @var rex_addon $this */
 
-if ($this->getPlugin('content')->isInstalled() && rex_string::versionCompare($this->getVersion(), '2.3.0', '<')) {
-    rex_sql_table::get(rex::getTable('template'))
-        ->ensureColumn(new rex_sql_column('content', 'mediumtext', true))
-        ->alter();
-    rex_sql_table::get(rex::getTable('module'))
-        ->ensureColumn(new rex_sql_column('input', 'mediumtext', true))
-        ->ensureColumn(new rex_sql_column('output', 'mediumtext', true))
-        ->alter();
-}
+// use path relative to __DIR__ to get correct path in update temp dir
+$this->includeFile(__DIR__.'/install.php');
 
-if ($this->getPlugin('history')->isInstalled()) {
-    // version 2.3.0
-    rex_sql_table::get(rex::getTable('article_slice_history'))
-        ->ensureColumn(new rex_sql_column('history_user', 'varchar(255)'))
-        ->alter();
+foreach ($this->getInstalledPlugins() as $plugin) {
+    $file = __DIR__.'/plugins/'.$plugin->getName().'/install.php';
+
+    if (file_exists($file)) {
+        $plugin->includeFile($file);
+    }
 }


### PR DESCRIPTION
Das Struktur-Addon nutzt nun `rex_sql_table` in den `install.php`-Dateien.
Die werden bei einem Update aber nicht automatisch geladen, sondern das muss man selbst machen in der update.php
Die update.php gibt es nur in Addons, nicht in Plugins. Daher muss man dort auch Plugin-Updates steuern.