### PR TITLE
minibar: In popups wird die minibar per default nicht gerendert

### DIFF
--- a/redaxo/src/core/lib/minibar/minibar.php
+++ b/redaxo/src/core/lib/minibar/minibar.php
@@ -63,6 +63,12 @@ class rex_minibar
         }
 
         if (rex::isBackend()) {
+            $page = rex_be_controller::getCurrentPageObject();
+
+            if ($page && $page->isPopup()) {
+                return false;
+            }
+
             return true;
         }
 


### PR DESCRIPTION
refs https://github.com/redaxo/redaxo/issues/2348

da es bisher keine argumente gab, warum in popups die minibar dargestellt werden sollte - wird hier die von dirk vorgeschlagene änderung umgesetzt.

die minibar wird in popups somit nicht dargestellt. addons/plugins können via `rex_minibar->getInstance()->setActive(true)` nach eigenem gusto die minibar aktivieren (siehe https://github.com/redaxo/redaxo/pull/2377).

falls es doch noch gut argumente gibt die minibar in popups anzeigen zu wollen/müssen, können wir das ja gerne wieder reverten.