### PR TITLE
Phpmailer: log : Zeile entfernt

### DIFF
--- a/redaxo/src/addons/phpmailer/pages/system.log.phpmailer.php
+++ b/redaxo/src/addons/phpmailer/pages/system.log.phpmailer.php
@@ -3,7 +3,6 @@
 $func = rex_request('func', 'string');
 $error = '';
 $success = '';
-$addon = rex_addon::get('phpmailer');
 $logFile = rex_mailer::logFile();
 
 if ('mailer_delLog' == $func) {


### PR DESCRIPTION
$addon = rex_addon::get('phpmailer'); Wird nicht benötigt