### PR TITLE
Fix travis mariadb error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
                 - php redaxo/src/addons/tests/bin/setup.php
             script: php redaxo/src/addons/tests/bin/run_tests.php
             php: 7.1
+            dist: xenial
             env:
                 - TYPE=phpunit
                 - DB=mariadb

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
                 - TYPE=phpunit
                 - DB=mariadb
             addons:
-                mariadb: 10.1
+                mariadb: 10.2
         -   <<: *TEST
             php: 7.3
             addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
                 - TYPE=phpunit
                 - DB=mariadb
             addons:
-                mariadb: 10.2
+                mariadb: 10.1
         -   <<: *TEST
             php: 7.3
             addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
                 - php redaxo/src/addons/tests/bin/setup.php
             script: php redaxo/src/addons/tests/bin/run_tests.php
             php: 7.1
-            dist: xenial
+            dist: trusty
             env:
                 - TYPE=phpunit
                 - DB=mariadb


### PR DESCRIPTION
Es scheint wohl Probleme mit `mariadb:10.1` auf `bionic` zu geben, weil die Abhängigkeiten scheinbar nicht korrekt aufgelöst werden.

(siehe https://mariadb.com/kb/en/library/unable-to-install-mariadb-101-on-ubuntu-1804-after-apt-remove-purge-mysql/)

wird vermutlich auch das Problem aus https://github.com/redaxo/redaxo/pull/3011#issuecomment-557489228 sein.