### PR TITLE
Update $table-bg-accent für Klasse .table-striped

### DIFF
--- a/redaxo/src/addons/be_style/plugins/redaxo/scss/_variables.scss
+++ b/redaxo/src/addons/be_style/plugins/redaxo/scss/_variables.scss
@@ -211,7 +211,7 @@ $table-condensed-cell-padding:  5px !default;
 //** Default background color used for all tables.
 $table-bg:                      #fff;
 //** Background color used for `.table-striped`.
-$table-bg-accent:               transparent;
+$table-bg-accent:               #f9f9f9;
 //** Background color used for `.table-hover`.
 $table-bg-hover:                $color-d-lighter;
 $table-bg-active:               $table-bg-hover !default;


### PR DESCRIPTION
Mit R5 ist das wohl untergegangen. Wenn gewünscht werden Listen wieder im StreifenLook dargestellt.