### PR TITLE
rex_sql: shortcut getDbTypeAndVersion

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1647,6 +1647,11 @@ class rex_sql implements Iterator
         return $version;
     }
 
+    public function getDbTypeAndVersion(): string
+    {
+        return $this->getDbType().' '.$this->getDbVersion();
+    }
+
     /**
      * Creates a rex_sql instance.
      *

--- a/redaxo/src/core/lib/system_report.php
+++ b/redaxo/src/core/lib/system_report.php
@@ -39,9 +39,7 @@ class rex_system_report
                 continue;
             }
 
-            $sql = rex_sql::factory($dbId);
-
-            $dbData = ['Version' => $sql->getDbType().' '.$sql->getDbVersion()];
+            $dbData = ['Version' => rex_sql::factory($dbId)->getDbTypeAndVersion()];
 
             if (1 === $dbId) {
                 $dbData['Character set'] = rex::getConfig('utf8mb4') ? 'utf8mb4' : 'utf8';

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -642,11 +642,9 @@ if (5 === $step) {
 
     $formElements = [];
 
-    $sql = rex_sql::factory();
-
     $n = [];
     $n['label'] = '<label>'.rex_i18n::msg('version').'</label>';
-    $n['field'] = '<p class="form-control-static">'.$sql->getDbType().' '.$sql->getDbVersion().'</p>';
+    $n['field'] = '<p class="form-control-static">'.rex_sql::factory()->getDbTypeAndVersion().'</p>';
     $formElements[] = $n;
 
     $n = [];

--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -191,13 +191,11 @@ $fragment->setVar('title', rex_i18n::msg('version'));
 $fragment->setVar('content', $content, false);
 $sideContent[] = $fragment->parse('core/page/section.php');
 
-$sql = rex_sql::factory();
-
 $content = '
     <table class="table">
         <tr>
             <th class="rex-table-width-3">' . rex_i18n::msg('version') . '</th>
-            <td>' .  $sql->getDbType().' '.$sql->getDbVersion() . '</td>
+            <td>' .  rex_sql::factory()->getDbTypeAndVersion() . '</td>
         </tr>
         <tr>
             <th>' . rex_i18n::msg('name') . '</th>


### PR DESCRIPTION
Was meint ihr, ist es das wert?
So kann man halt direkt ausgeben mit `rex_sql::factory()->getDbTypeAndVersion()` und braucht nicht eine extra Variable für das sql-objekt.

Aber bin mir unsicher, somit auch ok, wenn wir es weglassen.
Ansonsten: Idee für einen schöneren Namen für die Methode?