### PR TITLE
R5.6 verhalten wiederhergestellt wenn assets nicht immutable sind

### DIFF
--- a/redaxo/src/core/fragments/core/top.php
+++ b/redaxo/src/core/fragments/core/top.php
@@ -14,6 +14,8 @@
             $path = rex_path::frontend(rex_path::absolute($file));
             if (!rex::isDebugMode() && strpos($path, $assetDir) === 0 && $mtime = @filemtime($path)) {
                 $file = rex_url::backendController(['asset' => $file, 'buster' => $mtime]);
+            } elseif ($mtime = @filemtime($path)) {
+                $file .= '?buster='. $mtime;
             }
             echo "\n" . '    <link rel="stylesheet" type="text/css" media="' . $media . '" href="' . $file .'" />';
         }
@@ -32,11 +34,13 @@
             list($file, $options) = $file;
         }
 
+        $path = rex_path::frontend(rex_path::absolute($file));
         if (array_key_exists(rex_view::JS_IMMUTABLE, $options) && $options[rex_view::JS_IMMUTABLE]) {
-            $path = rex_path::frontend(rex_path::absolute($file));
             if (!rex::isDebugMode() && strpos($path, $assetDir) === 0 && $mtime = @filemtime($path)) {
                 $file = rex_url::backendController(['asset' => $file, 'buster' => $mtime]);
             }
+        } elseif ($mtime = @filemtime($path)) {
+            $file .= '?buster='. $mtime;
         }
 
         $attributes = [];


### PR DESCRIPTION
Damit nach updates von paketen geänderte css/js dateien sofort neu zum browser übertragen werden (auch wenn immutable nicht genutzt wird)

Ungetestet 