### PR TITLE
rex_config: property statt lokaler Konstante verwenden

### DIFF
--- a/redaxo/src/core/lib/config.php
+++ b/redaxo/src/core/lib/config.php
@@ -354,7 +354,7 @@ class rex_config
         }
 
         // delete cache-file; will be regenerated on next request
-        rex_file::delete(REX_CONFIG_FILE_CACHE);
+        rex_file::delete(self::$cacheFile);
 
         // save all data to the db
         self::saveToDb();

--- a/redaxo/src/core/lib/config.php
+++ b/redaxo/src/core/lib/config.php
@@ -16,6 +16,13 @@ class rex_config
      * @var bool
      */
     private static $initialized = false;
+    
+    /*
+     * path to the cache file
+     *
+     * @var string
+     */
+    private static $cacheFile;
 
     /**
      * Flag which indicates if database needs an update, because settings have changed.
@@ -261,14 +268,14 @@ class rex_config
             return;
         }
 
-        define('REX_CONFIG_FILE_CACHE', rex_path::coreCache('config.cache'));
+        self::$cacheFile = rex_path::coreCache('config.cache');
 
         // take care, so we are able to write a cache file on shutdown
         // (check here, since exceptions in shutdown functions are not visible to the user)
-        $dir = dirname(REX_CONFIG_FILE_CACHE);
+        $dir = dirname(self::$cacheFile);
         rex_dir::create($dir);
         if (!is_writable($dir)) {
-            throw new rex_exception('rex-config: cache dir "' . dirname(REX_CONFIG_FILE_CACHE) . '" is not writable!');
+            throw new rex_exception('rex-config: cache dir "' . dirname(self::$cacheFile) . '" is not writable!');
         }
 
         // save cache on shutdown
@@ -300,8 +307,8 @@ class rex_config
     private static function loadFromFile()
     {
         // delete cache-file, will be regenerated on next request
-        if (file_exists(REX_CONFIG_FILE_CACHE)) {
-            self::$data = rex_file::getCache(REX_CONFIG_FILE_CACHE);
+        if (file_exists(self::$cacheFile)) {
+            self::$data = rex_file::getCache(self::$cacheFile);
             return true;
         }
         return false;
@@ -326,8 +333,8 @@ class rex_config
      */
     private static function generateCache()
     {
-        if (rex_file::putCache(REX_CONFIG_FILE_CACHE, self::$data) <= 0) {
-            throw new rex_exception('rex-config: unable to write cache file ' . REX_CONFIG_FILE_CACHE);
+        if (rex_file::putCache(self::$cacheFile, self::$data) <= 0) {
+            throw new rex_exception('rex-config: unable to write cache file ' . self::$cacheFile);
         }
     }
 

--- a/redaxo/src/core/lib/config.php
+++ b/redaxo/src/core/lib/config.php
@@ -16,7 +16,7 @@ class rex_config
      * @var bool
      */
     private static $initialized = false;
-    
+
     /*
      * path to the cache file
      *


### PR DESCRIPTION
Fixed phpstan Warnung
```
------ ------------------------------------------- 
  Line core/lib/config.php                        
 ------ ------------------------------------------- 
  303    Constant REX_CONFIG_FILE_CACHE not found.  
  304    Constant REX_CONFIG_FILE_CACHE not found.  
  329    Constant REX_CONFIG_FILE_CACHE not found.  
  330    Constant REX_CONFIG_FILE_CACHE not found.  
  350    Constant REX_CONFIG_FILE_CACHE not found.  
 ------ ------------------------------------------
```

Quer gesucht.. kein addon gefunden, z.b. Bei FOR dass diese konstante verwendet