### PR TITLE
Added editor_basepath property

### DIFF
--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -81,3 +81,4 @@ accesskeys:
     add: a
     add_2: y
 editor: null
+editor_basepath: null

--- a/redaxo/src/core/lib/util/editor.php
+++ b/redaxo/src/core/lib/util/editor.php
@@ -42,6 +42,12 @@ class rex_editor
 
         $editorUrl = null;
 
+        $editorBasepath = rex::getProperty('editor_basepath');
+        if ($editorBasepath) {
+            // replace remote base path with local base path
+            $filePath = str_replace(rex_path::base(), $editorBasepath, $filePath);
+        }
+
         if (false !== strpos($filePath, '://')) {
             // don't provide editor urls for paths containing "://", like "rex://..."
             // but they can be converted into an url by the extension point below


### PR DESCRIPTION
fügt eine neue `config.yml` property `editor_basepath` hinzu. Damit kann der Dateipfad zum Öffnen einer Datei im Editor gemappt/umgeschrieben werden.

closes #2625