### PR TITLE
Datumsformat vereinheitlicht für Sprachen

### DIFF
--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -3,12 +3,12 @@ htmllang = de
 yes = ja
 no = nein
 general = Allgemein
-dateformat = %d. %b. %Y
 setlocale = de_DE,de_DE@euro,deu_deu,german_germany,de,ge
 phpini_settings = PHP.ini Einstellungen
 
-datetimeformat = %d. %b. %Y - %H:%Mh
-timeformat = %H:%Mh
+dateformat = %d. %b. %Y
+datetimeformat = %d. %b. %Y, %H:%M
+timeformat = %H:%M
 ctrl = Mehrfachauswahl mit <kbd>STRG</kbd> bzw. <kbd>CMD</kbd>
 translatable = Übersetzbar via <code>translate:i18n_key</code>
 
@@ -139,7 +139,7 @@ debug_mode_off = Debug-Modus deaktivieren
 debug_mode_info_on = Der Debug-Modus wurde aktiviert
 debug_mode_info_off = Der Debug-Modus wurde deaktiviert
 debug_mode_marker = Der Debug-Modus ist aktiv
-debug_confirm = Der Debug-Modus sollte nicht im Live-Betrieb verwendet werden. Dennoch den Debug-Modus aktivieren?  
+debug_confirm = Der Debug-Modus sollte nicht im Live-Betrieb verwendet werden. Dennoch den Debug-Modus aktivieren?
 
 system_report = Systembericht
 system_report_markdown = Als markdown

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -3,11 +3,11 @@ htmllang = en
 yes = yes
 no = no
 general = General
-dateformat = %d %b %Y
 setlocale = en_GB,en_UK,en_US,en_EN,en_AU,en_CA,American,ENG,English
 phpini_settings = PHP.ini Settings
 
-datetimeformat = %Y-%b-%d %H:%M
+dateformat = %d %b %Y
+datetimeformat = %d %b %Y, %H:%M
 timeformat = %H:%M
 ctrl = Select multiple using <kbd>CTRL</kbd> or <kbd>CMD</kbd> respectively
 translatable = Translatable via <code>translate:i18n_key</code>

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -3,7 +3,7 @@ htmllang = en
 yes = yes
 no = no
 general = General
-dateformat = %Y-%b-%d
+dateformat = %d %b %Y
 setlocale = en_GB,en_UK,en_US,en_EN,en_AU,en_CA,American,ENG,English
 phpini_settings = PHP.ini Settings
 
@@ -139,7 +139,7 @@ debug_mode_off = Disable debug mode
 debug_mode_info_on = Debug mode has been activated
 debug_mode_info_off = Debug mode was deactivated
 debug_mode_marker = Debug mode is enabled
-debug_confirm = Debug mode should not be activated in live mode. Still activate debug mode?  
+debug_confirm = Debug mode should not be activated in live mode. Still activate debug mode?
 
 system_report = System report
 system_report_markdown = As markdown

--- a/redaxo/src/core/lang/es_es.lang
+++ b/redaxo/src/core/lang/es_es.lang
@@ -3,11 +3,11 @@ htmllang = es
 yes = si
 no = no
 general = general
-dateformat = %d %b. %Y
 setlocale = es_ES,es_BO,latin_america,ES,Español,castellano
 phpini_settings = Ajustes PHP.ini
 
-datetimeformat = %d-%b-%Y %H:%M
+dateformat = %d %b. %Y
+datetimeformat = %d %b. %Y, %H:%M
 timeformat = %H:%M
 ctrl = Selección múltiple mediante CTRL
 translatable = Traducible a través de <code>translate:i18n_key</code>

--- a/redaxo/src/core/lang/es_es.lang
+++ b/redaxo/src/core/lang/es_es.lang
@@ -3,7 +3,7 @@ htmllang = es
 yes = si
 no = no
 general = general
-dateformat = %d-%b-%Y
+dateformat = %d %b. %Y
 setlocale = es_ES,es_BO,latin_america,ES,Español,castellano
 phpini_settings = Ajustes PHP.ini
 

--- a/redaxo/src/core/lang/it_it.lang
+++ b/redaxo/src/core/lang/it_it.lang
@@ -3,11 +3,11 @@ htmllang = it
 yes = si
 no = no
 general = generale
-dateformat = %d %b %Y
 setlocale = it_IT,it_IT@euro
 phpini_settings = Impostazioni PHP.ini
 
-datetimeformat = %d-%m-%Y - %H:%M
+dateformat = %d %b %Y
+datetimeformat = %d %b %Y, %H:%M
 timeformat = %H:%M
 ctrl = Per seleziona multipla usare <kbd>STRG</kbd> risp. <kbd>CMD</kbd>
 

--- a/redaxo/src/core/lang/it_it.lang
+++ b/redaxo/src/core/lang/it_it.lang
@@ -3,7 +3,7 @@ htmllang = it
 yes = si
 no = no
 general = generale
