### PR TITLE
Use class-string instead of a plain string

### DIFF
--- a/redaxo/src/addons/backup/boot.php
+++ b/redaxo/src/addons/backup/boot.php
@@ -1,5 +1,5 @@
 <?php
 
 if (rex_addon::get('cronjob')->isAvailable() && !rex::isSafeMode()) {
-    rex_cronjob_manager::registerType('rex_cronjob_export');
+    rex_cronjob_manager::registerType(rex_cronjob_export::class);
 }


### PR DESCRIPTION
Should fix

> INFO: ArgumentTypeCoercion - redaxo/src/addons/backup/boot.php:4:39 - Argument 1 of rex_cronjob_manager::registertype expects class-string<rex_cronjob>, parent type string(rex_cronjob_export) provided
377    rex_cronjob_manager::registerType('rex_cronjob_export');

Todo
- [x] ~~an weiteren stellen verwenden~~ -> gibt keine