### PR TITLE
rex_sql::insertOrUpdate: Updates ohne tatsächliche Änderungen erlauben (keine Exception)

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -903,11 +903,6 @@ class rex_sql implements Iterator
             $this->values
         );
 
-        // provide debug infos, if insert is considered successfull, but no rows were inserted.
-        // this happens when you violate against a NOTNULL constraint
-        if (0 == $this->getRows()) {
-            throw new rex_sql_exception('Error while inserting into table "' . $tableName . '" with values ' . print_r($values, true) . '! Check your null/not-null constraints!', null, $this);
-        }
         return $this;
     }
 


### PR DESCRIPTION
Bei der Nutzung von `insertOrUpdate` wurde eine exception geworfen, wenn ein Update Befehl erfolgte und der Datensatz sich nicht verändert hat.