### PR TITLE
Performanceoptimierte rex_stopwatch

### DIFF
--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -96,12 +96,10 @@ class rex_response
 
     private static function sendServerTimingHeaders()
     {
-        if (rex::isDebugMode() || ($user = rex::getUser()) && $user->isAdmin()) {
-            // see https://w3c.github.io/server-timing/#the-server-timing-header-field
-            foreach (rex_stopwatch::$timers as $label => $durationMs) {
-                $label = preg_replace('{[^!#$%&\'*+-\.\^_`|~\w]}i', '_', $label);
-                header('Server-Timing: '. $label .';dur='. number_format($durationMs, 3, '.', ''), false);
-            }
+        // see https://w3c.github.io/server-timing/#the-server-timing-header-field
+        foreach (rex_stopwatch::$timers as $label => $durationMs) {
+            $label = preg_replace('{[^!#$%&\'*+-\.\^_`|~\w]}i', '_', $label);
+            header('Server-Timing: '. $label .';dur='. number_format($durationMs, 3, '.', ''), false);
         }
     }
 

--- a/redaxo/src/core/lib/util/stopwatch.php
+++ b/redaxo/src/core/lib/util/stopwatch.php
@@ -55,6 +55,19 @@ class rex_stopwatch
 
     public static function measure($label, callable $callable)
     {
+        static $enabled = false;
+
+        // we might get called very early in the process, in which case we can't determine yet whether the user is logged in.
+        // this also means, in debug-mode we get more timings in comparison to admin-only timings.
+        if (!$enabled) {
+            // dont create the user (can cause session locks), to prevent influencing the things we try to measure.
+            $enabled = rex::isDebugMode() || ($user = rex::getUser()) && $user->isAdmin();
+        }
+
+        if (!$enabled) {
+            return $callable();
+        }
+
         $watch = new self($label);
 
         $watch->start();


### PR DESCRIPTION
hier mal eine max-perf-optimierte variante der rex_stopwatch.

hier kostet uns eine stopwatch nur ~3-fn calls, sollte also quasi gar nicht mehr ins gewicht fallen.

motiviert aus der diskussion in https://github.com/redaxo/redaxo/pull/2360#issuecomment-450579198