### PR TITLE
fix flickering tests

### DIFF
--- a/redaxo/src/addons/tests/bin/setup.php
+++ b/redaxo/src/addons/tests/bin/setup.php
@@ -69,6 +69,7 @@ if (rex::isSetup()) {
 
     $config['setup'] = false;
     if (rex_file::putConfig($configFile, $config)) {
+        rex_delete_cache();
         echo 'instance setup successfull', PHP_EOL;
         exit(0);
     }


### PR DESCRIPTION
closes #3227 

Problem sind nicht die tests selbst, sondern das setup (aus `tests/bin/setup.php`)

"Kurze" Workflow Erklärung:

erst wird im Setup eine mini config.yml erzeugt und in data abgelegt
https://github.com/redaxo/redaxo/blob/9ade306e8a7cdce0605a11ffebf6cb4f62737af1/redaxo/src/addons/tests/bin/setup.php#L27

dann wird die boot.php eingebunden, die schließlich die config.yml.cache anlegt (gemergt mit der default ist `setup:true`)
https://github.com/redaxo/redaxo/blob/9ade306e8a7cdce0605a11ffebf6cb4f62737af1/redaxo/src/addons/tests/bin/setup.php#L30

dann zum Ende speichert der `setup:false` mit in die config.yml in data.
https://github.com/redaxo/redaxo/blob/9ade306e8a7cdce0605a11ffebf6cb4f62737af1/redaxo/src/addons/tests/bin/setup.php#L70-L71

Status nach Setup:
data/core/config.yml => `setup: false`
cache/core/config.yml.cache => `setup: true`


Das flickern kommt dadurch, dass der beim Bootstrap der tests einmalig die `boot.php` einbindet (ist OK).
Dort entscheidet der anhand der `filemtime()` der Cache-Datei, ob er die nimmt oder sich die neu mit `default.config.yml` und `config.yml` zusammenbaut.

Je nach dem kommt es vor, dass dann die config.yml einen neueren timestamp hat als die Cache-Datei und damit entweder `setup:false` da raus kommt. Wenn das nicht so ist, kommt der mit `setup:true` daraus.

Also kurz und knackig am Ende des Setups einmal den Cache löschen.