### PR TITLE
Perm-Selects: Max-Zeilen von 10 auf 20

### DIFF
--- a/redaxo/src/addons/users/pages/roles.php
+++ b/redaxo/src/addons/users/pages/roles.php
@@ -91,7 +91,7 @@ if ('' == $func) {
         $select = $field->getSelect();
         $select->setMultiple(true);
         $perms = rex_perm::getAll($permgroup);
-        $select->setSize(min(10, max(3, count($perms))));
+        $select->setSize(min(20, max(3, count($perms))));
         $select->addArrayOptions($perms);
     }
 
@@ -122,7 +122,7 @@ if ('' == $func) {
                 $select->addSqlOptions($params['sql_options']);
             }
             $select->get();
-            $select->setSize(min(10, max(3, $select->countOptions())));
+            $select->setSize(min(20, max(3, $select->countOptions())));
         }
     }
 


### PR DESCRIPTION
Bei den Mehrfachselects für die Perms ist es nervig, wenn sie scrollen.
Mit den neuen Strukturrechten wird man leicht über 10 kommen.
Finde es angenehmer, wenn die Selects dann auch entsprechend größer sind, deswegen nun 20 als max. Size.