### PR TITLE
Command config:get: writeln statt write

### DIFF
--- a/redaxo/src/core/lib/console/config/get.php
+++ b/redaxo/src/core/lib/console/config/get.php
@@ -43,7 +43,7 @@ class rex_command_config_get extends rex_console_command
             $config = $config[$pathPart];
         }
 
-        $output->write(json_encode($config));
+        $output->writeln(json_encode($config));
 
         return 0;
     }


### PR DESCRIPTION
Die Ausgabe sollte mit einer Newline enden.

![Screenshot 2019-03-27 22 50 46](https://user-images.githubusercontent.com/330436/55114812-3e07af00-50e3-11e9-8dc2-f5968b2ababb.png)

Oben vorher, unten nachher.

Bei mir wird bei fehlender Newline also diese "%" ausgegeben, andere Terminals würden den neuen Befehl tatsächlich auf der gleichen Zeile beginnen.

Würde ich in 5.7.1 mit reinnehmen.