### PR TITLE
Addon nach Download markieren

### DIFF
--- a/redaxo/src/addons/install/lib/api_package_add.php
+++ b/redaxo/src/addons/install/lib/api_package_add.php
@@ -15,7 +15,7 @@ class rex_api_install_package_add extends rex_api_install_package_download
     protected function getSuccessMessage()
     {
         return rex_i18n::msg('install_info_addon_downloaded', $this->addonkey)
-            . ' <a href="' . rex_url::backendPage('packages') . '">' . rex_i18n::msg('install_to_addon_page') . '</a>';
+            . ' <a href="' . rex_url::backendPage('packages', ['mark' => $this->addonkey]) . '">' . rex_i18n::msg('install_to_addon_page') . '</a>';
     }
 
     protected function getPackages()

--- a/redaxo/src/core/pages/packages.php
+++ b/redaxo/src/core/pages/packages.php
@@ -176,6 +176,8 @@ if ('' == $subpage) {
                         </td>
                     </tr>';
             $class = ' mark';
+        } elseif ($package->getPackageId() == rex_get('mark', 'string')) {
+            $class = ' mark';
         }
 
         $version = ('' != trim($package->getVersion())) ? ' <span class="rex-' . $type . '-version">' . trim($package->getVersion()) . '</span>' : '';
@@ -228,7 +230,7 @@ if ('' == $subpage) {
         jQuery(function($) {
             var table = $("#rex-js-table-available-packages-addons");
             var tablebody = table.find("tbody");
-            
+
             $("#rex-js-available-addon-search .form-control").keyup(function () {
                 table.find("tr").show();
                 var search = $(this).val().toLowerCase();


### PR DESCRIPTION
Aber nur wenn man in der Erfolgsmeldung über den Link "Zur Addonverwaltung" geht.

closes #2216

![Screenshot 2020-01-12 19 37 49](https://user-images.githubusercontent.com/330436/72223812-5615c580-3573-11ea-9cfc-8bd1287eab2f.png)
