### PR TITLE
rex_sql_table::alter(): Originaltabellenname in Fehlermeldung, wenn Tabelle noch nicht existiert

### DIFF
--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -702,7 +702,7 @@ class rex_sql_table
     public function alter()
     {
         if ($this->new) {
-            throw new rex_exception(sprintf('Table "%s" does not exist.', $this->name));
+            throw new rex_exception(sprintf('Table "%s" does not exist.', $this->originalName));
         }
 
         $parts = [];

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -579,4 +579,14 @@ class rex_sql_table_test extends TestCase
         $this->assertSame(rex_sql_index::UNIQUE, $table->getIndex('i_status_timestamp')->getType());
         $this->assertTrue($table->hasIndex('i_description'));
     }
+
+    public function testRenameNonExistingTable()
+    {
+        $this->expectException(rex_exception::class);
+        $this->expectExceptionMessage('Table "rex_non_existing" does not exist.');
+
+        rex_sql_table::get('rex_non_existing')
+            ->setName('rex_foo')
+            ->alter();
+    }
 }


### PR DESCRIPTION
fixes #2917