### PR TITLE
Installer: extend exclude pattern, exclude some dev sources

### DIFF
--- a/redaxo/src/addons/install/lib/api_package_upload.php
+++ b/redaxo/src/addons/install/lib/api_package_upload.php
@@ -30,14 +30,18 @@ class rex_api_install_package_upload extends rex_api_function
         try {
             if ($upload['upload_file']) {
                 $archive = rex_path::addonCache('install', md5($addonkey . time()) . '.zip');
-                $exclude = [];
+                $excludeDirs = [];
+                $excludeFiles = [];
                 if ($upload['replace_assets']) {
-                    $exclude[] = 'assets';
+                    $excludeDirs[] = 'assets';
                 }
                 if ($upload['ignore_tests']) {
-                    $exclude[] = 'tests';
+                    $excludeDirs[] = 'tests';
                 }
-                rex_install_archive::copyDirToArchive(rex_path::addon($addonkey), $archive, null, $exclude);
+                $excludeDirs[] = '.git';
+                $excludeDirs[] = 'node_modules';
+                $excludeFiles[] = '.env';
+                rex_install_archive::copyDirToArchive(rex_path::addon($addonkey), $archive, null, $excludeDirs, $excludeFiles);
                 if ($upload['replace_assets']) {
                     rex_install_archive::copyDirToArchive(rex_url::addonAssets($addonkey), $archive, $addonkey . '/assets');
                 }

--- a/redaxo/src/addons/install/lib/api_package_upload.php
+++ b/redaxo/src/addons/install/lib/api_package_upload.php
@@ -38,7 +38,6 @@ class rex_api_install_package_upload extends rex_api_function
                 if ($upload['ignore_tests']) {
                     $excludeDirs[] = 'tests';
                 }
-                $excludeDirs[] = '.git';
                 $excludeDirs[] = 'node_modules';
                 $excludeFiles[] = '.env';
                 rex_install_archive::copyDirToArchive(rex_path::addon($addonkey), $archive, null, $excludeDirs, $excludeFiles);

--- a/redaxo/src/addons/install/lib/archive.php
+++ b/redaxo/src/addons/install/lib/archive.php
@@ -30,7 +30,7 @@ class rex_install_archive
         return rex_dir::copy($archive, $dir);
     }
 
-    public static function copyDirToArchive($dir, $archive, $basename = null, $excludeDirs = null)
+    public static function copyDirToArchive($dir, $archive, $basename = null, $excludeDirs = null, $excludeFiles = null)
     {
         $dir = rtrim($dir, '/\\');
         $basename = $basename ?: basename($dir);
@@ -39,6 +39,9 @@ class rex_install_archive
         $iterator = rex_finder::factory($dir)->recursive()->filesOnly();
         if ($excludeDirs) {
             $iterator->ignoreDirs($excludeDirs, false);
+        }
+        if ($excludeFiles) {
+            $iterator->ignoreFiles($excludeFiles, false);
         }
         foreach ($iterator as $path => $file) {
             $subpath = str_replace($dir, $basename, $path);


### PR DESCRIPTION
 - rename `$exclude` to `$excludeDirs`
- add `$excludeFiles`
- exclude dev sources: `node_modules`, `.git`
- exlude private sources: `.env`

ref #1272