### PR TITLE
psalm: mark never returning methods

### DIFF
--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -118,6 +118,8 @@ class rex_response
      * @param string $url URL
      *
      * @throws InvalidArgumentException
+     *
+     * @psalm-return no-return
      */
     public static function sendRedirect($url)
     {


### PR DESCRIPTION
should fix
```
ERROR: InvalidReturnType - redaxo/src/core/lib/login/api_user_impersonate.php:10:21 - The declared return type 'rex_api_result' for rex_api_user_impersonate::execute is incorrect, got 'void'
    public function execute()
```

see https://github.com/vimeo/psalm/issues/2213