### PR TITLE
Fix psalm warning

### DIFF
--- a/redaxo/src/core/lib/form/form_base.php
+++ b/redaxo/src/core/lib/form/form_base.php
@@ -30,7 +30,7 @@ abstract class rex_form_base
     protected $message;
 
     /** @var array */
-    protected $errorMessages= [];
+    protected $errorMessages = [];
 
     /** @var string */
     protected $warning;

--- a/redaxo/src/core/lib/form/form_base.php
+++ b/redaxo/src/core/lib/form/form_base.php
@@ -30,7 +30,7 @@ abstract class rex_form_base
     protected $message;
 
     /** @var array */
-    protected $errorMessages;
+    protected $errorMessages= [];
 
     /** @var string */
     protected $warning;


### PR DESCRIPTION
psalm

```
INFO: PropertyNotSetInConstructor - redaxo/src/addons/cronjob/lib/form.php:13:7 - Property rex_form_base::$errorMessages is not defined in constructor of rex_cronjob_form and in any methods called in the constructor

class rex_cronjob_form extends rex_form
```