### PR TITLE
rex_article_content: Einheitliches Format für createdate/updatedate

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -125,10 +125,6 @@ class rex_article_content_base
             $this->template_id = $this->getValue('template_id');
             $this->category_id = $this->getValue('category_id');
 
-            // use same timestamp format like in frontend via `rex_article`
-            $sql->setValue('createdate', $sql->getDateTimeValue('createdate'));
-            $sql->setValue('updatedate', $sql->getDateTimeValue('updatedate'));
-
             return true;
         }
 
@@ -185,6 +181,11 @@ class rex_article_content_base
     protected function _getValue($value)
     {
         $value = $this->correctValue($value);
+
+        // use same timestamp format like in frontend via `rex_article`
+        if (in_array($value, ['createdate', 'updatedate'], true)) {
+            return $this->getSqlInstance()->getDateTimeValue($value);
+        }
 
         return $this->getSqlInstance()->getValue($value);
     }

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -124,6 +124,11 @@ class rex_article_content_base
         if (1 == $sql->getRows()) {
             $this->template_id = $this->getValue('template_id');
             $this->category_id = $this->getValue('category_id');
+
+            // use same timestamp format like in frontend via `rex_article`
+            $sql->setValue('createdate', $sql->getDateTimeValue('createdate'));
+            $sql->setValue('updatedate', $sql->getDateTimeValue('updatedate'));
+
             return true;
         }
 

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -124,7 +124,6 @@ class rex_article_content_base
         if (1 == $sql->getRows()) {
             $this->template_id = $this->getValue('template_id');
             $this->category_id = $this->getValue('category_id');
-
             return true;
         }
 


### PR DESCRIPTION
fixes #2792

Es wird nun einheitlich das unix-timestamp-format genutzt, wie im Frontend (da kommen die Daten via `rex_article`).