### PR TITLE
composer.json im Root für Tools

### DIFF
--- a/.github/workflows/csfix.yml
+++ b/.github/workflows/csfix.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Dependencies
       run: composer install --prefer-dist
 
-    - run: vendor/bin/php-cs-fixer fix --diff # global to not modify project-local files
+    - run: vendor/bin/php-cs-fixer fix --diff
 
     - name: Commit changed files
       uses: stefanzweifel/git-auto-commit-action@v2.5.0

--- a/.github/workflows/csfix.yml
+++ b/.github/workflows/csfix.yml
@@ -16,7 +16,20 @@ jobs:
       uses: shivammathur/setup-php@v1
       with:
         php-version: 7.1
-    - run: composer global require friendsofphp/php-cs-fixer:2.16.* && ~/.composer/vendor/bin/php-cs-fixer fix --diff # global to not modify project-local files
+
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        restore-keys: ${{ runner.os }}-composer-
+    - name: Install Dependencies
+      run: composer install --prefer-dist
+
+    - run: vendor/bin/php-cs-fixer fix --diff # global to not modify project-local files
 
     - name: Commit changed files
       uses: stefanzweifel/git-auto-commit-action@v2.5.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,6 +65,18 @@ jobs:
                 php-version: 7.3
                 extensions: intl, imagick
                 coverage: none # disable xdebug, pcov
+                tools: cs2pr
+          - name: Get Composer Cache Directory
+            id: composer-cache
+            run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+          - name: Cache dependencies
+            uses: actions/cache@v1
+            with:
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+                restore-keys: ${{ runner.os }}-composer-
+          - name: Install Dependencies
+            run: composer install --prefer-dist
           - run: |
                 mysql -uroot -h127.0.0.1 -proot -e 'create database redaxo5;'
                 git apply .github/workflows/default.config.yml.github-action.diff
@@ -77,9 +89,7 @@ jobs:
                 php redaxo/bin/console package:install debug
                 php redaxo/bin/console package:install structure/history
                 php redaxo/bin/console package:install structure/version
-                composer require --dev vimeo/psalm:^3.8.1
-                composer require staabm/annotate-pull-request-from-checkstyle:^1.0
-                vendor/bin/psalm --show-info=false --shepherd --output-format=checkstyle | vendor/bin/cs2pr
+                vendor/bin/psalm --show-info=false --shepherd --output-format=checkstyle | cs2pr
 
   phpstan-analysis:
       name: phpstan static code analysis
@@ -97,6 +107,18 @@ jobs:
                 php-version: 7.3
                 extensions: intl, imagick
                 coverage: none # disable xdebug, pcov
+                tools: cs2pr
+          - name: Get Composer Cache Directory
+            id: composer-cache
+            run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+          - name: Cache dependencies
+            uses: actions/cache@v1
+            with:
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+                restore-keys: ${{ runner.os }}-composer-
+          - name: Install Dependencies
+            run: composer install --prefer-dist
           - run: |
                 mysql -uroot -h127.0.0.1 -proot -e 'create database redaxo5;'
                 git apply .github/workflows/default.config.yml.github-action.diff
@@ -109,9 +131,7 @@ jobs:
                 php redaxo/bin/console package:install debug
                 php redaxo/bin/console package:install structure/history
                 php redaxo/bin/console package:install structure/version
-                composer require --dev phpstan/phpstan:^0.12
-                composer require staabm/annotate-pull-request-from-checkstyle:^1.0
-                vendor/bin/phpstan analyse --no-progress --error-format=checkstyle | vendor/bin/cs2pr
+                vendor/bin/phpstan analyse --no-progress --error-format=checkstyle | cs2pr
 
   php-cs-fixer:
       name: check php-cs-fixer codestyles
@@ -124,10 +144,19 @@ jobs:
                 php-version: 7.1
                 extensions: intl
                 coverage: none # disable xdebug, pcov
-          - run: |
-                composer global require friendsofphp/php-cs-fixer:2.16.*
-                composer require staabm/annotate-pull-request-from-checkstyle:^1.0
-                ~/.composer/vendor/bin/php-cs-fixer fix --diff --dry-run --format=checkstyle | vendor/bin/cs2pr
+                tools: cs2pr
+          - name: Get Composer Cache Directory
+            id: composer-cache
+            run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+          - name: Cache dependencies
+            uses: actions/cache@v1
+            with:
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+                restore-keys: ${{ runner.os }}-composer-
+          - name: Install Dependencies
+            run: composer install --prefer-dist
+          - run: vendor/bin/php-cs-fixer fix --diff --dry-run --format=checkstyle | cs2pr
 
   phpunit:
     name: unit tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
         restore-keys: ${{ runner.os }}-composer-
     - name: Install Dependencies
       run: composer install --prefer-dist

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,12 +28,23 @@ jobs:
         php-version: 7.1
         extensions: intl
         coverage: none # disable xdebug, pcov
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+    - name: Install Dependencies
+      run: composer install --prefer-dist
     - run: |
         mysql -uroot -h127.0.0.1 -proot -e 'create database redaxo5;'
         git apply .github/workflows/default.config.yml.github-action.diff
     - run: |
         php redaxo/src/addons/tests/bin/setup.php
-        composer require --dev friendsofredaxo/linter && vendor/bin/rexlint
+        vendor/bin/rexlint
         php redaxo/bin/console be_style:compile
         git checkout -- redaxo/src/core/default.config.yml # revert changes made initially
         git diff HEAD --exit-code # check if compiling the scss lead to uncommitted changes

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 .php_cs.cache
 /.htaccess
+/composer.lock
 /assets/
 /media/
 /redaxo/cache/
 /redaxo/data/
 /releases/
 /resources/
+/vendor/
 
 # Addons
 /redaxo/src/addons/*

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "friendsofredaxo/linter": "^1.2",
+        "phpstan/phpstan": "^0.12.11",
+        "vimeo/psalm": "^3.9"
+    },
+
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true,
+        "platform": {
+            "php": "7.1.3"
+        }
+    }
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 parameters:
     level: 2
     paths:
+        # restrict to core and core addons, ignore other locally installed addons
         - redaxo/src/core
         - redaxo/src/addons/backup
         - redaxo/src/addons/be_style

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,20 @@
 parameters:
     level: 2
     paths:
-        - redaxo/src/
+        - redaxo/src/core
+        - redaxo/src/addons/backup
+        - redaxo/src/addons/be_style
+        - redaxo/src/addons/cronjob
+        - redaxo/src/addons/debug
+        - redaxo/src/addons/install
+        - redaxo/src/addons/media_manager
+        - redaxo/src/addons/mediapool
+        - redaxo/src/addons/metainfo
+        - redaxo/src/addons/phpmailer
+        - redaxo/src/addons/project
+        - redaxo/src/addons/structure
+        - redaxo/src/addons/tests
+        - redaxo/src/addons/users
     bootstrap: phpstan-bootstrap.php
     excludes_analyse:
         - redaxo/src/addons/be_style/vendor/

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@ xmlns="https://getpsalm.org/schema/config"
 autoloader="phpstan-bootstrap.php"
 >
     <projectFiles>
+        <!-- restrict to core and core addons, ignore other locally installed addons -->
         <directory name="redaxo/src/core"/>
         <directory name="redaxo/src/addons/backup"/>
         <directory name="redaxo/src/addons/be_style"/>


### PR DESCRIPTION
Ich schlage vor, im Root eine composer.json anzulegen für die Tools, die wir verwenden.
So kann man sie leicht lokal ausführen, mit der selben Version, wie wir sie bei den Actions nutzen.