### PR TITLE
use GithubActions for phpstan-analysis

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,5 +71,35 @@ jobs:
                 composer require --dev vimeo/psalm:^3.4.12
                 vendor/bin/psalm --show-info=false
 
-
+  phpstan-analysis:
+      name: phpstan static code analysis
+      runs-on: ubuntu-latest
+      services:
+          mysql:
+              image: mysql:5.7
+              ports:
+                  - 3306
+      steps:
+          - uses: actions/checkout@master
+          - name: Setup PHP
+            uses: shivammathur/setup-php@master
+            with:
+                php-version: 7.3
+                extension-csv: intl
+                coverage: none # disable xdebug, pcov
+          - run: |
+                git submodule update --init --recursive
+                mysql -uroot -h127.0.0.1 -proot -e 'create database redaxo_5_0;'
+                git apply .github/workflows/default.config.yml.github-action.diff
+          - run: |
+                php redaxo/src/addons/tests/bin/setup.php
+                php redaxo/bin/console package:install phpmailer
+                php redaxo/bin/console package:install cronjob
+                php redaxo/bin/console package:install cronjob/article_status
+                php redaxo/bin/console package:install cronjob/optimize_tables
+                php redaxo/bin/console package:install debug
+                php redaxo/bin/console package:install structure/history
+                php redaxo/bin/console package:install structure/version
+                composer require --dev phpstan/phpstan-shim
+                vendor/bin/phpstan analyse
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,23 +20,6 @@ before_install:
 
 jobs:
     include:
-        -   php: 7.3
-            env: TYPE=phpstan
-            services:
-                - mysql
-            script:
-                - mysql -e 'create database redaxo_5_0;'
-                - php redaxo/src/addons/tests/bin/setup.php
-                - php redaxo/bin/console package:install phpmailer
-                - php redaxo/bin/console package:install cronjob
-                - php redaxo/bin/console package:install cronjob/article_status
-                - php redaxo/bin/console package:install cronjob/optimize_tables
-                - php redaxo/bin/console package:install debug
-                - php redaxo/bin/console package:install structure/history
-                - php redaxo/bin/console package:install structure/version
-                - composer require --dev phpstan/phpstan-shim
-                - vendor/bin/phpstan analyse
-
         -   &TEST
             install:
                 - mysql -e 'create database redaxo_5_0;'
@@ -68,7 +51,3 @@ jobs:
         -   <<: *TEST_MYSQL
             php: 7.4snapshot
             dist: xenial
-matrix:
-     allow_failures:
-       - php: 7.3
-         env: TYPE=phpstan


### PR DESCRIPTION
dieser build darf failen, da er es auch unter travis CI bereits gemacht hat

ich habe ihn nur umgestellt um eine ungefähre gleichverteilung an jobs zwischen GithubActions und TravisCI zu erreichen.. d.h. ich werde jetzt erstmal keine weiteren Jobs umstellen.