### PR TITLE
Whoops: Safe-mode war nicht aktivierbar

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -136,7 +136,8 @@ abstract class rex_error_handler
                         left: 0;
                         right: 0;
                         height: 70px;
-                        background: #b00;                            
+                        background: #b00;
+                        z-index: 9999999999;
                     }
                     .rex-logo {
                         padding-left: 40px;


### PR DESCRIPTION
In der Release 5.8 ist der Safe-Mode über Whoops nicht mehr aktivierbar. Der Redaxo-Whoops-Header liegt im "Hintergrund".

Besteht wohl seit PR Composer Update (#2788), wo die Zeile im Upstream dazu kam.
https://github.com/redaxo/redaxo/blob/6a535df0350b8d480013bfdccee7ebd8e3764657/redaxo/src/core/vendor/filp/whoops/src/Whoops/Resources/css/whoops.base.css#L17