### PR TITLE
Auto-cs-fixer: Going back to actions/checkout@v1

### DIFF
--- a/.github/workflows/csfix.yml
+++ b/.github/workflows/csfix.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     
     - name: Setup PHP
       uses: shivammathur/setup-php@v1


### PR DESCRIPTION
Auto-commit Doesnt work with checkout v2  right now, see https://github.com/stefanzweifel/git-auto-commit-action/pull/33