### PR TITLE
rex_view: async/defered optionen für javascript dateien unterstützen

### DIFF
--- a/redaxo/src/core/fragments/core/top.php
+++ b/redaxo/src/core/fragments/core/top.php
@@ -27,32 +27,27 @@
     foreach ($this->jsFiles as $file) {
         if (is_string($file)) {
             // BC Case
+            $options = array();
+        } else {
+            list($file, $options) = $file;
+        }
+
+        if (array_key_exists(rex_view::JS_IMMUTABLE, $options) && $options[rex_view::JS_IMMUTABLE]) {
             $path = rex_path::frontend(rex_path::absolute($file));
             if (strpos($path, $assetDir) === 0 && $mtime = @filemtime($path)) {
                 $file = rex_url::backendController(['asset' => $file, 'buster' => $mtime]);
             }
-
-            echo "\n" . '    <script type="text/javascript" src="' . $file .'"></script>';
-        } else {
-            list($file, $options) = $file;
-
-            if (array_key_exists(rex_view::JS_IMMUTABLE, $options) && $options[rex_view::JS_IMMUTABLE]) {
-                $path = rex_path::frontend(rex_path::absolute($file));
-                if (strpos($path, $assetDir) === 0 && $mtime = @filemtime($path)) {
-                    $file = rex_url::backendController(['asset' => $file, 'buster' => $mtime]);
-                }
-            }
-
-            $attributes = [];
-            if (array_key_exists(rex_view::JS_ASYNC, $options) && $options[rex_view::JS_ASYNC]) {
-                $attributes[] = 'async="async"';
-            }
-            if (array_key_exists(rex_view::JS_DEFERED, $options) && $options[rex_view::JS_DEFERED]) {
-                $attributes[] = 'defer="defer"';
-            }
-
-            echo "\n" . '    <script type="text/javascript" src="' . $file .'" '. implode(' ', $attributes) .'></script>';
         }
+
+        $attributes = [];
+        if (array_key_exists(rex_view::JS_ASYNC, $options) && $options[rex_view::JS_ASYNC]) {
+            $attributes[] = 'async="async"';
+        }
+        if (array_key_exists(rex_view::JS_DEFERED, $options) && $options[rex_view::JS_DEFERED]) {
+            $attributes[] = 'defer="defer"';
+        }
+
+        echo "\n" . '    <script type="text/javascript" src="' . $file .'" '. implode(' ', $attributes) .'></script>';
     }
 ?>
 

