### PR TITLE
rex_log_file: Notice vermeiden

### DIFF
--- a/redaxo/src/core/lib/util/log_file.php
+++ b/redaxo/src/core/lib/util/log_file.php
@@ -221,7 +221,7 @@ class rex_log_entry
     public static function createFromString($string)
     {
         $data = [];
-        foreach (explode(' | ', $string) as $part) {
+        foreach (explode(' |', $string) as $part) {
             $data[] = trim(stripcslashes($part));
         }
 

--- a/redaxo/src/core/tests/util/log_entry_test.php
+++ b/redaxo/src/core/tests/util/log_entry_test.php
@@ -20,11 +20,11 @@ class rex_log_entry_test extends TestCase
     public function testCreateFromString()
     {
         $time = time();
-        $entry = rex_log_entry::createFromString(date('Y-m-d H:i:s', $time) . ' | test1 |  |  test2\nt \| test3');
+        $entry = rex_log_entry::createFromString(date('Y-m-d H:i:s', $time) . ' | test1 |  |  test2\nt \| test3 |');
 
         $this->assertInstanceOf('rex_log_entry', $entry);
         $this->assertSame($time, $entry->getTimestamp());
-        $this->assertSame(['test1', '', "test2\nt | test3"], $entry->getData());
+        $this->assertSame(['test1', '', "test2\nt | test3", ''], $entry->getData());
     }
 
     /**


### PR DESCRIPTION
Durch meinen anderen PR kam hier ein Problem rein, wenn das letzte Log-Daten-Element leer ist.