### PR TITLE
dependabot: only security fixes

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,9 +5,18 @@ update_configs:
     - package_manager: "php:composer"
       directory: "/redaxo/src/addons/phpmailer"
       update_schedule: "live"
+      allowed_updates:
+        - match:
+            update_type: "security"
     - package_manager: "php:composer"
       directory: "/redaxo/src/addons/tests"
       update_schedule: "live"
+      allowed_updates:
+        - match:
+            update_type: "security"
     - package_manager: "php:composer"
       directory: "/redaxo/src/core"
       update_schedule: "live"
+      allowed_updates:
+        - match:
+            update_type: "security"


### PR DESCRIPTION
nur noch über security fixes "informieren".

Anpassung anhand config reference https://dependabot.com/docs/config-file/#allowed_updates

refs #3165  
refs #3166