### PR TITLE
Backup: archive anhand des dateinamens sortieren

### DIFF
--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -40,14 +40,11 @@ class rex_backup
         $folder = $filtered;
 
         usort($folder, static function ($file_a, $file_b) use ($dir) {
-            $time_a = filemtime($dir . '/' . $file_a);
-            $time_b = filemtime($dir . '/' . $file_b);
-
-            if ($time_a == $time_b) {
+            if ($file_a == $file_b) {
                 return 0;
             }
 
-            return ($time_a > $time_b) ? -1 : 1;
+            return ($file_b > $file_a) ? -1 : 1;
         });
 
         return $folder;

--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -39,12 +39,8 @@ class rex_backup
         }
         $folder = $filtered;
 
-        usort($folder, static function ($file_a, $file_b) use ($dir) {
-            if ($file_a == $file_b) {
-                return 0;
-            }
-
-            return ($file_b > $file_a) ? -1 : 1;
+        usort($folder, static function ($file_a, $file_b) {
+            return $file_a <=> $file_b;
         });
 
         return $folder;


### PR DESCRIPTION
closes #3180 

Sortierung der Datei-Backups nicht mehr anhand des Timestamps, sondern anhand des Dateinamens.