### PR TITLE
Installer-Messages verbessert

### DIFF
--- a/redaxo/src/addons/install/lang/de_de.lang
+++ b/redaxo/src/addons/install/lang/de_de.lang
@@ -43,13 +43,15 @@ install_info_core_updated = Der Core wurde aktualisiert!
 install_warning_core_not_updated = Der Core konnte aus folgendem Grund nicht aktualisiert werden:
 install_warning_core_zip_not_extracted = Die Zip-Datei konnte nicht in das "src"-Verzeichnis entpackt werden!
 
-install_info_addon_downloaded = AddOn "{0}" wurde heruntergeladen!
-install_warning_addon_not_downloaded = AddOn "{0}" konnte aus folgendem Grund nicht heruntergeladen werden:
-install_info_addon_updated = AddOn "{0}" wurde aktualisiert!
-install_warning_addon_not_updated = AddOn "{0}" konnte aus folgendem Grund nicht aktualisiert werden:
-install_info_addon_uploaded = AddOn "{0}" wurde hochgeladen!
-install_info_addon_deleted = AddOn-Version von "{0}" wurde gelöscht!
+install_info_addon_downloaded = AddOn <b>{0}</b> wurde heruntergeladen!
+install_warning_addon_not_downloaded = AddOn <b>{0}</b> konnte aus folgendem Grund nicht heruntergeladen werden:
+install_info_addon_updated = AddOn <b>{0}</b> wurde aktualisiert!
+install_warning_addon_not_updated = AddOn <b>{0}</b> konnte aus folgendem Grund nicht aktualisiert werden:
+install_info_addon_uploaded = AddOn <b>{0}</b> wurde hochgeladen!
+install_info_addon_deleted = AddOn-Version von <b>{0}</b> wurde gelöscht!
 install_warning_addon_zip_not_extracted = Beim Entpacken der Zip-Datei in das AddOn-Verzeichnis ist ein Fehler aufgetreten. Möglicherweise fehlen Schreibrechte oder der Ordnername innerhalb der Zip-Datei entspricht nicht dem AddOn-Key.
+install_warning_message_from_addon = AddOn <b>{0}</b> meldet:
+install_warning_message_from_plugin = PlugIn <b>{0}</b> meldet:
 
 install_warning_zip_wrong_checksum = Die Prüfsumme der heruntergeladenen Zip-Datei stimmt nicht mit der erwarteten überein. Bitte in wenigen Minuten noch einmal probieren!
 install_warning_zip_wrong_format = Die Zip-Datei ist nicht im erforderlichen Format.

--- a/redaxo/src/addons/install/lang/en_gb.lang
+++ b/redaxo/src/addons/install/lang/en_gb.lang
@@ -43,13 +43,15 @@ install_info_core_updated = Core has been updated!
 install_warning_core_not_updated = The core could not be updated for the following reason:
 install_warning_core_zip_not_extracted = The zip file could not be unpacked in the "src" directory!
 
-install_info_addon_downloaded = AddOn "{0}" downloaded!
-install_warning_addon_not_downloaded = AddOn "{0}" could not be downloaded due to the following reasons:
-install_info_addon_updated = AddOn "{0}" has been updated!
-install_warning_addon_not_updated = AddOn "{0}" could not be downloaded due to the following reasons:
-install_info_addon_uploaded = AddOn "{0}" has been uploaded!
-install_info_addon_deleted = AddOn-Version of "{0}" has been deleted!
+install_info_addon_downloaded = AddOn <b>{0}</b> downloaded!
+install_warning_addon_not_downloaded = AddOn <b>{0}</b> could not be downloaded due to the following reasons:
+install_info_addon_updated = AddOn <b>{0}</b> has been updated!
+install_warning_addon_not_updated = AddOn <b>{0}</b> could not be downloaded due to the following reasons:
+install_info_addon_uploaded = AddOn <b>{0}</b> has been uploaded!
+install_info_addon_deleted = AddOn-Version of <b>{0}</b> has been deleted!
 install_warning_addon_zip_not_extracted = Zip file could not bee extracted in the AddOn directory. You may have missing write permissions or the folder name within the zip file does not match the AddOn-Key.
+install_warning_message_from_addon = AddOn <b>{0}</b> reports:
+install_warning_message_from_plugin = PlugIn <b>{0}</b> reports:
 
 install_warning_zip_wrong_checksum = The checksum of the downloaded zip file does not match. Please try again in a few minutes!
 install_warning_zip_wrong_format = The zip file is not in the required format.

--- a/redaxo/src/addons/install/lang/es_es.lang
+++ b/redaxo/src/addons/install/lang/es_es.lang
@@ -43,12 +43,12 @@ install_info_core_updated = Core se ha actualizado!
 install_warning_core_not_updated = El núcleo no se pudo actualizar por el siguiente motivo:
 install_warning_core_zip_not_extracted = El archivo zip no se pudo desempaquetar en el directorio "src"!
 
