### PR TITLE
 Reihenfolge der Elemente im System

### DIFF
--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -184,6 +184,11 @@ $n['field'] = '<input class="form-control" type="text" id="rex-id-servername" na
 $formElements[] = $n;
 
 $n = [];
+$n['label'] = '<label for="rex-id-lang">' . rex_i18n::msg('backend_language') . '</label>';
+$n['field'] = $sel_lang->get();
+$formElements[] = $n;
+
+$n = [];
 $n['label'] = '<label for="rex-id-error-email">' . rex_i18n::msg('error_email') . '</label>';
 $n['field'] = '<input class="form-control" type="text" id="rex-id-error-email" name="settings[error_email]" value="' . rex_escape(rex::getErrorEmail()) . '" />';
 $formElements[] = $n;
@@ -192,16 +197,6 @@ $fragment = new rex_fragment();
 $fragment->setVar('elements', $formElements, false);
 $content .= $fragment->parse('core/form/form.php');
 
-$formElements = [];
-
-$n = [];
-$n['label'] = '<label for="rex-id-lang">' . rex_i18n::msg('backend_language') . '</label>';
-$n['field'] = $sel_lang->get();
-$formElements[] = $n;
-
-$fragment = new rex_fragment();
-$fragment->setVar('elements', $formElements, false);
-$content .= $fragment->parse('core/form/form.php');
 
 foreach (rex_system_setting::getAll() as $setting) {
     $field = $setting->getField();
@@ -261,3 +256,4 @@ $fragment = new rex_fragment();
 $fragment->setVar('content', [implode('', $mainContent), implode('', $sideContent)], false);
 $fragment->setVar('classes', ['col-lg-8', 'col-lg-4'], false);
 echo $fragment->parse('core/page/grid.php');
+

--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -197,7 +197,6 @@ $fragment = new rex_fragment();
 $fragment->setVar('elements', $formElements, false);
 $content .= $fragment->parse('core/form/form.php');
 
-
 foreach (rex_system_setting::getAll() as $setting) {
     $field = $setting->getField();
     if (!($field instanceof rex_form_element)) {
@@ -256,4 +255,3 @@ $fragment = new rex_fragment();
 $fragment->setVar('content', [implode('', $mainContent), implode('', $sideContent)], false);
 $fragment->setVar('classes', ['col-lg-8', 'col-lg-4'], false);
 echo $fragment->parse('core/page/grid.php');
-


### PR DESCRIPTION
Vertauscht Backendsprachenauswahl und Errormail, so dass anschließend die E-Mailbenachrichtigung bei Fehlern daran anschließen kann. 

fix für: https://github.com/redaxo/redaxo/issues/2406

Neue Darstellung:

<img width="912" alt="bildschirmfoto 2019-01-10 um 22 56 14" src="https://user-images.githubusercontent.com/791247/50999636-fbdec080-152a-11e9-9c6e-7d4f97ae9649.png">
