### PR TITLE
Console: Fixed 'PHP Notice: Undefined index: REQUEST_URI'

### DIFF
--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -1,10 +1,11 @@
 <?php
 
+// all these debugging capabilities require ChromePhp, which only works in the browser
 if (rex_server('REQUEST_URI')) {
-    require 'vendor/chromephp/ChromePhp.php';
-}
+    require_once 'vendor/chromephp/ChromePhp.php';
 
-rex_sql::setFactoryClass('rex_sql_debug');
-rex_extension::setFactoryClass('rex_extension_debug');
-rex_logger::setFactoryClass('rex_logger_debug');
-rex_api_function::setFactoryClass('rex_api_function_debug');
+    rex_sql::setFactoryClass('rex_sql_debug');
+    rex_extension::setFactoryClass('rex_extension_debug');
+    rex_logger::setFactoryClass('rex_logger_debug');
+    rex_api_function::setFactoryClass('rex_api_function_debug');
+}


### PR DESCRIPTION
Alle debugging extensions des addons erfordern ChromePHP und dies funktioniert nur im browser.

closes https://github.com/redaxo/redaxo/issues/2442