### PR TITLE
rex_escape: nicht unnötig html_attr nutzen

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/boot.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/boot.php
@@ -141,7 +141,7 @@ if (rex::isBackend() && rex::getUser()) {
     if ($config['showlink']) {
         rex_view::setJsProperty(
             'customizer_showlink',
-            '<h1 class="be-style-customizer-title"><a href="'. rex_escape(rex::getServer(), 'html_attr') .'" target="_blank" rel="noreferrer noopener"><span class="be-style-customizer-title-name">' . rex_escape(rex::getServerName()) . '</span><i class="fa fa-external-link"></i></a></h1>'
+            '<h1 class="be-style-customizer-title"><a href="'. rex_escape(rex::getServer()) .'" target="_blank" rel="noreferrer noopener"><span class="be-style-customizer-title-name">' . rex_escape(rex::getServerName()) . '</span><i class="fa fa-external-link"></i></a></h1>'
         );
     }
 }

--- a/redaxo/src/addons/cronjob/lib/form.php
+++ b/redaxo/src/addons/cronjob/lib/form.php
@@ -164,8 +164,8 @@ class rex_cronjob_form_interval_element extends rex_form_element
         $checked = 'all' === $value ? ' checked="checked"' : '';
 
         $elements[] = [
-            'label' => '<label class="control-label" for="' . rex_escape($id, 'html_attr') . '">' . $optionAll . '</label>',
-            'field' => '<input type="checkbox" id="' . rex_escape($id, 'html_attr') . '" name="' . rex_escape($name, 'html_attr') . '" value="all"' . $checked . ' />',
+            'label' => '<label class="control-label" for="' . rex_escape($id) . '">' . $optionAll . '</label>',
+            'field' => '<input type="checkbox" id="' . rex_escape($id) . '" name="' . rex_escape($name) . '" value="all"' . $checked . ' />',
         ];
 
         $fragment = new rex_fragment();
@@ -182,8 +182,8 @@ class rex_cronjob_form_interval_element extends rex_form_element
             $checked = is_array($value) && in_array($key, $value) ? ' checked="checked"' : '';
 
             $elements[] = [
-                'label' => '<label class="control-label" for="' . rex_escape($id, 'html_attr') . '">' . $label . '</label>',
-                'field' => '<input type="checkbox" id="' . rex_escape($id, 'html_attr') . '" name="' . rex_escape($name, 'html_attr') . '" value="' . $key . '"' . $checked . ' />',
+                'label' => '<label class="control-label" for="' . rex_escape($id) . '">' . $label . '</label>',
+                'field' => '<input type="checkbox" id="' . rex_escape($id) . '" name="' . rex_escape($name) . '" value="' . $key . '"' . $checked . ' />',
             ];
         }
 

