### PR TITLE
PHPMailer::Errormail Setze aktuelle Zeit

### DIFF
--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -74,10 +74,6 @@ if (!rex::isBackend() && $addon->getConfig('errormail') != 0) {
                 $mailBody .= '    </tbody>';
                 $mailBody .= '</table>';
                 //End - generate mailbody
-
-                //Start  send mail
-                $fileTime = filemtime($logFile);
-
                 $mail = new rex_mailer();
                 $mail->Subject = rex::getServerName() . ' - error report ';
                 $mail->Body = $mailBody;

--- a/redaxo/src/addons/phpmailer/boot.php
+++ b/redaxo/src/addons/phpmailer/boot.php
@@ -84,7 +84,7 @@ if (!rex::isBackend() && $addon->getConfig('errormail') != 0) {
                 $mail->AltBody = strip_tags($mailBody);
                 $mail->setFrom(rex::getErrorEmail(), 'REDAXO error report');
                 $mail->addAddress(rex::getErrorEmail());
-                $addon->setConfig('last_log_file_send_time', $fileTime);
+                $addon->setConfig('last_log_file_send_time', time());
                 if ($mail->Send()) {
                     // mail has been sent
                 }


### PR DESCRIPTION
fixed: https://github.com/redaxo/redaxo/issues/2538
Zur Info: Es wurde immer die filetime des Logs gesetzt, anstelle des eigentlichen Sendezeitpunktes. 
