### PR TITLE
Hotfix: Fehlerhafter Zeilenumbruch

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/boot.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/boot.php
@@ -142,7 +142,7 @@ if (rex::isBackend() && rex::getUser()) {
     if ($config['showlink']) {
         rex_view::setJsProperty(
             'customizer_showlink',
-            '<h1 class="be-style-customizer-title"><a href="'. rex_escape(rex::getServer()) .'" target="_blank" rel="noreferrer noopener"><span class="be-style-customizer-title-name">' . rex_escape(rex::getServerName()) . '</span><i class="fa fa-external-link"></i></a></h1>'
+            '<h1 class="be-style-customizer-title"><a href="'. rex_escape(rex::getServer()) .'" target="_blank" rel="noreferrer noopener"><span class="be-style-customizer-title-name">' . rex_escape(rex::getServerName()) . ' <i class="fa fa-external-link"></i></span></a></h1>'
         );
     }
 }


### PR DESCRIPTION
Nach dem Update von Redaxo 5.7beta2 auf beta3 (aktiviertes be_style Plugin "Customizer") taucht im eingefügten Webseiten-Link (Header) plötzlich ein Zeilenumbruch zwischen Link und Link-Icon auf. Die Anpassung behebt dieses Problem!