### PR TITLE
Exit code immer explizit angeben

### DIFF
--- a/redaxo/src/addons/be_style/lib/command/compile.php
+++ b/redaxo/src/addons/be_style/lib/command/compile.php
@@ -26,5 +26,7 @@ class rex_be_style_command_compile extends rex_console_command
         rex_be_style::compile();
 
         $io->success('Styles successfully compiled');
+
+        return 0;
     }
 }

--- a/redaxo/src/addons/cronjob/lib/command/run.php
+++ b/redaxo/src/addons/cronjob/lib/command/run.php
@@ -87,8 +87,12 @@ class rex_command_cronjob_run extends rex_console_command
 
         if ($success) {
             $io->success(sprintf('Cronjob "%s" executed successfully%s.', $name, $msg));
-        } else {
-            $io->error(sprintf('Cronjob "%s" failed%s.', $name, $msg));
+
+            return 0;
         }
+
+        $io->error(sprintf('Cronjob "%s" failed%s.', $name, $msg));
+
+        return 1;
     }
 }

--- a/redaxo/src/core/lib/console/db/connection_options.php
+++ b/redaxo/src/core/lib/console/db/connection_options.php
@@ -52,5 +52,7 @@ EOF
             '--password='.escapeshellarg($db['password']),
             escapeshellarg($db['name']),
         ]);
+
+        return 0;
     }
 }

--- a/redaxo/src/core/lib/console/db/dump_schema.php
+++ b/redaxo/src/core/lib/console/db/dump_schema.php
@@ -35,5 +35,7 @@ class rex_command_db_dump_schema extends rex_console_command
 
         $io = $this->getStyle($input, $output)->getErrorStyle();
         $io->success('Generated schema for table "'.$table->getName().'".');
+
+        return 0;
     }
 }

--- a/redaxo/src/core/lib/console/system/report.php
+++ b/redaxo/src/core/lib/console/system/report.php
@@ -79,5 +79,7 @@ class rex_command_system_report extends rex_console_command
             $table->render();
             $io->newLine();
         }
+
+        return 0;
     }
 }

--- a/redaxo/src/core/lib/console/user/create.php
+++ b/redaxo/src/core/lib/console/user/create.php
@@ -79,5 +79,7 @@ class rex_command_user_create extends rex_console_command
         $user->insert();
 
         $io->success(sprintf('User "%s" successfully created.', $login));
+
+        return 0;
     }
 }

--- a/redaxo/src/core/lib/console/user/set_password.php
+++ b/redaxo/src/core/lib/console/user/set_password.php
@@ -76,5 +76,7 @@ class rex_command_user_set_password extends rex_console_command
         ], true));
 
         $io->success(sprintf('Saved new password for user "%s".', $username));
+
+        return 0;
     }
 }


### PR DESCRIPTION
Seit SF 4.4 ist es deprecated, keinen Exit code zu returnen.
In SF 5 würde es dann zu einem Fehler führen.