-install_info_addon_downloaded = AddOn "{0}" descargado!
-install_warning_addon_not_downloaded = No se pudo descargar AddOn "{0}" debido a lo siguiente:
-install_info_addon_updated = ¡Se ha actualizado AddOn "{0}"!
-install_warning_addon_not_updated = No se pudo descargar AddOn "{0}" debido a lo siguiente:
-install_info_addon_uploaded = ¡Se ha cargado AddOn "{0}"!
-install_info_addon_deleted = ¡La versión AddOn de "{0}" ha sido eliminada!
+install_info_addon_downloaded = AddOn <b>{0}</b> descargado!
+install_warning_addon_not_downloaded = No se pudo descargar AddOn <b>{0}</b> debido a lo siguiente:
+install_info_addon_updated = ¡Se ha actualizado AddOn <b>{0}</b>!
+install_warning_addon_not_updated = No se pudo descargar AddOn <b>{0}</b> debido a lo siguiente:
+install_info_addon_uploaded = ¡Se ha cargado AddOn <b>{0}</b>!
+install_info_addon_deleted = ¡La versión AddOn de <b>{0}</b> ha sido eliminada!
 install_warning_addon_zip_not_extracted = El archivo Zip no se pudo extraer en el directorio AddOn. Es posible que tenga permisos de escritura que faltan o que el nombre de carpeta dentro del archivo zip no coincide con la clave de agregado.
 
 install_warning_zip_wrong_checksum = La suma de comprobación del archivo zip descargado no coincide!

--- a/redaxo/src/addons/install/lang/pt_br.lang
+++ b/redaxo/src/addons/install/lang/pt_br.lang
@@ -40,12 +40,12 @@ install_info_core_updated = Core foi atualizado!
 install_warning_core_not_updated = O core não pôde ser atualizado devido às seguintes razões:
 install_warning_core_zip_not_extracted = O arquivo Zip não pôde ser extraído no diretório "src"!
 
-install_info_addon_downloaded = AddOn "{0}" baixado!
-install_warning_addon_not_downloaded = AddOn "{0}"  não pôde ser baixado devido aos seguintes motivos:
-install_info_addon_updated = AddOn "{0}"  foi atualizado!
-install_warning_addon_not_updated = AddOn "{0}" não pôde ser baixado devido às seguintes razões:
-install_info_addon_uploaded = AddOn "{0}" foi atualizado!
-install_info_addon_deleted = Versão AddOn do "{0}" foi atualizada!
+install_info_addon_downloaded = AddOn <b>{0}</b> baixado!
+install_warning_addon_not_downloaded = AddOn <b>{0}</b>  não pôde ser baixado devido aos seguintes motivos:
+install_info_addon_updated = AddOn <b>{0}</b>  foi atualizado!
+install_warning_addon_not_updated = AddOn <b>{0}</b> não pôde ser baixado devido às seguintes razões:
+install_info_addon_uploaded = AddOn <b>{0}</b> foi atualizado!
+install_info_addon_deleted = Versão AddOn do <b>{0}</b> foi atualizada!
 install_warning_addon_zip_not_extracted = O arquivo Zip não pôde ser extraído no diretório AddOn. Você talvez não possua as permissões ou o nome do arquivo Zip não corresponde à chave AddOn.
 
 install_warning_zip_wrong_checksum = A soma de verificação do arquivo zip baixado não corresponde

--- a/redaxo/src/addons/install/lang/sv_se.lang
+++ b/redaxo/src/addons/install/lang/sv_se.lang
@@ -43,12 +43,12 @@ install_info_core_updated = Koden aktualiserades!
 install_warning_core_not_updated = Kärnan (Core) kunde av följande skäl inte aktualiseras:
 install_warning_core_zip_not_extracted = Zip-filen kunde inte packas upp i "src"-katalogen!
 
