### PR TITLE
rex_api_function::hasMessage() immer aufrufbar machen

### DIFF
--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -195,6 +195,11 @@ abstract class rex_api_function
     public static function hasMessage()
     {
         $apiFunc = self::factory();
+
+        if (!$apiFunc) {
+            return false;
+        }
+
         $result = $apiFunc->getResult();
         return $result && null !== $result->getMessage();
     }


### PR DESCRIPTION
Ich bin mir nicht ganz sicher, aber hätte jetzt gesagt, dass die statische Methode `rex_api_function::hasMessage()` immer aufrufbar sein sollte, auch wenn es gar keine aktuelle Api-Func gibt.

Oder was meint ihr?

Aktuell kommt es da zur Exception.