### PR TITLE
allow-failures on php7.1 with mariadb 10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,3 @@ allow_failures:
     env:
         - TYPE=phpunit
         - DB=mariadb
-    addons:
-        mariadb: 10.1
-    

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,3 +71,12 @@ jobs:
             php: 7.2
         -   <<: *TEST_MYSQL
             php: 7.3
+
+allow_failures:
+  - php: 7.1
+    env:
+        - TYPE=phpunit
+        - DB=mariadb
+    addons:
+        mariadb: 10.1
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,9 @@ jobs:
         -   <<: *TEST_MYSQL
             php: 7.3
 
-allow_failures:
-  - php: 7.1
-    env:
-        - TYPE=phpunit
-        - DB=mariadb
+matrix:
+    allow_failures:
+      - php: 7.1
+        env:
+            - TYPE=phpunit
+            - DB=mariadb


### PR DESCRIPTION
da es aktuell regelmäßig failed.

habe dem travis support geschrieben um das problem zu prüfen.