### PR TITLE
Autoloader-Reload aktivieren bei Debug-Modus

### DIFF
--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -105,7 +105,7 @@ class rex_autoload
         // but only if an admin is logged in
         if (
             (!self::$reloaded || $force) &&
-            (rex::isSetup() || rex::getConsole() || ($user = rex_backend_login::createUser()) && $user->isAdmin())
+            (rex::isSetup() || rex::getConsole() || rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin())
         ) {
             self::reload($force);
             return self::autoload($class);


### PR DESCRIPTION
Aus meiner Sicht sollte sich der Autoloader bei aktiviertem Debug-Modus genauso verhalten, wie wenn ein Admin eingeloggt ist.