### PR TITLE
Präfix "rex_htaccess_check" als Indikator für Quelle

### DIFF
--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -444,11 +444,11 @@ jQuery(function($){
         });
     $("[autofocus]").trigger("focus");
 
-    if ($('#rex-page-setup, #rex-page-login').length == 0 && getCookie('htaccess_check') == '')
+    if ($('#rex-page-setup, #rex-page-login').length == 0 && getCookie('rex_setup_htaccess_check') == '')
     {
         time = new Date();
         time.setTime(time.getTime() + 1000 * 60 * 60 * 24);
-        setCookie('htaccess_check', '1', time.toGMTString(), '', '', false, 'lax');
+        setCookie('rex_setup_htaccess_check', '1', time.toGMTString(), '', '', false, 'lax');
         checkHtaccess('bin', 'console');
         checkHtaccess('cache', '.redaxo');
         checkHtaccess('data', '.redaxo');
@@ -460,7 +460,7 @@ jQuery(function($){
         $.get(dir +'/'+ file +'?redaxo-security-self-test',
             function(data) {
                 $('#rex-js-page-main').prepend('<div class="alert alert-danger" style="margin-top: 20px;">The folder <code>redaxo/'+ dir +'</code> is insecure. Please protect this folder.</div>');
-                setCookie('htaccess_check', '');
+                setCookie('rex_setup_htaccess_check', '');
             }
         );
     }

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -444,11 +444,11 @@ jQuery(function($){
         });
     $("[autofocus]").trigger("focus");
 
-    if ($('#rex-page-setup, #rex-page-login').length == 0 && getCookie('rex_setup_htaccess_check') == '')
+    if ($('#rex-page-setup, #rex-page-login').length == 0 && getCookie('rex_htaccess_check') == '')
     {
         time = new Date();
         time.setTime(time.getTime() + 1000 * 60 * 60 * 24);
-        setCookie('rex_setup_htaccess_check', '1', time.toGMTString(), '', '', false, 'lax');
+        setCookie('rex_htaccess_check', '1', time.toGMTString(), '', '', false, 'lax');
         checkHtaccess('bin', 'console');
         checkHtaccess('cache', '.redaxo');
         checkHtaccess('data', '.redaxo');
@@ -460,7 +460,7 @@ jQuery(function($){
         $.get(dir +'/'+ file +'?redaxo-security-self-test',
             function(data) {
                 $('#rex-js-page-main').prepend('<div class="alert alert-danger" style="margin-top: 20px;">The folder <code>redaxo/'+ dir +'</code> is insecure. Please protect this folder.</div>');
-                setCookie('rex_setup_htaccess_check', '');
+                setCookie('rex_htaccess_check', '');
             }
         );
     }


### PR DESCRIPTION
Erläutert, dass dieses Cookie im Zuge des Setups von REDAXO erzeugt wird. closes #3042