### PR TITLE
Mindestphp version anheben auf php 7.1

### DIFF
--- a/redaxo/src/addons/phpmailer/composer.json
+++ b/redaxo/src/addons/phpmailer/composer.json
@@ -1,3 +1,9 @@
 {
-    "require": { "phpmailer/phpmailer": "~6.0" }
+    "require": { "phpmailer/phpmailer": "~6.0" },
+
+    "config": {
+        "platform": {
+            "php": "7.1.3"
+        }
+    }
 }

--- a/redaxo/src/addons/phpmailer/composer.lock
+++ b/redaxo/src/addons/phpmailer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b8f62ead819fdd0d761e1886a093025",
+    "content-hash": "1ee771e3e72e6d298585490b159e81a0",
     "packages": [
         {
             "name": "phpmailer/phpmailer",
@@ -80,5 +80,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.1.3"
+    }
 }

--- a/redaxo/src/addons/tests/composer.json
+++ b/redaxo/src/addons/tests/composer.json
@@ -3,7 +3,7 @@
 
     "config": {
         "platform": {
-            "php": "5.5.9"
+            "php": "7.1.3"
         }
     }
 }

--- a/redaxo/src/addons/tests/composer.lock
+++ b/redaxo/src/addons/tests/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "653d17f1a2bdbb8853ff280736e4afb8",
+    "content-hash": "0b5ce402651cd1376afd84f492da854f",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -1063,7 +1063,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1196,6 +1196,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.5.9"
+        "php": "7.1.3"
     }
 }

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -9,7 +9,7 @@
  * @global boolean $REX['LOAD_PAGE']      [Optional] Wether the front controller should be loaded or not. Default value is false.
  */
 
-define('REX_MIN_PHP_VERSION', '5.5.9');
+define('REX_MIN_PHP_VERSION', '7.1.0');
 
 if (version_compare(PHP_VERSION, REX_MIN_PHP_VERSION) < 0) {
     throw new Exception('PHP version >=' . REX_MIN_PHP_VERSION . ' needed!');

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -9,7 +9,7 @@
  * @global boolean $REX['LOAD_PAGE']      [Optional] Wether the front controller should be loaded or not. Default value is false.
  */
 
-define('REX_MIN_PHP_VERSION', '7.1.0');
+define('REX_MIN_PHP_VERSION', '7.1.3');
 
 if (version_compare(PHP_VERSION, REX_MIN_PHP_VERSION) < 0) {
     throw new Exception('PHP version >=' . REX_MIN_PHP_VERSION . ' needed!');

--- a/redaxo/src/core/composer.json
+++ b/redaxo/src/core/composer.json
@@ -19,7 +19,7 @@
         "optimize-autoloader": true,
         "sort-packages": true,
         "platform": {
-            "php": "7.1"
+            "php": "7.1.3"
         }
     },
 

--- a/redaxo/src/core/composer.json
+++ b/redaxo/src/core/composer.json
@@ -19,7 +19,7 @@
         "optimize-autoloader": true,
         "sort-packages": true,
         "platform": {
-            "php": "5.6"
+            "php": "7.1"
         }
     },
 

--- a/redaxo/src/core/composer.lock
+++ b/redaxo/src/core/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca901a8e6d17e9e0b84c381090df49c1",
+    "content-hash": "c567b4c9bf623ffac3991dedbd372730",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -1189,6 +1189,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6"
+        "php": "7.1.3"
     }
 }

--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -3,8 +3,8 @@
 // don't use REX_MIN_PHP_VERSION or rex_setup::MIN_MYSQL_VERSION here!
 // while updating the core, the constants contain the old min versions from previous core version
 
-if (PHP_VERSION_ID < 70100) {
-    throw new rex_functional_exception(rex_i18n::msg('setup_301', PHP_VERSION, '7.1.0'));
+if (PHP_VERSION_ID < 70103) {
+    throw new rex_functional_exception(rex_i18n::msg('setup_301', PHP_VERSION, '7.1.3'));
 }
 
 $mysqlVersion = rex_sql::getServerVersion();

--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -1,10 +1,10 @@
 <?php
 
-// don't use REX_MIN_PHP_VERSION and rex_setup::MIN_MYSQL_VERSION here!
+// don't use REX_MIN_PHP_VERSION or rex_setup::MIN_MYSQL_VERSION here!
 // while updating the core, the constants contain the old min versions from previous core version
 
-if (PHP_VERSION_ID < 50509) {
-    throw new rex_functional_exception(rex_i18n::msg('setup_301', PHP_VERSION, '5.5.9'));
+if (PHP_VERSION_ID < 70100) {
+    throw new rex_functional_exception(rex_i18n::msg('setup_301', PHP_VERSION, '7.1.0'));
 }
 
 $mysqlVersion = rex_sql::getServerVersion();


### PR DESCRIPTION
Todo (ggf. Separate PRs)
- [ ] composer version constraints checken
- [ ] composer update
- [ ] codebase nach PHP_VERSION_ID durchsuchen und ggf. Dead code löschen