### PR TITLE
rex_config: error beim speichern in db

### DIFF
--- a/redaxo/src/core/lib/config.php
+++ b/redaxo/src/core/lib/config.php
@@ -381,7 +381,7 @@ class rex_config
             $where = [];
             $params = [];
             foreach (self::$deletedData as $namespace => $nsData) {
-                if (count($nsData) === 0) {
+                if (0 === count($nsData)) {
                     continue;
                 }
                 $params = array_merge($params, [$namespace], array_keys($nsData));

--- a/redaxo/src/core/lib/config.php
+++ b/redaxo/src/core/lib/config.php
@@ -381,12 +381,16 @@ class rex_config
             $where = [];
             $params = [];
             foreach (self::$deletedData as $namespace => $nsData) {
+                if (count($nsData) === 0) {
+                    continue;
+                }
                 $params = array_merge($params, [$namespace], array_keys($nsData));
                 $where[] = 'namespace = ? AND `key` IN ('.implode(', ', array_fill(0, count($nsData), '?')).')';
             }
-
-            $sql->setWhere(implode("\n    OR ", $where), $params);
-            $sql->delete();
+            if (count($where) > 0) {
+                $sql->setWhere(implode("\n    OR ", $where), $params);
+                $sql->delete();
+            }
         }
 
         // update all changed data


### PR DESCRIPTION
Wenn man in rex_config Werte löscht und danach die keys erneut setzt kann es beim Speichern in der Datenbank zu einem SQL-Error kommen.


Long Story short....

In meinem Case passiert folgendes:
`rex_config::removeNamespace('media_manager')`
`rex_config::set('media_manager', 'jpg_quality', 85)`
`rex_config::set('media_manager', 'png_compression', 5)`
`rex_config::set('media_manager', 'webp_quality', 85)`

erst wird durchs entfernen vom Config-Namespace
```php
$deleteData = [
    'media_manager' => ['interlace', 'png_compression', 'webp_quality']
]
```
durch das neu setzen mit `rex_config::set` verschwinden die Keys wieder daraus und es bleibt
```php
$deleteData = [
    'media_manager' => []
]
```

beim Speichern/Sync mit der DB wird an folgender Stelle das SQL-Statement mit leeren Klammern erzeugt
https://github.com/redaxo/redaxo/blob/29e56a64503338d64607b5f3262892ca75c9ed3f/redaxo/src/core/lib/config.php#L385


(Hoffentlich nachvollziehbar :wink: )

refs #3118 

<details>
<summary>Error und trace aus meinem real beispiel</summary>
<p>

```bash

In sql.php line 309:
                                                                                                                                                                 
  Error while executing statement "DELETE FROM `rex_config` WHERE namespace = ? AND `key` IN ()" using params ["media_manager"]! SQLSTATE[42000]: Syntax error   
  or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use ne  
  ar ')' at line 1                                                                                                                                               
                                                                                                                                                                 

In sql.php line 306:
                                                                                                                                                                 
  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version   
  for the right syntax to use near ')' at line 1                                                                                                                 
                                                                                                                                                                 

setup:run [--lang LANG] [--agree-licence] [--server SERVER] [--servername SERVERNAME] [--error-email ERROR-EMAIL] [--timezone TIMEZONE] [--db-host DB-HOST] [--db-login DB-LOGIN] [--db-password DB-PASSWORD] [--db-name DB-NAME] [--db-createdb] [--db-setup DB-SETUP] [--db-import DB-IMPORT] [--admin-username ADMIN-USERNAME] [--admin-password ADMIN-PASSWORD]

PHP Fatal error:  Uncaught PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1 in /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/sql/sql.php:306
Stack trace:
#0 /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/sql/sql.php(306): PDOStatement->execute(Array)
#1 /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/sql/sql.php(351): rex_sql->execute(Array, Array)
#2 /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/sql/sql.php(951): rex_sql->setQuery('DELETE FROM `re...', Array)
#3 /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/config.php(389): rex_sql->delete()
#4 /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/config.php(363): rex_config::saveToDb()
#5 [internal function]: rex_config::save()
#6 {main}

Next rex_sql_exception: Error while executing  in /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/sql/sql.php on line 309
PHP Stack trace:
PHP   1. {main}() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/bin/console:0
PHP   2. require() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/bin/console:11
PHP   3. rex_console_application->run() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/console.php:32

Fatal error: Uncaught PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1 in /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/sql/sql.php on line 309

Call Stack:
    0.0001     362392   1. {main}() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/bin/console:0
    0.0001     370264   2. require('/home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/console.php') /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/bin/console:11
    0.0177    2863560   3. rex_console_application->run() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/console.php:32

rex_sql_exception: Error while executing statement "DELETE FROM `rex_config` WHERE namespace = ? AND `key` IN ()" using params ["media_manager"]! SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1 in /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/sql/sql.php on line 309

Call Stack:
    0.0001     362392   1. {main}() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/bin/console:0
    0.0001     370264   2. require('/home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/console.php') /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/bin/console:11
    0.0177    2863560   3. rex_console_application->run() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/console.php:32
    2.2092    5852016   4. rex_config::save() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/config.php:0
    2.2092    5852016   5. rex_config::saveToDb() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/config.php:363
    2.2092    5853248   6. rex_sql->delete() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/config.php:389
    2.2092    5853344   7. rex_sql->setQuery() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/sql/sql.php:951
    2.2092    5853912   8. rex_sql->execute() /home/marcel/programmieren/www/redaxo/redaxo_dev/redaxo/src/core/lib/sql/sql.php:351

```

</p>

</details>