-dateformat = %d-%m-%Y
+dateformat = %d %b %Y
 setlocale = it_IT,it_IT@euro
 phpini_settings = Impostazioni PHP.ini
 

--- a/redaxo/src/core/lang/nl_nl.lang
+++ b/redaxo/src/core/lang/nl_nl.lang
@@ -3,11 +3,11 @@ htmllang = nl
 yes = ja
 no = nee
 general = Algemeen
-dateformat = %d %b. %Y
 setlocale = nl_NL,nl_NL.UTF8,dutch,nld_nld,nld,Nederlands
 phpini_settings = PHP.ini Instellingen
 
-datetimeformat = %d/%b/%Y %H:%M
+dateformat = %d %b. %Y
+datetimeformat = %d %b. %Y, %H:%M
 timeformat = %H:%M
 ctrl = Selecteer meerdere met <kbd>CTRL</kbd> of <kbd>CMD</kbd>
 

--- a/redaxo/src/core/lang/nl_nl.lang
+++ b/redaxo/src/core/lang/nl_nl.lang
@@ -3,7 +3,7 @@ htmllang = nl
 yes = ja
 no = nee
 general = Algemeen
-dateformat = %d/%b/%Y
+dateformat = %d %b. %Y
 setlocale = nl_NL,nl_NL.UTF8,dutch,nld_nld,nld,Nederlands
 phpini_settings = PHP.ini Instellingen
 

--- a/redaxo/src/core/lang/pt_br.lang
+++ b/redaxo/src/core/lang/pt_br.lang
@@ -3,12 +3,12 @@ htmllang = pt
 yes = sim
 no = não
 general = geral
-dateformat = %d/%b/%Y
 setlocale = en_GB,en_UK,en_US,en_EN,en_AU,en_CA,American,ENG,English
 phpini_settings = PHP.ini Configurações
 
-datetimeformat = %d. %m. %Y - %H:%Mh
-timeformat = %H:%Mh
+dateformat = %d/%b/%Y
+datetimeformat = %d/%b/%Y, %H:%M
+timeformat = %H:%M
 ctrl = Seleção múltipla usando <kbd>CTRL</kbd> ou <kbd>CMD</kbd>
 
 # Allgemein

--- a/redaxo/src/core/lang/pt_br.lang
+++ b/redaxo/src/core/lang/pt_br.lang
@@ -3,7 +3,7 @@ htmllang = pt
 yes = sim
 no = não
 general = geral
-dateformat = %d/ %b/ %Y
+dateformat = %d/%b/%Y
 setlocale = en_GB,en_UK,en_US,en_EN,en_AU,en_CA,American,ENG,English
 phpini_settings = PHP.ini Configurações
 

--- a/redaxo/src/core/lang/sv_se.lang
+++ b/redaxo/src/core/lang/sv_se.lang
@@ -3,7 +3,7 @@ htmllang = se
 yes = ja
 no = nej
 general = Allmänt
-dateformat = %d. %b. %Y
+dateformat = %d %b. %Y
 setlocale = se_SE,se_SE@euro,sve_sve,swedish_sweden,sv,se
 phpini_settings = PHP.ini inställningar
 

--- a/redaxo/src/core/lang/sv_se.lang
+++ b/redaxo/src/core/lang/sv_se.lang
@@ -3,12 +3,12 @@ htmllang = se
 yes = ja
 no = nej
 general = Allmänt
-dateformat = %d %b. %Y
 setlocale = se_SE,se_SE@euro,sve_sve,swedish_sweden,sv,se
 phpini_settings = PHP.ini inställningar
 
-datetimeformat = %d. %b. %Y - %H:%Mh
-timeformat = %H:%Mh
+dateformat = %d %b. %Y
+datetimeformat = %d %b. %Y, %H:%M
+timeformat = %H:%M
 ctrl = Flervalsurval med <kbd>STRG</kbd> resp. <kbd>CMD</kbd>
 translatable = Översättbar via <code> translate: i18n_key </ code>
 

--- a/redaxo/src/core/tests/util/formatter_test.php
+++ b/redaxo/src/core/tests/util/formatter_test.php
@@ -41,13 +41,13 @@ class rex_formatter_test extends TestCase
 
         $format = 'date';
         $this->assertEquals(
-            '2012-May-12',
+            '12 May 2012',
             rex_formatter::strftime($value, $format)
         );
 
         $format = 'datetime';
         $this->assertEquals(
-            '2012-May-12 10:24',
+            '12 May 2012, 10:24',
             rex_formatter::strftime($value, $format)
         );
 


### PR DESCRIPTION
Im Englischen hatten wir aktuell zum Beispiel ein komisches Format: 2020-Jan-15.

Habe es auf dieser Basis angepasst: https://3v4l.org/OGXnn
- In deutsch aber trotzdem weiterhin "15. Jan. 2020", auch wenn der Intl-Formatter für MEDIUM im deutschen das reine Zahlenformat angibt
- In Portugiesisch hingegen habe ich das Zahlenformat, da das andere so extrem lang ist