### PR TITLE
fix psalm warning

### DIFF
--- a/redaxo/src/addons/cronjob/lib/form.php
+++ b/redaxo/src/addons/cronjob/lib/form.php
@@ -14,7 +14,7 @@ class rex_cronjob_form extends rex_form
 {
     /** @var string */
     private $mainFieldset;
-    /** @var rex_cronjob_form_interval_element */
+    /** @var rex_cronjob_form_interval_element|null */
     private $intervalField;
 
     /**


### PR DESCRIPTION
```
INFO: PropertyNotSetInConstructor - redaxo/src/addons/cronjob/lib/form.php:18:13 - Property rex_cronjob_form::$intervalField is not defined in constructor of rex_cronjob_form and in any methods called in the constructor

    private $intervalField;
```