### PR TITLE
SQL-Debugausgabe: Parameter in fullquery richtig ersetzen

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1193,15 +1193,21 @@ class rex_sql implements Iterator
             $i = 0;
             $errors['fullquery'] = preg_replace_callback(
                 '/\?|((?<!:):[a-z0-9_]+)/i',
-                static function ($matches) use ($params, &$i) {
-                    $key = substr($matches[0], 1);
-                    if (!array_key_exists($i, $params) && (false === $key || !array_key_exists($key, $params))) {
-                        return $matches[0];
+                function ($matches) use ($params, &$i) {
+                    if ('?' === $matches[0]) {
+                        $keys = [$i];
+                    } else {
+                        $keys = [$matches[0], substr($matches[0], 1)];
                     }
-                    $value = array_key_exists($i, $params) ? $params[$i] : $params[$key];
-                    $result = self::factory()->escape($value);
-                    ++$i;
-                    return $result;
+
+                    foreach ($keys as $key) {
+                        if (array_key_exists($key, $params)) {
+                            ++$i;
+                            return $this->escape($params[$key]);
+                        }
+                    }
+
+                    return $matches[0];
                 },
                 $qry
             );


### PR DESCRIPTION
Man kann die Params im Array entweder mit dem Punkt vorne dran, oder auch ohne übergeben.
`:key` vs. `key`

Unsere fullquery in der Debugausgabe hat sie aber nur ersetzt, wenn sie ohne Doppelpunkt übergeben wurden.