### PR TITLE
psalm typeinfos für rex_type::cast()

### DIFF
--- a/psalm-utils.php
+++ b/psalm-utils.php
@@ -34,7 +34,7 @@ class RexTypeReturnProvider implements \Psalm\Plugin\Hook\MethodReturnTypeProvid
             && isset($call_args[1]->value->inferredType)
             && $call_args[1]->value->inferredType->hasSingleStringLiteral()
         ) {
-             $vartype = $call_args[1]->value
+             $vartype = (string) $call_args[1]->value->inferredType;
              
              switch ($vartype) {
                 case 'bool':
@@ -49,7 +49,8 @@ class RexTypeReturnProvider implements \Psalm\Plugin\Hook\MethodReturnTypeProvid
                 case 'array':
                     return Type::parseString($vartype);
             }
-            return Type::getNull();
+            // dont know..
+            return Type::getMixed();
         }
     }
 }

--- a/psalm-utils.php
+++ b/psalm-utils.php
@@ -36,7 +36,7 @@ class RexTypeReturnProvider implements \Psalm\Plugin\Hook\MethodReturnTypeProvid
             && isset($call_args[1]->value->inferredType)
             && $call_args[1]->value->inferredType->isSingleStringLiteral()
         ) {
-             $vartype = (string) $call_args[1]->value->inferredType->getSingleStringLiteral();
+             $vartype = (string) $call_args[1]->value->inferredType->getSingleStringLiteral()->value;
              
              switch ($vartype) {
                 case 'bool':

--- a/psalm-utils.php
+++ b/psalm-utils.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Psalm\Internal\Provider\ReturnTypeProvider;
+
 use PhpParser;
 use Psalm\CodeLocation;
 use Psalm\Context;

--- a/psalm-utils.php
+++ b/psalm-utils.php
@@ -36,7 +36,7 @@ class RexTypeReturnProvider implements \Psalm\Plugin\Hook\MethodReturnTypeProvid
             && isset($call_args[1]->value->inferredType)
             && $call_args[1]->value->inferredType->isSingleStringLiteral()
         ) {
-             $vartype = (string) $call_args[1]->value->inferredType;
+             $vartype = (string) $call_args[1]->value->inferredType->getSingleStringLiteral();
              
              switch ($vartype) {
                 case 'bool':

--- a/psalm-utils.php
+++ b/psalm-utils.php
@@ -34,7 +34,7 @@ class RexTypeReturnProvider implements \Psalm\Plugin\Hook\MethodReturnTypeProvid
     ) {
         if ($method_name_lowercase === 'cast'
             && isset($call_args[1]->value->inferredType)
-            && $call_args[1]->value->inferredType->hasSingleStringLiteral()
+            && $call_args[1]->value->inferredType->isSingleStringLiteral()
         ) {
              $vartype = (string) $call_args[1]->value->inferredType;
              

--- a/psalm-utils.php
+++ b/psalm-utils.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Psalm\Internal\Provider\ReturnTypeProvider;
-
 use PhpParser;
 use Psalm\CodeLocation;
 use Psalm\Context;

--- a/psalm-utils.php
+++ b/psalm-utils.php
@@ -1,0 +1,55 @@
+<?php
+
+use PhpParser;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\StatementsSource;
+use Psalm\Type;
+
+class RexTypeReturnProvider implements \Psalm\Plugin\Hook\MethodReturnTypeProviderInterface
+{
+
+    public static function getClassLikeNames() : array
+    {
+        return ['rex_type'];
+    }
+
+    /**
+     * @param  array<PhpParser\Node\Arg>    $call_args
+     *
+     * @return ?Type\Union
+     */
+    public static function getMethodReturnType(
+        StatementsSource $source,
+        string $fq_classlike_name,
+        string $method_name_lowercase,
+        array $call_args,
+        Context $context,
+        CodeLocation $code_location,
+        array $template_type_parameters = null,
+        string $called_fq_classlike_name = null,
+        string $called_method_name_lowercase = null
+    ) {
+        if ($method_name_lowercase === 'cast'
+            && isset($call_args[1]->value->inferredType)
+            && $call_args[1]->value->inferredType->hasSingleStringLiteral()
+        ) {
+             $vartype = $call_args[1]->value
+             
+             switch ($vartype) {
+                case 'bool':
+                case 'boolean':
+                case 'int':
+                case 'integer':
+                case 'double':
+                case 'float':
+                case 'real':
+                case 'string':
+                case 'object':
+                case 'array':
+                    return Type::parseString($vartype);
+            }
+            return Type::getNull();
+        }
+    }
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -25,6 +25,9 @@ autoloader="phpstan-bootstrap.php"
     <stubs>
         <file name="redaxo/src/core/.phpstorm.meta.php" />
     </stubs>
+    <plugins>
+        <plugin filename="psalm-utils.php" />
+    </plugins>
     <issueHandlers>
         <InvalidScope>
             <errorLevel type="suppress">

--- a/redaxo/src/core/lib/util/type.php
+++ b/redaxo/src/core/lib/util/type.php
@@ -45,30 +45,24 @@ class rex_type
                 // ---------------- PHP types
                 case 'bool':
                 case 'boolean':
-                    /** @psalm-assert bool $var */
                     $var = (bool) $var;
                     break;
                 case 'int':
                 case 'integer':
-                    /** @psalm-assert int $var */
                     $var = (int) $var;
                     break;
                 case 'double':
                 case 'float':
                 case 'real':
-                    /** @psalm-assert float $var */
                     $var = (float) $var;
                     break;
                 case 'string':
-                    /** @psalm-assert string $var */
                     $var = (string) $var;
                     break;
                 case 'object':
-                    /** @psalm-assert object $var */
                     $var = (object) $var;
                     break;
                 case 'array':
-                    /** @psalm-assert array $var */
                     if ('' === $var) {
                         $var = [];
                     } else {

--- a/redaxo/src/core/lib/util/type.php
+++ b/redaxo/src/core/lib/util/type.php
@@ -45,26 +45,30 @@ class rex_type
                 // ---------------- PHP types
                 case 'bool':
                 case 'boolean':
+                    /** @psalm-assert bool $var */
                     $var = (bool) $var;
                     break;
                 case 'int':
                 case 'integer':
+                    /** @psalm-assert int $var */
                     $var = (int) $var;
                     break;
                 case 'double':
-                    $var = (float) $var;
-                    break;
                 case 'float':
                 case 'real':
+                    /** @psalm-assert float $var */
                     $var = (float) $var;
                     break;
                 case 'string':
+                    /** @psalm-assert string $var */
                     $var = (string) $var;
                     break;
                 case 'object':
+                    /** @psalm-assert object $var */
                     $var = (object) $var;
                     break;
                 case 'array':
+                    /** @psalm-assert array $var */
                     if ('' === $var) {
                         $var = [];
                     } else {
@@ -78,6 +82,7 @@ class rex_type
                 default:
                     // check for array with generic type
                     if (0 === strpos($vartype, 'array[')) {
+                        /** @psalm-assert array $var */
                         if (empty($var)) {
                             $var = [];
                         } else {

--- a/redaxo/src/core/lib/util/type.php
+++ b/redaxo/src/core/lib/util/type.php
@@ -76,7 +76,6 @@ class rex_type
                 default:
                     // check for array with generic type
                     if (0 === strpos($vartype, 'array[')) {
-                        /** @psalm-assert array $var */
                         if (empty($var)) {
                             $var = [];
                         } else {


### PR DESCRIPTION
Noch Ungetestet.

Hoffnung ist, dass wir damit psalm mitteilen können welche typen variablen zur laufzeit haben

https://psalm.dev/docs/annotating_code/assertion_syntax/

~~Inspiriert von https://github.com/webmozart/assert/pull/102~~