### PR TITLE
rex_metainfo_table_manager konstanten definieren

### DIFF
--- a/redaxo/src/addons/metainfo/boot.php
+++ b/redaxo/src/addons/metainfo/boot.php
@@ -13,33 +13,33 @@ $addon = rex_addon::get('metainfo');
 
 if (!defined('REX_METAINFO_FIELD_TEXT')) {
     // Feldtypen
-    /** @deprecated use rex_metainfo_table_manager::FIELD_TEXT instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_TEXT instead */
     define('REX_METAINFO_FIELD_TEXT', 1);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_TEXT instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_TEXT instead */
     define('REX_METAINFO_FIELD_TEXTAREA', 2);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_TEXTAREA instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_TEXTAREA instead */
     define('REX_METAINFO_FIELD_SELECT', 3);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_SELECT instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_SELECT instead */
     define('REX_METAINFO_FIELD_RADIO', 4);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_RADIO instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_RADIO instead */
     define('REX_METAINFO_FIELD_CHECKBOX', 5);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_CHECKBOX instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_CHECKBOX instead */
     define('REX_METAINFO_FIELD_REX_MEDIA_WIDGET', 6);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_REX_MEDIA_WIDGET instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_REX_MEDIA_WIDGET instead */
     define('REX_METAINFO_FIELD_REX_MEDIALIST_WIDGET', 7);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_REX_MEDIALIST_WIDGET instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_REX_MEDIALIST_WIDGET instead */
     define('REX_METAINFO_FIELD_REX_LINK_WIDGET', 8);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_REX_LINK_WIDGET instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_REX_LINK_WIDGET instead */
     define('REX_METAINFO_FIELD_REX_LINKLIST_WIDGET', 9);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_REX_LINKLIST_WIDGET instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_REX_LINKLIST_WIDGET instead */
     define('REX_METAINFO_FIELD_DATE', 10);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_DATE instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_DATE instead */
     define('REX_METAINFO_FIELD_DATETIME', 11);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_DATETIME instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_DATETIME instead */
     define('REX_METAINFO_FIELD_LEGEND', 12);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_LEGEND instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_LEGEND instead */
     define('REX_METAINFO_FIELD_TIME', 13);
-    /** @deprecated use rex_metainfo_table_manager::FIELD_COUNT instead */    
+    /* @deprecated use rex_metainfo_table_manager::FIELD_COUNT instead */
     define('REX_METAINFO_FIELD_COUNT', 13);
 }
 

--- a/redaxo/src/addons/metainfo/boot.php
+++ b/redaxo/src/addons/metainfo/boot.php
@@ -13,19 +13,33 @@ $addon = rex_addon::get('metainfo');
 
 if (!defined('REX_METAINFO_FIELD_TEXT')) {
     // Feldtypen
+    /** @deprecated use rex_metainfo_table_manager::FIELD_TEXT instead */    
     define('REX_METAINFO_FIELD_TEXT', 1);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_TEXT instead */    
     define('REX_METAINFO_FIELD_TEXTAREA', 2);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_TEXTAREA instead */    
     define('REX_METAINFO_FIELD_SELECT', 3);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_SELECT instead */    
     define('REX_METAINFO_FIELD_RADIO', 4);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_RADIO instead */    
     define('REX_METAINFO_FIELD_CHECKBOX', 5);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_CHECKBOX instead */    
     define('REX_METAINFO_FIELD_REX_MEDIA_WIDGET', 6);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_REX_MEDIA_WIDGET instead */    
     define('REX_METAINFO_FIELD_REX_MEDIALIST_WIDGET', 7);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_REX_MEDIALIST_WIDGET instead */    
     define('REX_METAINFO_FIELD_REX_LINK_WIDGET', 8);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_REX_LINK_WIDGET instead */    
     define('REX_METAINFO_FIELD_REX_LINKLIST_WIDGET', 9);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_REX_LINKLIST_WIDGET instead */    
     define('REX_METAINFO_FIELD_DATE', 10);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_DATE instead */    
     define('REX_METAINFO_FIELD_DATETIME', 11);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_DATETIME instead */    
     define('REX_METAINFO_FIELD_LEGEND', 12);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_LEGEND instead */    
     define('REX_METAINFO_FIELD_TIME', 13);
+    /** @deprecated use rex_metainfo_table_manager::FIELD_COUNT instead */    
     define('REX_METAINFO_FIELD_COUNT', 13);
 }
 

