### PR TITLE
Metainfo: TEXT-Spalten ohne Defaults

### DIFF
--- a/redaxo/src/addons/metainfo/lib/table_expander.php
+++ b/redaxo/src/addons/metainfo/lib/table_expander.php
@@ -262,11 +262,6 @@ class rex_metainfo_table_expander extends rex_form
             $fieldDbType = $result[0]['dbtype'];
             $fieldDbLength = $result[0]['dblength'];
 
-            // TEXT Spalten duerfen in MySQL keine Defaultwerte haben
-            if ('text' == $fieldDbType) {
-                $fieldDefault = null;
-            }
-
             if (
                 strlen($fieldDefault) &&
                 (rex_metainfo_table_manager::FIELD_CHECKBOX === $fieldType || rex_metainfo_table_manager::FIELD_SELECT === $fieldType && isset(rex_string::split($fieldAttributes)['multiple']))

--- a/redaxo/src/addons/metainfo/lib/table_manager.php
+++ b/redaxo/src/addons/metainfo/lib/table_manager.php
@@ -50,7 +50,8 @@ class rex_metainfo_table_manager
             $qry .= '(' . $length . ')';
         }
 
-        if (null !== $default) {
+        // `text` columns in mysql can not have default values
+        if ('text' !== $type && null !== $default) {
             $qry .= ' DEFAULT \'' . str_replace("'", "\'", $default) . '\'';
         }
 
@@ -75,7 +76,8 @@ class rex_metainfo_table_manager
             $qry .= '(' . $length . ')';
         }
 
-        if (null !== $default) {
+        // `text` columns in mysql can not have default values
+        if ('text' !== $type && null !== $default) {
             $qry .= ' DEFAULT \'' . str_replace("'", "\'", $default) . '\'';
         }
 

--- a/redaxo/src/addons/metainfo/package.yml
+++ b/redaxo/src/addons/metainfo/package.yml
@@ -1,5 +1,5 @@
 package: metainfo
-version: '2.6.0'
+version: '2.6.1-dev'
 author: 'Markus Staab, Jan Kristinus'
 supportpage: www.redaxo.org/de/forum/
 


### PR DESCRIPTION
Wenn man Metainfos über die GUI anlegt, bekommen TEXT-Spalten keinen Default-Wert.
Bei Nutzung von `rex_metainfo_add_field`, was auch verwendet wird bei "Standardfelder erstellen", wird hingegen versucht einen leeren String als Default zu setzen.

Dieser PR vereinheitlicht das Verhalten, indem der Ausschluss an eine zentralere Stelle wandert.

Aufgefallen ist es bei Nutzung von YDeploy und Mischung von MariaDB und MySQL.
Denn MariaDB unterstützt Default-Values bei TEXT-Spalten, MySQL hingegen nicht.