### PR TITLE
Metainfo inputs: datetime getters funktionieren jetzt

### DIFF
--- a/redaxo/src/addons/metainfo/lib/input/datetime.php
+++ b/redaxo/src/addons/metainfo/lib/input/datetime.php
@@ -78,7 +78,7 @@ class rex_input_datetime extends rex_input
 
     public function getMinuteSelect()
     {
-        return $this->timeInput->getMminuteSelect();
+        return $this->timeInput->getMinuteSelect();
     }
 
     public function getHtml()

--- a/redaxo/src/addons/metainfo/lib/input/datetime.php
+++ b/redaxo/src/addons/metainfo/lib/input/datetime.php
@@ -58,27 +58,27 @@ class rex_input_datetime extends rex_input
 
     public function getDaySelect()
     {
-        return $this->dateInput->daySelect;
+        return $this->dateInput->getDaySelect();
     }
 
     public function getMonthSelect()
     {
-        return $this->dateInput->monthSelect;
+        return $this->dateInput->getMonthSelect();
     }
 
     public function getYearSelect()
     {
-        return $this->dateInput->yearSelect;
+        return $this->dateInput->getYearSelect();
     }
 
     public function getHourSelect()
     {
-        return $this->timeInput->hourSelect;
+        return $this->timeInput->getHourSelect();
     }
 
     public function getMinuteSelect()
     {
-        return $this->timeInput->minuteSelect;
+        return $this->timeInput->getMminuteSelect();
     }
 
     public function getHtml()


### PR DESCRIPTION
Refs https://github.com/redaxo/redaxo/pull/2818

> ERROR: InaccessibleProperty - redaxo/src/addons/metainfo/lib/input/datetime.php:61:16 - Cannot access private property rex_input_date::$daySelect from context rex_input_datetime
4874        return $this->dateInput->daySelect;