### PR TITLE
Gh-action: get rid of deprecated configs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,7 +53,7 @@ jobs:
             uses: shivammathur/setup-php@master
             with:
                 php-version: 7.3
-                extension-csv: intl
+                extensions: intl
                 coverage: none # disable xdebug, pcov
           - run: |
                 git submodule update --init --recursive
@@ -85,7 +85,7 @@ jobs:
             uses: shivammathur/setup-php@master
             with:
                 php-version: 7.3
-                extension-csv: intl
+                extensions: intl
                 coverage: none # disable xdebug, pcov
           - run: |
                 git submodule update --init --recursive


### PR DESCRIPTION
> ##[warning]Input 'extension-csv' has been deprecated with message: The extension-csv property will not be supported after February 1, 2020. Use extensions instead.