### PR TITLE
PHPMailer: Timeout auf 10 gesetzt.

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -17,7 +17,7 @@ class rex_mailer extends PHPMailer
     public function __construct($exceptions = false)
     {
         $addon = rex_addon::get('phpmailer');
-        $this->Timeout = 30;
+        $this->Timeout = 10;
         $this->setLanguage(rex_i18n::getLanguage(), $addon->getPath('vendor/phpmailer/phpmailer/language/'));
         $this->XMailer = 'REXMailer';
         $this->From = $addon->getConfig('from');

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -17,6 +17,7 @@ class rex_mailer extends PHPMailer
     public function __construct($exceptions = false)
     {
         $addon = rex_addon::get('phpmailer');
+        $this->Timeout = 30;
         $this->setLanguage(rex_i18n::getLanguage(), $addon->getPath('vendor/phpmailer/phpmailer/language/'));
         $this->XMailer = 'REXMailer';
         $this->From = $addon->getConfig('from');

--- a/redaxo/src/addons/phpmailer/package.yml
+++ b/redaxo/src/addons/phpmailer/package.yml
@@ -1,5 +1,5 @@
 package: phpmailer
-version: '2.5.2'
+version: '2.5.1'
 author: 'Markus Staab, Thomas Skerbis, Jan Kristinus, Brent R. Matzelle'
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/phpmailer/package.yml
+++ b/redaxo/src/addons/phpmailer/package.yml
@@ -1,5 +1,5 @@
 package: phpmailer
-version: '2.5.1'
+version: '2.5.2'
 author: 'Markus Staab, Thomas Skerbis, Jan Kristinus, Brent R. Matzelle'
 supportpage: www.redaxo.org/de/forum/
 


### PR DESCRIPTION
Es konnte zu einem Crash kommen, wenn die Laufzeit für PHP-Skripte serverseitig niedriger eingestellt ist, als im PHPMailer. 
Das Default-Timeout 300 vom PHPMailer erscheint mir viel zu hoch. 
Der PR setzt den PHPMailer Timeout auf 30
Fixes: https://github.com/redaxo/redaxo/issues/2699