### PR TITLE
Package-Ladereihenfolge korrigiert

### DIFF
--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -82,7 +82,7 @@ require_once rex_path::core('functions/function_rex_globals.php');
 require_once rex_path::core('functions/function_rex_other.php');
 
 // ----------------- VERSION
-rex::setProperty('version', '5.9.0');
+rex::setProperty('version', '5.9.1-dev');
 
 $cacheFile = rex_path::coreCache('config.yml.cache');
 $configFile = rex_path::coreData('config.yml');

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -596,10 +596,15 @@ abstract class rex_package_manager
      */
     public static function generatePackageOrder()
     {
+        /** @var string[] $early */
         $early = [];
+        /** @var string[] $normal */
         $normal = [];
+        /** @var string[] $late */
         $late = [];
+        /** @var array<string, array<string, true>> $requires */
         $requires = [];
+
         $add = static function ($id) use (&$add, &$normal, &$requires) {
             $normal[] = $id;
             unset($requires[$id]);

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -631,7 +631,7 @@ abstract class rex_package_manager
                 if (isset($req['packages']) && is_array($req['packages'])) {
                     foreach ($req['packages'] as $packageId => $reqP) {
                         $package = rex_package::get($packageId);
-                        if (!in_array($package, $normal) && !in_array($package->getProperty('load'), ['early', 'late'])) {
+                        if (!in_array($packageId, $normal) && !in_array($package->getProperty('load'), ['early', 'late'])) {
                             $requires[$id][$packageId] = true;
                         }
                     }


### PR DESCRIPTION
Bei tiefer verschachtelten Abhängigkeiten konnte es dazu kommen, dass nicht alle Packages tiefer im Baum untereinander noch die richtige Reihenfolge erhalten haben.

https://friendsofredaxo.slack.com/archives/C1BAXLN2F/p1581015964136000?thread_ts=1580991000.108600&cid=C1BAXLN2F