### PR TITLE
Backup: Null-Values als solche exportieren

### DIFF
--- a/redaxo/src/addons/backup/CHANGELOG.md
+++ b/redaxo/src/addons/backup/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 2.5.1 – 02.02.2020
+--------------------------
+
+### Bugfixes
+
+* `NULL`-Werte wurden nicht als solche exportiert, was zu Problemen bei den neuen Template-Keys führte (@gharlan)
+
+
 Version 2.5.0 – 02.02.2020
 --------------------------
 

--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -515,6 +515,12 @@ class rex_backup
                 foreach ($fields as $idx => $type) {
                     $column = $array[$idx];
 
+                    if (null === $column) {
+                        $record[] = 'NULL';
+
+                        continue;
+                    }
+
                     switch ($type) {
                         // prevent calling sql->escape() on values with a known format
                         case 'raw':

--- a/redaxo/src/addons/backup/package.yml
+++ b/redaxo/src/addons/backup/package.yml
@@ -1,5 +1,5 @@
 package: backup
-version: '2.5.0'
+version: '2.5.1'
 author: 'Jan Kristinus, Markus Staab'
 supportpage: www.redaxo.org/de/forum/
 


### PR DESCRIPTION
Das Backup-Addon exportiert aktuell `NULL`-Values falsch, für Varchars als `''`, für integers als `0`, etc.

Das muss schon Ewigkeiten so sein, aber scheinbar hat es bisher nirgends zu einem Problem geführt.

In 5.9 haben die Templates aber die nullable `key`-Spalte mit Unique-Index. Es kann also mehrere Zeilen mit key=null geben.
Beim Export wird es zu `''`.
Beim Import gibt es dann einen Fehler, da es bei nullable unique nur mehrere NULL-Values geben kann, aber eben nicht mehrere leere Strings.