### PR TITLE
Link des "Artikel anzeigen"-Tabs => Arbeitsversion aufnehmen

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/pages/content.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.php
@@ -380,7 +380,18 @@ if (1 == $article->getRows()) {
         $navigation = current($blocks);
         $content_navi_right = $navigation['navigation'];
 
-        $content_navi_right[] = ['title' => '<a href="' . rex_getUrl($article_id, $clang) . '" onclick="window.open(this.href); return false;"><i class="rex-icon rex-icon-view"></i> ' . rex_i18n::msg('article') . ' ' . rex_i18n::msg('show') . '</a>'];
+		### Wenn Version-Plugin aktiv => Link des "Artikel anzeigen"-Reiters => Arbeitsversion berücksichtigen
+		if(rex_plugin::get('structure', 'version')->isAvailable() === true){
+    		$revision = rex::getProperty('login')->getSessionVar('rex_version_article');
+			$link = ($revision[$article_id] == 1)
+	    		? rex_getUrl($article_id, $clang, ['rex_version' => $revision[$article_id]])
+				: rex_getUrl($article_id, $clang, []);
+		}
+		else {
+		    $link = rex_getUrl($article_id, $clang);
+		}
+				
+        $content_navi_right[] = ['title' => '<a href="' . $link . '" onclick="window.open(this.href); return false;"><i class="rex-icon rex-icon-view"></i> ' . rex_i18n::msg('article') . ' ' . rex_i18n::msg('show') . '</a>'];
 
         $fragment = new rex_fragment();
         $fragment->setVar('id', 'rex-js-structure-content-nav', false);


### PR DESCRIPTION
Häufiges Nutzerverhalten bei aktiviertem "Structure"-Plugin "Version":

Ein User befindet sich in der Arbeitsversion und möchte seinen Artikel sichtprüfen mit Klick auf den "Artikel anzeigen"-Tab. Problem: Der Tab ruft IMMER die Live-Version auf und der User merkt den Unterschied nicht, denn er erwartet die Voransicht der Arbeitsversion.

Zur Diskussion freigegeben:
Durch diesen Hack wird jetzt theoretisch der "Voransicht"-Link in der Version-Menüleiste obsolet. Ich würde bei Bedarf dort ebenfalls einen PR erstellen...