### PR TITLE
Leeres Array aus Cache akzeptieren

### DIFF
--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -95,8 +95,8 @@ class rex_media
         return static::getInstanceList('root_media', 'static::get', static function () {
             $list_path = rex_path::addonCache('mediapool', '0.mlist');
 
-            $list = rex_file::getCache($list_path);
-            if (!$list) {
+            $list = rex_file::getCache($list_path, null);
+            if (null === $list) {
                 rex_media_cache::generateList(0);
                 $list = rex_file::getCache($list_path);
             }

--- a/redaxo/src/addons/mediapool/lib/media_category.php
+++ b/redaxo/src/addons/mediapool/lib/media_category.php
@@ -98,8 +98,8 @@ class rex_media_category
         return self::getInstanceList([$parentId, 'children'], 'self::get', static function ($parentId) {
             $catlist_path = rex_path::addonCache('mediapool', $parentId . '.mclist');
 
-            $list = rex_file::getCache($catlist_path);
-            if (!$list) {
+            $list = rex_file::getCache($catlist_path, null);
+            if (null === $list) {
                 rex_media_cache::generateCategoryList($parentId);
                 $list = rex_file::getCache($catlist_path);
             }

--- a/redaxo/src/addons/mediapool/lib/media_category.php
+++ b/redaxo/src/addons/mediapool/lib/media_category.php
@@ -255,8 +255,8 @@ class rex_media_category
         return self::getInstanceList([$this->getId(), 'media'], 'rex_media::get', static function ($id) {
             $list_path = rex_path::addonCache('mediapool', $id . '.mlist');
 
-            $list = rex_file::getCache($list_path);
-            if (!$list) {
+            $list = rex_file::getCache($list_path, null);
+            if (null === $list) {
                 rex_media_cache::generateList($id);
                 $list = rex_file::getCache($list_path);
             }

--- a/redaxo/src/addons/structure/lib/structure_element.php
+++ b/redaxo/src/addons/structure/lib/structure_element.php
@@ -205,8 +205,8 @@ abstract class rex_structure_element
             static function ($parentId, $listType) {
                 $listFile = rex_path::addonCache('structure', $parentId . '.' . $listType);
 
-                $list = rex_file::getCache($listFile);
-                if (!$list) {
+                $list = rex_file::getCache($listFile, null);
+                if (null === $list) {
                     rex_article_cache::generateLists($parentId);
                     $list = rex_file::getCache($listFile);
                 }


### PR DESCRIPTION
Aktuell wurde bei `$cat->getChildren()` die Cache-Datei immer wieder neu generiert, wenn die Kategorie keine Kinder hat. Somit traten auch unnötige Datenbankabfragen auf.

Das war die Ursache für die langsamen `rex_category_select`, somit: fixes #2128

![Screenshot 2020-01-02 23 32 33](https://user-images.githubusercontent.com/330436/71697582-bc9f2480-2db8-11ea-8843-3546e3669ea1.png)
