### PR TITLE
rex_sql_table: Fix für PK zu existierender Tabelle hinzufügen

### DIFF
--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -46,7 +46,7 @@ class rex_sql_table
     private $primaryKey = [];
 
     /** @var bool */
-    private $primaryKeyModified = false;
+    private $primaryKeyExisting = [];
 
     /** @var rex_sql_index[] */
     private $indexes = [];
@@ -99,6 +99,8 @@ class rex_sql_table
                 $this->primaryKey[] = $column['name'];
             }
         }
+
+        $this->primaryKeyExisting = $this->primaryKey;
 
         $indexParts = $this->sql->getArray('SHOW INDEXES FROM '.$this->sql->escapeIdentifier($name));
         $indexes = [];
@@ -335,7 +337,6 @@ class rex_sql_table
 
         if (false !== $key = array_search($oldName, $this->primaryKey)) {
             $this->primaryKey[$key] = $newName;
-            $this->primaryKeyModified = true;
         }
 
         return $this;
@@ -380,8 +381,7 @@ class rex_sql_table
             return $this;
         }
 
-        $this->primaryKey = (array) $columns;
-        $this->primaryKeyModified = true;
+        $this->primaryKey = $columns;
 
         return $this;
     }
@@ -667,7 +667,7 @@ class rex_sql_table
         $this->columnsExisting = [];
         $this->implicitOrder = [];
         $this->positions = [];
-        $this->primaryKeyModified = !empty($this->primaryKey);
+        $this->primaryKeyExisting = [];
     }
 
     /**
@@ -733,7 +733,7 @@ class rex_sql_table
             $parts[] = 'RENAME '.$this->sql->escapeIdentifier($this->name);
         }
 
-        if ($this->primaryKeyModified) {
+        if ($this->primaryKeyExisting && $this->primaryKeyExisting !== $this->primaryKey) {
             $parts[] = 'DROP PRIMARY KEY';
         }
 
@@ -806,7 +806,7 @@ class rex_sql_table
             $parts[] = 'DROP '.$this->sql->escapeIdentifier($oldName);
         }
 
-        if ($this->primaryKeyModified && $this->primaryKey) {
+        if ($this->primaryKey && $this->primaryKey !== $this->primaryKeyExisting) {
             $parts[] = 'ADD PRIMARY KEY '.$this->getKeyColumnsDefintion($this->primaryKey);
         }
 
@@ -978,7 +978,7 @@ class rex_sql_table
         $this->implicitOrder = [];
         $this->positions = [];
 
-        $this->primaryKeyModified = false;
+        $this->primaryKeyExisting = $this->primaryKey;
 
         $indexes = $this->indexes;
         $this->indexes = [];

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -45,7 +45,7 @@ class rex_sql_table
     /** @var string[] */
     private $primaryKey = [];
 
-    /** @var bool */
+    /** @var string[] */
     private $primaryKeyExisting = [];
 
     /** @var rex_sql_index[] */

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -323,6 +323,15 @@ class rex_sql_table_test extends TestCase
         $table = rex_sql_table::get(self::TABLE);
 
         $this->assertNull($table->getPrimaryKey());
+
+        $table
+            ->setPrimaryKey('id')
+            ->alter();
+
+        rex_sql_table::clearInstance(self::TABLE);
+        $table = rex_sql_table::get(self::TABLE);
+
+        $this->assertSame(['id'], $table->getPrimaryKey());
     }
 
     public function testAddIndex()


### PR DESCRIPTION
Wenn man zu einer Tabelle einen PK hinzufügen wollte, die vorher noch keinen hatte, dann kam es zu einem Fehler, weil fälschlich `DROP PRIMARY KEY` ausgeführt wurde.