### PR TITLE
Console: disable package loading for db:set-connection

### DIFF
--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -51,6 +51,13 @@ class rex_console_application extends Application
 
     private function loadPackages(rex_console_command $command)
     {
+        // Some packages requires a working db connection in their boot.php
+        // in this case if no connection is available, no commands can be used
+        // but this command should be always usable
+        if ('db:set-connection' === $command->getName()) {
+            return;
+        }
+
         if ('ydeploy:migrate' === $command->getName()) {
             $command->getPackage()->boot();
 


### PR DESCRIPTION
Eine Whitelist, die `db:set-connection` ohne das Laden von packages ausführt.

closes #3102 