### PR TITLE
immutable assets: sourceMappingURL entfernen

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -22,8 +22,12 @@ if (rex_get('asset') && rex_get('buster')) {
 
     $ext = rex_file::extension($assetFile);
     if ('js' === $ext) {
+        $js = rex_file::get($assetFile);
+
+        $js = preg_replace('@^//# sourceMappingURL=.*$@m', '', $js);
+
         rex_response::sendCacheControl('max-age=31536000, immutable');
-        rex_response::sendFile($assetFile, 'application/javascript');
+        rex_response::sendContent($js, 'application/javascript');
     } elseif ('css' === $ext) {
         $styles = rex_file::get($assetFile);
 


### PR DESCRIPTION
closes #2664

So könnte man zumindest vermeiden, dass der Browser versucht die .map unter der falschen URL zu laden. So wird sie gar nicht mehr geladen.