### PR TITLE
Installer: Bei Aufruf Details nach oben scrollen

### DIFF
--- a/redaxo/src/addons/install/pages/packages.add.php
+++ b/redaxo/src/addons/install/pages/packages.add.php
@@ -138,7 +138,7 @@ if ($addonkey && isset($addons[$addonkey]) && !rex_addon::exists($addonkey)) {
         } else {
             $url = rex_url::currentBackendPage(['addonkey' => $key]);
             $content .= '
-                <tr>
+                <tr data-pjax-scroll-to="0">
                     <td class="rex-table-icon"><a href="' . $url . '"><i class="rex-icon rex-icon-package"></i></a></td>
                     <td data-title="' . $package->i18n('key') . '"><a href="' . $url . '">' . rex_escape($key) . '</a></td>
                     <td data-title="' . $package->i18n('name') . '"><b>' . rex_escape($addon['name']) . '</b><br /><span class="text-muted">' . $addon['author'] . '</span></td>

--- a/redaxo/src/addons/install/pages/packages.update.php
+++ b/redaxo/src/addons/install/pages/packages.update.php
@@ -35,7 +35,7 @@ if ($core && !empty($coreVersions)) {
     $fragment = new rex_fragment();
     foreach ($coreVersions as $id => $version) {
         $panel .= '
-                <tr>
+                <tr data-pjax-scroll-to="0">
                     <td class="rex-table-icon"><i class="rex-icon rex-icon-package"></i></td>
                     <td data-title="' . $package->i18n('version') . '">' . rex_escape($version['version']) . '</td>
                     <td data-title="' . $package->i18n('description') . '">' . $fragment->setVar('content', $markdown->parse($version['description']), false)->parse('core/page/readme.php') . '</td>

--- a/redaxo/src/addons/install/pages/packages.upload.php
+++ b/redaxo/src/addons/install/pages/packages.upload.php
@@ -195,7 +195,7 @@ if ($addonkey && isset($addons[$addonkey])) {
             $url = rex_url::currentBackendPage(['addonkey' => $addonkey, 'file' => $fileId]);
             $status = $file['status'] ? 'online' : 'offline';
             $panel .= '
-            <tr>
+            <tr data-pjax-scroll-to="0">
                 <td class="rex-table-icon"><a href="' . $url . '"><i class="rex-icon rex-icon-package"></i></a></td>
                 <td data-title="' . $package->i18n('version') . '">' . rex_escape($file['version']) . '</td>
                 <td data-title="REDAXO">' . rex_escape(implode(', ', $file['redaxo_versions'])) . '</td>
@@ -233,7 +233,7 @@ if ($addonkey && isset($addons[$addonkey])) {
         $url = rex_url::currentBackendPage(['addonkey' => $key]);
         $status = $addon['status'] ? 'online' : 'offline';
         $panel .= '
-            <tr>
+            <tr data-pjax-scroll-to="0">
                 <td class="rex-table-icon"><a href="' . $url . '"><i class="rex-icon rex-icon-package"></i></a></td>
                 <td data-title="' . $package->i18n('key') . '">' . rex_escape($key) . '</td>
                 <td data-title="' . $package->i18n('name') . '">' . rex_escape($addon['name']) . '</td>


### PR DESCRIPTION
Aktuell ist es so, wenn man in der Liste ein Addon weit unten anklickt, dann landet man in den Details auch entsprechend unten.
Da sollte aber immer nach oben gescrollt werden.