### PR TITLE
Prio auch nach Löschen eines Datensatz neu organisieren

### DIFF
--- a/redaxo/src/core/lib/form/elements/prio.php
+++ b/redaxo/src/core/lib/form/elements/prio.php
@@ -26,6 +26,7 @@ class rex_form_prio_element extends rex_form_select_element
         $this->select->setSize(1);
 
         rex_extension::register('REX_FORM_SAVED', [$this, 'organizePriorities']);
+        rex_extension::register('REX_FORM_DELETED', [$this, 'organizePriorities']);
     }
 
     /**


### PR DESCRIPTION
Behebt folgenden Fehler:

Ich habe ein eigenes AddOn mit einer rex_form-Eingabe und verwende damit ein "prio"-Feld.
Das funktioniert auch wunderbar, allerdings mit einer Einschränkung:
Wenn ich einen Datensatz komplett lösche, dann wird das prio-Feld nicht neu ausgewertet. Lösche ich also bei 3 Datensätzen den mit der prio = 1, dann beginnt meine rex_list-Ausgabe mit den übrig gebliebenen 2 Datensätzen bei prio = 2...