### PR TITLE
Revert "Clear-Site-Data: "executionContexts" (#2615)"

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -123,7 +123,7 @@ if (rex::isSetup()) {
             // clear in-browser data of a previous session with the same browser for security reasons.
             // a possible attacker should not be able to access cached data of a previous valid session on the same computer.
             // clearing "executionContext" or "cookies" would result in a endless loop.
-            rex_response::setHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
+            rex_response::setHeader('Clear-Site-Data', '"cache", "storage"');
 
             // Currently browsers like Safari do not support the header Clear-Site-Data.
             // we dont kill/regenerate the session so e.g. the frontend will not get logged out


### PR DESCRIPTION
This reverts commit e281e1a1e5c19a7aa93f8c8717e73ebd53317a19.

wg. endlosschleifen die manchmal auftauchen im Firefox
(z.b. wenn man eingeloggt ist, den cookie löscht und dann in der minibar ein lazy-element triggert)