### PR TITLE
fix psalm warning in be_controller

### DIFF
--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -339,10 +339,6 @@ class rex_be_controller
                         }
                         break;
                     }
-                    $setter = [$page, 'set' . ucfirst($key)];
-                    if (is_callable($setter)) {
-                        call_user_func($setter, $value);
-                    }
             }
         }
     }


### PR DESCRIPTION
ERROR: ParadoxicalCondition - redaxo\src\core\lib\be\controller.php:343:25 - Encountered a paradox when evaluating the conditionals ($setter==!callable) and ($setter==!callable)
                    if (is_callable($setter)) {

refs https://github.com/redaxo/redaxo/pull/2818