### PR TITLE
be_style/customizer: declare zip dependency

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/package.yml
+++ b/redaxo/src/addons/be_style/plugins/customizer/package.yml
@@ -11,3 +11,7 @@ page:
 
 pages:
     system/customizer: { title: 'translate:customizer', icon: rex-icon rex-icon-customizer }
+
+requires:
+    php:
+        extensions: [zip]


### PR DESCRIPTION
declare zip dependency because we use ZipArchive in https://github.com/redaxo/redaxo/blob/57609dff9493a33c2d598ff5f84284e77968a9df/redaxo/src/addons/be_style/plugins/customizer/install.php#L18

triggered in slack

![image](https://user-images.githubusercontent.com/120441/73666827-aaf4b980-46a3-11ea-9ee9-6231f343a851.png)

does not resolve the initial reported problem, but should solve installing the plugin on systems without zip extension and print a proper warning.