### PR TITLE
installer warnings gefixed

### DIFF
--- a/redaxo/src/addons/install/lib/api_package_add.php
+++ b/redaxo/src/addons/install/lib/api_package_add.php
@@ -7,9 +7,13 @@
  */
 class rex_api_install_package_add extends rex_api_install_package_download
 {
-    const GET_PACKAGES_FUNCTION = 'getAddPackages';
     const VERB = 'downloaded';
     const SHOW_LINK = true;
+
+    protected function getPackages()
+    {
+        return rex_install_packages::getAddPackages();
+    }
 
     protected function checkPreConditions()
     {

--- a/redaxo/src/addons/install/lib/api_package_add.php
+++ b/redaxo/src/addons/install/lib/api_package_add.php
@@ -7,8 +7,16 @@
  */
 class rex_api_install_package_add extends rex_api_install_package_download
 {
-    const VERB = 'downloaded';
-    const SHOW_LINK = true;
+    protected function getErrorMessage()
+    {
+        return rex_i18n::msg('install_warning_addon_not_downloaded', $this->addonkey);
+    }
+
+    protected function getSuccessMessage()
+    {
+        return rex_i18n::msg('install_info_addon_downloaded', $this->addonkey)
+            . ' <a href="' . rex_url::backendPage('packages') . '">' . rex_i18n::msg('install_to_addon_page') . '</a>';
+    }
 
     protected function getPackages()
     {

--- a/redaxo/src/addons/install/lib/api_package_download.php
+++ b/redaxo/src/addons/install/lib/api_package_download.php
@@ -41,11 +41,11 @@ abstract class rex_api_install_package_download extends rex_api_function
         }
         rex_file::delete($archivefile);
         if ($message) {
-            $message = rex_i18n::msg('install_warning_addon_not_' . static::VERB, $this->addonkey) . '<br />' . $message;
+            $message = $this->getErrorMessage() . '<br />' . $message;
             $success = false;
         } else {
-            $message = rex_i18n::msg('install_info_addon_' . static::VERB, $this->addonkey)
-                             . (static::SHOW_LINK ? ' <a href="' . rex_url::backendPage('packages') . '">' . rex_i18n::msg('install_to_addon_page') . '</a>' : '');
+            $message = $this->getSuccessMessage();
+
             $success = true;
             unset($_REQUEST['addonkey']);
         }
@@ -65,6 +65,10 @@ abstract class rex_api_install_package_download extends rex_api_function
         }
         return true;
     }
+
+    abstract protected function getSuccessMessage();
+
+    abstract protected function getErrorMessage();
 
     abstract protected function getPackages();
 

--- a/redaxo/src/addons/install/lib/api_package_download.php
+++ b/redaxo/src/addons/install/lib/api_package_download.php
@@ -18,8 +18,7 @@ abstract class rex_api_install_package_download extends rex_api_function
             throw new rex_api_exception('You do not have the permission!');
         }
         $this->addonkey = rex_request('addonkey', 'string');
-        $function = static::GET_PACKAGES_FUNCTION;
-        $packages = rex_install_packages::$function();
+        $packages = $this->getPackages();
         $this->fileId = rex_request('file', 'int');
         if (!isset($packages[$this->addonkey]['files'][$this->fileId])) {
             throw new rex_api_exception('The requested addon version can not be loaded, maybe it is already installed.');
@@ -66,6 +65,8 @@ abstract class rex_api_install_package_download extends rex_api_function
         }
         return true;
     }
+
+    abstract protected function getPackages();
 
     abstract protected function checkPreConditions();
 

--- a/redaxo/src/addons/install/lib/api_package_update.php
+++ b/redaxo/src/addons/install/lib/api_package_update.php
@@ -7,13 +7,20 @@
  */
 class rex_api_install_package_update extends rex_api_install_package_download
 {
-    const VERB = 'updated';
-    const SHOW_LINK = false;
-
     /**
      * @var rex_addon
      */
     private $addon;
+
+    protected function getErrorMessage()
+    {
+        return rex_i18n::msg('install_warning_addon_not_updated', $this->addonkey);
+    }
+
+    protected function getSuccessMessage()
+    {
+        return rex_i18n::msg('install_info_addon_updated', $this->addonkey);
+    }
 
     protected function getPackages()
     {

--- a/redaxo/src/addons/install/lib/api_package_update.php
+++ b/redaxo/src/addons/install/lib/api_package_update.php
@@ -7,7 +7,6 @@
  */
 class rex_api_install_package_update extends rex_api_install_package_download
 {
-    const GET_PACKAGES_FUNCTION = 'getUpdatePackages';
     const VERB = 'updated';
     const SHOW_LINK = false;
 
@@ -15,6 +14,11 @@ class rex_api_install_package_update extends rex_api_install_package_download
      * @var rex_addon
      */
     private $addon;
+
+    protected function getPackages()
+    {
+        return rex_install_packages::getUpdatePackages();
+    }
 
     protected function checkPreConditions()
     {


### PR DESCRIPTION
```
 ------ ---------------------------------------------------------------------- 
  Line   addons/install/lib/api_package_download.php                           
 ------ ---------------------------------------------------------------------- 
  21     Access to undefined constant                                          
         rex_api_install_package_download::GET_PACKAGES_FUNCTION.              
  45     Access to undefined constant rex_api_install_package_download::VERB.  
  48     Access to undefined constant rex_api_install_package_download::VERB.  
  49     Access to undefined constant                                          
         rex_api_install_package_download::SHOW_LINK.                          
 ------ ---------------------------------------------------------------------- 
```

gefunden via phpstan

weniger magic, mehr konkrete calls.
da die klassen internal sind und ich nicht glaube dass jemand den installer selbst erweitert hat, hab ich BC breaking changes vorgenommen.

habs grob angetestet.