### PR TITLE
travis: allow php 7.4snapshot to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,10 @@ jobs:
 
 matrix:
     allow_failures:
+      - php: 7.4snapshot
+        env:
+            - TYPE=phpunit
+            - DB=mysql
       - php: 7.1
         env:
             - TYPE=phpunit


### PR DESCRIPTION
wg. folgenden errors:

https://travis-ci.org/redaxo/redaxo/jobs/567468540

![image](https://user-images.githubusercontent.com/120441/62420493-673cdb00-b693-11e9-8d45-497ccd5a91f3.png)