### PR TITLE
EP CAT_MOVED: clang_id -> clang

### DIFF
--- a/redaxo/src/addons/structure/lib/service_category.php
+++ b/redaxo/src/addons/structure/lib/service_category.php
@@ -548,7 +548,8 @@ class rex_category_service
 
             rex_extension::registerPoint(new rex_extension_point('CAT_MOVED', null, [
                 'id' => $from_cat,
-                'clang_id' => $clang,
+                'clang_id' => $clang, // deprecated, use "clang" instead
+                'clang' => $clang,
                 'category_id' => $to_cat,
             ]));
         }


### PR DESCRIPTION
Alle anderen EPs nutzen "clang", nicht "clang_id". Daher hier nun auch.

Siehe auch https://github.com/yakamara/redaxo_yrewrite/issues/265.