### PR TITLE
REX_VARs: Var-Name an Callback übergeben

### DIFF
--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -347,7 +347,11 @@ abstract class rex_var
         }
 
         if ($this->hasArg('callback')) {
-            $args = ["'subject' => " . $content];
+            $args = [
+                "'var' => 'REX" . strtoupper(substr(static::class, 7)) . "'",
+                "'class' => '" . static::class . "'",
+                "'subject' => " . $content,
+            ];
             foreach ($this->args as $key => $value) {
                 $args[] = "'$key' => " . $this->getParsedArg($key);
             }

--- a/redaxo/src/core/tests/var/var_test.php
+++ b/redaxo/src/core/tests/var/var_test.php
@@ -129,14 +129,14 @@ EOT
             ['REX_TEST_VAR[content="" prefix=ab suffix=ef]', ''],
             ['REX_TEST_VAR[content=cd prefix=ab suffix=ef instead=gh ifempty=ij]', 'abghef'],
             ['REX_TEST_VAR[content="" prefix=ab suffix=ef instead=gh ifempty=ij]', 'abijef'],
-            ['REX_TEST_VAR[content=ab callback="rex_var_test::varCallback" suffix=cd]', 'subject:ab content:ab suffix:cd'],
-            ['REX_TEST_VAR[content="REX_TEST_VAR[ab]" callback="rex_var_test::varCallback" suffix=cd]', 'subject:ab content:ab suffix:cd'],
+            ['REX_TEST_VAR[content=ab callback="rex_var_test::varCallback" suffix=cd]', 'var:REX_TEST_VAR class:rex_var_test_var subject:ab content:ab suffix:cd'],
+            ['REX_TEST_VAR[content="REX_TEST_VAR[ab]" callback="rex_var_test::varCallback" suffix=cd]', 'var:REX_TEST_VAR class:rex_var_test_var subject:ab content:ab suffix:cd'],
         ];
     }
 
     public static function varCallback($params)
     {
-        return sprintf('subject:%s content:%s suffix:%s', $params['subject'], $params['content'], $params['suffix']);
+        return sprintf('var:%s class:%s subject:%s content:%s suffix:%s', $params['var'], $params['class'], $params['subject'], $params['content'], $params['suffix']);
     }
 
     /**


### PR DESCRIPTION
closes #676

Konnte mich nicht entscheiden, ob der Varname oder der Klassenname sinnvoller ist, daher habe ich beide übergeben.
Oder lieber nur eins von beiden?