### PR TITLE
Server timing api anbinden

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -51,10 +51,12 @@ class rex_mailer extends PHPMailer
 
     public function send()
     {
-        if ($this->log) {
-            $this->log();
-        }
-        return parent::send();
+        return rex_stopwatch::measure(__METHOD__, function() {
+            if ($this->log) {
+                $this->log();
+            }
+            return parent::send();
+        });
     }
 
     /*

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -51,7 +51,7 @@ class rex_mailer extends PHPMailer
 
     public function send()
     {
-        return rex_stopwatch::measure(__METHOD__, function() {
+        return rex_stopwatch::measure(__METHOD__, function () {
             if ($this->log) {
                 $this->log();
             }

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -393,7 +393,7 @@ class rex_login
                 $cookieParams['httponly']
             );
 
-            $started = rex_stopwatch::measure(__METHOD__, function() {
+            $started = rex_stopwatch::measure(__METHOD__, function () {
                 return @session_start();
             });
             if (!$started) {

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -393,7 +393,10 @@ class rex_login
                 $cookieParams['httponly']
             );
 
-            if (!@session_start()) {
+            $started = rex_stopwatch::measure(__METHOD__, function() {
+                return @session_start();
+            });
+            if (!$started) {
                 $error = error_get_last();
                 if ($error) {
                     rex_error_handler::handleError($error['type'], $error['message'], $error['file'], $error['line']);

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -96,10 +96,12 @@ class rex_response
 
     private static function sendServerTimingHeaders()
     {
-        // see https://w3c.github.io/server-timing/#the-server-timing-header-field
-        foreach (rex_stopwatch::$timers as $label => $durationMs) {
-            $label = preg_replace('{[^!#$%&\'*+-\.\^_`|~\w]}i', '_', $label);
-            header('Server-Timing: '. $label .';dur='. number_format($durationMs, 3, '.', ''), false);
+        if (rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin()) {
+            // see https://w3c.github.io/server-timing/#the-server-timing-header-field
+            foreach (rex_stopwatch::$timers as $label => $durationMs) {
+                $label = preg_replace('{[^!#$%&\'*+-\.\^_`|~\w]}i', '_', $label);
+                header('Server-Timing: '. $label .';dur='. number_format($durationMs, 3, '.', ''), false);
+            }
         }
     }
 

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -96,7 +96,7 @@ class rex_response
 
     private static function sendServerTimingHeaders()
     {
-        if (rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin()) {
+        if (rex::isDebugMode() || ($user = rex::getUser()) && $user->isAdmin()) {
             // see https://w3c.github.io/server-timing/#the-server-timing-header-field
             foreach (rex_stopwatch::$timers as $label => $durationMs) {
                 $label = preg_replace('{[^!#$%&\'*+-\.\^_`|~\w]}i', '_', $label);

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -95,8 +95,10 @@ class rex_response
     }
 
     private static function sendServerTimingHeaders() {
-        foreach(rex_stop_watch::$timers as $label => $durationMs) {
-            header('Server-Timing: '. $label .';dur='. $durationMs);
+        // see https://w3c.github.io/server-timing/#the-server-timing-header-field
+        foreach(rex_stopwatch::$timers as $label => $durationMs) {
+            $label = preg_replace('{[^!#$%&\'*+-\.\^_`|~\w]}i', '_', $label);
+            header('Server-Timing: '. $label .';dur='. number_format($durationMs, 3, '.', ''), false);
         }
     }
 

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -94,6 +94,12 @@ class rex_response
         }
     }
 
+    private static function sendServerTimingHeaders() {
+        foreach(rex_stop_watch::$timers as $label => $durationMs) {
+            header('Server-Timing: '. $label .';dur='. $durationMs);
+        }
+    }
+
     /**
      * Redirects to a URL.
      *
@@ -112,6 +118,7 @@ class rex_response
         self::cleanOutputBuffers();
         self::sendAdditionalHeaders();
         self::sendPreloadHeaders();
+        self::sendServerTimingHeaders();
 
         header('HTTP/1.1 ' . self::$httpStatus);
         header('Location: ' . $url);
@@ -159,6 +166,7 @@ class rex_response
 
         self::sendAdditionalHeaders();
         self::sendPreloadHeaders();
+        self::sendServerTimingHeaders();
 
         // dependency ramsey/http-range requires PHP >=5.6
         if (PHP_VERSION_ID >= 50600) {
@@ -304,6 +312,7 @@ class rex_response
 
         self::sendAdditionalHeaders();
         self::sendPreloadHeaders();
+        self::sendServerTimingHeaders();
 
         echo $content;
 

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -94,9 +94,10 @@ class rex_response
         }
     }
 
-    private static function sendServerTimingHeaders() {
+    private static function sendServerTimingHeaders()
+    {
         // see https://w3c.github.io/server-timing/#the-server-timing-header-field
-        foreach(rex_stopwatch::$timers as $label => $durationMs) {
+        foreach (rex_stopwatch::$timers as $label => $durationMs) {
             $label = preg_replace('{[^!#$%&\'*+-\.\^_`|~\w]}i', '_', $label);
             header('Server-Timing: '. $label .';dur='. number_format($durationMs, 3, '.', ''), false);
         }

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -351,7 +351,7 @@ class rex_sql implements Iterator
         }
 
         try {
-            $this->stmt = rex_stopwatch::measure(__METHOD__, function() use ($pdo, $query) {
+            $this->stmt = rex_stopwatch::measure(__METHOD__, function () use ($pdo, $query) {
                 return $pdo->query($query);
             });
 

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -351,7 +351,10 @@ class rex_sql implements Iterator
         }
 
         try {
-            $this->stmt = $pdo->query($query);
+            $this->stmt = rex_stopwatch::measure(__METHOD__, function() use ($pdo, $query) {
+                return $pdo->query($query);
+            });
+
             $this->rows = $this->stmt->rowCount();
         } catch (PDOException $e) {
             throw new rex_sql_exception('Error while executing statement "' . $query . '"! ' . $e->getMessage(), $e, $this);

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -17,8 +17,10 @@ class rex_file
      */
     public static function get($file, $default = null)
     {
-        $content = @file_get_contents($file);
-        return $content !== false ? $content : $default;
+        return rex_stop_watch::measure(__METHOD__.':'. $file, function() use ($file, $default) {
+            $content = @file_get_contents($file);
+            return $content !== false ? $content : $default;
+        });
     }
 
     /**
@@ -59,16 +61,18 @@ class rex_file
      */
     public static function put($file, $content)
     {
-        if (!rex_dir::create(dirname($file)) || file_exists($file) && !is_writable($file)) {
+        return rex_stop_watch::measure(__METHOD__.':'. $file, function() use ($file, $content) {
+            if (!rex_dir::create(dirname($file)) || file_exists($file) && !is_writable($file)) {
+                return false;
+            }
+
+            if (file_put_contents($file, $content) !== false) {
+                @chmod($file, rex::getFilePerm());
+                return true;
+            }
+
             return false;
-        }
-
-        if (file_put_contents($file, $content) !== false) {
-            @chmod($file, rex::getFilePerm());
-            return true;
-        }
-
-        return false;
+        });
     }
 
     /**

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -17,7 +17,7 @@ class rex_file
      */
     public static function get($file, $default = null)
     {
-        return rex_stop_watch::measure(__METHOD__.':'. $file, function() use ($file, $default) {
+        return rex_stopwatch::measure(__METHOD__, function() use ($file, $default) {
             $content = @file_get_contents($file);
             return $content !== false ? $content : $default;
         });
@@ -61,7 +61,7 @@ class rex_file
      */
     public static function put($file, $content)
     {
-        return rex_stop_watch::measure(__METHOD__.':'. $file, function() use ($file, $content) {
+        return rex_stopwatch::measure(__METHOD__, function() use ($file, $content) {
             if (!rex_dir::create(dirname($file)) || file_exists($file) && !is_writable($file)) {
                 return false;
             }
@@ -112,22 +112,24 @@ class rex_file
      */
     public static function copy($srcfile, $dstfile)
     {
-        if (is_file($srcfile)) {
-            if (is_dir($dstfile)) {
-                $dstdir = rtrim($dstfile, DIRECTORY_SEPARATOR);
-                $dstfile = $dstdir . DIRECTORY_SEPARATOR . basename($srcfile);
-            } else {
-                $dstdir = dirname($dstfile);
-                rex_dir::create($dstdir);
-            }
+        return rex_stopwatch::measure(__METHOD__, function() use ($srcfile, $dstfile) {
+            if (is_file($srcfile)) {
+                if (is_dir($dstfile)) {
+                    $dstdir = rtrim($dstfile, DIRECTORY_SEPARATOR);
+                    $dstfile = $dstdir . DIRECTORY_SEPARATOR . basename($srcfile);
+                } else {
+                    $dstdir = dirname($dstfile);
+                    rex_dir::create($dstdir);
+                }
 
-            if (rex_dir::isWritable($dstdir) && (!file_exists($dstfile) || is_writable($dstfile)) && copy($srcfile, $dstfile)) {
-                @chmod($dstfile, rex::getFilePerm());
-                touch($dstfile, filemtime($srcfile), fileatime($srcfile));
-                return true;
+                if (rex_dir::isWritable($dstdir) && (!file_exists($dstfile) || is_writable($dstfile)) && copy($srcfile, $dstfile)) {
+                    @chmod($dstfile, rex::getFilePerm());
+                    touch($dstfile, filemtime($srcfile), fileatime($srcfile));
+                    return true;
+                }
             }
-        }
-        return false;
+            return false;
+        });
     }
 
     /**
@@ -139,10 +141,12 @@ class rex_file
      */
     public static function delete($file)
     {
-        if (file_exists($file)) {
-            return unlink($file);
-        }
-        return true;
+        return rex_stopwatch::measure(__METHOD__, function() use ($file) {
+            if (file_exists($file)) {
+                return unlink($file);
+            }
+            return true;
+        });
     }
 
     /**

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -17,7 +17,7 @@ class rex_file
      */
     public static function get($file, $default = null)
     {
-        return rex_stopwatch::measure(__METHOD__, function() use ($file, $default) {
+        return rex_stopwatch::measure(__METHOD__, function () use ($file, $default) {
             $content = @file_get_contents($file);
             return $content !== false ? $content : $default;
         });
@@ -61,7 +61,7 @@ class rex_file
      */
     public static function put($file, $content)
     {
-        return rex_stopwatch::measure(__METHOD__, function() use ($file, $content) {
+        return rex_stopwatch::measure(__METHOD__, function () use ($file, $content) {
             if (!rex_dir::create(dirname($file)) || file_exists($file) && !is_writable($file)) {
                 return false;
             }
@@ -112,7 +112,7 @@ class rex_file
      */
     public static function copy($srcfile, $dstfile)
     {
-        return rex_stopwatch::measure(__METHOD__, function() use ($srcfile, $dstfile) {
+        return rex_stopwatch::measure(__METHOD__, function () use ($srcfile, $dstfile) {
             if (is_file($srcfile)) {
                 if (is_dir($dstfile)) {
                     $dstdir = rtrim($dstfile, DIRECTORY_SEPARATOR);
@@ -141,7 +141,7 @@ class rex_file
      */
     public static function delete($file)
     {
-        return rex_stopwatch::measure(__METHOD__, function() use ($file) {
+        return rex_stopwatch::measure(__METHOD__, function () use ($file) {
             if (file_exists($file)) {
                 return unlink($file);
             }

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -260,7 +260,7 @@ class rex_socket
      */
     public function doRequest($method, $data = '')
     {
-        return rex_stopwatch::measure(__METHOD__, function() use ($method, $data) {
+        return rex_stopwatch::measure(__METHOD__, function () use ($method, $data) {
             if (!is_string($data) && !is_callable($data)) {
                 throw new InvalidArgumentException(sprintf('Expecting $data to be a string or a callable, but %s given!', gettype($data)));
             }

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -260,47 +260,49 @@ class rex_socket
      */
     public function doRequest($method, $data = '')
     {
-        if (!is_string($data) && !is_callable($data)) {
-            throw new InvalidArgumentException(sprintf('Expecting $data to be a string or a callable, but %s given!', gettype($data)));
-        }
+        return rex_stopwatch::measure(__METHOD__, function() use ($method, $data) {
+            if (!is_string($data) && !is_callable($data)) {
+                throw new InvalidArgumentException(sprintf('Expecting $data to be a string or a callable, but %s given!', gettype($data)));
+            }
 
-        if (!$this->ssl) {
-            rex_logger::logError(E_WARNING, 'You should not use non-secure socket connections while connecting to "'. $this->host .'"!', __FILE__, __LINE__);
-        }
+            if (!$this->ssl) {
+                rex_logger::logError(E_WARNING, 'You should not use non-secure socket connections while connecting to "'. $this->host .'"!', __FILE__, __LINE__);
+            }
 
-        $this->openConnection();
-        $response = $this->writeRequest($method, $this->path, $this->headers, $data);
+            $this->openConnection();
+            $response = $this->writeRequest($method, $this->path, $this->headers, $data);
 
-        if ('GET' !== $method || !$this->followRedirects || !$response->isRedirection()) {
-            return $response;
-        }
-
-        $location = $response->getHeader('location');
-
-        if (!$location) {
-            return $response;
-        }
-
-        if (false === strpos($location, '//')) {
-            $socket = self::factory($this->host, $this->port, $this->ssl)->setPath($location);
-        } else {
-            $socket = self::factoryUrl($location);
-
-            if ($this->ssl && !$socket->ssl) {
+            if ('GET' !== $method || !$this->followRedirects || !$response->isRedirection()) {
                 return $response;
             }
-        }
 
-        $socket->setTimeout($this->timeout);
-        $socket->followRedirects($this->followRedirects - 1);
+            $location = $response->getHeader('location');
 
-        foreach ($this->headers as $key => $value) {
-            if ('Host' !== $key) {
-                $socket->addHeader($key, $value);
+            if (!$location) {
+                return $response;
             }
-        }
 
-        return $socket->doGet();
+            if (false === strpos($location, '//')) {
+                $socket = self::factory($this->host, $this->port, $this->ssl)->setPath($location);
+            } else {
+                $socket = self::factoryUrl($location);
+
+                if ($this->ssl && !$socket->ssl) {
+                    return $response;
+                }
+            }
+
+            $socket->setTimeout($this->timeout);
+            $socket->followRedirects($this->followRedirects - 1);
+
+            foreach ($this->headers as $key => $value) {
+                if ('Host' !== $key) {
+                    $socket->addHeader($key, $value);
+                }
+            }
+
+            return $socket->doGet();
+        });
     }
 
     /**

--- a/redaxo/src/core/lib/util/stopwatch.php
+++ b/redaxo/src/core/lib/util/stopwatch.php
@@ -1,0 +1,101 @@
+<?php
+
+class rex_stop_watch
+{
+    /**
+     * The minimum duration (in milliseconds) a callable needs to consume for beeing recorded.
+     * Faster callables will not be recorded.
+     *
+     * @var integer
+     */
+    const MIN_DURATION = 10;
+
+    /**
+     * List of already callables which exceeded MIN_DURATION
+     *
+     * @var string[]
+     */
+    public static $timers = array();
+
+    private $label;
+
+    private $start;
+
+    private $duration;
+
+    /**
+     *
+     * @param string $label
+     */
+    public function __construct($label)
+    {
+        $this->label = $label;
+    }
+
+    public function start()
+    {
+        if ($this->start) {
+            throw new LogicException('can only be started once.');
+        }
+        $this->start = microtime(true);
+    }
+
+    public function stop()
+    {
+        if (! $this->start) {
+            throw new LogicException('missing start() call before stop().');
+        }
+
+        $start = $this->start;
+        $label = $this->label;
+
+        $durationSec = microtime(true) - $start;
+        $durationMs = $durationSec * 1000;
+
+        // dont record events which are fast as hell.
+        if ($durationMs > self::MIN_DURATION) {
+            $this->duration = $durationMs;
+
+            $durationMs = number_format($durationMs, 3);
+
+            $uniqueLabel = $label;
+            $i = 1;
+            while (isset(self::$timers[$uniqueLabel])) {
+                $uniqueLabel = $label . $i;
+                $i++;
+            }
+            $this->probeMarker($uniqueLabel . ' ' . $durationMs . ' ms');
+            self::$timers[$uniqueLabel] = $durationMs;
+        }
+    }
+
+    public static function measure($label, callable $callable)
+    {
+        $watch = new self($label);
+
+        $watch->start();
+        $result = $callable();
+        $watch->stop();
+
+        return $result;
+    }
+
+    private function probeMarker($label)
+    {
+        // addMarker is available since ext-blackfire 1.15.0
+        // https://github.com/blackfireio/php-sdk/issues/23
+        if (class_exists('BlackfireProbe', false) && method_exists('BlackfireProbe', 'addMarker')) {
+            BlackfireProbe::addMarker($label);
+        }
+    }
+
+    /**
+     * Returns the measured duration in milliseconds
+     *
+     * @return float
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+}

--- a/redaxo/src/core/lib/util/stopwatch.php
+++ b/redaxo/src/core/lib/util/stopwatch.php
@@ -3,7 +3,7 @@
 class rex_stopwatch
 {
     /**
-     * List of already callables which exceeded MIN_DURATION.
+     * List of fired callables
      *
      * @var float[]
      */

--- a/redaxo/src/core/lib/util/stopwatch.php
+++ b/redaxo/src/core/lib/util/stopwatch.php
@@ -3,7 +3,7 @@
 class rex_stopwatch
 {
     /**
-     * List of fired callables
+     * List of fired callables.
      *
      * @var float[]
      */

--- a/redaxo/src/core/lib/util/stopwatch.php
+++ b/redaxo/src/core/lib/util/stopwatch.php
@@ -6,16 +6,16 @@ class rex_stopwatch
      * The minimum duration (in milliseconds) a callable needs to consume for beeing recorded.
      * Faster callables will not be recorded.
      *
-     * @var integer
+     * @var int
      */
     const MIN_DURATION = 10;
 
     /**
-     * List of already callables which exceeded MIN_DURATION
+     * List of already callables which exceeded MIN_DURATION.
      *
      * @var float[]
      */
-    public static $timers = array();
+    public static $timers = [];
 
     private $label;
 
@@ -24,7 +24,6 @@ class rex_stopwatch
     private $duration;
 
     /**
-     *
      * @param string $label
      */
     public function __construct($label)
@@ -42,7 +41,7 @@ class rex_stopwatch
 
     public function stop()
     {
-        if (! $this->start) {
+        if (!$this->start) {
             throw new LogicException('missing start() call before stop().');
         }
 
@@ -75,7 +74,7 @@ class rex_stopwatch
     }
 
     /**
-     * Returns the measured duration in milliseconds
+     * Returns the measured duration in milliseconds.
      *
      * @return float
      */

--- a/redaxo/src/core/lib/util/stopwatch.php
+++ b/redaxo/src/core/lib/util/stopwatch.php
@@ -1,6 +1,6 @@
 <?php
 
-class rex_stop_watch
+class rex_stopwatch
 {
     /**
      * The minimum duration (in milliseconds) a callable needs to consume for beeing recorded.
@@ -13,7 +13,7 @@ class rex_stop_watch
     /**
      * List of already callables which exceeded MIN_DURATION
      *
-     * @var string[]
+     * @var float[]
      */
     public static $timers = array();
 
@@ -56,16 +56,10 @@ class rex_stop_watch
         if ($durationMs > self::MIN_DURATION) {
             $this->duration = $durationMs;
 
-            $durationMs = number_format($durationMs, 3);
-
-            $uniqueLabel = $label;
-            $i = 1;
-            while (isset(self::$timers[$uniqueLabel])) {
-                $uniqueLabel = $label . $i;
-                $i++;
+            if (isset(self::$timers[$label])) {
+                $durationMs += self::$timers[$label];
             }
-            $this->probeMarker($uniqueLabel . ' ' . $durationMs . ' ms');
-            self::$timers[$uniqueLabel] = $durationMs;
+            self::$timers[$label] = $durationMs;
         }
     }
 
@@ -78,15 +72,6 @@ class rex_stop_watch
         $watch->stop();
 
         return $result;
-    }
-
-    private function probeMarker($label)
-    {
-        // addMarker is available since ext-blackfire 1.15.0
-        // https://github.com/blackfireio/php-sdk/issues/23
-        if (class_exists('BlackfireProbe', false) && method_exists('BlackfireProbe', 'addMarker')) {
-            BlackfireProbe::addMarker($label);
-        }
     }
 
     /**

--- a/redaxo/src/core/lib/util/stopwatch.php
+++ b/redaxo/src/core/lib/util/stopwatch.php
@@ -3,14 +3,6 @@
 class rex_stopwatch
 {
     /**
-     * The minimum duration (in milliseconds) a callable needs to consume for beeing recorded.
-     * Faster callables will not be recorded.
-     *
-     * @var int
-     */
-    const MIN_DURATION = 10;
-
-    /**
      * List of already callables which exceeded MIN_DURATION.
      *
      * @var float[]
@@ -50,16 +42,12 @@ class rex_stopwatch
 
         $durationSec = microtime(true) - $start;
         $durationMs = $durationSec * 1000;
+        $this->duration = $durationMs;
 
-        // dont record events which are fast as hell.
-        if ($durationMs > self::MIN_DURATION) {
-            $this->duration = $durationMs;
-
-            if (isset(self::$timers[$label])) {
-                $durationMs += self::$timers[$label];
-            }
-            self::$timers[$label] = $durationMs;
+        if (isset(self::$timers[$label])) {
+            $durationMs += self::$timers[$label];
         }
+        self::$timers[$label] = $durationMs;
     }
 
     public static function measure($label, callable $callable)


### PR DESCRIPTION
ziel ist ein grober performance überblick. hier kann z.B. aus sysadmin-vogelperspektive gesehen werden, ob locks die performance beeinflussen, das filesystem langsam ist, oder externe operationen die meiste zeit verbrauchen.

wer in-detail schwachstellen finden will muss einen richtigen profiler verwenden.

details zur idee im verlinkten issue.

Beispiel:

![image](https://user-images.githubusercontent.com/120441/50490975-31a28600-0a10-11e9-8dec-41e4d362e449.png)

closes https://github.com/redaxo/redaxo/issues/2333