### PR TITLE
Immutable opt in

### DIFF
--- a/redaxo/src/addons/be_style/boot.php
+++ b/redaxo/src/addons/be_style/boot.php
@@ -42,10 +42,10 @@ if (rex::isBackend()) {
 
     rex_view::addCssFile($addon->getAssetsUrl('css/styles.css'));
     rex_view::addCssFile($addon->getAssetsUrl('css/bootstrap-select.min.css'));
-    rex_view::addJsFile($addon->getAssetsUrl('javascripts/bootstrap.js'));
-    rex_view::addJsFile($addon->getAssetsUrl('javascripts/bootstrap-select.min.js'));
-    rex_view::addJsFile($addon->getAssetsUrl('javascripts/bootstrap-select-defaults-de_DE.min.js'));
-    rex_view::addJsFile($addon->getAssetsUrl('javascripts/main.js'));
+    rex_view::addJsFile($addon->getAssetsUrl('javascripts/bootstrap.js'), [rex_view::JS_IMMUTABLE => true]);
+    rex_view::addJsFile($addon->getAssetsUrl('javascripts/bootstrap-select.min.js'), [rex_view::JS_IMMUTABLE => true]);
+    rex_view::addJsFile($addon->getAssetsUrl('javascripts/bootstrap-select-defaults-de_DE.min.js'), [rex_view::JS_IMMUTABLE => true]);
+    rex_view::addJsFile($addon->getAssetsUrl('javascripts/main.js'), [rex_view::JS_IMMUTABLE => true]);
 
     // make sure to send preload headers only on fullpage requests
     if (stripos(rex_request::server('HTTP_ACCEPT'), 'text/html') !== false && !rex_request::isXmlHttpRequest()) {

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -158,11 +158,11 @@ if (rex::getUser()) {
     rex_be_controller::setCurrentPage(trim(rex_request('page', 'string')));
 }
 
-rex_view::addJsFile(rex_url::coreAssets('jquery.min.js'));
-rex_view::addJsFile(rex_url::coreAssets('jquery-ui.custom.min.js'));
-rex_view::addJsFile(rex_url::coreAssets('jquery-pjax.min.js'));
-rex_view::addJsFile(rex_url::coreAssets('standard.js'));
-rex_view::addJsFile(rex_url::coreAssets('sha1.js'));
+rex_view::addJsFile(rex_url::coreAssets('jquery.min.js'), [rex_view::JS_IMMUTABLE => true]);
+rex_view::addJsFile(rex_url::coreAssets('jquery-ui.custom.min.js'), [rex_view::JS_IMMUTABLE => true]);
+rex_view::addJsFile(rex_url::coreAssets('jquery-pjax.min.js'), [rex_view::JS_IMMUTABLE => true]);
+rex_view::addJsFile(rex_url::coreAssets('standard.js'), [rex_view::JS_IMMUTABLE => true]);
+rex_view::addJsFile(rex_url::coreAssets('sha1.js'), [rex_view::JS_IMMUTABLE => true]);
 
 rex_view::setJsProperty('backend', true);
 rex_view::setJsProperty('accesskeys', rex::getProperty('use_accesskeys'));

--- a/redaxo/src/core/lib/view.php
+++ b/redaxo/src/core/lib/view.php
@@ -51,7 +51,7 @@ class rex_view
     public static function addJsFile($file, array $options = [])
     {
         if (empty($options)) {
-            $options[self::JS_IMMUTABLE] = true;
+            $options[self::JS_IMMUTABLE] = false;
         }
 
         if (in_array($file, self::$jsFiles)) {

--- a/redaxo/src/core/tests/view_test.php
+++ b/redaxo/src/core/tests/view_test.php
@@ -26,7 +26,7 @@ class rex_view_test extends PHPUnit_Framework_TestCase
         $files = rex_view::getJsFilesWithOptions();
         list($file, $options) = end($files);
         $this->assertTrue($file == 'my.js');
-        $this->assertTrue($options == [rex_view::JS_IMMUTABLE => true], 'options default to JS_IMMUTABLE');
+        $this->assertTrue($options == [rex_view::JS_IMMUTABLE => false], 'options default to JS_IMMUTABLE');
 
         rex_view::addJsFile('my.js', [rex_view::JS_IMMUTABLE => true]);
         $files = rex_view::getJsFilesWithOptions();

--- a/redaxo/src/core/tests/view_test.php
+++ b/redaxo/src/core/tests/view_test.php
@@ -26,7 +26,7 @@ class rex_view_test extends PHPUnit_Framework_TestCase
         $files = rex_view::getJsFilesWithOptions();
         list($file, $options) = end($files);
         $this->assertTrue($file == 'my.js');
-        $this->assertTrue($options == [rex_view::JS_IMMUTABLE => false], 'options default to JS_IMMUTABLE');
+        $this->assertTrue($options == [rex_view::JS_IMMUTABLE => false], 'options default to JS_IMMUTABLE=false');
 
         rex_view::addJsFile('my.js', [rex_view::JS_IMMUTABLE => true]);
         $files = rex_view::getJsFilesWithOptions();


### PR DESCRIPTION
Es werden zunächst nur die großen Framework libs als auch die Dateien vom core als immutable ausgeliefert.

Hintergrund:
wir wollen das risiko minimieren falls der neue Mechanismus noch Probleme mitbringt.
Die jetzt immutable behandelten libraries sollten sich nur durch core-updates ändern und sind aber auch zugleich verantwortlich für den großteil des javascripts des Backends.

Closes https://github.com/redaxo/redaxo/issues/2512