### PR TITLE
fix(users): quote `admin`, reserved in MySQL 8

### DIFF
--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -518,8 +518,8 @@ if (isset($SHOW) && $SHOW) {
             id,
             IF(name <> "", name, login) as name,
             login,
-            admin,
-            IF(admin, "Admin", IFNULL((SELECT GROUP_CONCAT(name ORDER BY name SEPARATOR ",") FROM '.rex::getTable('user_role').' r WHERE FIND_IN_SET(r.id, u.role)), "'.$noRole.'")) as role,
+            `admin`,
+            IF(`admin`, "Admin", IFNULL((SELECT GROUP_CONCAT(name ORDER BY name SEPARATOR ",") FROM '.rex::getTable('user_role').' r WHERE FIND_IN_SET(r.id, u.role)), "'.$noRole.'")) as role,
             status,
             lastlogin
         FROM ' . rex::getTable('user') . ' u


### PR DESCRIPTION
With MySQL 8, `admin` has become a reserved word, see https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-new-8-0-A
It becomes nonreserved again with MySQL 8.0.12, see https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-8-0-detailed-A

Use quoted to avoid exceptions!