### PR TITLE
psalm: activate shepherd.dev mode to collect type coverage

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -69,7 +69,7 @@ jobs:
                 php redaxo/bin/console package:install structure/history
                 php redaxo/bin/console package:install structure/version
                 composer require --dev vimeo/psalm:^3.8.1
-                vendor/bin/psalm --show-info=false
+                vendor/bin/psalm --show-info=false --shepherd
 
   phpstan-analysis:
       name: phpstan static code analysis

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Your marker still missing? [Learn how to place it on the map](https://github.com
 
 ## Developer setup instructions
 
+![Psalm coverage](https://shepherd.dev/github/redaxo/redaxo/coverage.svg)
+
 In case you want to support the development of REDAXO, this is how to set up the system on your local machine:
 
 	$ git clone https://github.com/redaxo/redaxo.git


### PR DESCRIPTION
Quote https://psalm.dev/articles/php-or-type-safety-pick-any-two

Tracking type coverage in public projects

Many public GitHub projects (Psalm included) display a small badge showing how much of the project’s code is covered by PHPUnit tests, because test coverage is a useful metric when trying to get an idea of a project’s code quality.

Hopefully, if you’ve got this far, you think type coverage is also important. To that end, I’ve created a service that allows you to display your project’s type coverage anywhere you want.

Psalm, PHPUnit and many other projects now display a type coverage badge in their READMEs.

You can generate your own by adding --shepherd to your CI Psalm command. Your badge will then be available at

https://shepherd.dev/github/{username}/{repo}/coverage.svg
This service is the beginning of an ongoing effort for Psalm to support open-source PHP projects hosted on GitHub.