### PR TITLE
cronjob/optimize_tables: fix escaping, add message

### DIFF
--- a/redaxo/src/addons/cronjob/plugins/optimize_tables/lib/cronjob.php
+++ b/redaxo/src/addons/cronjob/plugins/optimize_tables/lib/cronjob.php
@@ -17,9 +17,10 @@ class rex_cronjob_optimize_tables extends rex_cronjob
             $sql = rex_sql::factory();
             // $sql->setDebug();
             try {
-                $sql->setQuery('OPTIMIZE TABLE ' . implode(', ', $tables));
+                $sql->setQuery('OPTIMIZE TABLE ' . implode(', ', array_map([$sql, "escapeIdentifier"], $tables)));
                 return true;
             } catch (rex_sql_exception $e) {
+                $this->setMessage($e->getMessage());
                 return false;
             }
         }

--- a/redaxo/src/addons/cronjob/plugins/optimize_tables/lib/cronjob.php
+++ b/redaxo/src/addons/cronjob/plugins/optimize_tables/lib/cronjob.php
@@ -17,7 +17,7 @@ class rex_cronjob_optimize_tables extends rex_cronjob
             $sql = rex_sql::factory();
             // $sql->setDebug();
             try {
-                $sql->setQuery('OPTIMIZE TABLE ' . implode(', ', array_map([$sql, "escapeIdentifier"], $tables)));
+                $sql->setQuery('OPTIMIZE TABLE ' . implode(', ', array_map([$sql, 'escapeIdentifier'], $tables)));
                 return true;
             } catch (rex_sql_exception $e) {
                 $this->setMessage($e->getMessage());


### PR DESCRIPTION
closes #2982

![image](https://user-images.githubusercontent.com/3855487/68435723-5208a880-01bc-11ea-8ee2-5985711714b0.png)

(die Meldung kommt im Fehlerfall, der Fehlerfall ist aber auch durch das escaping korrigiert.)