### PR TITLE
Customizer: Styles für Link zur Website angepasst

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/assets/css/styles.css
+++ b/redaxo/src/addons/be_style/plugins/customizer/assets/css/styles.css
@@ -1,29 +1,50 @@
 .be-style-customizer-title {
-    float: left;
-    margin: -1px 0 0 40px;
-    line-height: 1;
+    position: absolute;
+    top: 9px;
+    left: 250px;
+    margin: 0;
+    line-height: 0;
 }
-.be-style-customizer-title i,
 .be-style-customizer-title a {
+    display: block;
+    padding: 15px;
     color: #fff;
-    font-size: 17px;
+}
+.be-style-customizer-title a:hover .be-style-customizer-title-name,
+.be-style-customizer-title a:focus .be-style-customizer-title-name {
+    text-decoration: underline;
+}
+.be-style-customizer-title-name,
+.be-style-customizer-title i {
+    font-size: 14px;
+    line-height: 20px;
     font-weight: normal;
 }
+.be-style-customizer-title-name {
+    display: inline-block;
+    vertical-align: middle;
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-right: 8px;
+}
 .be-style-customizer-title i {
-    margin-left: 10px;
+    display: inline-block;
+    vertical-align: middle;
 }
 @media (max-width: 991px) {
     .be-style-customizer-title {
-        position: absolute;
-        right: 15px;
-        bottom: 9px;
-        font-size: 17px;
+        left: auto;
+        top: 5px;
+        right: 40px;
+        font-size: 20px;
     }
     .be-style-customizer-title-name {
         display: none
     }
-    .be-style-customizer-title i {
-        margin-left: 0;
+    .be-style-customizer-title a {
+        padding: 5px 10px;
     }
 }
 

--- a/redaxo/src/addons/be_style/plugins/customizer/assets/css/styles.css
+++ b/redaxo/src/addons/be_style/plugins/customizer/assets/css/styles.css
@@ -48,6 +48,10 @@
     }
 }
 
+.rex-is-popup .be-style-customizer-title {
+    display: none;
+}
+
 .CodeMirror {
     min-height: 330px;
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;

--- a/redaxo/src/addons/be_style/plugins/customizer/assets/js/main.js
+++ b/redaxo/src/addons/be_style/plugins/customizer/assets/js/main.js
@@ -119,7 +119,7 @@ Customizer.init = function (container) {
     });
 
     if (typeof rex.customizer_labelcolor !== "undefined" && rex.customizer_labelcolor != '') {
-        $('.rex-nav-top').css('border-bottom', '10px solid ' + rex.customizer_labelcolor)
+        $('.rex-nav-top').css('border-bottom', '7px solid ' + rex.customizer_labelcolor)
     }
 
     if (typeof rex.customizer_showlink !== "undefined" && rex.customizer_showlink != '' && !$('.be-style-customizer-title').length) {


### PR DESCRIPTION
Dieser PR verbessert die Position und das Verhalten des Links zur Website:

- Schriftgröße und vertikale Ausrichtung mit anderem Text im Header (Nutzer, abmelden).
- Horizontale Ausrichtung mit Seiteninhalt.
- Auspünkteln nach 300px. Damit passt es gerade noch gut ins kleinste Desktop-Layout.
- Umstellung auf absolute Positionierung, weil etwas robuster als floats zuvor.

fixes #1091

#### Standardansicht in schmalem Layout
![customizer_01](https://user-images.githubusercontent.com/1297466/51076043-d91beb80-1693-11e9-984f-011d7cb1ba54.png)

#### Zu langer Seitentitel wird ausgepünktelt
![customizer_02](https://user-images.githubusercontent.com/1297466/51076044-d91beb80-1693-11e9-868a-36a057fb4daf.png)

#### Mobile
![customizer_03](https://user-images.githubusercontent.com/1297466/51076045-d9b48200-1693-11e9-87ae-d3a8961805e3.png)