### PR TITLE
MP: "Hinzufügen und übernehmen" korrigiert

### DIFF
--- a/redaxo/src/addons/mediapool/assets/mediapool.js
+++ b/redaxo/src/addons/mediapool/assets/mediapool.js
@@ -228,9 +228,8 @@ function selectMedia(filename, alt)
 
     opener.jQuery(window).trigger(event, [filename, alt]);
     if (!event.isDefaultPrevented()) {
-        var opener_id = jQuery("#opener_input_field").val();
-        if (opener_id) {
-            opener.document.getElementById(opener_id).value = filename;
+        if (rex.mediapoolOpenerInputField) {
+            opener.document.getElementById(rex.mediapoolOpenerInputField).value = filename;
         }
         self.close();
     }
@@ -238,10 +237,9 @@ function selectMedia(filename, alt)
 
 function selectMedialist(filename)
 {
-    var opener_id = jQuery("#opener_input_field").data("opener-id");
-
-    if (opener_id) {
-        var medialist = "REX_MEDIALIST_SELECT_" + opener_id;
+    if (rex.mediapoolOpenerInputField && 0 === rex.mediapoolOpenerInputField.indexOf('REX_MEDIALIST_')) {
+        var openerId = rex.mediapoolOpenerInputField.slice('REX_MEDIALIST_'.length);
+        var medialist = "REX_MEDIALIST_SELECT_" + openerId;
 
         var source = opener.document.getElementById(medialist);
         var sourcelength = source.options.length;
@@ -251,16 +249,15 @@ function selectMedialist(filename)
         option.value = filename;
 
         source.options.add(option, sourcelength);
-        opener.writeREXMedialist(opener_id);
+        opener.writeREXMedialist(openerId);
     }
 }
 
 function selectMediaListArray(files)
 {
-    var opener_id = jQuery("#opener_input_field").data("opener-id");
-
-    if (opener_id) {
-        var medialist = "REX_MEDIALIST_SELECT_" + opener_id;
+    if (rex.mediapoolOpenerInputField && 0 === rex.mediapoolOpenerInputField.indexOf('REX_MEDIALIST_')) {
+        var openerId = rex.mediapoolOpenerInputField.slice('REX_MEDIALIST_'.length);
+        var medialist = "REX_MEDIALIST_SELECT_" + openerId;
 
         var source = opener.document.getElementById(medialist);
         var sourcelength = source.options.length;
@@ -280,8 +277,7 @@ function selectMediaListArray(files)
             }
         }
 
-        opener.writeREXMedialist(opener_id);
-        self.close();
+        opener.writeREXMedialist(openerId);
     }
 }
 

--- a/redaxo/src/addons/mediapool/pages/index.php
+++ b/redaxo/src/addons/mediapool/pages/index.php
@@ -39,7 +39,7 @@ if ($opener_input_field != '') {
     }
 
     $arg_url['opener_input_field'] = $opener_input_field;
-    $arg_fields .= '<input type="hidden" id="opener_input_field" name="opener_input_field" value="' . rex_escape($opener_input_field) . '" data-opener-id="'. $opener_id .'"/>' . "\n";
+    $arg_fields .= '<input type="hidden" name="opener_input_field" value="' . rex_escape($opener_input_field) . '"/>' . "\n";
 }
 
 // -------------- CatId in Session speichern
@@ -97,6 +97,7 @@ if (!rex_request::isXmlHttpRequest()) {
     ?>
     <script type="text/javascript">
         rex_retain_popup_event_handlers("rex:selectMedia");
+        <?= $opener_input_field ? 'rex.mediapoolOpenerInputField = "'.rex_escape($opener_input_field, 'js').'";' : '' ?>
     </script>
     <?php
 }


### PR DESCRIPTION
fixes #2471

Ursache war [dieser Commit](https://github.com/redaxo/redaxo/pull/2160/commits/818c27813eda24bf401b04c0cb778a9ed0d89fc7)

Empfinde den Fix als bisschen hacky. aber selectMedia() erwartet seit dem Commit ein input-Feld mit dem opener-field. Das gibt es an dieser Stelle aber (bisher) nicht.