### PR TITLE
Im debug mode das frontend vor seo crawlern verstecken

### DIFF
--- a/redaxo/src/core/frontend.php
+++ b/redaxo/src/core/frontend.php
@@ -8,6 +8,10 @@ if (rex::isSetup()) {
     rex_response::sendRedirect(rex_url::backendController());
 }
 
+if (rex::isDebugMode()) {
+    header('X-Robots-Tag: noindex, nofollow, noarchive');
+}
+
 // ----- INCLUDE ADDONS
 include_once rex_path::core('packages.php');
 


### PR DESCRIPTION
Im setup leiten wir bereits vom frontend aufs backend um. Im backend werden diese header immer verwendet (ist bereits so).

Daher wird hier nur noch im frontend der noindex header ergänzt, wenn der debug-mode aktiv ist

Closes https://github.com/redaxo/redaxo/issues/2670

Ungetestet 