-install_info_addon_downloaded = AddOn "{0}" laddades ner!
-install_warning_addon_not_downloaded = AddOn "{0}" kunde av följande skäl inte laddas ner:
-install_info_addon_updated = AddOn "{0}" aktualiserades!
-install_warning_addon_not_updated = AddOn "{0}" kunde av följande skäl inte aktualiseras:
-install_info_addon_uploaded = AddOn "{0}" har laddas upp!
-install_info_addon_deleted = AddOn-version av "{0}" raderades!
+install_info_addon_downloaded = AddOn <b>{0}</b> laddades ner!
+install_warning_addon_not_downloaded = AddOn <b>{0}</b> kunde av följande skäl inte laddas ner:
+install_info_addon_updated = AddOn <b>{0}</b> aktualiserades!
+install_warning_addon_not_updated = AddOn <b>{0}</b> kunde av följande skäl inte aktualiseras:
+install_info_addon_uploaded = AddOn <b>{0}</b> har laddas upp!
+install_info_addon_deleted = AddOn-version av <b>{0}</b> raderades!
 install_warning_addon_zip_not_extracted = Fel uppstod vid uppackningen av zip-filen i addon-katalogen. Möjligtvis saknas det skrivrättigheter eller mappens namn i zip-filen motsvara inte AddOn-nyckeln.
 
 install_warning_zip_wrong_checksum = Checksumman av de nedladdade zip-filerna stämmer inte överens med den förväntade summan!

--- a/redaxo/src/addons/install/lib/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api_core_update.php
@@ -234,9 +234,9 @@ class rex_api_install_core_update extends rex_api_function
         foreach (rex_package::getAvailablePackages() as $package) {
             $manager = rex_package_manager::factory($package);
             if (!$manager->checkRequirements()) {
-                $messages[] = $package->getPackageId() . ': ' . $manager->getMessage();
+                $messages[] = $this->messageFromPackage($package, $manager);
             } elseif (!$manager->checkConflicts()) {
-                $messages[] = $package->getPackageId() . ': ' . $manager->getMessage();
+                $messages[] = $this->messageFromPackage($package, $manager);
             }
         }
 
@@ -253,7 +253,12 @@ class rex_api_install_core_update extends rex_api_function
         }
 
         if (!empty($messages)) {
-            throw new rex_functional_exception(implode('<br />', $messages));
+            throw new rex_functional_exception('<ul><li>'.implode('</li><li>', $messages).'</li></ul>');
         }
+    }
+
+    private function messageFromPackage(rex_package $package, rex_package_manager $manager): string
+    {
+        return rex_i18n::msg('install_warning_message_from_'.$package->getType(), $package->getPackageId()).' '.$manager->getMessage();
     }
 }

--- a/redaxo/src/addons/install/lib/api_package_update.php
+++ b/redaxo/src/addons/install/lib/api_package_update.php
@@ -178,10 +178,10 @@ class rex_api_install_package_update extends rex_api_install_package_download
             foreach ($availablePlugins as $plugin) {
                 $manager = rex_plugin_manager::factory($plugin);
                 if (!$manager->checkRequirements()) {
-                    $messages[] = $plugin->getPackageId() . ': ' . $manager->getMessage();
+                    $messages[] = $this->messageFromPackage($plugin, $manager);
                 }
                 if (!$manager->checkConflicts()) {
-                    $messages[] = $plugin->getPackageId() . ': ' . $manager->getMessage();
+                    $messages[] = $this->messageFromPackage($plugin, $manager);
                 }
             }
             foreach (rex_package::getAvailablePackages() as $package) {
@@ -190,11 +190,11 @@ class rex_api_install_package_update extends rex_api_install_package_download
                 }
                 $manager = rex_package_manager::factory($package);
                 if (!$manager->checkPackageRequirement($this->addon->getPackageId())) {
-                    $messages[] = $package->getPackageId() . ': ' . $manager->getMessage();
+                    $messages[] = $this->messageFromPackage($package, $manager);
                 } else {
                     foreach ($versions as $reqPlugin) {
                         if (!$manager->checkPackageRequirement($reqPlugin->getPackageId())) {
-                            $messages[] = $package->getPackageId() . ': ' . $manager->getMessage();
+                            $messages[] = $this->messageFromPackage($package, $manager);
                         }
                     }
                 }
@@ -212,7 +212,12 @@ class rex_api_install_package_update extends rex_api_install_package_download
             $package->setProperty('conflicts', $conflicts[$package]);
         }
 
-        return empty($messages) ? true : implode('<br />', $messages);
+        return empty($messages) ? true : '<ul><li>'.implode('</li><li>', $messages).'</li></ul>';
+    }
+
+    private function messageFromPackage(rex_package $package, rex_package_manager $manager): string
+    {
+        return rex_i18n::msg('install_warning_message_from_'.$package->getType(), $package->getPackageId()).' '.$manager->getMessage();
     }
 
     public function __destruct()


### PR DESCRIPTION
closes #2633

**Vorher**

![Screenshot 2020-01-15 21 21 02](https://user-images.githubusercontent.com/330436/72468293-1baf6100-37dd-11ea-8197-049ad5c9d0f5.png)

**Nachher**

![Screenshot 2020-01-15 21 20 32](https://user-images.githubusercontent.com/330436/72468308-25d15f80-37dd-11ea-8198-a299d4e37fc6.png)

Ich hoffe, es macht die Meldungen zumindest etwas verständlicher.