### PR TITLE
travis: php 8 testen; bionic nutzen, wo möglich

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
                 mariadb: 10.1
         -   <<: *TEST
             php: 7.4
-            dist: xenial
+            dist: trusty
             addons:
                 mariadb: 10.4
         -   &TEST_MYSQL
@@ -53,10 +53,3 @@ jobs:
             php: 7.4
         -   <<: *TEST_MYSQL
             php: nightly
-
-matrix:
-    allow_failures:
-        - php: nightly
-          env:
-              - TYPE=phpunit
-              - DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,13 @@ jobs:
                 - php redaxo/src/addons/tests/bin/setup.php
             script: php redaxo/src/addons/tests/bin/run_tests.php
             php: 7.1
-            dist: bionic
             env:
                 - TYPE=phpunit
                 - DB=mariadb
             addons:
                 mariadb: 10.1
         -   <<: *TEST
-            php: 7.3
+            php: 7.4
             addons:
                 mariadb: 10.4
         -   &TEST_MYSQL
@@ -51,4 +50,3 @@ jobs:
             php: 7.3
         -   <<: *TEST_MYSQL
             php: 7.4
-            dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
                 mariadb: 10.1
         -   <<: *TEST
             php: 7.4
+            dist: xenial
             addons:
                 mariadb: 10.4
         -   &TEST_MYSQL
@@ -50,3 +51,12 @@ jobs:
             php: 7.3
         -   <<: *TEST_MYSQL
             php: 7.4
+        -   <<: *TEST_MYSQL
+            php: nightly
+
+matrix:
+    allow_failures:
+        - php: nightly
+          env:
+              - TYPE=phpunit
+              - DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
             addons:
                 mariadb: 10.1
         -   <<: *TEST
-            php: 7.4
+            php: 7.3
             dist: trusty
             addons:
                 mariadb: 10.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
                 - php redaxo/src/addons/tests/bin/setup.php
             script: php redaxo/src/addons/tests/bin/run_tests.php
             php: 7.1
-            dist: trusty
+            dist: bionic
             env:
                 - TYPE=phpunit
                 - DB=mariadb
@@ -51,4 +51,4 @@ jobs:
             php: 7.3
         -   <<: *TEST_MYSQL
             php: 7.4
-            dist: xenial
+            dist: bionic


### PR DESCRIPTION
Seit https://github.com/redaxo/redaxo/pull/3016 nutzen wir für fast alle Builds wieder trusty.
(Wir nutzen da YAML-Referenzen, deswegen wir es in die anderen Builds vererbt.

Ich teste jetzt hier auch allgemein nochmal durch, bei welchen builds es noch notwendig ist, was anderes als bionic zu nutzen (ggf. hat sich ja was verändert).