### PR TITLE
setup: only allow https settings via https call

### DIFF
--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -258,6 +258,7 @@ sql_unable_to_open_database = Die angegebene Datenbank konnte nicht geöffnet we
 
 setup_security = Sicherheit
 
+https_only_over_https = Diese Optionen sind nur bei einem Aufruf über HTTPS verfügbar
 https_activate_redirect_for = Automatische HTTPS-Umleitung
 https_disable = deaktivieren
 https_only_frontend = nur für Frontend aktivieren

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -294,6 +294,13 @@ if (4 === $step) {
 
     $hsts_checked = rex_post('use_hsts', 'boolean') ? 'checked="checked"' : '';
 
+    // If the setup is called over http disable https options to prevent user from being locked out
+    if (!rex_request::isHttps()) {
+        $httpsRedirectSel->setAttribute('disabled', 'disabled');
+        $hsts_checked .= 'disabled';
+    }
+
+
     $content .= '<legend>' . rex_i18n::msg('setup_402') . '</legend>';
 
     $formElements = [];
@@ -363,6 +370,12 @@ if (4 === $step) {
     $content .= '</fieldset><fieldset><legend>' . rex_i18n::msg('setup_security') . '</legend>';
 
     $formElements = [];
+
+    if (!rex_request::isHttps()) {
+        $n = [];
+        $n['field'] = '<label class="form-control-static"><i class="fa fa-warning"></i> '.rex_i18n::msg('https_only_over_https').'</label>';
+        $formElements[] = $n;
+    }
 
     $n = [];
     $n['label'] = '<label>'.rex_i18n::msg('https_activate_redirect_for').'</label>';

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -300,7 +300,6 @@ if (4 === $step) {
         $hsts_checked .= 'disabled';
     }
 
-
     $content .= '<legend>' . rex_i18n::msg('setup_402') . '</legend>';
 
     $formElements = [];


### PR DESCRIPTION
fixes #2767 

Bei einem Aufruf über http werden die Felder deaktiviert und eine Warnung/Hinweis ausgegeben.



vorher:
![image](https://user-images.githubusercontent.com/21292755/69467863-21af3580-0d8a-11ea-9c50-7d3435a0a4fc.png)

nachher:
![image](https://user-images.githubusercontent.com/21292755/69467844-0b08de80-0d8a-11ea-8ecc-7821477d7eb6.png)
