### PR TITLE
Neue Methode rex_file::mimeType(), um svg-Problem zu lösen

### DIFF
--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -91,11 +91,9 @@ class rex_managed_media
         $format = $this->format;
 
         // if mimetype detected and in imagemap -> change format
-        if (class_exists('finfo') && $finfo = new finfo(FILEINFO_MIME_TYPE)) {
-            if ($ftype = @$finfo->file($this->getSourcePath())) {
-                if (array_key_exists($ftype, $this->mimetypeMap)) {
-                    $format = $this->mimetypeMap[$ftype];
-                }
+        if ($ftype = rex_file::mimeType($this->getSourcePath())) {
+            if (array_key_exists($ftype, $this->mimetypeMap)) {
+                $format = $this->mimetypeMap[$ftype];
             }
         }
 
@@ -368,28 +366,10 @@ class rex_managed_media
         }
 
         $header = $this->getHeader();
-        if (!isset($header['Content-Type'])) {
-            $content_type = '';
+        if (!isset($header['Content-Type']) && $this->sourcePath) {
+            $content_type = rex_file::mimeType($this->sourcePath);
 
-            if (!$content_type && function_exists('mime_content_type')) {
-                $content_type = mime_content_type($this->getSourcePath());
-            }
-
-            if (!$content_type && function_exists('finfo_open')) {
-                $finfo = finfo_open(FILEINFO_MIME_TYPE);
-                $content_type = finfo_file($finfo, $this->getSourcePath());
-            }
-
-            // In case mime_content_type() returns 'text/plain' for CSS / JS files:
-            if ('text/plain' == $content_type) {
-                if ('css' == pathinfo($this->getSourcePath(), PATHINFO_EXTENSION)) {
-                    $content_type = 'text/css';
-                } elseif ('js' == pathinfo($this->getSourcePath(), PATHINFO_EXTENSION)) {
-                    $content_type = 'application/javascript';
-                }
-            }
-
-            if ('' != $content_type) {
+            if ($content_type) {
                 $this->setHeader('Content-Type', $content_type);
             }
         }

--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -16,5 +16,5 @@ page:
 requires:
     php:
         extensions: [gd]
-    redaxo: ^5.6.0
+    redaxo: ^5.9.1-dev
 

--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -95,14 +95,14 @@ function rex_mediapool_saveMedia($FILE, $rex_file_category, $FILEINFOS, $userlog
 
     $success = true;
     if ($isFileUpload) { // Fileupload?
-        $FILETYPE = mime_content_type($FILE['tmp_name']);
+        $FILETYPE = rex_file::mimeType($FILE['tmp_name']);
 
         if (!@move_uploaded_file($FILE['tmp_name'], $dstFile)) {
             $message[] = rex_i18n::msg('pool_file_movefailed');
             $success = false;
         }
     } else { // Filesync?
-        $FILETYPE = mime_content_type($srcFile);
+        $FILETYPE = rex_file::mimeType($srcFile);
 
         if (!@rename($srcFile, $dstFile)) {
             $message[] = rex_i18n::msg('pool_file_movefailed');
@@ -196,7 +196,7 @@ function rex_mediapool_updateMedia($FILE, &$FILEINFOS, $userlogin = null)
     $updated = false;
     if ('' != $FILE['name'] && 'none' != $FILE['name']) {
         $ffilename = $FILE['tmp_name'];
-        $ffiletype = mime_content_type($FILE['tmp_name']);
+        $ffiletype = rex_file::mimeType($FILE['tmp_name']);
         $ffilesize = $FILE['size'];
 
         $extensionNew = mb_strtolower(pathinfo($FILE['name'], PATHINFO_EXTENSION));
@@ -298,13 +298,8 @@ function rex_mediapool_syncFile($physical_filename, $category_id, $title, $files
         $filesize = filesize($abs_file);
     }
 
-    if (empty($filetype) && function_exists('mime_content_type')) {
-        $filetype = mime_content_type($abs_file);
-    }
-
-    if (empty($filetype) && function_exists('finfo_open')) {
-        $finfo = finfo_open(FILEINFO_MIME_TYPE); // return mime type ala mimetype extension
-        $filetype = finfo_file($finfo, $abs_file);
+    if (empty($filetype)) {
+        $filetype = rex_file::mimeType($abs_file);
     }
 
     $FILE = [];
@@ -618,7 +613,7 @@ function rex_mediapool_isAllowedMimeType($path, $filename = null)
         return false;
     }
 
-    $mime_type = mime_content_type($path);
+    $mime_type = rex_file::mimeType($path);
 
     return in_array($mime_type, $whitelist[$extension]);
 }

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -1,5 +1,5 @@
 package: mediapool
-version: '2.7.0'
+version: '2.7.1-dev'
 author: 'Jan Kristinus'
 supportpage: www.redaxo.org/de/forum/
 
@@ -30,4 +30,4 @@ allowed_doctypes: [bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, mp4, 
 image_extensions: [bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]
 
 requires:
-    redaxo: ^5.5.0
+    redaxo: ^5.9.1-dev

--- a/redaxo/src/addons/mediapool/pages/media.detail.php
+++ b/redaxo/src/addons/mediapool/pages/media.detail.php
@@ -62,7 +62,7 @@ if (rex_post('btn_update', 'string')) {
         } elseif (!rex::getUser()->getComplexPerm('media')->hasCategoryPerm($gf->getValue('category_id')) || !rex::getUser()->getComplexPerm('media')->hasCategoryPerm($rex_file_category)) {
             $error = rex_i18n::msg('no_permission');
         } elseif (!empty($_FILES['file_new']['tmp_name']) && !rex_mediapool_isAllowedMimeType($_FILES['file_new']['tmp_name'], $_FILES['file_new']['name'])) {
-            $error = rex_i18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . rex_file::extension($_FILES['file_new']['name']) . '</code> (<code>' . mime_content_type($_FILES['file_new']['tmp_name']) . '</code>)';
+            $error = rex_i18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . rex_file::extension($_FILES['file_new']['name']) . '</code> (<code>' . rex_file::mimeType($_FILES['file_new']['tmp_name']) . '</code>)';
         } else {
             $FILEINFOS = [];
             $FILEINFOS['rex_file_category'] = $rex_file_category;

--- a/redaxo/src/addons/mediapool/pages/upload.php
+++ b/redaxo/src/addons/mediapool/pages/upload.php
@@ -24,7 +24,7 @@ if ('add_file' == $media_method) {
                         ? '<br />' . rex_i18n::msg('pool_file_allowed_mediatypes') . ' <code>' . rtrim(implode('</code>, <code>', $whitelist), ', ') . '</code>'
                         : '<br />' . rex_i18n::msg('pool_file_banned_mediatypes') . ' <code>' . rtrim(implode('</code>, <code>', rex_mediapool_getMediaTypeBlacklist()), ', ') . '</code>';
                 } elseif (!rex_mediapool_isAllowedMimeType($_FILES['file_new']['tmp_name'], $_FILES['file_new']['name'])) {
-                    $warning = rex_i18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . rex_file::extension($_FILES['file_new']['name']) . '</code> (<code>' . mime_content_type($_FILES['file_new']['tmp_name']) . '</code>)';
+                    $warning = rex_i18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . rex_file::extension($_FILES['file_new']['name']) . '</code> (<code>' . rex_file::mimeType($_FILES['file_new']['tmp_name']) . '</code>)';
                 } else {
                     $FILEINFOS['title'] = rex_request('ftitle', 'string');
 

--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -10,7 +10,7 @@ class rex_setup
     public const MIN_PHP_VERSION = REX_MIN_PHP_VERSION;
     public const MIN_MYSQL_VERSION = '5.5.3';
 
-    private static $MIN_PHP_EXTENSIONS = ['session', 'pdo', 'pdo_mysql', 'pcre', 'tokenizer'];
+    private static $MIN_PHP_EXTENSIONS = ['fileinfo', 'pcre', 'pdo', 'pdo_mysql', 'session', 'tokenizer'];
 
     /**
      * very basic setup steps, so everything is in place for our browser-based setup wizard.

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -175,21 +175,29 @@ class rex_file
     {
         $mimeType = mime_content_type($file);
 
-        switch ($mimeType) {
-            case 'image/svg':
-                $mimeType = 'image/svg+xml';
-                break;
-            case 'text/plain':
-                $extension = self::extension($file);
-                if ('css' === $extension) {
-                    $mimeType = 'text/css';
-                } elseif ('js' === $extension) {
-                    $mimeType = 'application/javascript';
-                }
-                break;
+        if (false === $mimeType) {
+            return null;
         }
 
-        return $mimeType ?: null;
+        // map less common types to their more common equivalent
+        static $mapping = [
+            'application/xml' => 'text/xml',
+            'image/svg' => 'image/svg+xml',
+        ];
+
+        if ('text/plain' !== $mimeType) {
+            $mimeType = $mapping[$mimeType] ?? $mimeType;
+
+            return $mimeType ?: null;
+        }
+
+        static $extensions = [
+            'css' => 'text/css',
+            'js' => 'application/javascript',
+            'svg' => 'image/svg+xml',
+        ];
+
+        return $extensions[strtolower(self::extension($file))] ?? $mimeType;
     }
 
     /**

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -165,6 +165,34 @@ class rex_file
     }
 
     /**
+     * Detects the mime type of the given file.
+     *
+     * @param string $file Path to the file
+     *
+     * @return null|string Mime type or `null` if the type could not be detected
+     */
+    public static function mimeType($file): ?string
+    {
+        $mimeType = mime_content_type($file);
+
+        switch ($mimeType) {
+            case 'image/svg':
+                $mimeType = 'image/svg+xml';
+                break;
+            case 'text/plain':
+                $extension = self::extension($file);
+                if ('css' === $extension) {
+                    $mimeType = 'text/css';
+                } elseif ('js' === $extension) {
+                    $mimeType = 'application/javascript';
+                }
+                break;
+        }
+
+        return $mimeType ?: null;
+    }
+
+    /**
      * Formates the filesize of the given file into a userfriendly form.
      *
      * @param string $file   Path to the file

--- a/redaxo/src/core/tests/util/file_test.php
+++ b/redaxo/src/core/tests/util/file_test.php
@@ -133,6 +133,25 @@ class rex_file_test extends TestCase
         static::assertEquals($expectedExtension, rex_file::extension($file), 'extension() returns file extension');
     }
 
+    public function dataTestMimeType(): iterable
+    {
+        return [
+            ['image/png', rex_path::pluginAssets('be_style', 'redaxo', 'icons/apple-touch-icon.png')],
+            ['text/xml', rex_path::pluginAssets('be_style', 'redaxo', 'icons/browserconfig.xml')],
+            ['text/css', rex_path::pluginAssets('be_style', 'redaxo', 'css/styles.css')],
+            ['application/javascript', rex_path::pluginAssets('be_style', 'redaxo', 'javascripts/redaxo.js')],
+            ['image/svg+xml', rex_path::addonAssets('be_style', 'images/redaxo-logo.svg')],
+        ];
+    }
+
+    /**
+     * @dataProvider dataTestMimeType
+     */
+    public function testMimeType(string $expectedMimeType, string $file): void
+    {
+        static::assertEquals($expectedMimeType, rex_file::mimeType($file));
+    }
+
     public function testGetOutput()
     {
         $file = $this->getPath('test.php');


### PR DESCRIPTION
`mime_content_type` liefert für SVGs, die keinen `<?xml`-Tag enthalten, den Typ `image/svg`.
Der ist aber unüblich und wird von Browsers nicht korrekt behandelt.

Um es allgemein zu lösen, gibt es nun eine neue Methode `rex_file::mimeType`, die an allen Stellen verwendet wird.
Diese enthält auch die Sonderbehandlung für CSS und JS, die wir an einer Stelle im MM hatten.

Es ist zwar in gewisser Weise auch ein neues Feature, da aber die Intention eher ist, Bugs zu beseitigen, würde ich es so in bugfix mergen.

https://friendsofredaxo.slack.com/archives/C1BAXLN2F/p1582125071115100
https://github.com/yakamara/redaxo_yrewrite/issues/332