### PR TITLE
minibar: artikel element erweitert

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/minibar/article.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/minibar/article.php
@@ -24,15 +24,7 @@ class rex_minibar_element_structure_article extends rex_minibar_lazy_element
 
         // Return if user have no rights to the site start article
         if (rex::isBackend() && !rex::getUser()->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())) {
-            return
-                '<div class="rex-minibar-item">
-                    <span class="rex-minibar-icon">
-                        <i class="rex-icon rex-icon-article"></i>
-                    </span>
-                    <span class="rex-minibar-value">
-                        0
-                    </span>
-                </div>';
+            return '';
         }
 
         return
@@ -41,7 +33,7 @@ class rex_minibar_element_structure_article extends rex_minibar_lazy_element
                 <i class="rex-minibar-icon--fa rex-minibar-icon--fa-file-text-o"></i>
             </span>
             <span class="rex-minibar-value">
-                '.$article->getId().'
+                Artikel "'.$article->getName() .'"
             </span>
         </div>';
     }
@@ -56,15 +48,7 @@ class rex_minibar_element_structure_article extends rex_minibar_lazy_element
 
         // Return if user have no rights to the site start article
         if (rex::isBackend() && !rex::getUser()->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())) {
-            return
-                '<div class="rex-minibar-item">
-                    <span class="rex-minibar-icon">
-                        <i class="rex-icon rex-icon-article"></i>
-                    </span>
-                    <span class="rex-minibar-value">
-                        0
-                    </span>
-                </div>';
+            return '';
         }
 
         $articleLink = '<a href="'.rex_url::backendPage('content/edit', ['article_id' => $article->getId(), 'clang' => $article->getClangId(), 'mode' => 'edit']).'">'.rex_i18n::msg('structure_content_minibar_article_edit').' </a>';
@@ -100,7 +84,7 @@ class rex_minibar_element_structure_article extends rex_minibar_lazy_element
                 <i class="rex-minibar-icon--fa rex-minibar-icon--fa-file-text-o"></i>
             </span>
             <span class="rex-minibar-value">
-            '.$article->getId().'
+            Artikel "'.$article->getName() .'"
             </span>
         </div>
         <div class="rex-minibar-info">


### PR DESCRIPTION
Vorschlag, da die ID alleine wenig aussagekraft hat und die user sich vermutlich fragen, was das für ne zahl ist.

Artikelname anzeigen statt nur die "id"
Wenn keine rechte dann das element gar nicht rendern statt "0"

![image](https://user-images.githubusercontent.com/120441/51436735-0881b800-1c93-11e9-9092-17d03d45ccf3.png)

falls das so als idee akzeptanz findet, könnte/müsste man vermutlich mit elipsis die max breite des elements beschränken