### PR TITLE
tar: deprecated-message vermeiden

### DIFF
--- a/redaxo/src/addons/backup/vendor/tar.php
+++ b/redaxo/src/addons/backup/vendor/tar.php
@@ -128,19 +128,19 @@ class tar {
       $file_mode    = substr($this->tar_file,$main_offset + 100,8);
 
       // Parse the file user ID
-      $file_uid   = octdec(substr($this->tar_file,$main_offset + 108,8));
+      $file_uid   = octdec(rtrim(substr($this->tar_file,$main_offset + 108,8), "\x00"));
 
       // Parse the file group ID
-      $file_gid   = octdec(substr($this->tar_file,$main_offset + 116,8));
+      $file_gid   = octdec(rtrim(substr($this->tar_file,$main_offset + 116,8), "\x00"));
 
       // Parse the file size
-      $file_size    = octdec(substr($this->tar_file,$main_offset + 124,12));
+      $file_size    = octdec(rtrim(substr($this->tar_file,$main_offset + 124,12), "\x00"));
 
       // Parse the file update time - unix timestamp format
-      $file_time    = octdec(substr($this->tar_file,$main_offset + 136,12));
+      $file_time    = octdec(rtrim(substr($this->tar_file,$main_offset + 136,12), "\x00"));
 
       // Parse Checksum
-      $file_chksum    = octdec(substr($this->tar_file,$main_offset + 148,6));
+      $file_chksum    = octdec(rtrim(substr($this->tar_file,$main_offset + 148,6), "\x00"));
 
       // Parse user name
       $file_uname   = $this->__parseNullPaddedString(substr($this->tar_file,$main_offset + 265,32));


### PR DESCRIPTION
fixes #3183

Also `octdec` meckert über invalide Zeichen. Daher habe ich geschaut, was für Zeichen enthalten sind, und gesehen, dass die meisten der dort ausgelesenen Strings als letztes ein "\x00" haben.
Vermutlich ein Trenner im Tar zwischen den verschiedenen Werten.

Theoretisch könnte ich also jeweils ein Byte weniger auslesen. Da ich mich mit tar aber nicht auskenne und mir das nicht ganz geheuer war, habe ich lieber mit rtrim gearbeitet.

Bin mir nicht wirklich sicher, aber vermute, dass es so passt. Bei mir kommen die Meldungen jedenfalls nicht mehr und die tars werden scheinbar korrekt entpackt.