### PR TITLE
fix phpdoc

### DIFF
--- a/redaxo/src/addons/be_style/lib/be_style.php
+++ b/redaxo/src/addons/be_style/lib/be_style.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package redaxo\be_style
+ * @package redaxo\be-style
  *
  * @author bloep
  */

--- a/redaxo/src/addons/be_style/lib/command/compile.php
+++ b/redaxo/src/addons/be_style/lib/command/compile.php
@@ -4,7 +4,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @package redaxo\be_style
+ * @package redaxo\be-style
  *
  * @author bloep
  *


### PR DESCRIPTION
Im Namespace muss bei uns immer aus `_` ein `-` werden, da unsere Api-Doc-Lib ein `_` auch als Namespace-Trenner interpretiert.