### PR TITLE
Einheitliche Collation _unicode_ci verwenden

### DIFF
--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -719,7 +719,7 @@ class rex_sql_table
 
         $query = 'CREATE TABLE '.$this->sql->escapeIdentifier($this->name)." (\n    ";
         $query .= implode(",\n    ", $parts);
-        $query .= "\n) ENGINE=InnoDB DEFAULT CHARSET=$charset;";
+        $query .= "\n) ENGINE=InnoDB DEFAULT CHARSET=$charset COLLATE={$charset}_unicode_ci;";
 
         $this->sql->setQuery($query);
 


### PR DESCRIPTION
rex_sql_table setzt beim Erstellen von Tabellen nur `CHARSET=utf8(mb4)`, und belässt die Collation bei der zugehörigen Default.
Beim Wechsel des Charsets (über das Setup) setzt rex_sql_table hingegen explizit die Collation `utf8(mb4)_unicode_ci`.
Diese ist auch vor `_general_ci` vorzuziehen (bessere Vergleiche/Sortierungen für verschiedene Sprachen).

Aufgefallen ist es mir beim lokalen Ausführen der Unittests. Da Testen wir auch Foreign Keys auf varchars. Und ich hatte da nun einen Mischmasch von _unicode_ci und _general_ci, weswegen die Tests fehlschlugen.

Daher wird nun auch beim Erstellen von Tabellen explizit _unicode_ci verwenden.