### PR TITLE
svg auch convert2img verarbeiten

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php
@@ -19,7 +19,7 @@ class rex_effect_convert2img extends rex_effect_abstract
         'bmp',
         'eps',
         'ico',
-        // 'svg'
+        'svg'
     ];
     private static $convert_to = [
         'jpg' => [

--- a/redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php
@@ -19,7 +19,7 @@ class rex_effect_convert2img extends rex_effect_abstract
         'bmp',
         'eps',
         'ico',
-        'svg'
+        'svg',
     ];
     private static $convert_to = [
         'jpg' => [


### PR DESCRIPTION
#2785 Svgs werden nun auch im convert2img beachtet und verarbeitet

wir sind mittlerweile der meinung dass der convert2img filter impliziert dass man eine pixelgrafik haben will um z.B. anschließend weitere pixel-bild-effekte darauf anzuwenden.

svgs können dabei qualität verlieren aber dafür kann man eben auch image effekte anwenden.
wer svgs nicht darüber handeln will muss dieser vorm aufruf der mediamanager urls explizit abfragen, siehe zum Beispiel https://github.com/redaxo/redaxo/blob/621f24af5869198224d2b1c6c13a36316a7faedf/redaxo/src/addons/mediapool/pages/media.list.php#L303-L305