### PR TITLE
Customizer: Favicon mit der Erkennungsfarbe einfärben

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/assets/js/main.js
+++ b/redaxo/src/addons/be_style/plugins/customizer/assets/js/main.js
@@ -122,6 +122,7 @@ Customizer.init = function (container) {
         $('.rex-nav-top').css('border-bottom', '7px solid ' + rex.customizer_labelcolor)
     }
 
+    // inspired by https://blog.roomanna.com/09-24-2011/dynamically-coloring-a-favicon
     if (typeof rex.customizer_inkfavicon !== "undefined" && rex.customizer_inkfavicon != '') {
         var link = document.querySelector("link[rel~='icon']");
         if (!link) {

--- a/redaxo/src/addons/be_style/plugins/customizer/assets/js/main.js
+++ b/redaxo/src/addons/be_style/plugins/customizer/assets/js/main.js
@@ -122,6 +122,31 @@ Customizer.init = function (container) {
         $('.rex-nav-top').css('border-bottom', '7px solid ' + rex.customizer_labelcolor)
     }
 
+    if (typeof rex.customizer_inkfavicon !== "undefined" && rex.customizer_inkfavicon != '') {
+        var link = document.querySelector("link[rel~='icon']");
+        if (!link) {
+            link = document.createElement("link");
+            link.setAttribute("rel", "shortcut icon");
+            document.head.appendChild(link);
+        }
+        var faviconUrl = link.href || window.location.origin + "/favicon.ico";
+
+        var img = document.createElement("img");
+        img.addEventListener("load", function () {
+            var canvas = document.createElement("canvas");
+            canvas.width = img.width;
+            canvas.height = img.height;
+            var context = canvas.getContext("2d");
+            context.fillStyle = rex.customizer_labelcolor;
+            context.fillRect(0, 0, img.width, img.height);
+            context.drawImage(img, 0, 0);
+            context.fill();
+            link.type = "image/x-icon";
+            link.href = canvas.toDataURL();
+        });
+        img.src = faviconUrl;
+    }
+
     if (typeof rex.customizer_showlink !== "undefined" && rex.customizer_showlink != '' && !$('.be-style-customizer-title').length) {
         $('.rex-nav-top .navbar-header').append(rex.customizer_showlink);
     }

--- a/redaxo/src/addons/be_style/plugins/customizer/boot.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/boot.php
@@ -138,6 +138,7 @@ if (rex::isBackend() && rex::getUser()) {
 
     if ($config['labelcolor'] != '') {
         rex_view::setJsProperty('customizer_labelcolor', $config['labelcolor']);
+        rex_view::setJsProperty('customizer_inkfavicon', $config['inkfavicon']);
     }
     if ($config['showlink']) {
         rex_view::setJsProperty(

--- a/redaxo/src/addons/be_style/plugins/customizer/install.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/install.php
@@ -12,6 +12,10 @@ if (!$plugin->hasConfig()) {
     $plugin->setConfig('codemirror-tools', 0);
     $plugin->setConfig('showlink', 1);
 }
+/* Spaeter dazugekommene configs */
+if (!$plugin->hasConfig('inkfavicon')) {
+    $plugin->setConfig('inkfavicon', 1);
+}
 
 /* Codemirror-Assets entpacken */
 $message = '';

--- a/redaxo/src/addons/be_style/plugins/customizer/lang/de_de.lang
+++ b/redaxo/src/addons/be_style/plugins/customizer/lang/de_de.lang
@@ -16,6 +16,8 @@ customizer_codemirror_info = Sobald CodeMirror aktiviert ist, wird dieser bei Te
 customizer_labeling = Ergänzungen
 customizer_labelcolor = Erkennungsfarbe
 customizer_labelcolor_notice = Beliebige valide CSS-Farbangabe (<code>#03f0ab</code>, <code>rgba(255, 100, 0, 0.5)</code> etc.)
+customizer_inkfavicon = Backend-Favicon einfärben?
+customizer_inkfavicon_text = Backend-Favicon mit der Erkennungsfarbe einfärben. Nach Änderung einmal die Webseite mit <kbd>STRG+R</kbd> bzw. <kbd>CMD+R</kbd> neuladen.
 customizer_showlink = Link zur Webseite anzeigen ?
 
 customizer_config_updated = Eingaben wurden gespeichert

--- a/redaxo/src/addons/be_style/plugins/customizer/lang/en_gb.lang
+++ b/redaxo/src/addons/be_style/plugins/customizer/lang/en_gb.lang
@@ -14,6 +14,8 @@ customizer_codemirror_info = When CodeMirror is activated it will automatically 
 customizer_labeling = Additions
 customizer_labelcolor = Color
 customizer_labelcolor_notice = Any valid css color expression (<code>#03f0ab</code>, <code>rgba(255, 100, 0, 0.5)</code> etc.)
+customizer_inkfavicon = color backend-favicon?
+customizer_inkfavicon_text = color the backend-favicon. Hard reload the browser with <kbd>CTRL+R</kbd> bzw. <kbd>CMD+R</kbd> after a settings change.
 customizer_showlink = Show link to website?
 
 customizer_config_updated = Settings have been saved

--- a/redaxo/src/addons/be_style/plugins/customizer/pages/system.customizer.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/pages/system.customizer.php
@@ -48,6 +48,10 @@ if (rex_post('btn_save', 'string') != '') {
         $tempConfig['showlink'] = 1;
     }
 
+    $tempConfig['inkfavicon'] = 0;
+    if (isset($newConfig['inkfavicon']) && $newConfig['inkfavicon'] == 1) {
+        $tempConfig['inkfavicon'] = 1;
+    }
     // save config
 
     if (empty($error) && rex_plugin::get('be_style', 'customizer')->setConfig($tempConfig)) {
@@ -169,6 +173,12 @@ $n = [];
 $n['label'] = '<label for="customizer-labelcolor">' . rex_i18n::msg('customizer_labelcolor') . '</label>';
 $n['field'] = '<input class="form-control" id="customizer-labelcolor" type="text" name="settings[labelcolor]" value="' . htmlspecialchars($config['labelcolor']) . '" />';
 $n['note'] = rex_i18n::msg('customizer_labelcolor_notice');
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="customizer-inkfavicon">' . rex_i18n::msg('customizer_inkfavicon') . '</label>';
+$n['field'] = '<input type="checkbox" id="customizer-inkfavicon" name="settings[inkfavicon]" value="1" ' . ($config['inkfavicon'] ? 'checked="checked" ' : '') . ' />';
+$n['field'] .= ' '.rex_i18n::msg('customizer_inkfavicon_text');
 $formElements[] = $n;
 
 $n = [];


### PR DESCRIPTION
die lösung aus https://github.com/danspringer/be_branding ist sehr sperrig (große php lib), daher hab ich das ganze hier mit ein paar zeilen javascript stattdessn gelöst.

wer die "volle dröhnung" brauch, kann ja dennoch das be_branding addon nehmen, wo man auch eigene bilder hochladen kann etc.

hier beschränke ich mich rein auf das einfärben der hintergrundfarbe des standard backend favicons

getestet im Firefox

![image](https://user-images.githubusercontent.com/120441/54076215-4f5e5800-42a9-11e9-9680-594ee677c474.png)

closes https://github.com/redaxo/redaxo/issues/797