### PR TITLE
In cli nicht session_cache_limiter aufrufen

### DIFF
--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -26,8 +26,10 @@ foreach (array('HTDOCS_PATH', 'BACKEND_FOLDER', 'REDAXO') as $key) {
 ob_start();
 ob_implicit_flush(0);
 
-// deactivate session cache limiter
-session_cache_limiter(false);
+if ('cli' !== PHP_SAPI) {
+    // deactivate session cache limiter
+    session_cache_limiter(false);
+}
 
 // set arg_separator to get valid html output if session.use_trans_sid is activated
 ini_set('arg_separator.output', '&amp;');


### PR DESCRIPTION
Wenn ich psalm bei mir lokal ausführe erhalte ich immer diese Warnung:

> PHP Warning:  session_cache_limiter(): Cannot change cache limiter when headers already sent in /Users/gharlan/workspace/redaxo/redaxo/src/core/boot.php on line 31

Da es in der cli eigentlich so oder so keinen Sinn hat, habe ich den Aufruf da nun ganz unterdrückt.