### PR TITLE
travis: qa tools am ende sammeln

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
         -   <<: *TEST_MYSQL
             php: 7.3
             
-        -   stage: code qa
+        -   stage: Code QA
             php: 7.1
             env: TYPE=linting
             script: if find . -name "*.php" ! -path "*/vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,27 +19,6 @@ before_install:
 
 jobs:
     include:
-        -   php: 7.1
-            env: TYPE=linting
-            script: if find . -name "*.php" ! -path "*/vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
-
-        -   php: 7.3
-            env: TYPE=phpstan
-            services:
-                - mysql
-            script:
-                - mysql -e 'create database redaxo_5_0;'
-                - php redaxo/src/addons/tests/bin/setup.php
-                - php redaxo/bin/console package:install phpmailer
-                - php redaxo/bin/console package:install cronjob
-                - php redaxo/bin/console package:install cronjob/article_status
-                - php redaxo/bin/console package:install cronjob/optimize_tables
-                - php redaxo/bin/console package:install debug
-                - php redaxo/bin/console package:install structure/history
-                - php redaxo/bin/console package:install structure/version
-                - composer require --dev phpstan/phpstan
-                - vendor/bin/phpstan analyse
-
         -   &TEST
             install:
                 - mysql -e 'create database redaxo_5_0;'
@@ -68,3 +47,25 @@ jobs:
             php: 7.2
         -   <<: *TEST_MYSQL
             php: 7.3
+            
+        -   stage: code qa
+            php: 7.1
+            env: TYPE=linting
+            script: if find . -name "*.php" ! -path "*/vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
+
+        -   php: 7.3
+            env: TYPE=phpstan
+            services:
+                - mysql
+            script:
+                - mysql -e 'create database redaxo_5_0;'
+                - php redaxo/src/addons/tests/bin/setup.php
+                - php redaxo/bin/console package:install phpmailer
+                - php redaxo/bin/console package:install cronjob
+                - php redaxo/bin/console package:install cronjob/article_status
+                - php redaxo/bin/console package:install cronjob/optimize_tables
+                - php redaxo/bin/console package:install debug
+                - php redaxo/bin/console package:install structure/history
+                - php redaxo/bin/console package:install structure/version
+                - composer require --dev phpstan/phpstan
+                - vendor/bin/phpstan analyse


### PR DESCRIPTION
code qa builds sind dann jetzt bei travis schön separiert

![grafik](https://user-images.githubusercontent.com/120441/54418961-9bc0f200-4706-11e9-90bd-db6c86ca54e9.png)