--- a/redaxo/src/addons/install/pages/packages.upload.php
+++ b/redaxo/src/addons/install/pages/packages.upload.php
@@ -38,7 +38,7 @@ if ($addonkey && isset($addons[$addonkey])) {
         $n = [];
         $n['label'] = '<label for="rex-js-install-packages-upload-version">' . $this->i18n('version') . '</label>';
         $n['field'] = '<p class="form-control-static" id="rex-js-install-packages-upload-version">' . rex_escape($new ? $newVersion : $file['version']) . '</p>
-                           <input type="hidden" name="upload[oldversion]" value="' . rex_escape($file['version'], 'html_attr') . '" />';
+                           <input type="hidden" name="upload[oldversion]" value="' . rex_escape($file['version']) . '" />';
         $formElements[] = $n;
 
         $n = [];

--- a/redaxo/src/addons/install/pages/settings.php
+++ b/redaxo/src/addons/install/pages/settings.php
@@ -52,12 +52,12 @@ $panel .= '
 
                 $n = [];
                 $n['label'] = '<label for="install-settings-api-login">' . $this->i18n('settings_api_login') . '</label>';
-                $n['field'] = '<input class="form-control" id="install-settings-api-login" type="text" name="settings[api_login]" value="' . rex_escape($config['api_login'], 'html_attr') . '" />';
+                $n['field'] = '<input class="form-control" id="install-settings-api-login" type="text" name="settings[api_login]" value="' . rex_escape($config['api_login']) . '" />';
                 $formElements[] = $n;
 
                 $n = [];
                 $n['label'] = '<label for="install-settings-api-key">' . $this->i18n('settings_api_key') . '</label>';
-                $n['field'] = '<input class="form-control" id="install-settings-api-key" type="text" name="settings[api_key]" value="' . rex_escape($config['api_key'], 'html_attr') . '" />';
+                $n['field'] = '<input class="form-control" id="install-settings-api-key" type="text" name="settings[api_key]" value="' . rex_escape($config['api_key']) . '" />';
                 $formElements[] = $n;
 
                 $fragment = new rex_fragment();

--- a/redaxo/src/addons/media_manager/pages/settings.php
+++ b/redaxo/src/addons/media_manager/pages/settings.php
@@ -40,8 +40,8 @@ $formElements = [];
 $inputGroups = [];
 $n = [];
 $n['class'] = 'rex-range-input-group';
-$n['left'] = '<input id="rex-js-rating-source-jpg-quality" type="range" min="0" max="100" step="1" value="' . rex_escape($this->getConfig('jpg_quality'), 'html_attr') . '" />';
-$n['field'] = '<input class="form-control" id="rex-js-rating-text-jpg-quality" type="text" name="settings[jpg_quality]" value="' . rex_escape($this->getConfig('jpg_quality'), 'html_attr') . '" />';
+$n['left'] = '<input id="rex-js-rating-source-jpg-quality" type="range" min="0" max="100" step="1" value="' . rex_escape($this->getConfig('jpg_quality')) . '" />';
+$n['field'] = '<input class="form-control" id="rex-js-rating-text-jpg-quality" type="text" name="settings[jpg_quality]" value="' . rex_escape($this->getConfig('jpg_quality')) . '" />';
 $inputGroups[] = $n;
 
 $fragment = new rex_fragment();
@@ -56,8 +56,8 @@ $formElements[] = $n;
 $inputGroups = [];
 $n = [];
 $n['class'] = 'rex-range-input-group';
-$n['left'] = '<input id="rex-js-rating-source-webp-quality" type="range" min="0" max="100" step="1" value="' . rex_escape($this->getConfig('webp_quality'), 'html_attr') . '" />';
-$n['field'] = '<input class="form-control" id="rex-js-rating-text-webp-quality" type="text" name="settings[webp_quality]" value="' . rex_escape($this->getConfig('webp_quality'), 'html_attr') . '" />';
+$n['left'] = '<input id="rex-js-rating-source-webp-quality" type="range" min="0" max="100" step="1" value="' . rex_escape($this->getConfig('webp_quality')) . '" />';
+$n['field'] = '<input class="form-control" id="rex-js-rating-text-webp-quality" type="text" name="settings[webp_quality]" value="' . rex_escape($this->getConfig('webp_quality')) . '" />';
 $inputGroups[] = $n;
 
 $fragment = new rex_fragment();
@@ -72,8 +72,8 @@ $formElements[] = $n;
 $inputGroups = [];
 $n = [];
 $n['class'] = 'rex-range-input-group';
-$n['left'] = '<input id="rex-js-rating-source-png-compression" type="range" min="0" max="9" step="1" value="' . rex_escape($this->getConfig('png_compression'), 'html_attr') . '" />';
-$n['field'] = '<input class="form-control" id="rex-js-rating-text-png-compression" type="text" name="settings[png_compression]" value="' . rex_escape($this->getConfig('png_compression'), 'html_attr') . '" />';
+$n['left'] = '<input id="rex-js-rating-source-png-compression" type="range" min="0" max="9" step="1" value="' . rex_escape($this->getConfig('png_compression')) . '" />';
+$n['field'] = '<input class="form-control" id="rex-js-rating-text-png-compression" type="text" name="settings[png_compression]" value="' . rex_escape($this->getConfig('png_compression')) . '" />';
 $inputGroups[] = $n;
 
 $fragment = new rex_fragment();

--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -453,12 +453,12 @@ function rex_mediapool_Mediaform($form_title, $button_title, $rex_file_category,
 
     $arg_fields = '';
     foreach (rex_request('args', 'array') as $arg_name => $arg_value) {
-        $arg_fields .= '<input type="hidden" name="args[' . rex_escape($arg_name, 'html_attr') . ']" value="' . rex_escape($arg_value, 'html_attr') . '" />' . "\n";
+        $arg_fields .= '<input type="hidden" name="args[' . rex_escape($arg_name) . ']" value="' . rex_escape($arg_value) . '" />' . "\n";
     }
 
     $opener_input_field = rex_request('opener_input_field', 'string');
     if ($opener_input_field != '') {
-        $arg_fields .= '<input type="hidden" name="opener_input_field" value="' . rex_escape($opener_input_field, 'html_attr') . '" />' . "\n";
+        $arg_fields .= '<input type="hidden" name="opener_input_field" value="' . rex_escape($opener_input_field) . '" />' . "\n";
     }
 
     $add_submit = '';
@@ -477,7 +477,7 @@ function rex_mediapool_Mediaform($form_title, $button_title, $rex_file_category,
 
     $e = [];
     $e['label'] = '<label for="rex-mediapool-title">' . rex_i18n::msg('pool_file_title') . '</label>';
-    $e['field'] = '<input class="form-control" type="text" id="rex-mediapool-title" name="ftitle" value="' . rex_escape($ftitle, 'html_attr') . '" />';
+    $e['field'] = '<input class="form-control" type="text" id="rex-mediapool-title" name="ftitle" value="' . rex_escape($ftitle) . '" />';
     $formElements[] = $e;
 
     $fragment = new rex_fragment();

--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -251,13 +251,13 @@ class rex_media
 
         if (!isset($params['alt'])) {
             if ($title != '') {
-                $params['alt'] = rex_escape($title, 'html_attr');
+                $params['alt'] = rex_escape($title);
             }
         }
 
         if (!isset($params['title'])) {
             if ($title != '') {
-                $params['title'] = rex_escape($title, 'html_attr');
+                $params['title'] = rex_escape($title);
             }
         }
 

--- a/redaxo/src/addons/mediapool/pages/index.php
+++ b/redaxo/src/addons/mediapool/pages/index.php
@@ -21,7 +21,7 @@ $error = preg_replace($regex, '<$1>', $error);
 $arg_url = ['args' => $args];
 $arg_fields = '';
 foreach ($args as $arg_name => $arg_value) {
-    $arg_fields .= '<input type="hidden" name="args[' . rex_escape($arg_name, 'html_attr') . ']" value="' . rex_escape($arg_value, 'html_attr') . '" />' . "\n";
+    $arg_fields .= '<input type="hidden" name="args[' . rex_escape($arg_name) . ']" value="' . rex_escape($arg_value) . '" />' . "\n";
 }
 
 // ----- opener_input_field setzen
@@ -39,7 +39,7 @@ if ($opener_input_field != '') {
     }
 
     $arg_url['opener_input_field'] = $opener_input_field;
-    $arg_fields .= '<input type="hidden" id="opener_input_field" name="opener_input_field" value="' . rex_escape($opener_input_field, 'html_attr') . '" data-opener-id="'. $opener_id .'"/>' . "\n";
+    $arg_fields .= '<input type="hidden" id="opener_input_field" name="opener_input_field" value="' . rex_escape($opener_input_field) . '" data-opener-id="'. $opener_id .'"/>' . "\n";
 }
 
 // -------------- CatId in Session speichern

--- a/redaxo/src/addons/mediapool/pages/media.detail.php
+++ b/redaxo/src/addons/mediapool/pages/media.detail.php
@@ -132,7 +132,7 @@ if ($isImage) {
     } else {
         $sidebar = '
                 <a href="' . $img_max . '">
-                    <img class="img-responsive" src="' . $imgn . '"' . $width . ' alt="' . rex_escape($ftitle, 'html_attr') . '" title="' . rex_escape($ftitle, 'html_attr') . '" />
+                    <img class="img-responsive" src="' . $imgn . '"' . $width . ' alt="' . rex_escape($ftitle) . '" title="' . rex_escape($ftitle) . '" />
                 </a>';
     }
 }
@@ -185,7 +185,7 @@ if ($TPERM) {
 
     $e = [];
     $e['label'] = '<label for="rex-mediapool-title">' . rex_i18n::msg('pool_file_title') . '</label>';
-    $e['field'] = '<input class="form-control" type="text" id="rex-mediapool-title" name="ftitle" value="' . rex_escape($ftitle, 'html_attr') . '" />';
+    $e['field'] = '<input class="form-control" type="text" id="rex-mediapool-title" name="ftitle" value="' . rex_escape($ftitle) . '" />';
     $formElements[] = $e;
 
     $e = [];

--- a/redaxo/src/addons/mediapool/pages/media.list.php
+++ b/redaxo/src/addons/mediapool/pages/media.list.php
@@ -248,7 +248,7 @@ $panel = '
                     $alt = '';
                     foreach (['title'] as $col) {
                         if ($files->hasValue($col) && $files->getValue($col) != '') {
-                            $alt = rex_escape($files->getValue($col), 'html_attr');
+                            $alt = rex_escape($files->getValue($col));
                             break;
                         }
                     }

--- a/redaxo/src/addons/mediapool/pages/media.php
+++ b/redaxo/src/addons/mediapool/pages/media.php
@@ -37,7 +37,7 @@ echo rex_extension::registerPoint(new rex_extension_point('PAGE_MEDIAPOOL_HEADER
 
 $formElements = [];
 $n = [];
-$n['field'] = '<input class="form-control" type="text" name="media_name" id="be_search-media-name" value="' . rex_escape($media_name, 'html_attr') . '" />';
+$n['field'] = '<input class="form-control" type="text" name="media_name" id="be_search-media-name" value="' . rex_escape($media_name) . '" />';
 $n['before'] = $sel_media->get();
 $n['right'] = '<button class="btn btn-search" type="submit"><i class="rex-icon rex-icon-search"></i></button>';
 $formElements[] = $n;

--- a/redaxo/src/addons/mediapool/pages/structure.php
+++ b/redaxo/src/addons/mediapool/pages/structure.php
@@ -129,7 +129,7 @@ if ($PERMALL) {
                 <tr class="mark">
                     <td class="rex-table-icon"><i class="rex-icon rex-icon-media-category"></i></td>
                     <td class="rex-table-id" data-title="' . rex_i18n::msg('id') . '">' . $iid . '</td>
-                    <td data-title="' . rex_i18n::msg('pool_kat_name') . '"><input class="form-control" type="text" name="cat_name" value="' . rex_escape($iname, 'html_attr') . '" /></td>
+                    <td data-title="' . rex_i18n::msg('pool_kat_name') . '"><input class="form-control" type="text" name="cat_name" value="' . rex_escape($iname) . '" /></td>
                     <td class="rex-table-action" colspan="2">
                         <input type="hidden" name="edit_id" value="' . $edit_id . '" />
                         <button class="btn btn-save" type="submit" value="' . rex_i18n::msg('pool_kat_update') . '"' . rex::getAccesskey(rex_i18n::msg('pool_kat_update'), 'save') . '>' . rex_i18n::msg('pool_kat_update') . '</button>
@@ -139,7 +139,7 @@ if ($PERMALL) {
         } else {
             $table .= '
                 <tr>
-                    <td class="rex-table-icon"><a href="' . $link . $iid . '" title="' . rex_escape($OOCat->getName(), 'html_attr') . '"><i class="rex-icon rex-icon-media-category"></i></a></td>
+                    <td class="rex-table-icon"><a href="' . $link . $iid . '" title="' . rex_escape($OOCat->getName()) . '"><i class="rex-icon rex-icon-media-category"></i></a></td>
                     <td class="rex-table-id" data-title="' . rex_i18n::msg('id') . '">' . $iid . '</td>
                     <td data-title="' . rex_i18n::msg('pool_kat_name') . '"><a href="' . $link . $iid . '">' . rex_escape($OOCat->getName()) . '</a></td>
                     <td class="rex-table-action"><a href="' . $link . $cat_id . '&amp;media_method=update_file_cat&amp;edit_id=' . $iid . '"><i class="rex-icon rex-icon-edit"></i> ' . rex_i18n::msg('pool_kat_edit') . '</a></td>

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -69,7 +69,7 @@ abstract class rex_metainfo_handler
                 $label = rex_escape($name);
             }
 
-            $id = 'rex-metainfo-'.rex_escape(preg_replace('/[^a-zA-Z0-9_-]/', '_', $name), 'html_attr');
+            $id = 'rex-metainfo-'.rex_escape(preg_replace('/[^a-zA-Z0-9_-]/', '_', $name));
             $labelIt = true;
 
             $label = '<label for="' . $id . '">' . $label . '</label>';
@@ -181,10 +181,10 @@ abstract class rex_metainfo_handler
                         if ($oneValue) {
                             $e['label'] = $label;
                         } else {
-                            $currentId .= '-'.rex_escape(preg_replace('/[^a-zA-Z0-9_-]/', '_', $key), 'html_attr');
-                            $e['label'] = '<label for="' . $currentId . '">' . rex_escape($value, 'html_attr') . '</label>';
+                            $currentId .= '-'.rex_escape(preg_replace('/[^a-zA-Z0-9_-]/', '_', $key));
+                            $e['label'] = '<label for="' . $currentId . '">' . rex_escape($value) . '</label>';
                         }
-                        $e['field'] = '<input type="' . $typeLabel . '" name="' . $name . '" value="' . rex_escape($key, 'html_attr') . '" id="' . $currentId . '" ' . $attrStr . $selected . ' />';
+                        $e['field'] = '<input type="' . $typeLabel . '" name="' . $name . '" value="' . rex_escape($key) . '" id="' . $currentId . '" ' . $attrStr . $selected . ' />';
                         $formElements[] = $e;
                     }
 

--- a/redaxo/src/addons/metainfo/lib/input/text.php
+++ b/redaxo/src/addons/metainfo/lib/input/text.php
@@ -16,7 +16,7 @@ class rex_input_text extends rex_input
 
     public function getHtml()
     {
-        $value = rex_escape($this->value, 'html_attr');
+        $value = rex_escape($this->value);
         return '<input' . $this->getAttributeString() . ' value="' . $value . '" />';
     }
 }

--- a/redaxo/src/addons/metainfo/pages/content.metainfo.php
+++ b/redaxo/src/addons/metainfo/pages/content.metainfo.php
@@ -20,7 +20,7 @@ $form = $metainfoHandler->getForm([
 
 $n = [];
 $n['label'] = '<label for="rex-id-meta-article-name">' . rex_i18n::msg('header_article_name') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="rex-id-meta-article-name" name="meta_article_name" value="' . rex_escape(rex_article::get($article_id, $clang)->getValue('name'), 'html_attr') . '" />';
+$n['field'] = '<input class="form-control" type="text" id="rex-id-meta-article-name" name="meta_article_name" value="' . rex_escape(rex_article::get($article_id, $clang)->getValue('name')) . '" />';
 $formElements = [$n];
 
 $fragment = new rex_fragment();

--- a/redaxo/src/addons/structure/functions/function_rex_searchbar.php
+++ b/redaxo/src/addons/structure/functions/function_rex_searchbar.php
@@ -201,7 +201,7 @@ function rex_structure_searchbar(rex_context $context)
 
     $formElements = [];
     $n = [];
-    $n['field'] = '<input class="form-control" type="text" name="search_article_name" value="' . rex_escape($search_article_name, 'html_attr') . '" placeholder="' . rex_escape(rex_i18n::msg('be_search_article_name') . '/' . rex_i18n::msg('be_search_article_id'), 'html_attr') . '" />';
+    $n['field'] = '<input class="form-control" type="text" name="search_article_name" value="' . rex_escape($search_article_name) . '" placeholder="' . rex_escape(rex_i18n::msg('be_search_article_name') . '/' . rex_i18n::msg('be_search_article_id')) . '" />';
     $n['right'] = '<button class="btn btn-search" type="submit" name="search_start" value="1">' . rex_i18n::msg('be_search_start') . '</button>';
     $formElements[] = $n;
 

--- a/redaxo/src/addons/structure/lib/linkmap/var_link.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_link.php
@@ -70,7 +70,7 @@ class rex_var_link extends rex_var
         }
 
         $e = [];
-        $e['field'] = '<input class="form-control" type="text" name="REX_LINK_NAME[' . $id . ']" value="' . rex_escape($art_name, 'html_attr') . '" id="REX_LINK_' . $id . '_NAME" readonly="readonly" /><input type="hidden" name="' . $name . '" id="REX_LINK_' . $id . '" value="' . $value . '" />';
+        $e['field'] = '<input class="form-control" type="text" name="REX_LINK_NAME[' . $id . ']" value="' . rex_escape($art_name) . '" id="REX_LINK_' . $id . '_NAME" readonly="readonly" /><input type="hidden" name="' . $name . '" id="REX_LINK_' . $id . '" value="' . $value . '" />';
         $e['functionButtons'] = '
                         <a href="#" class="btn btn-popup' . $class . '" onclick="' . $open_func . 'return false;" title="' . rex_i18n::msg('var_link_open') . '"><i class="rex-icon rex-icon-open-linkmap"></i></a>
                         <a href="#" class="btn btn-popup' . $class . '" onclick="' . $delete_func . 'return false;" title="' . rex_i18n::msg('var_link_delete') . '"><i class="rex-icon rex-icon-delete-link"></i></a>';

--- a/redaxo/src/addons/structure/lib/structure_element.php
+++ b/redaxo/src/addons/structure/lib/structure_element.php
@@ -408,7 +408,7 @@ abstract class rex_structure_element
     public function toLink(array $params = [], array $attributes = [], $sorroundTag = null, array $sorroundAttributes = [])
     {
         $name = $this->getName();
-        $link = '<a href="' . $this->getUrl($params) . '"' . $this->_toAttributeString($attributes) . ' title="' . rex_escape($name, 'html_attr') . '">' . rex_escape($name) . '</a>';
+        $link = '<a href="' . $this->getUrl($params) . '"' . $this->_toAttributeString($attributes) . ' title="' . rex_escape($name) . '">' . rex_escape($name) . '</a>';
 
         if ($sorroundTag !== null && is_string($sorroundTag)) {
             $link = '<' . $sorroundTag . $this->_toAttributeString($sorroundAttributes) . '>' . $link . '</' . $sorroundTag . '>';

--- a/redaxo/src/addons/structure/pages/index.php
+++ b/redaxo/src/addons/structure/pages/index.php
@@ -206,7 +206,7 @@ if ($KAT->getRows() > 0) {
         $i_category_id = $KAT->getValue('id');
 
         $kat_link = $context->getUrl(['category_id' => $i_category_id]);
-        $kat_icon_td = '<td class="rex-table-icon"><a href="' . $kat_link . '" title="' . rex_escape($KAT->getValue('catname'), 'html_attr') . '"><i class="rex-icon rex-icon-category"></i></a></td>';
+        $kat_icon_td = '<td class="rex-table-icon"><a href="' . $kat_link . '" title="' . rex_escape($KAT->getValue('catname')) . '"><i class="rex-icon rex-icon-category"></i></a></td>';
 
         $kat_status = $catStatusTypes[$KAT->getValue('status')][0];
         $status_class = $catStatusTypes[$KAT->getValue('status')][1];
@@ -241,8 +241,8 @@ if ($KAT->getRows() > 0) {
                     <tr class="' . $class . '">
                         ' . $kat_icon_td . '
                         <td class="rex-table-id" data-title="' . rex_i18n::msg('header_id') . '">' . $i_category_id . '</td>
-                        <td data-title="' . rex_i18n::msg('header_category') . '"><input class="form-control" type="text" name="category-name" value="' . rex_escape($KAT->getValue('catname'), 'html_attr') . '" class="rex-js-autofocus" autofocus /></td>
-                        <td class="rex-table-priority" data-title="' . rex_i18n::msg('header_priority') . '"><input class="form-control" type="text" name="category-position" value="' . rex_escape($KAT->getValue('catpriority'), 'html_attr') . '" /></td>
+                        <td data-title="' . rex_i18n::msg('header_category') . '"><input class="form-control" type="text" name="category-name" value="' . rex_escape($KAT->getValue('catname')) . '" class="rex-js-autofocus" autofocus /></td>
+                        <td class="rex-table-priority" data-title="' . rex_i18n::msg('header_priority') . '"><input class="form-control" type="text" name="category-position" value="' . rex_escape($KAT->getValue('catpriority')) . '" /></td>
                         <td class="rex-table-action">' . $meta_buttons . '</td>
                         <td class="rex-table-action" colspan="2">' . $add_buttons . '</td>
                     </tr>';
@@ -477,12 +477,12 @@ if ($category_id > 0 || ($category_id == 0 && !rex::getUser()->getComplexPerm('s
                 $tmpl_td = '<td data-title="' . rex_i18n::msg('header_template') . '">' . $template_select->get() . '</td>';
             }
             $echo .= '<tr class="mark' . $class_startarticle . '">
-                            <td class="rex-table-icon"><a href="' . $context->getUrl(['page' => 'content/edit', 'article_id' => $sql->getValue('id')]) . '" title="' . rex_escape($sql->getValue('name'), 'html_attr') . '"><i class="rex-icon' . $class . '"></i></a></td>
+                            <td class="rex-table-icon"><a href="' . $context->getUrl(['page' => 'content/edit', 'article_id' => $sql->getValue('id')]) . '" title="' . rex_escape($sql->getValue('name')) . '"><i class="rex-icon' . $class . '"></i></a></td>
                             <td class="rex-table-id" data-title="' . rex_i18n::msg('header_id') . '">' . $sql->getValue('id') . '</td>
-                            <td data-title="' . rex_i18n::msg('header_article_name') . '"><input class="form-control" type="text" name="article-name" value="' . rex_escape($sql->getValue('name'), 'html_attr') . '" autofocus /></td>
+                            <td data-title="' . rex_i18n::msg('header_article_name') . '"><input class="form-control" type="text" name="article-name" value="' . rex_escape($sql->getValue('name')) . '" autofocus /></td>
                             ' . $tmpl_td . '
                             <td data-title="' . rex_i18n::msg('header_date') . '">' . rex_formatter::strftime($sql->getDateTimeValue('createdate'), 'date') . '</td>
-                            <td class="rex-table-priority" data-title="' . rex_i18n::msg('header_priority') . '"><input class="form-control" type="text" name="article-position" value="' . rex_escape($sql->getValue('priority'), 'html_attr') . '" /></td>
+                            <td class="rex-table-priority" data-title="' . rex_i18n::msg('header_priority') . '"><input class="form-control" type="text" name="article-position" value="' . rex_escape($sql->getValue('priority')) . '" /></td>
                             <td class="rex-table-action" colspan="3">'.rex_api_article_edit::getHiddenFields().'<button class="btn btn-save" type="submit" name="artedit_function"' . rex::getAccesskey(rex_i18n::msg('article_save'), 'save') . '>' . rex_i18n::msg('article_save') . '</button></td>
                         </tr>';
         } elseif ($KATPERM) {
@@ -518,7 +518,7 @@ if ($category_id > 0 || ($category_id == 0 && !rex::getUser()->getComplexPerm('s
             }
 
             $echo .= '<tr' . (($class_startarticle != '') ? ' class="' . trim($class_startarticle) . '"' : '') . '>
-                            <td class="rex-table-icon"><a href="' . $editModeUrl . '" title="' . rex_escape($sql->getValue('name'), 'html_attr') . '"><i class="rex-icon' . $class . '"></i></a></td>
+                            <td class="rex-table-icon"><a href="' . $editModeUrl . '" title="' . rex_escape($sql->getValue('name')) . '"><i class="rex-icon' . $class . '"></i></a></td>
                             <td class="rex-table-id" data-title="' . rex_i18n::msg('header_id') . '">' . $sql->getValue('id') . '</td>
                             <td data-title="' . rex_i18n::msg('header_article_name') . '"><a href="' . $editModeUrl . '">' . rex_escape($sql->getValue('name')) . '</a></td>
                             ' . $tmpl_td . '

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
@@ -236,7 +236,7 @@ if ($function == 'add' || $function == 'edit') {
 
         $n = [];
         $n['label'] = '<label for="name">' . rex_i18n::msg('action_name') . '</label>';
-        $n['field'] = '<input class="form-control" type="text" id="name" name="name" value="' . rex_escape($name, 'html_attr') . '" />';
+        $n['field'] = '<input class="form-control" type="text" id="name" name="name" value="' . rex_escape($name) . '" />';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();
@@ -489,7 +489,7 @@ if ($OUT) {
 
             $content .= '
                         <tr>
-                            <td class="rex-table-icon"><a href="' . rex_url::currentBackendPage(['action_id' => $sql->getValue('id'), 'function' => 'edit']) . '" title="' . rex_escape($sql->getValue('name'), 'html_attr') . '"><i class="rex-icon rex-icon-action"></i></a></td>
+                            <td class="rex-table-icon"><a href="' . rex_url::currentBackendPage(['action_id' => $sql->getValue('id'), 'function' => 'edit']) . '" title="' . rex_escape($sql->getValue('name')) . '"><i class="rex-icon rex-icon-action"></i></a></td>
                             <td class="rex-table-id" data-title="' . rex_i18n::msg('id') . '">' . $sql->getValue('id') . '</td>
                             <td data-title="' . rex_i18n::msg('action_name') . '"><a href="' . rex_url::currentBackendPage(['action_id' => $sql->getValue('id'), 'function' => 'edit']) . '">' . rex_escape($sql->getValue('name')) . '</a></td>
                             <td data-title="' . rex_i18n::msg('action_header_preview') . '">' . implode('/', $previewmode) . '</td>

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
@@ -214,7 +214,7 @@ if ($function == 'add' || $function == 'edit') {
 
         $n = [];
         $n['label'] = '<label for="mname">' . rex_i18n::msg('module_name') . '</label>';
-        $n['field'] = '<input class="form-control" id="mname" type="text" name="mname" value="' . rex_escape($mname, 'html_attr') . '" />';
+        $n['field'] = '<input class="form-control" id="mname" type="text" name="mname" value="' . rex_escape($mname) . '" />';
         $formElements[] = $n;
 
         $n = [];
@@ -279,7 +279,7 @@ if ($function == 'add' || $function == 'edit') {
                     $action_name = rex_i18n::translate($gma->getValue('name'));
 
                     $actions .= '<tr>
-                        <td class="rex-table-icon"><a href="' . $action_edit_url . '" title="' . rex_escape($action_name, 'html_attr') . '"><i class="rex-icon rex-icon-action"></i></a></td>
+                        <td class="rex-table-icon"><a href="' . $action_edit_url . '" title="' . rex_escape($action_name) . '"><i class="rex-icon rex-icon-action"></i></a></td>
                         <td class="rex-table-id" data-title="' . rex_i18n::msg('id') . '">' . $gma->getValue('id') . '</td>
                         <td data-title="' . rex_i18n::msg('action_name') . '"><a href="' . $action_edit_url . '">' . $action_name . '</a></td>
                         <td class="rex-table-action"><a href="' . $action_edit_url . '"><i class="rex-icon rex-icon-edit"></i> ' . rex_i18n::msg('edit') . '</a></td>

--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -254,7 +254,7 @@ if ($function == 'add' || $function == 'edit') {
                 $formElements = [];
                 $n = [];
                 $n['label'] = '<label for="rex-id-ctype' . $i . '">' . rex_i18n::msg('name') . '</label>';
-                $n['field'] = '<input class="form-control" id="rex-id-ctype' . $i . '" type="text" name="ctype[' . $i . ']" value="' . rex_escape($name, 'html_attr') . '" />';
+                $n['field'] = '<input class="form-control" id="rex-id-ctype' . $i . '" type="text" name="ctype[' . $i . ']" value="' . rex_escape($name) . '" />';
                 $formElements[] = $n;
 
                 $fragment = new rex_fragment();
@@ -345,7 +345,7 @@ if ($function == 'add' || $function == 'edit') {
         $formElements = [];
         $n = [];
         $n['label'] = '<label for="rex-id-templatename">' . rex_i18n::msg('template_name') . '</label>';
-        $n['field'] = '<input class="form-control" id="rex-id-templatename" type="text" name="templatename" value="' . rex_escape($templatename, 'html_attr') . '" />';
+        $n['field'] = '<input class="form-control" id="rex-id-templatename" type="text" name="templatename" value="' . rex_escape($templatename) . '" />';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -367,7 +367,7 @@ if ($FUNC_ADD != '' || $user_id > 0) {
             $add_admin_chkbox = '';
         }
         $add_status_chkbox = '<input type="checkbox" id="rex-user-status" name="userstatus" value="1" ' . $statuschecked . ' />';
-        $add_user_login = '<input class="form-control" type="text" id="rex-user-login" name="userlogin" value="' . rex_escape($userlogin, 'html_attr') . '" autofocus />';
+        $add_user_login = '<input class="form-control" type="text" id="rex-user-login" name="userlogin" value="' . rex_escape($userlogin) . '" autofocus />';
 
         $formElements = [];
 
@@ -406,17 +406,17 @@ if ($FUNC_ADD != '' || $user_id > 0) {
 
     $n = [];
     $n['label'] = '<label for="rex-user-name">' . rex_i18n::msg('name') . '</label>';
-    $n['field'] = '<input class="form-control" type="text" id="rex-user-name" name="username" value="' . rex_escape($username, 'html_attr') . '" />';
+    $n['field'] = '<input class="form-control" type="text" id="rex-user-name" name="username" value="' . rex_escape($username) . '" />';
     $formElements[] = $n;
 
     $n = [];
     $n['label'] = '<label for="rex-user-description">' . rex_i18n::msg('description') . '</label>';
-    $n['field'] = '<input class="form-control" type="text" id="rex-user-description" name="userdesc" value="' . rex_escape($userdesc, 'html_attr') . '" />';
+    $n['field'] = '<input class="form-control" type="text" id="rex-user-description" name="userdesc" value="' . rex_escape($userdesc) . '" />';
     $formElements[] = $n;
 
     $n = [];
     $n['label'] = '<label for="rex-user-email">' . rex_i18n::msg('email') . '</label>';
-    $n['field'] = '<input class="form-control" type="email" placeholder="name@domain.tld" id="rex-user-email" name="useremail" value="' . rex_escape($useremail, 'html_attr') . '" />';
+    $n['field'] = '<input class="form-control" type="email" placeholder="name@domain.tld" id="rex-user-email" name="useremail" value="' . rex_escape($useremail) . '" />';
     $formElements[] = $n;
 
     $fragment = new rex_fragment();

--- a/redaxo/src/core/functions/function_rex_escape.php
+++ b/redaxo/src/core/functions/function_rex_escape.php
@@ -12,14 +12,10 @@
  * @param mixed  $value    The value to escape
  * @param string $strategy Supported strategies:
  *                         "html": escapes a string for the HTML context.
- *                         "html_attr": escapes a string for the HTML attrubute context. It is only necessary for dynamic
- *                              attribute names and attribute values without quotes (`data-foo=bar`). For attribute values
- *                              within quotes you can use default strategy "html".
+ *                         "html_attr": escapes a string for the HTML attrubute context. It is only necessary for dynamic attribute names and attribute values without quotes (`data-foo=bar`). For attribute values within quotes you can use default strategy "html".
  *                         "js": escapes a string for the JavaScript/JSON context.
- *                         "css": escapes a string for the CSS context. CSS escaping can be applied to any string being
- *                              inserted into CSS and escapes everything except alphanumerics.
- *                         "url": escapes a string for the URI or parameter contexts. This should not be used to escape
- *                              an entire URI; only a subcomponent being inserted.
+ *                         "css": escapes a string for the CSS context. CSS escaping can be applied to any string being inserted into CSS and escapes everything except alphanumerics.
+ *                         "url": escapes a string for the URI or parameter contexts. This should not be used to escape an entire URI; only a subcomponent being inserted.
  *
  * @throws InvalidArgumentException
  *

--- a/redaxo/src/core/functions/function_rex_escape.php
+++ b/redaxo/src/core/functions/function_rex_escape.php
@@ -10,7 +10,16 @@
  * @package redaxo\core
  *
  * @param mixed  $value    The value to escape
- * @param string $strategy One of "html", "html_attr", "css", "js", "url"
+ * @param string $strategy Supported strategies:
+ *                         "html": escapes a string for the HTML context.
+ *                         "html_attr": escapes a string for the HTML attrubute context. It is only necessary for dynamic
+ *                              attribute names and attribute values without quotes (`data-foo=bar`). For attribute values
+ *                              within quotes you can use default strategy "html".
+ *                         "js": escapes a string for the JavaScript/JSON context.
+ *                         "css": escapes a string for the CSS context. CSS escaping can be applied to any string being
+ *                              inserted into CSS and escapes everything except alphanumerics.
+ *                         "url": escapes a string for the URI or parameter contexts. This should not be used to escape
+ *                              an entire URI; only a subcomponent being inserted.
  *
  * @throws InvalidArgumentException
  *

--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -129,7 +129,7 @@ abstract class rex_api_function
         // remove the `rex_api_` prefix
         $name = substr($class, 8);
 
-        return sprintf('<input type="hidden" name="%s" value="%s"/>', self::REQ_CALL_PARAM, rex_escape($name, 'html_attr'))
+        return sprintf('<input type="hidden" name="%s" value="%s"/>', self::REQ_CALL_PARAM, rex_escape($name))
             .rex_csrf_token::factory($class)->getHiddenField();
     }
 

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -152,10 +152,10 @@ class rex_context implements rex_context_provider_interface
         foreach ($array as $name => $value) {
             if (is_array($value)) {
                 foreach ($value as $valName => $valVal) {
-                    $inputString .= '<input type="hidden" name="' . rex_escape($name, 'html_attr') . '[' . rex_escape($valName, 'html_attr') . ']" value="' . rex_escape($valVal, 'html_attr') . '" />';
+                    $inputString .= '<input type="hidden" name="' . rex_escape($name) . '[' . rex_escape($valName) . ']" value="' . rex_escape($valVal) . '" />';
                 }
             } else {
-                $inputString .= '<input type="hidden" name="' . rex_escape($name, 'html_attr') . '" value="' . rex_escape($value, 'html_attr') . '" />';
+                $inputString .= '<input type="hidden" name="' . rex_escape($name) . '" value="' . rex_escape($value) . '" />';
             }
         }
 

--- a/redaxo/src/core/lib/form/elements/checkbox.php
+++ b/redaxo/src/core/lib/form/elements/checkbox.php
@@ -39,7 +39,7 @@ class rex_form_checkbox_element extends rex_form_options_element
             if ($attributeName == 'name' || $attributeName == 'id') {
                 continue;
             }
-            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . rex_escape($attributeValue, 'html_attr') . '"';
+            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . rex_escape($attributeValue) . '"';
         }
 
         $formElements = [];
@@ -49,12 +49,12 @@ class rex_form_checkbox_element extends rex_form_options_element
             if ($opt_value != '') {
                 $opt_id .= '-' . rex_string::normalize($opt_value, '-');
             }
-            $opt_attr = $attr . ' id="' . rex_escape($opt_id, 'html_attr') . '"';
+            $opt_attr = $attr . ' id="' . rex_escape($opt_id) . '"';
             $checked = in_array($opt_value, $values) ? ' checked="checked"' : '';
 
             $n = [];
-            $n['label'] = '<label class="control-label" for="' . rex_escape($opt_id, 'html_attr') . '">' . rex_escape($opt_name) . '</label>';
-            $n['field'] = '<input type="checkbox" name="' . rex_escape($name, 'html_attr') . '[' . rex_escape($opt_value, 'html_attr') . ']" value="' . rex_escape($opt_value, 'html_attr') . '"' . $opt_attr . $checked . ' />';
+            $n['label'] = '<label class="control-label" for="' . rex_escape($opt_id) . '">' . rex_escape($opt_name) . '</label>';
+            $n['field'] = '<input type="checkbox" name="' . rex_escape($name) . '[' . rex_escape($opt_value) . ']" value="' . rex_escape($opt_value) . '"' . $opt_attr . $checked . ' />';
             $formElements[] = $n;
         }
 

--- a/redaxo/src/core/lib/form/elements/container.php
+++ b/redaxo/src/core/lib/form/elements/container.php
@@ -96,12 +96,12 @@ class rex_form_container_element extends rex_form_element
                 continue;
             }
 
-            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . rex_escape($attributeValue, 'html_attr') . '"';
+            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . rex_escape($attributeValue) . '"';
         }
 
         $format = '';
         foreach ($this->fields as $group => $groupFields) {
-            $format .= '<div id="rex-' . rex_escape($group, 'html_attr') . '"' . $attr . '>';
+            $format .= '<div id="rex-' . rex_escape($group) . '"' . $attr . '>';
             foreach ($groupFields as $field) {
                 $format .= $field->get();
             }

--- a/redaxo/src/core/lib/form/elements/element.php
+++ b/redaxo/src/core/lib/form/elements/element.php
@@ -223,7 +223,7 @@ class rex_form_element
         $tag = rex_escape($this->getTag(), 'html_attr');
 
         foreach ($this->getAttributes() as $attributeName => $attributeValue) {
-            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . rex_escape($attributeValue, 'html_attr') . '"';
+            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . rex_escape($attributeValue) . '"';
         }
 
         if ($this->hasSeparateEnding()) {
@@ -232,7 +232,7 @@ class rex_form_element
             }
             return '<' . $tag . $attr . '>' . rex_escape($value) . '</' . $tag . '>';
         }
-        $attr .= ' value="' . rex_escape($value, 'html_attr') . '"';
+        $attr .= ' value="' . rex_escape($value) . '"';
         return '<' . $tag . $attr . ' />';
     }
 

--- a/redaxo/src/core/lib/form/elements/radio.php
+++ b/redaxo/src/core/lib/form/elements/radio.php
@@ -31,7 +31,7 @@ class rex_form_radio_element extends rex_form_options_element
             if ($attributeName == 'id') {
                 continue;
             }
-            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . rex_escape($attributeValue, 'html_attr') . '"';
+            $attr .= ' ' . rex_escape($attributeName, 'html_attr') . '="' . rex_escape($attributeValue) . '"';
         }
 
         $formElements = [];
@@ -43,7 +43,7 @@ class rex_form_radio_element extends rex_form_options_element
 
             $n = [];
             $n['label'] = '<label class="control-label" for="' . $opt_id . '">' . rex_escape($opt_name) . '</label>';
-            $n['field'] = '<input type="radio" value="' . rex_escape($opt_value, 'html_attr') . '"' . $opt_attr . $checked . ' />';
+            $n['field'] = '<input type="radio" value="' . rex_escape($opt_value) . '"' . $opt_attr . $checked . ' />';
             $formElements[] = $n;
         }
 

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -917,7 +917,7 @@ class rex_list implements rex_url_provider_interface
         $s = '';
 
         foreach ($array as $name => $value) {
-            $s .= ' ' . rex_escape($name, 'html_attr') . '="' . rex_escape($value, 'html_attr') . '"';
+            $s .= ' ' . rex_escape($name, 'html_attr') . '="' . rex_escape($value) . '"';
         }
 
         return $s;

--- a/redaxo/src/core/lib/select.php
+++ b/redaxo/src/core/lib/select.php
@@ -121,7 +121,7 @@ class rex_select
                 $this->setSelected($sectvalue);
             }
         } else {
-            $this->option_selected[] = (string) rex_escape($selected, 'html_attr');
+            $this->option_selected[] = (string) rex_escape($selected);
         }
     }
 
@@ -239,7 +239,7 @@ class rex_select
         foreach ($this->options as $optgroup => $options) {
             $this->currentOptgroup = $optgroup;
             if ($optgroupLabel = isset($this->optgroups[$optgroup]) ? $this->optgroups[$optgroup] : null) {
-                $ausgabe .= '  <optgroup label="' . rex_escape($optgroupLabel, 'html_attr') . '">' . "\n";
+                $ausgabe .= '  <optgroup label="' . rex_escape($optgroupLabel) . '">' . "\n";
             }
             if (is_array($options)) {
                 $ausgabe .= $this->outGroup(0);
@@ -293,7 +293,7 @@ class rex_select
         $name = rex_escape($name);
         // for BC reasons, we always expect value to be a string.
         // this also makes sure that the strict in_array() check below works.
-        $value = (string) rex_escape($value, 'html_attr');
+        $value = (string) rex_escape($value);
 
         $bsps = '';
         if ($level > 0) {

--- a/redaxo/src/core/lib/util/formatter.php
+++ b/redaxo/src/core/lib/util/formatter.php
@@ -289,7 +289,7 @@ abstract class rex_formatter
             $value = 'http://' . $value;
         }
 
-        return '<a href="' . rex_escape($value . $format['params'], 'html_attr') . '"' . $format['attr'] . '>' . rex_escape($value) . '</a>';
+        return '<a href="' . rex_escape($value . $format['params']) . '"' . $format['attr'] . '>' . rex_escape($value) . '</a>';
     }
 
     /**
@@ -319,7 +319,7 @@ abstract class rex_formatter
             }
         }
         // Url formatierung
-        return '<a href="mailto:' . rex_escape($value . $format['params'], 'html_attr') . '"' . $format['attr'] . '>' . rex_escape($value) . '</a>';
+        return '<a href="mailto:' . rex_escape($value . $format['params']) . '"' . $format['attr'] . '>' . rex_escape($value) . '</a>';
     }
 
     /**

--- a/redaxo/src/core/pages/login.php
+++ b/redaxo/src/core/pages/login.php
@@ -46,7 +46,7 @@ $formElements = [];
 
 $inputGroups = [];
 $n = [];
-$n['field'] = '<input class="form-control" type="text" value="' . rex_escape($rex_user_login, 'html_attr') . '" id="rex-id-login-user" name="rex_user_login" autofocus />';
+$n['field'] = '<input class="form-control" type="text" value="' . rex_escape($rex_user_login) . '" id="rex-id-login-user" name="rex_user_login" autofocus />';
 $n['left'] = '<i class="rex-icon rex-icon-user"></i>';
 $inputGroups[] = $n;
 

--- a/redaxo/src/core/pages/packages.php
+++ b/redaxo/src/core/pages/packages.php
@@ -186,7 +186,7 @@ if ($subpage == '') {
                         <td data-title="' . rex_i18n::msg('package_hname') . '">' . $name . '</td>
                         <td data-title="' . rex_i18n::msg('package_hversion') . '">' . $version . '</td>
                         <td class="rex-table-slim" data-title="' . rex_i18n::msg('package_hhelp') . '">
-                            <a href="' . rex_url::currentBackendPage(['subpage' => 'help', 'package' => $packageId]) . '" title="' . rex_i18n::msg('package_help') . ' ' . rex_escape($package->getName(), 'html_attr') . '"><i class="rex-icon rex-icon-help"></i> ' . rex_i18n::msg('package_hhelp') . ' <span class="sr-only">' . rex_escape($package->getName()) . '</span></a>
+                            <a href="' . rex_url::currentBackendPage(['subpage' => 'help', 'package' => $packageId]) . '" title="' . rex_i18n::msg('package_help') . ' ' . rex_escape($package->getName()) . '"><i class="rex-icon rex-icon-help"></i> ' . rex_i18n::msg('package_hhelp') . ' <span class="sr-only">' . rex_escape($package->getName()) . '</span></a>
                         </td>
                         <td class="rex-table-width-6" data-title="' . rex_i18n::msg('package_hlicense') . '">'. $license .'</td>
                         <td class="rex-table-action" data-pjax-container="#rex-js-page-container">' . $install . '</td>

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -151,17 +151,17 @@ $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="rex-id-username">' . rex_i18n::msg('name') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="rex-id-username" name="username" value="' . rex_escape($username, 'html_attr') . '" autofocus />';
+$n['field'] = '<input class="form-control" type="text" id="rex-id-username" name="username" value="' . rex_escape($username) . '" autofocus />';
 $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="rex-id-userdesc">' . rex_i18n::msg('description') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="rex-id-userdesc" name="userdesc" value="' . rex_escape($userdesc, 'html_attr') . '" />';
+$n['field'] = '<input class="form-control" type="text" id="rex-id-userdesc" name="userdesc" value="' . rex_escape($userdesc) . '" />';
 $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="rex-id-useremail">' . rex_i18n::msg('email') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="rex-id-useremail" name="useremail" value="' . rex_escape($useremail, 'html_attr') . '" />';
+$n['field'] = '<input class="form-control" type="text" id="rex-id-useremail" name="useremail" value="' . rex_escape($useremail) . '" />';
 $formElements[] = $n;
 
 $fragment = new rex_fragment();

--- a/redaxo/src/core/pages/system.clangs.php
+++ b/redaxo/src/core/pages/system.clangs.php
@@ -115,8 +115,8 @@ if ($func == 'addclang') {
                 <tr class="mark">
                     <td class="rex-table-icon"><i class="rex-icon rex-icon-language"></i></td>
                     <td class="rex-table-id" data-title="' . rex_i18n::msg('id') . '">–</td>
-                    <td data-title="' . rex_i18n::msg('clang_code') . '"><input class="form-control" type="text" id="rex-form-clang-code" name="clang_code" value="' . rex_escape($clang_code, 'html_attr') . '" autofocus /></td>
-                    <td data-title="' . rex_i18n::msg('clang_name') . '"><input class="form-control" type="text" id="rex-form-clang-name" name="clang_name" value="' . rex_escape($clang_name, 'html_attr') . '" /></td>
+                    <td data-title="' . rex_i18n::msg('clang_code') . '"><input class="form-control" type="text" id="rex-form-clang-code" name="clang_code" value="' . rex_escape($clang_code) . '" autofocus /></td>
+                    <td data-title="' . rex_i18n::msg('clang_name') . '"><input class="form-control" type="text" id="rex-form-clang-name" name="clang_name" value="' . rex_escape($clang_name) . '" /></td>
                     <td class="rex-table-priority" data-title="' . rex_i18n::msg('clang_priority') . '"><input class="form-control" type="text" id="rex-form-clang-prio" name="clang_prio" value="' . ($clang_prio ?: rex_clang::count() + 1) . '" /></td>
                     <td class="rex-table-action">' . $metaButtons . '</td>
                     <td class="rex-table-action" colspan="2"><button class="btn btn-save" type="submit" name="add_clang_save"' . rex::getAccesskey(rex_i18n::msg('clang_add'), 'save') . ' value="1">' . rex_i18n::msg('clang_add') . '</button></td>
@@ -148,9 +148,9 @@ foreach ($sql as $row) {
                     <tr class="mark">
                         <td class="rex-table-icon"><i class="rex-icon rex-icon-language"></i></td>
                         ' . $add_td . '
-                        <td data-title="' . rex_i18n::msg('clang_code') . '"><input class="form-control" type="text" id="rex-form-clang-code" name="clang_code" value="' . rex_escape($sql->getValue('code'), 'html_attr') . '" autofocus /></td>
-                        <td data-title="' . rex_i18n::msg('clang_name') . '"><input class="form-control" type="text" id="rex-form-clang-name" name="clang_name" value="' . rex_escape($sql->getValue('name'), 'html_attr') . '" /></td>
-                        <td class="rex-table-priority" data-title="' . rex_i18n::msg('clang_priority') . '"><input class="form-control" type="text" id="rex-form-clang-prio" name="clang_prio" value="' . rex_escape($sql->getValue('priority'), 'html_attr') . '" /></td>
+                        <td data-title="' . rex_i18n::msg('clang_code') . '"><input class="form-control" type="text" id="rex-form-clang-code" name="clang_code" value="' . rex_escape($sql->getValue('code')) . '" autofocus /></td>
+                        <td data-title="' . rex_i18n::msg('clang_name') . '"><input class="form-control" type="text" id="rex-form-clang-name" name="clang_name" value="' . rex_escape($sql->getValue('name')) . '" /></td>
+                        <td class="rex-table-priority" data-title="' . rex_i18n::msg('clang_priority') . '"><input class="form-control" type="text" id="rex-form-clang-prio" name="clang_prio" value="' . rex_escape($sql->getValue('priority')) . '" /></td>
                         <td class="rex-table-action">' . $metaButtons . '</td>
                         <td class="rex-table-action" colspan="2"><button class="btn btn-save" type="submit" name="edit_clang_save"' . rex::getAccesskey(rex_i18n::msg('clang_update'), 'save') . ' value="1">' . rex_i18n::msg('clang_update') . '</button></td>
                     </tr>';
@@ -164,7 +164,7 @@ foreach ($sql as $row) {
 
         $content .= '
                     <tr>
-                        <td class="rex-table-icon"><a href="' . $editLink . '" title="' . rex_escape($clang_name, 'html_attr') . '"><i class="rex-icon rex-icon-language"></i></a></td>
+                        <td class="rex-table-icon"><a href="' . $editLink . '" title="' . rex_escape($clang_name) . '"><i class="rex-icon rex-icon-language"></i></a></td>
                         ' . $add_td . '
                         <td data-title="' . rex_i18n::msg('clang_code') . '">' . rex_escape($sql->getValue('code')) . '</td>
                         <td data-title="' . rex_i18n::msg('clang_name') . '">' . rex_escape($sql->getValue('name')) . '</td>

--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -175,17 +175,17 @@ $formElements = [];
 
 $n = [];
 $n['label'] = '<label for="rex-id-server">' . rex_i18n::msg('server') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="rex-id-server" name="settings[server]" value="' . rex_escape(rex::getServer(), 'html_attr') . '" />';
+$n['field'] = '<input class="form-control" type="text" id="rex-id-server" name="settings[server]" value="' . rex_escape(rex::getServer()) . '" />';
 $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="rex-id-servername">' . rex_i18n::msg('servername') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="rex-id-servername" name="settings[servername]" value="' . rex_escape(rex::getServerName(), 'html_attr') . '" />';
+$n['field'] = '<input class="form-control" type="text" id="rex-id-servername" name="settings[servername]" value="' . rex_escape(rex::getServerName()) . '" />';
 $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="rex-id-error-email">' . rex_i18n::msg('error_email') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="rex-id-error-email" name="settings[error_email]" value="' . rex_escape(rex::getErrorEmail(), 'html_attr') . '" />';
+$n['field'] = '<input class="form-control" type="text" id="rex-id-error-email" name="settings[error_email]" value="' . rex_escape(rex::getErrorEmail()) . '" />';
 $formElements[] = $n;
 
 $fragment = new rex_fragment();

--- a/redaxo/src/core/tests/context_test.php
+++ b/redaxo/src/core/tests/context_test.php
@@ -20,13 +20,13 @@ class rex_context_test extends PHPUnit_Framework_TestCase
         $context = new rex_context($globalParams);
 
         $this->assertEquals(
-            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a&#x20;b&#x24;c&amp;&#x3F;&gt;" />',
+            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a b$c&amp;?&gt;" />',
             $context->getHiddenInputFields(),
             'parameters get properly encoded'
         );
 
         $this->assertEquals(
-            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a&#x20;b&#x24;c&amp;&#x3F;&gt;" /><input type="hidden" name="&lt;mystr&gt;" value="abc" />',
+            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a b$c&amp;?&gt;" /><input type="hidden" name="&lt;mystr&gt;" value="abc" />',
             $context->getHiddenInputFields(['<mystr>' => 'abc']),
             'names get properly encoded'
         );
@@ -38,19 +38,19 @@ class rex_context_test extends PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a&#x20;b&#x24;c&amp;&#x3F;&gt;" /><input type="hidden" name="str2" value="xyz" />',
+            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a b$c&amp;?&gt;" /><input type="hidden" name="str2" value="xyz" />',
             $context->getHiddenInputFields(['str2' => 'xyz']),
             'new params are appended'
         );
 
         $this->assertEquals(
-            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a&#x20;b&#x24;c&amp;&#x3F;&gt;" /><input type="hidden" name="myarr[0]" value="xyz" /><input type="hidden" name="myarr[1]" value="123" />',
+            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a b$c&amp;?&gt;" /><input type="hidden" name="myarr[0]" value="xyz" /><input type="hidden" name="myarr[1]" value="123" />',
             $context->getHiddenInputFields(['myarr' => ['xyz', 123]]),
             'numeric arrays are handled'
         );
 
         $this->assertEquals(
-            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a&#x20;b&#x24;c&amp;&#x3F;&gt;" /><input type="hidden" name="myarr[a]" value="xyz" /><input type="hidden" name="myarr[b]" value="123" />',
+            '<input type="hidden" name="int" value="25" /><input type="hidden" name="str" value="&lt;a b$c&amp;?&gt;" /><input type="hidden" name="myarr[a]" value="xyz" /><input type="hidden" name="myarr[b]" value="123" />',
             $context->getHiddenInputFields(['myarr' => ['a' => 'xyz', 'b' => 123]]),
             'assoc arrays are handled'
         );

--- a/redaxo/src/core/tests/util/formatter_test.php
+++ b/redaxo/src/core/tests/util/formatter_test.php
@@ -178,7 +178,7 @@ class rex_formatter_test extends PHPUnit_Framework_TestCase
             'params' => 'ilike=+1',
         ];
         $this->assertEquals(
-            '<a href="http&#x3A;&#x2F;&#x2F;example.org&#x3F;ilike&#x3D;&#x2B;1" data-haha="foo">http://example.org</a>',
+            '<a href="http://example.org?ilike=+1" data-haha="foo">http://example.org</a>',
             rex_formatter::url($value, $format)
         );
     }
@@ -192,7 +192,7 @@ class rex_formatter_test extends PHPUnit_Framework_TestCase
             'params' => 'ilike=+1',
         ];
         $this->assertEquals(
-            '<a href="mailto:dude&#x40;example.org&#x3F;ilike&#x3D;&#x2B;1" data-haha="foo">dude@example.org</a>',
+            '<a href="mailto:dude@example.org?ilike=+1" data-haha="foo">dude@example.org</a>',
             rex_formatter::email($value, $format)
         );
     }


### PR DESCRIPTION
Mir war nicht wirklich bewusst, wann man die `html_attr`-Strategie von `rex_escape` wirklich braucht.
Daher habe ich mal gesucht, und habe diese Erläuterung gefunden: https://github.com/twigphp/Twig/issues/2615

Daraus folgend habe ich `html_attr` überall entfernt, wo es für Attribute-Values genommen wurde, die in Anführungzeichen ausgegeben werden.

fixes #2402