### PR TITLE
prevent warnings when the error log is not readable by the apache user

### DIFF
--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -158,7 +158,7 @@ class rex_be_controller
 
         $logsPage = (new rex_be_page('log', rex_i18n::msg('logfiles')))->setSubPath(rex_path::core('pages/system.log.php'));
         $logsPage->addSubpage((new rex_be_page('redaxo', rex_i18n::msg('syslog_redaxo')))->setSubPath(rex_path::core('pages/system.log.redaxo.php')));
-        if (is_readable(ini_get('error_log'))) {
+        if (@is_readable(ini_get('error_log'))) {
             $logsPage->addSubpage((new rex_be_page('php', rex_i18n::msg('syslog_phperrors')))->setSubPath(rex_path::core('pages/system.log.external.php')));
         }
 


### PR DESCRIPTION
es kann durchaus legitim sein, keine rechte auf das php error log zu haben.
daher warning unterdrücken und weiter.

closes https://github.com/redaxo/redaxo/issues/3052