### PR TITLE
Core-Update: install.php einbinden

### DIFF
--- a/redaxo/src/core/install.php
+++ b/redaxo/src/core/install.php
@@ -10,9 +10,11 @@ rex_sql_table::get(rex::getTable('clang'))
     ->ensure();
 
 $sql = rex_sql::factory();
-$sql->setTable(rex::getTable('clang'));
-$sql->setValues(['id' => 1, 'code' => 'de', 'name' => 'deutsch', 'priority' => 1, 'status' => 1, 'revision' => 0]);
-$sql->insertOrUpdate();
+if (!$sql->setQuery('SELECT 1 FROM '.rex::getTable('clang').' LIMIT 1')->getRows()) {
+    $sql->setTable(rex::getTable('clang'));
+    $sql->setValues(['id' => 1, 'code' => 'de', 'name' => 'deutsch', 'priority' => 1, 'status' => 1, 'revision' => 0]);
+    $sql->insert();
+}
 
 rex_sql_table::get(rex::getTable('config'))
     ->ensureColumn(new rex_sql_column('namespace', 'varchar(75)'))

--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -39,3 +39,5 @@ rex_file::putConfig($path, array_merge(
     rex_file::getConfig(__DIR__.'/default.config.yml'),
     rex_file::getConfig($path)
 ));
+
+require __DIR__.'/install.php';


### PR DESCRIPTION
Da wir inzwischen dort auch rex_sql_table verwenden.

Außerdem war mir aufgefallen, dass ein Setup mit Aktualisierung der DB auf utf8mb4, die Core-Tabellen gar nicht umgestellt wurden, nur die Addons.