### PR TITLE
rex_config_form: $namespace korrekt in form-hash einbeziehen

### DIFF
--- a/redaxo/src/core/lib/form/config_form.php
+++ b/redaxo/src/core/lib/form/config_form.php
@@ -13,7 +13,7 @@ class rex_config_form extends rex_form_base
 
     protected function __construct($namespace, $fieldset = null, $debug = false)
     {
-        parent::__construct($fieldset, md5($this->namespace.$fieldset), 'post', $debug);
+        parent::__construct($fieldset, md5($namespace.$fieldset), 'post', $debug);
 
         $this->namespace = $namespace;
 


### PR DESCRIPTION
fixes #2752