### PR TITLE
Fix psalm error

### DIFF
--- a/redaxo/src/core/lib/base/instance_pool_trait.php
+++ b/redaxo/src/core/lib/base/instance_pool_trait.php
@@ -10,6 +10,8 @@
 trait rex_instance_pool_trait
 {
     /**
+     * @psalm-var array<array-key, array<array-key, null|static>>
+     *
      * @var static[][]
      */
     private static $instances = [];


### PR DESCRIPTION
`ERROR: InvalidPropertyAssignmentValue - redaxo/src/core/lib/base/instance_pool_trait.php:69:13 - rex_instance_pool_trait::$instances with declared type 'array<array-key, array<array-key, rex_sql_table>>' cannot be assigned type 'non-empty-array<array-key, array<array-key, null|rex_instance_pool_trait|rex_sql_table>>'`