### PR TITLE
Markdown-Pages: Sprachvariante unterstützen

### DIFF
--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -430,6 +430,11 @@ class rex_be_controller
             return self::includePath($path, $context);
         }
 
+        $languagePath = substr($path, 0, -3).'.'.rex_i18n::getLanguage().'.md';
+        if (is_readable($languagePath)) {
+            $path = $languagePath;
+        }
+
         $fragment = new rex_fragment();
         $fragment->setVar('content', rex_markdown::factory()->parse(rex_file::get($path)), false);
         $content = $fragment->parse('core/page/docs.php');


### PR DESCRIPTION
Analog zur Readme-Ausgabe in der Addons-Page sollten aus meiner Sicht allgemein bei Markdown-Pages Sprachvarianten unterstützt werden.

Beispiel:

```yaml
pages:
    title: Mein Addon
    subpages:
        foo: { title: Foo }
        readme: { title: Hilfe, subPath: Readme.md }
```

Wenn es eine `Readme.de.md` gibt, wird diese stattdessen genommen.

Refs #1862