### PR TITLE
travis: use non-snapshot php7.4 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,3 @@ jobs:
             php: 7.3
         -   <<: *TEST_MYSQL
             php: 7.4
-            dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,5 @@ jobs:
         -   <<: *TEST_MYSQL
             php: 7.3
         -   <<: *TEST_MYSQL
-            php: 7.4snapshot
+            php: 7.4
             dist: xenial


### PR DESCRIPTION
da sie sehr langsam sind..mal sehen.. ggf. hat travis schon aktuellere php 7.4 builds