### PR TITLE
Installer: Nach Addon-Version hochladen, auf Addon-Details landen

### DIFF
--- a/redaxo/src/addons/install/lib/api_package_upload.php
+++ b/redaxo/src/addons/install/lib/api_package_upload.php
@@ -56,7 +56,6 @@ class rex_api_install_package_upload extends rex_api_function
         if ($archive) {
             rex_file::delete($archive);
         }
-        unset($_REQUEST['addonkey']);
         unset($_REQUEST['file']);
         rex_install_packages::deleteCache();
         return new rex_api_result(true, rex_i18n::msg('install_info_addon_uploaded', $addonkey));


### PR DESCRIPTION
Es nervt mich immer, wenn man eine neue Version hochlädt, dass man dann auf der Addonliste landet, statt in den Addon-Details, wo man die hochgeladene Version dann nochmal sieht.