### PR TITLE
%DATABASE% als Platzhalter aufgenommen

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -146,7 +146,7 @@ class rex_sql implements Iterator
      *
      * @return string
      */
-    protected static function stripQueryDBID(&$qry)
+    public static function stripQueryDBID(&$qry)
     {
         $qry = trim($qry);
 

--- a/redaxo/src/core/lib/sql/util.php
+++ b/redaxo/src/core/lib/sql/util.php
@@ -68,7 +68,7 @@ class rex_sql_util
         return true;
     }
 
-    private static function prepareQuery($qry)
+    public static function prepareQuery($qry)
     {
         // rex::getUser() gibts im Setup nicht
         $user = rex::getUser() ? rex::getUser()->getValue('login') : '';
@@ -77,6 +77,10 @@ class rex_sql_util
         $qry = str_replace('%TIME%', time(), $qry);
         $qry = str_replace('%TABLE_PREFIX%', rex::getTablePrefix(), $qry);
         $qry = str_replace('%TEMP_PREFIX%', rex::getTempPrefix(), $qry);
+
+        $dbconfig = rex::getProperty('db');
+        $dbid = rex_sql::stripQueryDBID($qry) ?: 1;
+        $qry = str_replace('%DATABASE%', $dbconfig[$dbid]['name'], $qry);
 
         return $qry;
     }


### PR DESCRIPTION
Hintergrund: Damit lassen sich bei SQL-Methoden wie `rex_select::addSqlOptions` oder beim Choice Value solche Queries erzeugen und somit Tabellen zur Auswahl anbieten

```
SELECT table_name AS id,  table_name AS name FROM information_schema.tables WHERE table_schema= "%DATABASE%" ORDER BY name

(DB2) SELECT table_name AS id,  table_name AS name FROM information_schema.tables WHERE table_schema= "%DATABASE%" ORDER BY name
```