### PR TITLE
'set -e' in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
         -   php: 7.1
             env: TYPE=linting
             script:
+                - set -e
                 - composer require --dev friendsofredaxo/linter
                 - vendor/bin/rexlint
 
@@ -31,6 +32,7 @@ jobs:
             services:
                 - mysql
             script:
+                - set -e
                 - mysql -e 'create database redaxo_5_0;'
                 - php redaxo/src/addons/tests/bin/setup.php
                 - php redaxo/bin/console package:install phpmailer


### PR DESCRIPTION
https://stackoverflow.com/questions/19622198/what-does-set-e-mean-in-a-bash-script

> Basically, set -e aborts the execution of a command (e.g. a shell script) and returns the exit status code of the command that failed (i.e. the inner script, not the outer script).