### PR TITLE
fix psalm warnings in rex::getVersionHash()

### DIFF
--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -369,7 +369,7 @@ class rex
 
         if (!isset($gitHash[$path])) {
             $gitHash[$path] = false; // exec only once
-            $output = array();
+            $output = [];
             $exitCode = -1;
 
             if (0 == strcasecmp(substr(PHP_OS, 0, 3), 'WIN')) {

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -369,8 +369,8 @@ class rex
 
         if (!isset($gitHash[$path])) {
             $gitHash[$path] = false; // exec only once
-            $output = '';
-            $exitCode = null;
+            $output = array();
+            $exitCode = -1;
 
             if (0 == strcasecmp(substr(PHP_OS, 0, 3), 'WIN')) {
                 $command = 'where git 2>&1 1>/dev/null && cd '. escapeshellarg($path) .' && git show --oneline -s';


### PR DESCRIPTION
ERROR: InvalidArgument - redaxo\src\core\lib\rex.php:381:29 - Argument 2 of exec expects array<array-key, mixed>, string() provided
            @exec($command, $output, $exitCode);

ERROR: NullArgument - redaxo\src\core\lib\rex.php:381:38 - Argument 3 of exec cannot be null, null value provided to parameter with type int
            @exec($command, $output, $exitCode);

refs https://github.com/redaxo/redaxo/pull/2818