### PR TITLE
Medienpool: php 7.4 notice bei upload vermeiden

### DIFF
--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -155,7 +155,7 @@ function rex_mediapool_saveMedia($FILE, $rex_file_category, $FILEINFOS, $userlog
     $RETURN['filename'] = $NFILENAME;
     $RETURN['old_filename'] = $FILENAME;
 
-    if (isset($size)) {
+    if (isset($size) && $size) {
         $RETURN['width'] = $size[0];
         $RETURN['height'] = $size[1];
     }


### PR DESCRIPTION
`$size` kann auch false sein.