### PR TITLE
Mindestvoraussetzung MySQL auf 5.6 erhöhen

### DIFF
--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -8,7 +8,7 @@ if (PHP_VERSION_ID < 70103) {
 }
 
 $mysqlVersion = rex_sql::getServerVersion();
-$minMysqlVersion = '5.5.3';
+$minMysqlVersion = '5.6.15';
 if (rex_string::versionCompare($mysqlVersion, $minMysqlVersion, '<')) {
     // The message was added in REDAXO 5.6.0, so it does not exist while updating from previous versions
     $message = rex_i18n::hasMsg('sql_database_min_version')


### PR DESCRIPTION
closes #2913 

https://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-15.html

gewählt habe ich 5.6.15, weil zuvor ebenfalls nicht die 5.5.0 verwendet wurde und die Version 5.6.15 Ende 2013 erschien - ich denke, man kann erwarten, dass dieses Update bereits vorhanden ist.

Stichproben von Hostingpaketen waren 5.6.39 (unbekannt), 5.7.26 (all-inkl), 5.6.19 (domainfactory)