### PR TITLE
MP: Cache nicht löschen in install.php

### DIFF
--- a/redaxo/src/addons/mediapool/install.php
+++ b/redaxo/src/addons/mediapool/install.php
@@ -8,8 +8,6 @@
  * @package redaxo5
  */
 
-rex_delete_cache();
-
 rex_sql_table::get(rex::getTable('media'))
     ->ensurePrimaryIdColumn()
     ->ensureColumn(new rex_sql_column('category_id', 'int(10) unsigned'))

--- a/redaxo/src/addons/mediapool/uninstall.php
+++ b/redaxo/src/addons/mediapool/uninstall.php
@@ -8,7 +8,5 @@
  * @package redaxo5
  */
 
-rex_delete_cache();
-
 rex_sql_table::get(rex::getTable('media'))->drop();
 rex_sql_table::get(rex::getTable('media_category'))->drop();


### PR DESCRIPTION
Seit 5.9 binden wir in der update.php die install.php ein.
So wird es zum Problem während des Core-Updates, dass hier der Cache gelöscht wird, da im Cache-Ordner benötigte Dateien für das Core-Update liegen.

Das Cache-Löschen hat Jan hier eingeführt: https://github.com/redaxo/redaxo/commit/82eeb6c8ae4b81714581c46f7368c80fd62d2038#diff-91420c7e4017130d603003ff56855cabR20

Ohne genau zu verstehen, warum das damals nötig war, denke ich nicht, dass es jetzt noch notwendig ist.