--- a/redaxo/src/core/fragments/core/top.php
+++ b/redaxo/src/core/fragments/core/top.php
@@ -25,11 +25,34 @@
     echo "\n" . '    //-->';
     echo "\n" . '    </script>';
     foreach ($this->jsFiles as $file) {
-        $path = rex_path::frontend(rex_path::absolute($file));
-        if (strpos($path, $assetDir) === 0 && $mtime = @filemtime($path)) {
-            $file = rex_url::backendController(['asset' => $file, 'buster' => $mtime]);
+        if (is_string($file)) {
+            // BC Case
+            $path = rex_path::frontend(rex_path::absolute($file));
+            if (strpos($path, $assetDir) === 0 && $mtime = @filemtime($path)) {
+                $file = rex_url::backendController(['asset' => $file, 'buster' => $mtime]);
+            }
+
+            echo "\n" . '    <script type="text/javascript" src="' . $file .'"></script>';
+        } else {
+            list($file, $options) = $file;
+
+            if (array_key_exists(rex_view::JS_IMMUTABLE, $options) && $options[rex_view::JS_IMMUTABLE]) {
+                $path = rex_path::frontend(rex_path::absolute($file));
+                if (strpos($path, $assetDir) === 0 && $mtime = @filemtime($path)) {
+                    $file = rex_url::backendController(['asset' => $file, 'buster' => $mtime]);
+                }
+            }
+
+            $attributes = [];
+            if (array_key_exists(rex_view::JS_ASYNC, $options) && $options[rex_view::JS_ASYNC]) {
+                $attributes[] = 'async="async"';
+            }
+            if (array_key_exists(rex_view::JS_DEFERED, $options) && $options[rex_view::JS_DEFERED]) {
+                $attributes[] = 'defer="defer"';
+            }
+
+            echo "\n" . '    <script type="text/javascript" src="' . $file .'" '. implode(' ', $attributes) .'></script>';
         }
-        echo "\n" . '    <script type="text/javascript" src="' . $file .'"></script>';
     }
 ?>
 

--- a/redaxo/src/core/layout/top.php
+++ b/redaxo/src/core/layout/top.php
@@ -207,7 +207,7 @@ if (!rex_request::isPJAXContainer('#rex-js-page-container')) {
     $fragment = new rex_fragment();
     $fragment->setVar('pageTitle', rex_be_controller::getPageTitle());
     $fragment->setVar('cssFiles', rex_view::getCssFiles());
-    $fragment->setVar('jsFiles', rex_view::getJsFiles());
+    $fragment->setVar('jsFiles', rex_view::getJsFilesWithOptions());
     $fragment->setVar('jsProperties', json_encode(rex_view::getJsProperties()), false);
     $fragment->setVar('favicon', rex_view::getFavicon());
     $fragment->setVar('pageHeader', rex_extension::registerPoint(new rex_extension_point('PAGE_HEADER', '')), false);

--- a/redaxo/src/core/lib/view.php
+++ b/redaxo/src/core/lib/view.php
@@ -5,6 +5,10 @@
  */
 class rex_view
 {
+    const JS_DEFERED = 'defer';
+    const JS_ASYNC = 'async';
+    const JS_IMMUTABLE = 'immutable';
+
     private static $cssFiles = [];
     private static $jsFiles = [];
     private static $jsProperties = [];
@@ -44,13 +48,17 @@ class rex_view
      *
      * @throws rex_exception
      */
-    public static function addJsFile($file)
+    public static function addJsFile($file, array $options = [])
     {
+        if (empty($options)) {
+            $options[self::JS_IMMUTABLE] = true;
+        }
+
         if (in_array($file, self::$jsFiles)) {
             throw new rex_exception(sprintf('The JS file "%s" is already added.', $file));
         }
 
-        self::$jsFiles[] = $file;
+        self::$jsFiles[] = [$file, $options];
     }
 
     /**
@@ -59,6 +67,19 @@ class rex_view
      * @return string[]
      */
     public static function getJsFiles()
+    {
+        // transform for BC
+        return array_map(function ($jsFile) {
+            return $jsFile[0];
+        }, self::$jsFiles);
+    }
+
+    /**
+     * Returns all JS files besides their options.
+     *
+     * @return array
+     */
+    public static function getJsFilesWithOptions()
     {
         return self::$jsFiles;
     }

--- a/redaxo/src/core/tests/view_text.php
+++ b/redaxo/src/core/tests/view_text.php
@@ -1,0 +1,40 @@
+<?php
+
+class rex_view_test extends PHPUnit_Framework_TestCase
+{
+    public function testAddGetCss() {
+        rex_view::addCssFile('my.css');
+        $files = rex_view::getCssFiles()['all'];
+        $this->assertTrue(end($files) == 'my.css');
+
+        rex_view::addCssFile('print.css', 'print');
+        $files = rex_view::getCssFiles()['print'];
+        $this->assertTrue(end($files) == 'print.css');
+    }
+
+    public function testAddGetJs() {
+        rex_view::addJsFile('my.js');
+        $files = rex_view::getJsFiles();
+        $this->assertTrue(end($files) == 'my.js');
+    }
+
+    public function testAddGetJsWithOptions() {
+        rex_view::addJsFile('my.js');
+        $files = rex_view::getJsFilesWithOptions();
+        list($file, $options) = end($files);
+        $this->assertTrue($file == 'my.js');
+        $this->assertTrue($options == [rex_view::JS_IMMUTABLE => true], 'options default to JS_IMMUTABLE');
+
+        rex_view::addJsFile('my.js', [rex_view::JS_IMMUTABLE => true]);
+        $files = rex_view::getJsFilesWithOptions();
+        list($file, $options) = end($files);
+        $this->assertTrue($file == 'my.js');
+        $this->assertTrue($options == [rex_view::JS_IMMUTABLE => true], 'explicit JS_IMMUTABLE option');
+
+        rex_view::addJsFile('my_async.js', [rex_view::JS_ASYNC => true, rex_view::JS_DEFERED => true]);
+        $files = rex_view::getJsFilesWithOptions();
+        list($file, $options) = end($files);
+        $this->assertTrue($file == 'my_async.js');
+        $this->assertTrue($options == [rex_view::JS_ASYNC => true, rex_view::JS_DEFERED => true], 'multiple options');
+    }
+}

--- a/redaxo/src/core/tests/view_text.php
+++ b/redaxo/src/core/tests/view_text.php
@@ -2,7 +2,8 @@
 
 class rex_view_test extends PHPUnit_Framework_TestCase
 {
-    public function testAddGetCss() {
+    public function testAddGetCss()
+    {
         rex_view::addCssFile('my.css');
         $files = rex_view::getCssFiles()['all'];
         $this->assertTrue(end($files) == 'my.css');
@@ -12,13 +13,15 @@ class rex_view_test extends PHPUnit_Framework_TestCase
         $this->assertTrue(end($files) == 'print.css');
     }
 
-    public function testAddGetJs() {
+    public function testAddGetJs()
+    {
         rex_view::addJsFile('my.js');
         $files = rex_view::getJsFiles();
         $this->assertTrue(end($files) == 'my.js');
     }
 
-    public function testAddGetJsWithOptions() {
+    public function testAddGetJsWithOptions()
+    {
         rex_view::addJsFile('my.js');
         $files = rex_view::getJsFilesWithOptions();
         list($file, $options) = end($files);


### PR DESCRIPTION
Motivation:
in tinymce müssen wir für 5.7 das immutable flag abschalten um https://github.com/redaxo/redaxo/issues/2341 zu lösen

Beispiel-Aufruf mit allen Optionen:

```php
rex_view::addJsFile(
  rex_url::addonAssets('tinymce4', 'tinymce/tinymce.min.js'),
  [rex_view::JS_IMMUTABLE => false, rex_view::JS_ASYNC => true, rex_view::JS_DEFERED => true]
);
```

refs https://github.com/redaxo/redaxo/issues/2269