--- a/redaxo/src/addons/metainfo/boot.php
+++ b/redaxo/src/addons/metainfo/boot.php
@@ -15,15 +15,15 @@ if (!defined('REX_METAINFO_FIELD_TEXT')) {
     // Feldtypen
     /* @deprecated use rex_metainfo_table_manager::FIELD_TEXT instead */
     define('REX_METAINFO_FIELD_TEXT', 1);
-    /* @deprecated use rex_metainfo_table_manager::FIELD_TEXT instead */
-    define('REX_METAINFO_FIELD_TEXTAREA', 2);
     /* @deprecated use rex_metainfo_table_manager::FIELD_TEXTAREA instead */
-    define('REX_METAINFO_FIELD_SELECT', 3);
+    define('REX_METAINFO_FIELD_TEXTAREA', 2);
     /* @deprecated use rex_metainfo_table_manager::FIELD_SELECT instead */
-    define('REX_METAINFO_FIELD_RADIO', 4);
+    define('REX_METAINFO_FIELD_SELECT', 3);
     /* @deprecated use rex_metainfo_table_manager::FIELD_RADIO instead */
-    define('REX_METAINFO_FIELD_CHECKBOX', 5);
+    define('REX_METAINFO_FIELD_RADIO', 4);
     /* @deprecated use rex_metainfo_table_manager::FIELD_CHECKBOX instead */
+    define('REX_METAINFO_FIELD_CHECKBOX', 5);
+    /* @deprecated use rex_metainfo_table_manager::FIELD_MEDIA_WIDGET instead */
     define('REX_METAINFO_FIELD_REX_MEDIA_WIDGET', 6);
     /* @deprecated use rex_metainfo_table_manager::FIELD_REX_MEDIA_WIDGET instead */
     define('REX_METAINFO_FIELD_REX_MEDIALIST_WIDGET', 7);

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -558,7 +558,7 @@ abstract class rex_metainfo_handler
      * Retrieves the posted value for the given field and converts it into a saveable format.
      *
      * @param string $fieldName       The name of the field
-     * @param int    $fieldType       One of the REX_METAINFO_FIELD_* constants
+     * @param int    $fieldType       One of the rex_metainfo_table_manager::FIELD_* constants
      * @param string $fieldAttributes The attributes of the field
      *
      * @return string
@@ -600,8 +600,8 @@ abstract class rex_metainfo_handler
                 $saveValue = '|' . implode('|', $postValue) . '|';
             } else {
                 $postValue = $postValue[0] ?? '';
-                if (REX_METAINFO_FIELD_SELECT == $fieldType && false !== strpos($fieldAttributes, 'multiple') ||
-                     REX_METAINFO_FIELD_CHECKBOX == $fieldType
+                if (rex_metainfo_table_manager::FIELD_SELECT == $fieldType && false !== strpos($fieldAttributes, 'multiple') ||
+                     rex_metainfo_table_manager::FIELD_CHECKBOX == $fieldType
                 ) {
                     // Mehrwertiges Feld, aber nur ein Wert ausgewählt
                     $saveValue = '|' . $postValue . '|';

--- a/redaxo/src/addons/metainfo/lib/table_expander.php
+++ b/redaxo/src/addons/metainfo/lib/table_expander.php
@@ -27,7 +27,7 @@ class rex_metainfo_table_expander extends rex_form
     {
         // ----- EXTENSION POINT
         // IDs aller Feldtypen bei denen das Parameter-Feld eingeblendet werden soll
-        $typeFields = rex_extension::registerPoint(new rex_extension_point('METAINFO_TYPE_FIELDS', [REX_METAINFO_FIELD_SELECT, REX_METAINFO_FIELD_RADIO, REX_METAINFO_FIELD_CHECKBOX, REX_METAINFO_FIELD_REX_MEDIA_WIDGET, REX_METAINFO_FIELD_REX_MEDIALIST_WIDGET, REX_METAINFO_FIELD_REX_LINK_WIDGET, REX_METAINFO_FIELD_REX_LINKLIST_WIDGET, REX_METAINFO_FIELD_DATE, REX_METAINFO_FIELD_DATETIME]));
+        $typeFields = rex_extension::registerPoint(new rex_extension_point('METAINFO_TYPE_FIELDS', [rex_metainfo_table_manager::FIELD_SELECT, rex_metainfo_table_manager::FIELD_RADIO, rex_metainfo_table_manager::FIELD_CHECKBOX, rex_metainfo_table_manager::FIELD_REX_MEDIA_WIDGET, rex_metainfo_table_manager::FIELD_REX_MEDIALIST_WIDGET, rex_metainfo_table_manager::FIELD_REX_LINK_WIDGET, rex_metainfo_table_manager::FIELD_REX_LINKLIST_WIDGET, rex_metainfo_table_manager::FIELD_DATE, rex_metainfo_table_manager::FIELD_DATETIME]));
 
         $field = $this->addReadOnlyField('prefix', $this->metaPrefix);
         $field->setLabel(rex_i18n::msg('minfo_field_label_prefix'));
@@ -86,7 +86,7 @@ class rex_metainfo_table_expander extends rex_form
         $select->addSqlOptions($qry);
 
         $notices = '';
-        for ($i = 1; $i < REX_METAINFO_FIELD_COUNT; ++$i) {
+        for ($i = 1; $i < rex_metainfo_table_manager::FIELD_COUNT; ++$i) {
             if (rex_i18n::hasMsg('minfo_field_params_notice_' . $i)) {
                 $notices .= '<span id="metainfo-field-params-notice-' . $i . '" style="display:none">' . rex_i18n::msg('minfo_field_params_notice_' . $i) . '</span>' . "\n";
             }
@@ -247,7 +247,7 @@ class rex_metainfo_table_expander extends rex_form
 
             if (
                 strlen($fieldDefault) &&
-                (REX_METAINFO_FIELD_CHECKBOX === $fieldType || REX_METAINFO_FIELD_SELECT === $fieldType && isset(rex_string::split($fieldAttributes)['multiple']))
+                (rex_metainfo_table_manager::FIELD_CHECKBOX === $fieldType || rex_metainfo_table_manager::FIELD_SELECT === $fieldType && isset(rex_string::split($fieldAttributes)['multiple']))
             ) {
                 $fieldDefault = '|'.trim($fieldDefault, '|').'|';
             }

--- a/redaxo/src/addons/metainfo/lib/table_manager.php
+++ b/redaxo/src/addons/metainfo/lib/table_manager.php
@@ -26,7 +26,7 @@ class rex_metainfo_table_manager
     public const FIELD_LEGEND = 12;
     public const FIELD_TIME = 13;
     public const FIELD_COUNT = 13;
-    
+
     private $tableName;
     private $DBID;
 

--- a/redaxo/src/addons/metainfo/lib/table_manager.php
+++ b/redaxo/src/addons/metainfo/lib/table_manager.php
@@ -12,6 +12,21 @@
 
 class rex_metainfo_table_manager
 {
+    public const FIELD_TEXT = 1;
+    public const FIELD_TEXTAREA = 2;
+    public const FIELD_SELECT = 3;
+    public const FIELD_RADIO = 4;
+    public const FIELD_CHECKBOX = 5;
+    public const FIELD_REX_MEDIA_WIDGET = 6;
+    public const FIELD_REX_MEDIALIST_WIDGET = 7;
+    public const FIELD_REX_LINK_WIDGET = 8;
+    public const FIELD_REX_LINKLIST_WIDGET = 9;
+    public const FIELD_DATE = 10;
+    public const FIELD_DATETIME = 11;
+    public const FIELD_LEGEND = 12;
+    public const FIELD_TIME = 13;
+    public const FIELD_COUNT = 13;
+    
     private $tableName;
     private $DBID;
 


### PR DESCRIPTION
statt globaler konstanten

refs https://github.com/redaxo/redaxo/pull/2818

Hintergrund: klassen konstanten sind autoload'dable und deshalb besser für tools zu verstehen