### PR TITLE
Linkmap Id anhand css stylen können

### DIFF
--- a/redaxo/src/addons/structure/lib/linkmap/linkmap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/linkmap.php
@@ -30,7 +30,7 @@ class rex_linkmap_category_tree extends rex_linkmap_tree_renderer
         $badgeCat = ($countChildren > 0) ? '<span class="badge">' . $countChildren . '</span>' : '';
         $li = '';
         $li .= '<li' . $liClasses . '>';
-        $li .= '<a' . $linkClasses . ' href="' . $this->context->getUrl(['category_id' => $cat->getId()]) . '">' . $liIcon . rex_escape($label) . '</a>';
+        $li .= '<a' . $linkClasses . ' href="' . $this->context->getUrl(['category_id' => $cat->getId()]) . '">' . $liIcon . rex_escape($label) . '</a> <span class="rex-linkmap-id rex-linkmap-category-tree-id">' . $cat->getId() . '</span>';
         $li .= $badgeCat;
         $li .= $subHtml;
         $li .= '</li>' . "\n";
@@ -57,6 +57,6 @@ class rex_linkmap_article_list extends rex_linkmap_article_list_renderer
     {
         $liAttr = ' class="list-group-item"';
         $url = 'javascript:insertLink(\'redaxo://' . $article->getId() . '\',\'' . rex_escape(trim(sprintf('%s [%s]', $article->getName(), $article->getId())), 'js') . '\');';
-        return rex_linkmap_tree_renderer::formatLi($article, $category_id, $this->context, $liAttr, ' href="' . $url . '"') . '</li>' . "\n";
+        return rex_linkmap_tree_renderer::formatLi($article, $category_id, $this->context, $liAttr, ' href="' . $url . '"') . ' <span class="rex-linkmap-id rex-linkmap-article-list-id">' . $article->getId() . '</span></li>' . "\n";
     }
 }

--- a/redaxo/src/addons/structure/lib/linkmap/renderer.php
+++ b/redaxo/src/addons/structure/lib/linkmap/renderer.php
@@ -91,8 +91,6 @@ abstract class rex_linkmap_tree_renderer
             $label = '&nbsp;';
         }
 
-        $label .= ' [' . $OOobject->getId() . ']';
-
         if ($OOobject instanceof rex_article && !$OOobject->hasTemplate()) {
             $label .= ' [' . rex_i18n::msg('linkmap_has_no_template') . ']';
         }


### PR DESCRIPTION
refs #2519

Soweit richtig? CSS fehlt noch. Wo sollen die Styles dazu rein?
Gibts sonst noch Stellen wo die Eckige-Klammer-Variante vorkommt?

Aktuell siehts so aus:

![Bildschirmfoto vom 2019-03-11 09-43-57](https://user-images.githubusercontent.com/2674480/54110701-618fe180-43e2-11e9-8148-d72d9bebcce0.png)
