### PR TITLE
Customizer: Erkennungsfarbe für mask-icon verwenden

### DIFF
--- a/redaxo/src/addons/be_style/plugins/redaxo/boot.php
+++ b/redaxo/src/addons/be_style/plugins/redaxo/boot.php
@@ -41,13 +41,15 @@ if (rex::isBackend()) {
     rex_view::addJsFile($plugin->getAssetsUrl('javascripts/redaxo.js'));
 
     rex_extension::register('PAGE_HEADER', function (rex_extension_point $ep) use ($plugin) {
+        $labelColor = rex_plugin::get('be_style', 'customizer')->getConfig('labelcolor') ?: '#404040';
+
         $icons = [];
 
         $icons[] = '<link rel="apple-touch-icon" sizes="180x180" href="' . $plugin->getAssetsUrl('icons/apple-touch-icon.png') . '" />';
         $icons[] = '<link rel="icon" type="image/png" sizes="32x32" href="' . $plugin->getAssetsUrl('icons/favicon-32x32.png') . '" />';
         $icons[] = '<link rel="icon" type="image/png" sizes="16x16" href="' . $plugin->getAssetsUrl('icons/favicon-16x16.png') . '" />';
         $icons[] = '<link rel="manifest" href="' . $plugin->getAssetsUrl('icons/manifest.json') . '">';
-        $icons[] = '<link rel="mask-icon" href="' . $plugin->getAssetsUrl('icons/safari-pinned-tab.svg') . '" color="#404040">';
+        $icons[] = '<link rel="mask-icon" href="' . $plugin->getAssetsUrl('icons/safari-pinned-tab.svg') . '" color="' . $labelColor . '">';
         $icons[] = '<link rel="shortcut icon" href="' . $plugin->getAssetsUrl('icons/favicon.ico') . '">';
         $icons[] = '<meta name="msapplication-TileColor" content="#ffffff">';
         $icons[] = '<meta name="msapplication-TileImage" content="' . $plugin->getAssetsUrl('icons/mstile-144x144.png') . '">';


### PR DESCRIPTION
ref #2574

Ist der Customizer aktiv und hat eine Erkennungsfarbe definiert, kann man diese fürs mask-icon verwenden. Im Safari schaut es dann so aus:

![Screenshot 2019-03-10 at 11 07 07](https://user-images.githubusercontent.com/1297466/54083515-b5d48c00-4324-11e9-99e6-1ade16806e9e.png)

Allerdings muss man dafür Icons in den Einstellungen aktivieren. Gibt es seit Safari 12.x, glaube ich, und ich weiß gerade nicht, ob die per Default aktiviert sind oder nicht. Jedenfalls, dort geht’s:

<img width="775" alt="Screenshot_2019-03-10_at_11_07_56" src="https://user-images.githubusercontent.com/1297466/54083535-faf8be00-4324-11e9-84e6-df645059aa13.png">