### PR TITLE
rex_escape anstelle von htmlspecialchars

### DIFF
--- a/redaxo/src/core/lib/form/elements/checkbox.php
+++ b/redaxo/src/core/lib/form/elements/checkbox.php
@@ -39,7 +39,7 @@ class rex_form_checkbox_element extends rex_form_options_element
             if ($attributeName == 'name' || $attributeName == 'id') {
                 continue;
             }
-            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . htmlspecialchars($attributeValue, 'html_attr') . '"';
+            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . rex_escape($attributeValue, 'html_attr') . '"';
         }
 
         $formElements = [];


### PR DESCRIPTION
rex_escape anstelle von htmlspecialchars
fix for https://github.com/redaxo/redaxo/issues/2346, close