### PR TITLE
Use fixed phpstan version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -100,7 +100,7 @@ jobs:
                 php redaxo/bin/console package:install debug
                 php redaxo/bin/console package:install structure/history
                 php redaxo/bin/console package:install structure/version
-                composer require --dev phpstan/phpstan
+                composer require --dev phpstan/phpstan:^0.12
                 vendor/bin/phpstan analyse --no-progress
 
   php-cs-fixer:


### PR DESCRIPTION
Maximize stability in ci builds.

Make sure our build does not depend on external package releases