### PR TITLE
rex-timer: Monotone zeitstempel verwenden

### DIFF
--- a/redaxo/src/core/lib/util/timer.php
+++ b/redaxo/src/core/lib/util/timer.php
@@ -74,7 +74,7 @@ class rex_timer
      */
     public function reset()
     {
-        $this->start = microtime(true);
+        $this->start = hrtime(true);
     }
 
     /**
@@ -82,7 +82,7 @@ class rex_timer
      */
     public function stop()
     {
-        $this->duration = microtime(true) - $this->start;
+        $this->duration = hrtime(true) - $this->start;
     }
 
     /**
@@ -94,7 +94,7 @@ class rex_timer
      */
     public function getDelta($precision = self::MILLISEC)
     {
-        $duration = null === $this->duration ? microtime(true) - $this->start : $this->duration;
+        $duration = null === $this->duration ? hrtime(true) - $this->start : $this->duration;
 
         return $duration * $precision;
     }


### PR DESCRIPTION
Refs https://github.com/symfony/symfony/pull/33333

Via symfony/polyfill haben wir bereits hrtime für ältere php versionen vorhanden:
https://github.com/redaxo/redaxo/blob/7a7f0bd0ae1446fac88eedbce5708f8806e49958/redaxo/src/core/vendor/symfony/polyfill-php73/Php73.php#L29

Todo
- [ ] class-konstanten anpassen