### PR TITLE
fixed psalm warning in backend_login

### DIFF
--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -20,10 +20,10 @@ class rex_login
     protected $loginStatus = 0; // 0 = noch checken, 1 = ok, -1 = not ok
     protected $message = '';
 
-    /** @var rex_sql */
+    /** @var rex_sql|rex_user */
     protected $user;
 
-    /** @var rex_sql */
+    /** @var rex_sql|rex_user */
     protected $impersonator;
 
     /**


### PR DESCRIPTION
ERROR: InvalidPropertyAssignmentValue - redaxo\src\core\lib\login\backend_login.php:89:27 - $this->user with declared type 'rex_sql' cannot be assigned type 'rex_user'
            $this->user = new rex_user($this->user);

ERROR: InvalidPropertyAssignmentValue - redaxo\src\core\lib\login\backend_login.php:92:39 - $this->impersonator with declared type 'rex_sql' cannot be assigned type 'rex_user'
                $this->impersonator = new rex_user($this->impersonator);

refs https://github.com/redaxo/redaxo/pull/2818