### PR TITLE
Setup: Vor Reinstallation der Addons, diese listen

### DIFF
--- a/redaxo/src/core/lib/setup/import.php
+++ b/redaxo/src/core/lib/setup/import.php
@@ -243,6 +243,9 @@ class rex_setup_importer
         rex_package_manager::synchronizeWithFileSystem();
 
         foreach (rex::getConfig('package-order') as $packageId) {
+            rex_package::get($packageId)->enlist();
+        }
+        foreach (rex::getConfig('package-order') as $packageId) {
             $package = rex_package::get($packageId);
             $manager = rex_package_manager::factory($package);
 

--- a/redaxo/src/core/lib/setup/import.php
+++ b/redaxo/src/core/lib/setup/import.php
@@ -242,6 +242,7 @@ class rex_setup_importer
         rex_addon::initialize();
         rex_package_manager::synchronizeWithFileSystem();
 
+        // enlist activated packages to ensure that all their classess are known in autoloader and can be referenced in other package's install.php
         foreach (rex::getConfig('package-order') as $packageId) {
             rex_package::get($packageId)->enlist();
         }


### PR DESCRIPTION
closes #3234

Focuspoint sollte seine Abhängigkeit trotzdem unbedingt notieren.

Aber das enlist hier ist trotzdem sinnvoll, gerade für optionale Abhängigkeiten mit class_exists, dass dann in den install.php auch alle Klassen bereits bekannt sind