### PR TITLE
Meldung "no startarticle" nutzt den FE Ooops.

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -79,7 +79,10 @@ if (rex::isBackend()) {
         if ($article->setArticleId(rex_article::getCurrentId())) {
             $content .= $article->getArticleTemplate();
         } else {
-            $content .= 'Kein Startartikel selektiert / No starting Article selected. Please click here to enter <a href="' . rex_url::backendController() . '">redaxo</a>';
+            $fragment = new rex_fragment([
+                'content' => '<p><b>Kein Startartikel selektiert - No starting Article selected.</b><br />Please click here to enter <a href="' . rex_url::backendController() . '">redaxo</a>.</p>',
+            ]);
+            $content .= $fragment->parse('core/fe_ooops.php');
             rex_response::sendPage($content);
             exit;
         }

--- a/redaxo/src/core/fragments/core/fe_ooops.php
+++ b/redaxo/src/core/fragments/core/fe_ooops.php
@@ -29,6 +29,13 @@
             text-align: center;
         }
 
+        .ooops-error a {
+            color: #666;
+        }
+        .ooops-error a:hover {
+            color: #111;
+        }
+
         .ooops-error-title {
             margin: 0;
             font-size: 50px;
@@ -46,6 +53,7 @@
         <div class="ooops-error">
             <p class="ooops-error-title">Ooops</p>
             <p class="ooops-error-message">Looks like something went wrong.</p>
+            <?= $this->getVar('content', '') ?>
         </div>
     </div>
 </body>


### PR DESCRIPTION
close #1107

Screenshot
<img width="1276" alt="Bildschirmfoto 2019-03-09 um 22 43 59" src="https://user-images.githubusercontent.com/338267/54077785-b5ed7100-42bd-11e9-9bdc-7eaaa1565e26.png">


@eaCe Da ich gern die schwarze Zeile weg haben wollte, könnten wir ja erst einmal die FE Ooops nutzen. Später können wir gern es noch wie in deinen Screens farbig machen.