### PR TITLE
console: setup eol warnings

### DIFF
--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -254,7 +254,13 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         $io->title('Step 5 of 6 / Database');
 
         $sql = rex_sql::factory();
-        $io->block('Database version: '.$sql->getDbType(). ' '.$sql->getDbVersion());
+        $dbEol = rex_setup::checkDbSecurity();
+        if (!empty($dbEol)) {
+            $io->warning($this->decodeMessage($dbEol));
+        } else {
+            $io->block('Database version: '.$sql->getDbType(). ' '.$sql->getDbVersion());
+        }
+
 
         // Search for exports
         $backups = [];
@@ -521,7 +527,12 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         /** Cloned from comannd setup:check*/
         $errors = rex_setup::checkEnvironment();
         if (0 == count($errors)) {
-            $this->io->success('PHP version ok');
+            $phpEol = rex_setup::checkPhpSecurity();
+            if (!empty($phpEol)) {
+                $this->io->warning($this->decodeMessage($phpEol));
+            } else {
+                $this->io->success('PHP version ok');
+            }
         } else {
             $errors = array_map([$this, 'decodeMessage'], $errors);
             $this->io->error("PHP version errors:\n" .implode("\n", $errors));

--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -261,7 +261,6 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
             $io->block('Database version: '.$sql->getDbType(). ' '.$sql->getDbVersion());
         }
 
-
         // Search for exports
         $backups = [];
         foreach (rex_backup::getBackupFiles('') as $file) {


### PR DESCRIPTION
die eol warnings aus dem backend setup werden jetzt auch in dem console setup angezeigt

refs #3317 

![image](https://user-images.githubusercontent.com/21292755/75091982-82116700-5573-11ea-87c0-e90173b7a9a4.png)

![image](https://user-images.githubusercontent.com/21292755/75091991-97869100-5573-11ea-9e64-d42451de7174.png)
