### PR TITLE
Minibar: Klasse für CSS im body anbringen, wenn sichtbar

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -199,7 +199,7 @@ rex_be_controller::includeCurrentPage();
 rex_extension::register('OUTPUT_FILTER', function (rex_extension_point $ep) {
     if (rex_minibar::getInstance()->isActive() === false) {
         $ep->setSubject(preg_replace(
-            '/(<body.*|<html.*)rex-minibar-is-visible(.*>)/i',
+            '/(<body.*|<html.*)rex-minibar-is-active(.*>)/i',
             '$1$2',
             $ep->getSubject())
         );

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -199,8 +199,8 @@ rex_be_controller::includeCurrentPage();
 rex_extension::register('OUTPUT_FILTER', function (rex_extension_point $ep) {
     if (rex_minibar::getInstance()->isActive() === false) {
         $ep->setSubject(preg_replace(
-            '/(<body.*|<html.*)rex-minibar-is-active(.*>)/i',
-            '$1$2',
+            '/(<(body|html)[^>]*)rex-minibar-is-active/iU',
+            '$1',
             $ep->getSubject())
         );
     }

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -195,6 +195,17 @@ if ($page != 'login') {
 // include the requested backend page
 rex_be_controller::includeCurrentPage();
 
+// update body class if minibar has been set inactive
+rex_extension::register('OUTPUT_FILTER', function (rex_extension_point $ep) {
+    if (rex_minibar::getInstance()->isActive() === false) {
+        $ep->setSubject(preg_replace(
+            '/(<body.*)rex-minibar-is-visible(.*>)/i',
+            '$1$2',
+            $ep->getSubject())
+        );
+    }
+});
+
 // ----- caching end für output filter
 $CONTENT = ob_get_clean();
 

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -199,7 +199,7 @@ rex_be_controller::includeCurrentPage();
 rex_extension::register('OUTPUT_FILTER', function (rex_extension_point $ep) {
     if (rex_minibar::getInstance()->isActive() === false) {
         $ep->setSubject(preg_replace(
-            '/(<body.*)rex-minibar-is-visible(.*>)/i',
+            '/(<body.*|<html.*)rex-minibar-is-visible(.*>)/i',
             '$1$2',
             $ep->getSubject())
         );

--- a/redaxo/src/core/layout/top.php
+++ b/redaxo/src/core/layout/top.php
@@ -43,8 +43,8 @@ if ($curPage->isPopup()) {
 if (rex::getImpersonator()) {
     $body_attr['class'][] = 'rex-is-impersonated';
 }
-if (rex_minibar::getInstance()->isVisible()) {
-    $body_attr['class'][] = 'rex-minibar-is-visible';
+if (rex_minibar::getInstance()->isActive() !== false) {
+    $body_attr['class'][] = 'rex-minibar-is-active';
 }
 
 // ----- EXTENSION POINT

--- a/redaxo/src/core/layout/top.php
+++ b/redaxo/src/core/layout/top.php
@@ -43,6 +43,10 @@ if ($curPage->isPopup()) {
 if (rex::getImpersonator()) {
     $body_attr['class'][] = 'rex-is-impersonated';
 }
+if (rex_minibar::getInstance()->isVisible()) {
+    $body_attr['class'][] = 'rex-minibar-is-visible';
+}
+
 // ----- EXTENSION POINT
 $body_attr = rex_extension::registerPoint(new rex_extension_point('PAGE_BODY_ATTR', $body_attr));
 


### PR DESCRIPTION
Weil die Minibar im Backend per default sichtbar ist, wird im <body> die Klasse `rex-minibar-is-visible` angebracht. Kurz vor der Ausgabe der Seite wird geprüft, ob die Minibar zwischenzeitlich ausgeblendet worden ist, etwa von einem AddOn oder der aktuellen Seite. In dem Fall wird die zuvor gesetzte Klasse wieder entfernt.

fixes #2400