### PR TITLE
Linkmap: Whoops vermeiden, wenn keine aktuelle Kategorie

### DIFF
--- a/redaxo/src/addons/structure/lib/linkmap/var_link.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_link.php
@@ -47,7 +47,7 @@ class rex_var_link extends rex_var
     {
         $art_name = '';
         $art = rex_article::get($value);
-        $category = rex_category::getCurrent()->getId(); // Aktuelle Kategorie vorauswählen
+        $category = rex_category::getCurrent() ? rex_category::getCurrent()->getId() : 0; // Aktuelle Kategorie vorauswählen
 
         // Falls ein Artikel vorausgewählt ist, dessen Namen anzeigen und beim Öffnen der Linkmap dessen Kategorie anzeigen
         if ($art instanceof rex_article) {

--- a/redaxo/src/addons/structure/lib/linkmap/var_linklist.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_linklist.php
@@ -41,7 +41,7 @@ class rex_var_linklist extends rex_var
 
     public static function getWidget($id, $name, $value, array $args = [])
     {
-        $category = rex_category::getCurrent()->getId(); // Aktuelle Kategorie vorauswählen
+        $category = rex_category::getCurrent() ? rex_category::getCurrent()->getId() : 0; // Aktuelle Kategorie vorauswählen
 
         // Falls ein Kategorie-Parameter angegeben wurde, die Linkmap in dieser Kategorie öffnen
         if (isset($args['category'])) {


### PR DESCRIPTION
Das Problem kam durch #2476 rein.
Habe zum Beispiel auf der Systempage (Linkmap für Startartikel) ein Whoops bekommen.