### PR TITLE
Clang-id nicht unset()‘ten. Unnötiger 3. zustand

### DIFF
--- a/redaxo/src/core/pages/system.clangs.php
+++ b/redaxo/src/core/pages/system.clangs.php
@@ -35,7 +35,7 @@ if ('deleteclang' == $func && '' != $clang_id && rex_clang::exists($clang_id)) {
         rex_clang_service::deleteCLang($clang_id);
         $success = rex_i18n::msg('clang_deleted');
         $func = '';
-        unset($clang_id);
+        $clang_id = 0;
     } catch (rex_functional_exception $e) {
         echo rex_view::error($e->getMessage());
     }
@@ -50,7 +50,7 @@ if ('editstatus' === $func && rex_clang::exists($clang_id)) {
         rex_clang_service::editCLang($clang_id, $clang->getCode(), $clang->getName(), $clang->getPriority(), $clang_status);
         $success = rex_i18n::msg('clang_edited');
         $func = '';
-        unset($clang_id);
+        $clang_id = 0;
     } catch (rex_functional_exception $e) {
         echo rex_view::error($e->getMessage());
     }
@@ -70,14 +70,14 @@ if ($add_clang_save || $edit_clang_save) {
     } elseif ($add_clang_save) {
         $success = rex_i18n::msg('clang_created');
         rex_clang_service::addCLang($clang_code, $clang_name, $clang_prio);
-        unset($clang_id);
+        $clang_id = 0;
         $func = '';
     } else {
         if (rex_clang::exists($clang_id)) {
             rex_clang_service::editCLang($clang_id, $clang_code, $clang_name, $clang_prio);
             $success = rex_i18n::msg('clang_edited');
             $func = '';
-            unset($clang_id);
+            $clang_id = 0;
         }
     }
 }


### PR DESCRIPTION
Refs https://github.com/redaxo/redaxo/pull/2629

Initial wird clang-id auch auf 0 gehandelt, falls nicht via REQUEST übergeben

Fixes phpstan warnings
 ------ ------------------------------------------ 
455  Line   core/pages/system.clangs.php              
456 ------ ------------------------------------------ 
457  44     Variable $clang_id might not be defined.  
458  49     Variable $clang_id might not be defined.  
459  50     Variable $clang_id might not be defined.  
460  76     Variable $clang_id might not be defined.  
461  77     Variable $clang_id might not be defined.  
462  143    Variable $clang_id might not be defined.  
463  145    Variable $clang_id might not be defined.  
464  159    Variable $clang_id might not be defined.  
465  194    Variable $clang_id might not be defined.  
466 ------ ------------------------------------------