### PR TITLE
Sponsor: remove non-registered users

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [dergel, gharlan, tbaddade, staabm]
+github: [staabm]


### PR DESCRIPTION
Bei GitHub Sponsor erscheint eine Fehlermeldung, wenn nicht registrierte Benutzer hinterlegt sind.