### PR TITLE
Psalm: Dateien besser filtern

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -16,7 +16,7 @@ $finder = rex_finder::factory('redaxo/src/')
     ->filesOnly();
 /** @var SplFileInfo $file */
 foreach ($finder as $path => $file) {
-    if (strpos($file->getPath(), 'functions') !== false) {
+    if (false !== strpos($file->getPath(), 'functions') && '.php' === substr($path, -4)) {
         require_once $file->getRealPath();
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,20 @@ xmlns="https://getpsalm.org/schema/config"
 autoloader="phpstan-bootstrap.php"
 >
     <projectFiles>
-        <directory name="redaxo/src"/>
+        <directory name="redaxo/src/core"/>
+        <directory name="redaxo/src/addons/backup"/>
+        <directory name="redaxo/src/addons/be_style"/>
+        <directory name="redaxo/src/addons/cronjob"/>
+        <directory name="redaxo/src/addons/debug"/>
+        <directory name="redaxo/src/addons/install"/>
+        <directory name="redaxo/src/addons/media_manager"/>
+        <directory name="redaxo/src/addons/mediapool"/>
+        <directory name="redaxo/src/addons/metainfo"/>
+        <directory name="redaxo/src/addons/phpmailer"/>
+        <directory name="redaxo/src/addons/project"/>
+        <directory name="redaxo/src/addons/structure"/>
+        <directory name="redaxo/src/addons/tests"/>
+        <directory name="redaxo/src/addons/users"/>
         <ignoreFiles>
             <directory name="redaxo/src/addons/be_style/vendor/" />
             <directory name="redaxo/src/addons/debug/vendor/" />


### PR DESCRIPTION
* Explizit nur unsere Standard-Addons scannen, sonst hagelt es bei mir lokal Fehler aus den sonstigen Addons, die ich hier noch in der Installation liegen habe
* Die Functions beschränken auf .php-Dateien, denn bei mir wurde irgendeine js-datei geladen