### PR TITLE
Speicheroptimierung bei Backups / weniger Speicherbedarf

### DIFF
--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -482,7 +482,7 @@ class rex_backup
     {
         do {
             $sql = rex_sql::factory();
-            $array = $sql->getArray('SELECT * FROM ' . $sql->escapeIdentifier($table) . ' LIMIT ' . $start . ',' . $max, [], PDO::FETCH_NUM);
+            $sql->setQuery('SELECT * FROM ' . $sql->escapeIdentifier($table) . ' LIMIT ' . $start . ',' . $max);
             $count = $sql->getRows();
 
             if ($count > 0 && 0 == $start) {
@@ -495,11 +495,12 @@ class rex_backup
             $start += $max;
             $values = [];
 
-            foreach ($array as $row) {
+            foreach ($sql as $row) {
                 $record = [];
+                $array = $row->getRow(PDO::FETCH_NUM);
 
                 foreach ($fields as $idx => $type) {
-                    $column = $row[$idx];
+                    $column = $array[$idx];
 
                     switch ($type) {
                         // prevent calling sql->escape() on values with a known format
@@ -507,10 +508,10 @@ class rex_backup
                             $record[] = "'" . $column . "'";
                             break;
                         case 'int':
-                            $record[] = (int)$column;
+                            $record[] = (int) $column;
                             break;
                         case 'double':
-                            $record[] = sprintf('%.10F', (float)$column);
+                            $record[] = sprintf('%.10F', (float) $column);
                             break;
                         case 'string':
                             // fast-exit for very frequent used harmless values

--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -536,8 +536,21 @@ class rex_backup
             }
 
             if (!empty($values)) {
-                fwrite($fp, $nl . 'INSERT INTO ' . $sql->escapeIdentifier($table) . ' VALUES ' . implode(',', $values) . ';');
+                fwrite($fp, $nl . 'INSERT INTO ' . $sql->escapeIdentifier($table) . ' VALUES ');
+
+                // iterate the values instead of implode() to save a few MB memory
+                $numValues = count($values);
+                $lastIdx = $numValues - 1;
+                for ($i = 0; $i < $numValues; ++$i) {
+                    if ($i == $lastIdx) {
+                        fwrite($fp, $values[$i]);
+                    } else {
+                        fwrite($fp, $values[$i]. ',');
+                    }
+                }
                 unset($values);
+
+                fwrite($fp, ';');
             }
         } while ($count >= $max);
     }


### PR DESCRIPTION
Vorher
![image](https://user-images.githubusercontent.com/120441/59507019-03274300-8eaa-11e9-9f5f-1f7cba137ffa.png)

Nachher
![image](https://user-images.githubusercontent.com/120441/59507032-0d494180-8eaa-11e9-9a8c-4eb4f02b5f39.png)

bitte *nicht squashen* beim merge

=> ca. 45% weniger Speicherbedarf