### PR TITLE
Revert "be_style: rex_copy() return wert während installation auswerten"

### DIFF
--- a/redaxo/src/addons/be_style/install.php
+++ b/redaxo/src/addons/be_style/install.php
@@ -16,5 +16,6 @@ $addon = rex_addon::get('be_style');
 $files = require __DIR__.'/vendor_files.php';
 
 foreach ($files as $source => $destination) {
+    // ignore errors, because this file is included very early in setup, before the regular file permissions check
     rex_file::copy($addon->getPath($source), $addon->getAssetsPath($destination));
 }

--- a/redaxo/src/addons/be_style/install.php
+++ b/redaxo/src/addons/be_style/install.php
@@ -16,7 +16,5 @@ $addon = rex_addon::get('be_style');
 $files = require __DIR__.'/vendor_files.php';
 
 foreach ($files as $source => $destination) {
-    if (false === rex_file::copy($addon->getPath($source), $addon->getAssetsPath($destination))) {
-        throw new rex_functional_exception('Unable to copy file from "'. $addon->getPath($source) .'" to "'. $addon->getAssetsPath($destination) .'"');
-    }
+    rex_file::copy($addon->getPath($source), $addon->getAssetsPath($destination));
 }


### PR DESCRIPTION
Revert #2658

Erläuterung siehe [hier](https://github.com/redaxo/redaxo/pull/2658#issuecomment-520241257).

Ich habe es nun auch getestet, und in der Tat kommt man so nicht bis zum eigentlichen Rechtecheck im Setup.
Da ich gerade nicht recht weiß, wie man es stattdessen am besten löst, erstmal von mir nur ein Revert.
Die Änderung wurde ja vor allem für das Entwickeln an der git-Version gemacht, und ich denke da ist die UX bei der ZIP-Version wichtiger.

---

Diese Meldung bekommt man sonst direkt beim Setup aufrufen, wenn die Schreibrechte noch nicht passen:

**rex_functional_exception:** Unable to copy file from "/Users/gharlan/workspace/redaxo/redaxo/src/addons/be_style/vendor/bootstrap/assets/javascripts/bootstrap.js" to "/Users/gharlan/workspace/redaxo/assets/addons/be_style/javascripts/bootstrap.js"
**File:** redaxo/src/addons/be_style/install.php
**Line:** 20

<details>
<summary>Stacktrace</summary>

| Function                              | File                                     | Line     |
| ------------------------------------- | ---------------------------------------- | -------- |
| include                               | redaxo/src/core/lib/packages/package.php | 228      |
| rex_package->includeFile              | redaxo/src/core/lib/setup/setup.php      | 38       |
| rex_setup::init                       | redaxo/src/core/pages/setup.php          | 17       |
| include                               | redaxo/src/core/lib/be/controller.php    | 467      |
| rex_be_controller::includePath        | redaxo/src/core/lib/be/controller.php    | 413      |
| rex_be_controller::includeCurrentPage | redaxo/src/core/backend.php              | 215      |
| require                               | redaxo/src/core/boot.php                 | 135      |
| require                               | redaxo/index.php                         | 9        |

</details>
<details>
<summary>System report (REDAXO 5.8.0-dev#105ac374f, PHP 7.3.7)</summary>

| REDAXO        |                     |
| ------------: | :------------------ |
|       Version | 5.8.0-dev#105ac374f |


| PHP           |            |
| ------------: | :--------- |
|       Version | 7.3.7      |
|       OPcache | yes        |
|        Xdebug | no         |


| Database      |                        |
| ------------: | :--------------------- |
|       Version | 5.5.5-10.3.14-MariaDB  |
| Character set | utf8 (utf8_general_ci) |


| Database 2    |                        |
| ------------: | :--------------------- |
|       Version | 5.5.5-10.3.14-MariaDB  |
| Character set | utf8 (utf8_general_ci) |


| Server        |                |
| ------------: | :------------- |
|            OS | Darwin         |
|          SAPI | apache2handler |
|     Webserver | Apache/2.4.39  |


| Request       |             |
| ------------: | :---------- |
|       Browser | Safari/13.0 |
|      Protocol | HTTP/1.1    |
|         HTTPS | no          |


| Packages      |            |
| ------------: | :--------- |

</details>