### PR TITLE
Atomic-Writes in rex_file::put() verwenden

### DIFF
--- a/redaxo/src/addons/tests/bin/setup.php
+++ b/redaxo/src/addons/tests/bin/setup.php
@@ -35,6 +35,8 @@ include_once rex_path::core('packages.php');
 // run setup, if instance not already prepared
 if (rex::isSetup()) {
     $err = '';
+    
+    rex_dir::create(rex_path::coreCache());
 
     // read initial config
     $configFile = rex_path::coreData('config.yml');

--- a/redaxo/src/addons/tests/bin/setup.php
+++ b/redaxo/src/addons/tests/bin/setup.php
@@ -35,8 +35,6 @@ include_once rex_path::core('packages.php');
 // run setup, if instance not already prepared
 if (rex::isSetup()) {
     $err = '';
-    
-    rex_dir::create(rex_path::coreCache());
 
     // read initial config
     $configFile = rex_path::coreData('config.yml');

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -71,7 +71,7 @@ class rex_file
             if (file_put_contents($tmpFile, $content) !== false) {
                 if (!@rename($tmpFile, $file)) {
                     // in case there exist open handles to the destination file,
-                    // use copy() instead, which will work nevertheless
+                    // use copy() instead, which will work nevertheless (on windows)
                     if (@copy($tmpFile, $file)) {
                         unlink($tmpFile);
                     }

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -67,6 +67,7 @@ class rex_file
             }
 
             // mimic a atomic write
+            rex_dir::create(rex_path::coreCache());
             $tmpFile = rex_path::coreCache(uniqid('rex_file', true));
             if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {
                 @chmod($file, rex::getFilePerm());

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -65,7 +65,7 @@ class rex_file
             if (!rex_dir::create(dirname($file)) || file_exists($file) && !is_writable($file)) {
                 return false;
             }
- 
+
             // mimic a atomic write
             $tmpFile = rex_path::cache(uniqid('rex_file', true));
             if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -65,7 +65,7 @@ class rex_file
             if (!rex_dir::create(dirname($file)) || file_exists($file) && !is_writable($file)) {
                 return false;
             }
-            
+ 
             // mimic a atomic write
             $tmpFile = rex_path::cache(uniqid('rex_file', true));
             if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -68,14 +68,7 @@ class rex_file
 
             // mimic a atomic write
             $tmpFile = @tempnam(dirname($file), basename($file));
-            if (file_put_contents($tmpFile, $content) !== false) {
-                if (!@rename($tmpFile, $file)) {
-                    // in case there exist open handles to the destination file,
-                    // use copy() instead, which will work nevertheless (on windows)
-                    if (@copy($tmpFile, $file)) {
-                        unlink($tmpFile);
-                    }
-                }
+            if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {
                 @chmod($file, rex::getFilePerm());
                 return true;
             }

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -67,7 +67,7 @@ class rex_file
             }
 
             // mimic a atomic write
-            $tmpFile = rex_path::cache(uniqid('rex_file', true));
+            $tmpFile = rex_path::coreCache(uniqid('rex_file', true));
             if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {
                 @chmod($file, rex::getFilePerm());
                 return true;

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -65,11 +65,14 @@ class rex_file
             if (!rex_dir::create(dirname($file)) || file_exists($file) && !is_writable($file)) {
                 return false;
             }
-
-            if (file_put_contents($file, $content) !== false) {
+            
+            // mimic a atomic write via write+rename
+            $tmpFile = rex_path::cache(uniqid('rex_file', true));
+            if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {
                 @chmod($file, rex::getFilePerm());
                 return true;
             }
+            @unlink($tmpFile);
 
             return false;
         });

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -67,11 +67,8 @@ class rex_file
             }
 
             // mimic a atomic write
-            rex_dir::create(rex_path::coreCache());
-            $tmpFile = rex_path::coreCache(uniqid('rex_file', true));
-            if (file_put_contents($tmpFile, $content) !== false) {
-                @chmod($tmpFile, 0644);
-                rename($tmpFile, $file);
+            $tmpFile = @tempnam(\dirname($file), basename($file));
+            if (file_put_contents($tmpFile, $content) !== false && @rename($tmpFile, $file)) {
                 @chmod($file, rex::getFilePerm());
                 return true;
             }

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -68,7 +68,7 @@ class rex_file
 
             // mimic a atomic write
             $tmpFile = @tempnam(\dirname($file), basename($file));
-            if (file_put_contents($tmpFile, $content) !== false && @rename($tmpFile, $file)) {
+            if (file_put_contents($tmpFile, $content) !== false && chmod($tmpFile, 0777) && rename($tmpFile, $file)) {
                 @chmod($file, rex::getFilePerm());
                 return true;
             }

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -68,9 +68,9 @@ class rex_file
 
             // mimic a atomic write
             $tmpFile = rex_path::coreCache(uniqid('rex_file', true));
-            if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {
-                @chmod($file, rex::getFilePerm());
-                return true;
+            if (file_put_contents($tmpFile, $content) !== false) {
+                @chmod($tmpFile, rex::getFilePerm());
+                return rename($tmpFile, $file);
             }
             @unlink($tmpFile);
 

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -69,7 +69,9 @@ class rex_file
             // mimic a atomic write
             rex_dir::create(rex_path::coreCache());
             $tmpFile = rex_path::coreCache(uniqid('rex_file', true));
-            if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {
+            if (file_put_contents($tmpFile, $content) !== false) {
+                @chmod($tmpFile, 0644);
+                rename($tmpFile, $file);
                 @chmod($file, rex::getFilePerm());
                 return true;
             }

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -68,9 +68,9 @@ class rex_file
 
             // mimic a atomic write
             $tmpFile = rex_path::coreCache(uniqid('rex_file', true));
-            if (file_put_contents($tmpFile, $content) !== false) {
-                @chmod($tmpFile, rex::getFilePerm());
-                return rename($tmpFile, $file);
+            if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {
+                @chmod($file, rex::getFilePerm());
+                return true;
             }
             @unlink($tmpFile);
 

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -67,8 +67,15 @@ class rex_file
             }
 
             // mimic a atomic write
-            $tmpFile = @tempnam(\dirname($file), basename($file));
-            if (file_put_contents($tmpFile, $content) !== false && chmod($tmpFile, 0777) && rename($tmpFile, $file)) {
+            $tmpFile = @tempnam(dirname($file), basename($file));
+            if (file_put_contents($tmpFile, $content) !== false) {
+                if (!@rename($tmpFile, $file)) {
+                    // in case there exist open handles to the destination file,
+                    // use copy() instead, which will work nevertheless
+                    if (@copy($tmpFile, $file)) {
+                        unlink($tmpFile);
+                    }
+                }
                 @chmod($file, rex::getFilePerm());
                 return true;
             }

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -66,7 +66,7 @@ class rex_file
                 return false;
             }
             
-            // mimic a atomic write via write+rename
+            // mimic a atomic write
             $tmpFile = rex_path::cache(uniqid('rex_file', true));
             if (file_put_contents($tmpFile, $content) !== false && rename($tmpFile, $file)) {
                 @chmod($file, rex::getFilePerm());

--- a/redaxo/src/core/tests/util/log_file_test.php
+++ b/redaxo/src/core/tests/util/log_file_test.php
@@ -66,6 +66,7 @@ EOF;
         $log = new rex_log_file($path);
         $this->assertSame([], iterator_to_array($log));
 
+        unset($log); // free handles to the underlying file
         rex_file::put($path, <<<'EOF'
 2013-08-27 23:07:02 | test1a | test1b
 2013-08-27 23:09:43 | test2a | test2b
@@ -75,8 +76,10 @@ EOF
             new rex_log_entry(mktime(23, 9, 43, 8, 27, 2013), ['test2a', 'test2b']),
             new rex_log_entry(mktime(23, 7, 2, 8, 27, 2013), ['test1a', 'test1b']),
         ];
+        $log = new rex_log_file($path);
         $this->assertEquals($expected, iterator_to_array($log));
 
+        unset($log); // free handles to the underlying file
         rex_file::put($path . '.2', <<<'EOF'
 
 2013-08-27 22:19:02 | test3
@@ -87,6 +90,7 @@ EOF
         );
         $expected[] = new rex_log_entry(mktime(22, 22, 43, 8, 27, 2013), ['test4']);
         $expected[] = new rex_log_entry(mktime(22, 19, 2, 8, 27, 2013), ['test3']);
+        $log = new rex_log_file($path);
         $this->assertEquals($expected, iterator_to_array($log));
     }
 

--- a/redaxo/src/core/tests/util/log_file_test.php
+++ b/redaxo/src/core/tests/util/log_file_test.php
@@ -2,11 +2,6 @@
 
 class rex_log_file_test extends PHPUnit_Framework_TestCase
 {
-    public function __construct() {
-        rex_dir::create(rex_path::coreCache());
-        parent::__construct();
-    }
-    
     public function tearDown()
     {
         rex_dir::delete($this->getPath());

--- a/redaxo/src/core/tests/util/log_file_test.php
+++ b/redaxo/src/core/tests/util/log_file_test.php
@@ -2,6 +2,11 @@
 
 class rex_log_file_test extends PHPUnit_Framework_TestCase
 {
+    public function __construct() {
+        rex_dir::create(rex_path::coreCache());
+        parent::__construct();
+    }
+    
     public function tearDown()
     {
         rex_dir::delete($this->getPath());


### PR DESCRIPTION
Ungetestet 

Ist Ggf. Auch ein Fix bzgl https://github.com/redaxo/redaxo/issues/2140