### PR TITLE
split setup steps into separate files

### DIFF
--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -4,8 +4,6 @@
  * @package redaxo5
  */
 
-// --------------------------------------------- END: SETUP FUNCTIONS
-
 $step = rex_request('step', 'int', 1);
 $send = rex_request('send', 'string');
 $createdb = rex_request('createdb', 'string');
@@ -14,21 +12,7 @@ $lang = rex_request('lang', 'string');
 
 // ---------------------------------- Step 1 . Language
 if (1 >= $step) {
-    rex_setup::init();
-
-    $langs = [];
-    foreach (rex_i18n::getLocales() as $locale) {
-        $label = rex_i18n::msgInLocale('lang', $locale);
-        $langs[$label] = '<a class="list-group-item" href="' . rex_url::backendPage('setup', ['step' => 2, 'lang' => $locale]) . '">' . $label . '</a>';
-    }
-    ksort($langs);
-    echo rex_view::title(rex_i18n::msg('setup_100'));
-    $content = '<div class="list-group">' . implode('', $langs) . '</div>';
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('heading', rex_i18n::msg('setup_101'), false);
-    $fragment->setVar('content', $content, false);
-    echo $fragment->parse('core/page/section.php');
+    require 'setup.step1.php';
 
     return;
 }
@@ -36,23 +20,7 @@ if (1 >= $step) {
 // ---------------------------------- Step 2 . license
 
 if (2 === $step) {
-    rex::setProperty('lang', $lang);
-
-    $license_file = rex_path::base('LICENSE.md');
-    $license = '<p>' . nl2br(rex_file::get($license_file)) . '</p>';
-
-    $content = rex_i18n::rawMsg('setup_202');
-    $content .= $license;
-
-    $buttons = '<a class="btn btn-setup" href="' . rex_url::backendPage('setup', ['step' => 3, 'lang' => $lang]) . '">' . rex_i18n::msg('setup_203') . '</a>';
-
-    echo rex_view::title(rex_i18n::msg('setup_200'));
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('heading', rex_i18n::msg('setup_201'), false);
-    $fragment->setVar('body', '<div class="rex-scrollable">' . $content . '</div>', false);
-    $fragment->setVar('buttons', $buttons, false);
-    echo $fragment->parse('core/page/section.php');
+    require 'setup.step2.php';
 
     return;
 }
@@ -91,62 +59,7 @@ if (count($error_array) > 0) {
 }
 
 if (3 === $step) {
-    $content = '';
-
-    if (count($success_array) > 0) {
-        $content .= '<ul><li>' . implode('</li><li>', $success_array) . '</li></ul>';
-    }
-
-    $buttons = '';
-    $class = '';
-    if (count($error_array) > 0) {
-        $class = 'error';
-        $content .= implode('', $error_array);
-
-        $buttons = '<a class="btn btn-setup" href="' . rex_url::backendPage('setup', ['step' => 4, 'lang' => $lang]) . '">' . rex_i18n::msg('setup_312') . '</a>';
-    } else {
-        $class = 'success';
-        $buttons = '<a class="btn btn-setup" href="' . rex_url::backendPage('setup', ['step' => 4, 'lang' => $lang]) . '">' . rex_i18n::msg('setup_310') . '</a>';
-    }
-
-    $security = '<div class="rex-js-setup-security-message" style="display:none">' . rex_view::error(rex_i18n::msg('setup_security_msg') . '<br />' . rex_i18n::msg('setup_no_js_security_msg')) . '</div>';
-    $security .= '<noscript>' . rex_view::error(rex_i18n::msg('setup_no_js_security_msg')) . '</noscript>';
-    $security .= '<script>
-
-    jQuery(function($){
-        var urls = [
-            "' . rex_url::backend('bin/console') . '",
-            "' . rex_url::backend('data/.redaxo') . '",
-            "' . rex_url::backend('src/core/boot.php') . '",
-            "' . rex_url::backend('cache/.redaxo') . '"
-        ];
-
-        $.each(urls, function (i, url) {
-            $.ajax({
-                url: url,
-                cache: false,
-                success: function(data) {
-                    $(".rex-js-setup-security-message").show();
-                    $(".rex-js-setup-section").hide();
-                }
-            });
-        });
-
-    })
-
-    </script>';
-
-    $security .= rex_setup::checkPhpSecurity();
-
-    echo rex_view::title(rex_i18n::msg('setup_300'));
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('class', $class, false);
-    $fragment->setVar('title', rex_i18n::msg('setup_307'), false);
-    $fragment->setVar('body', $content, false);
-    $fragment->setVar('buttons', $buttons, false);
-    echo '<div class="rex-js-setup-section">' . $fragment->parse('core/page/section.php') . '</div>';
-    echo $security;
+    require 'setup.step3.php';
 
     return;
 }
@@ -165,26 +78,26 @@ if (isset($_SERVER['HTTP_HOST']) && 'https://www.redaxo.org/' == $config['server
     $config['server'] = 'https://' . $_SERVER['HTTP_HOST'];
 }
 
-if ($step > 4 && '-1' != rex_post('serveraddress', 'string', '-1')) {
-    $config['server'] = rex_post('serveraddress', 'string');
-    $config['servername'] = rex_post('servername', 'string');
-    $config['lang'] = $lang;
-    $config['error_email'] = rex_post('error_email', 'string');
-    $config['timezone'] = rex_post('timezone', 'string');
-    $config['db'][1]['host'] = trim(rex_post('mysql_host', 'string'));
-    $config['db'][1]['login'] = trim(rex_post('redaxo_db_user_login', 'string'));
-    $config['db'][1]['password'] = rex_post('redaxo_db_user_pass', 'string');
-    $config['db'][1]['name'] = trim(rex_post('dbname', 'string'));
-    $config['use_https'] = rex_post('use_https', 'string');
-
-    if ('true' === $config['use_https']) {
-        $config['use_https'] = true;
-    } elseif ('false' === $config['use_https']) {
-        $config['use_https'] = false;
-    }
-}
-
 if ($step > 4) {
+    if ('-1' != rex_post('serveraddress', 'string', '-1')) {
+        $config['server'] = rex_post('serveraddress', 'string');
+        $config['servername'] = rex_post('servername', 'string');
+        $config['lang'] = $lang;
+        $config['error_email'] = rex_post('error_email', 'string');
+        $config['timezone'] = rex_post('timezone', 'string');
+        $config['db'][1]['host'] = trim(rex_post('mysql_host', 'string'));
+        $config['db'][1]['login'] = trim(rex_post('redaxo_db_user_login', 'string'));
+        $config['db'][1]['password'] = rex_post('redaxo_db_user_pass', 'string');
+        $config['db'][1]['name'] = trim(rex_post('dbname', 'string'));
+        $config['use_https'] = rex_post('use_https', 'string');
+
+        if ('true' === $config['use_https']) {
+            $config['use_https'] = true;
+        } elseif ('false' === $config['use_https']) {
+            $config['use_https'] = false;
+        }
+    }
+
     $redaxo_db_create = rex_post('redaxo_db_create', 'boolean');
 
     if (empty($config['instname'])) {
@@ -243,156 +156,7 @@ if ($step > 4) {
 }
 
 if (4 === $step) {
-    $headline = rex_view::title(rex_i18n::msg('setup_400'));
-
-    $content = '';
-
-    $submit_message = rex_i18n::msg('setup_410');
-    if (count($error_array) > 0) {
-        $submit_message = rex_i18n::msg('setup_414');
-    }
-
-    $content .= '
-            <fieldset>
-                <input type="hidden" name="page" value="setup" />
-                <input type="hidden" name="step" value="5" />
-                <input type="hidden" name="lang" value="' . rex_escape($lang) . '" />';
-
-    $timezone_sel = new rex_select();
-    $timezone_sel->setId('rex-form-timezone');
-    $timezone_sel->setStyle('class="form-control selectpicker"');
-    $timezone_sel->setAttribute('data-live-search', 'true');
-    $timezone_sel->setName('timezone');
-    $timezone_sel->setSize(1);
-    $timezone_sel->addOptions(DateTimeZone::listIdentifiers(), true);
-    $timezone_sel->setSelected($config['timezone']);
-
-    $db_create_checked = rex_post('redaxo_db_create', 'boolean') ? ' checked="checked"' : '';
-
-    $httpsRedirectSel = new rex_select();
-    $httpsRedirectSel->setId('rex-form-https');
-    $httpsRedirectSel->setStyle('class="form-control selectpicker"');
-    $httpsRedirectSel->setName('use_https');
-    $httpsRedirectSel->setSize(1);
-    $httpsRedirectSel->addArrayOptions(['false' => rex_i18n::msg('https_disable'), 'backend' => rex_i18n::msg('https_only_backend'), 'frontend' => rex_i18n::msg('https_only_frontend'), 'true' => rex_i18n::msg('https_activate')]);
-    $httpsRedirectSel->setSelected(true === $config['use_https'] ? 'true' : $config['use_https']);
-
-    // If the setup is called over http disable https options to prevent user from being locked out
-    if (!rex_request::isHttps()) {
-        $httpsRedirectSel->setAttribute('disabled', 'disabled');
-    }
-
-    $content .= '<legend>' . rex_i18n::msg('setup_402') . '</legend>';
-
-    $formElements = [];
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-serveraddress">' . rex_i18n::msg('server') . '</label>';
-    $n['field'] = '<input class="form-control" type="text" id="rex-form-serveraddress" name="serveraddress" value="' . rex_escape($config['server']) . '" autofocus />';
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-servername">' . rex_i18n::msg('servername') . '</label>';
-    $n['field'] = '<input class="form-control" type="text" id="rex-form-servername" name="servername" value="' . rex_escape($config['servername']) . '" />';
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-error-email">' . rex_i18n::msg('error_email') . '</label>';
-    $n['field'] = '<input class="form-control" type="text" id="rex-form-error-email" name="error_email" value="' . rex_escape($config['error_email']) . '" />';
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-timezone">' . rex_i18n::msg('setup_412') . '</label>';
-    $n['field'] = $timezone_sel->get();
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $content .= $fragment->parse('core/form/form.php');
-
-    $content .= '</fieldset><fieldset><legend>' . rex_i18n::msg('setup_403') . '</legend>';
-
-    $formElements = [];
-
-    $n = [];
-    $n['label'] = '<label for=rex-form-mysql-host">MySQL Host</label>';
-    $n['field'] = '<input class="form-control" type="text" id="rex-form-mysql-host" name="mysql_host" value="' . rex_escape($config['db'][1]['host']) . '" />';
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-db-user-login">Login</label>';
-    $n['field'] = '<input class="form-control" type="text" id="rex-form-db-user-login" name="redaxo_db_user_login" value="' . rex_escape($config['db'][1]['login']) . '" />';
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-db-user-pass">' . rex_i18n::msg('setup_409') . '</label>';
-    $n['field'] = '<input class="form-control" type="password" id="rex-form-db-user-pass" name="redaxo_db_user_pass" value="' . rex_escape($config['db'][1]['password']) . '" />';
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-dbname">' . rex_i18n::msg('setup_408') . '</label>';
-    $n['field'] = '<input class="form-control" type="text" value="' . rex_escape($config['db'][1]['name']) . '" id="rex-form-dbname" name="dbname" />';
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $content .= $fragment->parse('core/form/form.php');
-
-    $formElements = [];
-    $n = [];
-    $n['label'] = '<label>' . rex_i18n::msg('setup_411') . '</label>';
-    $n['field'] = '<input type="checkbox" name="redaxo_db_create" value="1"' . $db_create_checked . ' />';
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $content .= $fragment->parse('core/form/checkbox.php');
-
-    $content .= '</fieldset><fieldset><legend>' . rex_i18n::msg('setup_security') . '</legend>';
-
-    $formElements = [];
-
-    if (!rex_request::isHttps()) {
-        $n = [];
-        $n['field'] = '<label class="form-control-static"><i class="fa fa-warning"></i> '.rex_i18n::msg('https_only_over_https').'</label>';
-        $formElements[] = $n;
-    }
-
-    $n = [];
-    $n['label'] = '<label>'.rex_i18n::msg('https_activate_redirect_for').'</label>';
-    $n['field'] = $httpsRedirectSel->get();
-    $formElements[] = $n;
-
-    $n = [];
-    $n['field'] = '<p>'.rex_i18n::msg('hsts_more_information').'</p>';
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $content .= $fragment->parse('core/form/form.php');
-
-    $content .= '</fieldset>';
-
-    $formElements = [];
-
-    $n = [];
-    $n['field'] = '<button class="btn btn-setup" type="submit" value="' . rex_i18n::msg('system_update') . '">' . $submit_message . '</button>';
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $buttons = $fragment->parse('core/form/submit.php');
-
-    echo $headline;
-    echo implode('', $error_array);
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('title', rex_i18n::msg('setup_416'), false);
-    $fragment->setVar('body', $content, false);
-    $fragment->setVar('buttons', $buttons, false);
-    $content = $fragment->parse('core/page/section.php');
-
-    echo '<form action="' . rex_url::backendController() . '" method="post">' . $content . '</form>';
+    require 'setup.step4.php';
 
     return;
 }
@@ -466,246 +230,7 @@ if ($step > 5 && '' == !rex_setup_importer::verifyDbSchema()) {
 }
 
 if (5 === $step) {
-    $tables_complete = ('' == rex_setup_importer::verifyDbSchema()) ? true : false;
-
-    $createdb = rex_post('createdb', 'int', '');
-
-    $supportsUtf8mb4 = rex_setup_importer::supportsUtf8mb4();
-    $existingUtf8mb4 = false;
-    $utf8mb4 = false;
-    if ($supportsUtf8mb4) {
-        $utf8mb4 = rex_post('utf8mb4', 'bool', true);
-        $existingUtf8mb4 = $utf8mb4;
-        if ($tables_complete) {
-            $data = rex_sql::factory()->getArray('SELECT value FROM '.rex::getTable('config').' WHERE namespace="core" AND `key`="utf8mb4"');
-            $existingUtf8mb4 = isset($data[0]['value']) ? json_decode($data[0]['value']) : false;
-        }
-    }
-
-    // rex_sql will only work after rex_setup::checkDb() succeeded
-    $security = rex_setup::checkDbSecurity();
-
-    $headline = rex_view::title(rex_i18n::msg('setup_500'));
-
-    $content = '
-            <fieldset class="rex-js-setup-step-5">
-                <input type="hidden" name="page" value="setup" />
-                <input type="hidden" name="step" value="6" />
-                <input type="hidden" name="lang" value="' . rex_escape($lang) . '" />
-            ';
-
-    $submit_message = rex_i18n::msg('setup_511');
-    if (count($errors) > 0) {
-        $errors[] = rex_view::error(rex_i18n::msg('setup_503'));
-        $headline .= implode('', $errors);
-        $submit_message = rex_i18n::msg('setup_512');
-    }
-
-    if ($security) {
-        $headline .= $security;
-    }
-
-    $dbchecked = array_fill(0, 6, '');
-    switch ($createdb) {
-        case 1:
-        case 2:
-        case 3:
-        case 4:
-            $dbchecked[$createdb] = ' checked="checked"';
-            break;
-        default:
-            $dbchecked[0] = ' checked="checked"';
-    }
-
-    // Vorhandene Exporte auslesen
-    $sel_export = new rex_select();
-    $sel_export->setName('import_name');
-    $sel_export->setId('rex-form-import-name');
-    $sel_export->setSize(1);
-    $sel_export->setStyle('class="form-control selectpicker rex-js-import-name"');
-    $sel_export->setAttribute('onclick', 'checkInput(\'createdb_3\')');
-    $export_dir = rex_backup::getDir();
-    $exports_found = false;
-
-    if (is_dir($export_dir)) {
-        $export_sqls = [];
-
-        if ($handle = opendir($export_dir)) {
-            while (false !== ($file = readdir($handle))) {
-                if ('.' == $file || '..' == $file) {
-                    continue;
-                }
-
-                $isSql = ('.sql' == substr($file, strlen($file) - 4));
-                if ($isSql) {
-                    // cut .sql
-                    $export_sqls[] = substr($file, 0, -4);
-                    $exports_found = true;
-                }
-            }
-            closedir($handle);
-        }
-
-        foreach ($export_sqls as $sql_export) {
-            $sel_export->addOption($sql_export, $sql_export);
-        }
-    }
-
-    $formElements = [];
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-createdb-0">' . rex_i18n::msg('setup_504') . '</label>';
-    $n['field'] = '<input type="radio" id="rex-form-createdb-0" name="createdb" value="0"' . $dbchecked[0] . ' />';
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-createdb-1">' . rex_i18n::msg('setup_505') . '</label>';
-    $n['field'] = '<input type="radio" id="rex-form-createdb-1" name="createdb" value="1"' . $dbchecked[1] . ' />';
-    $n['note'] = rex_i18n::msg('setup_505_note');
-    $formElements[] = $n;
-
-    if ($tables_complete) {
-        $n = [];
-        $n['label'] = '<label for="rex-form-createdb-2">' . rex_i18n::msg('setup_506') . '</label>';
-        $n['field'] = '<input type="radio" id="rex-form-createdb-2" name="createdb" value="2"' . $dbchecked[2] . ' />';
-        $n['note'] = rex_i18n::msg('setup_506_note');
-        $formElements[] = $n;
-    }
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-createdb-4">' . rex_i18n::msg('setup_514') . '</label>';
-    $n['field'] = '<input type="radio" id="rex-form-createdb-4" name="createdb" value="4"' . $dbchecked[4] . ' />';
-    $n['note'] = rex_i18n::msg('setup_514_note');
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $mode = $fragment->parse('core/form/radio.php');
-
-    if ($exports_found) {
-        $formElements = [];
-        $n = [];
-        $n['label'] = '<label for="rex-form-createdb-3">' . rex_i18n::msg('setup_507') . '</label>';
-        $n['field'] = '<input type="radio" id="rex-form-createdb-3" name="createdb" value="3"' . $dbchecked[3] . ' />';
-        $formElements[] = $n;
-
-        $fragment = new rex_fragment();
-        $fragment->setVar('elements', $formElements, false);
-        $mode .= $fragment->parse('core/form/radio.php');
-
-        $formElements = [];
-        $n = [];
-        $n['field'] = $sel_export->get();
-        $n['note'] = rex_i18n::msg('backup_version_warning');
-        $formElements[] = $n;
-
-        $fragment = new rex_fragment();
-        $fragment->setVar('elements', $formElements, false);
-        $mode .= $fragment->parse('core/form/form.php');
-    }
-
-    $formElements = [];
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-utf8mb4">'.rex_i18n::msg('setup_charset_utf8mb4').'</label>';
-    $n['field'] = '<input type="radio" id="rex-form-utf8mb4" name="utf8mb4" value="1"'.($utf8mb4 ? ' checked' : '').($supportsUtf8mb4 ? '' : ' disabled').' />';
-    $n['note'] = rex_i18n::msg('setup_charset_utf8mb4_note');
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-utf8">'.rex_i18n::msg('setup_charset_utf8').'</label>';
-    $n['field'] = '<input type="radio" id="rex-form-utf8" name="utf8mb4" value="0"'.($utf8mb4 ? '' : ' checked').' />';
-    $n['note'] = rex_i18n::msg('setup_charset_utf8_note');
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $charset = $fragment->parse('core/form/radio.php');
-
-    $formElements = [];
-
-    $sql = rex_sql::factory();
-
-    $n = [];
-    $n['label'] = '<label>'.rex_i18n::msg('version').'</label>';
-    $n['field'] = '<p class="form-control-static">'.$sql->getDbType().' '.$sql->getDbVersion().'</p>';
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label>'.rex_i18n::msg('mode').'</label>';
-    $n['field'] = $mode;
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label>'.rex_i18n::msg('charset').'</label>';
-    $n['field'] = $charset;
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $content .= $fragment->parse('core/form/form.php');
-
-    $content .= '</fieldset>';
-
-    $formElements = [];
-
-    $n = [];
-    $n['field'] = '<button class="btn btn-setup" type="submit" value="' . $submit_message . '">' . $submit_message . '</button>';
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $buttons = $fragment->parse('core/form/submit.php');
-
-    $content .= '</form>';
-
-    $content .= '
-            <script type="text/javascript">
-                 <!--
-                jQuery(function($) {
-                    var $container = $(".rex-js-setup-step-5");
-
-                    // when opening backup dropdown -> mark corresponding radio button as checked
-                    $container.find(".rex-js-import-name").click(function () {
-                        $container.find("[name=createdb][value=3]").prop("checked", true);
-                    });
-
-                    if (!$container.find("[name=utf8mb4][value=1]").prop("disabled")) {
-                        // when changing mode -> reset disabled state
-                        $container.find("[name=createdb]").click(function () {
-                            $container.find("[name=utf8mb4]").prop("disabled", false);
-                        });
-
-                        // when selecting "existing db" -> select current charset and disable radios
-                        $container.find("[name=createdb][value=2]").click(function () {
-                            $container.find("[name=utf8mb4][value='.((int) $existingUtf8mb4).']").prop("checked", true);
-                            $container.find("[name=utf8mb4]").prop("disabled", true);
-                        });
-
-                        // when selecting "update db" -> select utf8mb4 charset
-                        $container.find("[name=createdb][value=4]").click(function () {
-                            $container.find("[name=utf8mb4][value=1]").prop("checked", true);
-                        });
-
-                        // when selecting "import backup" -> disable radios
-                        $container.find("[name=createdb][value=3]").click(function () {
-                            $container.find("[name=utf8mb4]").prop("disabled", true);
-                        });
-                    }
-                });
-                 //-->
-            </script>';
-
-    echo $headline;
-    echo implode('', $error_array);
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('title', rex_i18n::msg('setup_501'), false);
-    $fragment->setVar('body', $content, false);
-    $fragment->setVar('buttons', $buttons, false);
-    $content = $fragment->parse('core/page/section.php');
-
-    echo '<form action="' . rex_url::backendController() . '" method="post">' . $content . '</form>';
+    require 'setup.step5.php';
 
     return;
 }
@@ -771,119 +296,7 @@ if (7 === $step) {
 }
 
 if (6 === $step) {
-    $user_sql = rex_sql::factory();
-    $user_sql->setQuery('select * from ' . rex::getTablePrefix() . 'user LIMIT 1');
-
-    $headline = rex_view::title(rex_i18n::msg('setup_600'));
-
-    $submit_message = rex_i18n::msg('setup_610');
-    if (count($errors) > 0) {
-        $submit_message = rex_i18n::msg('setup_611');
-        $headline .= implode('', $errors);
-    }
-
-    $content = '';
-
-    $content .= '
-        <fieldset>
-            <input class="rex-js-javascript" type="hidden" name="javascript" value="0" />
-            <input type="hidden" name="page" value="setup" />
-            <input type="hidden" name="step" value="7" />
-            <input type="hidden" name="lang" value="' . rex_escape($lang) . '" />
-            ';
-
-    $redaxo_user_login = rex_post('redaxo_user_login', 'string');
-    $redaxo_user_pass = rex_post('redaxo_user_pass', 'string');
-
-    if ($user_sql->getRows() > 0) {
-        $formElements = [];
-        $n = [];
-
-        $checked = '';
-        if (!isset($_REQUEST['redaxo_user_login'])) {
-            $checked = 'checked="checked"';
-        }
-
-        $n['label'] = '<label>' . rex_i18n::msg('setup_609') . '</label>';
-        $n['field'] = '<input class="rex-js-noadmin" type="checkbox" name="noadmin" value="1" ' . $checked . ' />';
-        $formElements[] = $n;
-
-        $fragment = new rex_fragment();
-        $fragment->setVar('elements', $formElements, false);
-        $content .= $fragment->parse('core/form/checkbox.php');
-    }
-
-    $formElements = [];
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-redaxo-user-login">' . rex_i18n::msg('setup_607') . '</label>';
-    $n['field'] = '<input class="form-control" type="text" value="' . rex_escape($redaxo_user_login) . '" id="rex-form-redaxo-user-login" name="redaxo_user_login" autofocus />';
-    $formElements[] = $n;
-
-    $n = [];
-    $n['label'] = '<label for="rex-form-redaxo-user-pass">' . rex_i18n::msg('setup_608') . '</label>';
-    $n['field'] = '<input class="form-control rex-js-redaxo-user-pass" type="password" value="' . rex_escape($redaxo_user_pass) . '" id="rex-form-redaxo-user-pass" name="redaxo_user_pass" />';
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $content .= '<div class="rex-js-login-data">' . $fragment->parse('core/form/form.php') . '</div>';
-
-    $content .= '</fieldset>';
-
-    $formElements = [];
-
-    $n = [];
-    $n['field'] = '<button class="btn btn-setup" type="submit" value="' . $submit_message . '">' . $submit_message . '</button>';
-    $formElements[] = $n;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('elements', $formElements, false);
-    $buttons = $fragment->parse('core/form/submit.php');
-
-    $content .= '
-
-    <script type="text/javascript">
-         <!--
-        jQuery(function($) {
-            $(".rex-js-createadminform")
-                .submit(function(){
-                    var pwInp = $(".rex-js-redaxo-user-pass");
-                    if(pwInp.val() != "") {
-                        $(".rex-js-createadminform").append(\'<input type="hidden" name="\'+pwInp.attr("name")+\'" value="\'+Sha1.hash(pwInp.val())+\'" />\');
-                        pwInp.removeAttr("name");
-                    }
-            });
-
-            $(".rex-js-javascript").val("1");
-
-            $(".rex-js-createadminform .rex-js-noadmin").on("change",function (){
-
-                if($(this).is(":checked")) {
-                    $(".rex-js-login-data").each(function() {
-                        $(this).css("display","none");
-                    })
-                } else {
-                    $(".rex-js-login-data").each(function() {
-                        $(this).css("display","block");
-                    })
-                }
-
-            }).trigger("change");
-
-        });
-     //-->
-    </script>';
-
-    echo $headline;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('title', rex_i18n::msg('setup_606'), false);
-    $fragment->setVar('body', $content, false);
-    $fragment->setVar('buttons', $buttons, false);
-    $content = $fragment->parse('core/page/section.php');
-
-    echo '<form class="rex-js-createadminform" action="' . rex_url::backendController() . '" method="post" autocomplete="off">' . $content . '</form>';
+    require 'setup.step6.php';
 
     return;
 }
@@ -891,33 +304,5 @@ if (6 === $step) {
 // ---------------------------------- step 7 . thank you . setup false
 
 if (7 === $step) {
-    $configFile = rex_path::coreData('config.yml');
-    $config = array_merge(
-        rex_file::getConfig(rex_path::core('default.config.yml')),
-        rex_file::getConfig($configFile)
-    );
-    $config['setup'] = false;
-
-    if (rex_file::putConfig($configFile, $config)) {
-        $errmsg = '';
-        rex_file::delete(rex_path::coreCache('config.yml.cache'));
-    } else {
-        $errmsg = rex_i18n::msg('setup_701');
-    }
-
-    $headline = rex_view::title(rex_i18n::msg('setup_700'));
-
-    $content = '<h3>' . rex_i18n::msg('setup_703') . '</h3>';
-    $content .= rex_i18n::rawMsg('setup_704', '<a href="' . rex_url::backendController() . '">', '</a>');
-    $content .= '<p>' . rex_i18n::msg('setup_705') . '</p>';
-
-    $buttons = '<a class="btn btn-setup" href="' . rex_url::backendController() . '">' . rex_i18n::msg('setup_706') . '</a>';
-
-    echo $headline;
-
-    $fragment = new rex_fragment();
-    $fragment->setVar('heading', rex_i18n::msg('setup_702'), false);
-    $fragment->setVar('body', $content, false);
-    $fragment->setVar('buttons', $buttons, false);
-    echo $fragment->parse('core/page/section.php');
+    require 'setup.step7.php';
 }

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -12,7 +12,7 @@ $lang = rex_request('lang', 'string');
 
 // ---------------------------------- Step 1 . Language
 if (1 >= $step) {
-    require 'setup.step1.php';
+    require rex_path::core('pages/setup.step1.php');
 
     return;
 }
@@ -20,7 +20,7 @@ if (1 >= $step) {
 // ---------------------------------- Step 2 . license
 
 if (2 === $step) {
-    require 'setup.step2.php';
+    require rex_path::core('pages/setup.step2.php');
 
     return;
 }
@@ -59,7 +59,7 @@ if (count($error_array) > 0) {
 }
 
 if (3 === $step) {
-    require 'setup.step3.php';
+    require rex_path::core('pages/setup.step3.php');
 
     return;
 }
@@ -156,7 +156,7 @@ if ($step > 4) {
 }
 
 if (4 === $step) {
-    require 'setup.step4.php';
+    require rex_path::core('pages/setup.step4.php');
 
     return;
 }
@@ -230,7 +230,7 @@ if ($step > 5 && '' == !rex_setup_importer::verifyDbSchema()) {
 }
 
 if (5 === $step) {
-    require 'setup.step5.php';
+    require rex_path::core('pages/setup.step5.php');
 
     return;
 }
@@ -296,7 +296,7 @@ if (7 === $step) {
 }
 
 if (6 === $step) {
-    require 'setup.step6.php';
+    require rex_path::core('pages/setup.step6.php');
 
     return;
 }
@@ -304,5 +304,5 @@ if (6 === $step) {
 // ---------------------------------- step 7 . thank you . setup false
 
 if (7 === $step) {
-    require 'setup.step7.php';
+    require rex_path::core('pages/setup.step7.php');
 }

--- a/redaxo/src/core/pages/setup.step1.php
+++ b/redaxo/src/core/pages/setup.step1.php
@@ -1,0 +1,17 @@
+<?php
+
+rex_setup::init();
+
+$langs = [];
+foreach (rex_i18n::getLocales() as $locale) {
+    $label = rex_i18n::msgInLocale('lang', $locale);
+    $langs[$label] = '<a class="list-group-item" href="' . rex_url::backendPage('setup', ['step' => 2, 'lang' => $locale]) . '">' . $label . '</a>';
+}
+ksort($langs);
+echo rex_view::title(rex_i18n::msg('setup_100'));
+$content = '<div class="list-group">' . implode('', $langs) . '</div>';
+
+$fragment = new rex_fragment();
+$fragment->setVar('heading', rex_i18n::msg('setup_101'), false);
+$fragment->setVar('content', $content, false);
+echo $fragment->parse('core/page/section.php');

--- a/redaxo/src/core/pages/setup.step2.php
+++ b/redaxo/src/core/pages/setup.step2.php
@@ -1,0 +1,19 @@
+<?php
+
+rex::setProperty('lang', $lang);
+
+$license_file = rex_path::base('LICENSE.md');
+$license = '<p>' . nl2br(rex_file::get($license_file)) . '</p>';
+
+$content = rex_i18n::rawMsg('setup_202');
+$content .= $license;
+
+$buttons = '<a class="btn btn-setup" href="' . rex_url::backendPage('setup', ['step' => 3, 'lang' => $lang]) . '">' . rex_i18n::msg('setup_203') . '</a>';
+
+echo rex_view::title(rex_i18n::msg('setup_200'));
+
+$fragment = new rex_fragment();
+$fragment->setVar('heading', rex_i18n::msg('setup_201'), false);
+$fragment->setVar('body', '<div class="rex-scrollable">' . $content . '</div>', false);
+$fragment->setVar('buttons', $buttons, false);
+echo $fragment->parse('core/page/section.php');

--- a/redaxo/src/core/pages/setup.step3.php
+++ b/redaxo/src/core/pages/setup.step3.php
@@ -1,0 +1,58 @@
+<?php
+
+$content = '';
+
+if (count($success_array) > 0) {
+    $content .= '<ul><li>' . implode('</li><li>', $success_array) . '</li></ul>';
+}
+
+$buttons = '';
+$class = '';
+if (count($error_array) > 0) {
+    $class = 'error';
+    $content .= implode('', $error_array);
+
+    $buttons = '<a class="btn btn-setup" href="' . rex_url::backendPage('setup', ['step' => 4, 'lang' => $lang]) . '">' . rex_i18n::msg('setup_312') . '</a>';
+} else {
+    $class = 'success';
+    $buttons = '<a class="btn btn-setup" href="' . rex_url::backendPage('setup', ['step' => 4, 'lang' => $lang]) . '">' . rex_i18n::msg('setup_310') . '</a>';
+}
+
+$security = '<div class="rex-js-setup-security-message" style="display:none">' . rex_view::error(rex_i18n::msg('setup_security_msg') . '<br />' . rex_i18n::msg('setup_no_js_security_msg')) . '</div>';
+$security .= '<noscript>' . rex_view::error(rex_i18n::msg('setup_no_js_security_msg')) . '</noscript>';
+$security .= '<script>
+
+    jQuery(function($){
+        var urls = [
+            "' . rex_url::backend('bin/console') . '",
+            "' . rex_url::backend('data/.redaxo') . '",
+            "' . rex_url::backend('src/core/boot.php') . '",
+            "' . rex_url::backend('cache/.redaxo') . '"
+        ];
+
+        $.each(urls, function (i, url) {
+            $.ajax({
+                url: url,
+                cache: false,
+                success: function(data) {
+                    $(".rex-js-setup-security-message").show();
+                    $(".rex-js-setup-section").hide();
+                }
+            });
+        });
+
+    })
+
+</script>';
+
+$security .= rex_setup::checkPhpSecurity();
+
+echo rex_view::title(rex_i18n::msg('setup_300'));
+
+$fragment = new rex_fragment();
+$fragment->setVar('class', $class, false);
+$fragment->setVar('title', rex_i18n::msg('setup_307'), false);
+$fragment->setVar('body', $content, false);
+$fragment->setVar('buttons', $buttons, false);
+echo '<div class="rex-js-setup-section">' . $fragment->parse('core/page/section.php') . '</div>';
+echo $security;

--- a/redaxo/src/core/pages/setup.step4.php
+++ b/redaxo/src/core/pages/setup.step4.php
@@ -1,0 +1,152 @@
+<?php
+
+$headline = rex_view::title(rex_i18n::msg('setup_400'));
+
+$content = '';
+
+$submit_message = rex_i18n::msg('setup_410');
+if (count($error_array) > 0) {
+    $submit_message = rex_i18n::msg('setup_414');
+}
+
+$content .= '
+            <fieldset>
+                <input type="hidden" name="page" value="setup" />
+                <input type="hidden" name="step" value="5" />
+                <input type="hidden" name="lang" value="' . rex_escape($lang) . '" />';
+
+$timezone_sel = new rex_select();
+$timezone_sel->setId('rex-form-timezone');
+$timezone_sel->setStyle('class="form-control selectpicker"');
+$timezone_sel->setAttribute('data-live-search', 'true');
+$timezone_sel->setName('timezone');
+$timezone_sel->setSize(1);
+$timezone_sel->addOptions(DateTimeZone::listIdentifiers(), true);
+$timezone_sel->setSelected($config['timezone']);
+
+$db_create_checked = rex_post('redaxo_db_create', 'boolean') ? ' checked="checked"' : '';
+
+$httpsRedirectSel = new rex_select();
+$httpsRedirectSel->setId('rex-form-https');
+$httpsRedirectSel->setStyle('class="form-control selectpicker"');
+$httpsRedirectSel->setName('use_https');
+$httpsRedirectSel->setSize(1);
+$httpsRedirectSel->addArrayOptions(['false' => rex_i18n::msg('https_disable'), 'backend' => rex_i18n::msg('https_only_backend'), 'frontend' => rex_i18n::msg('https_only_frontend'), 'true' => rex_i18n::msg('https_activate')]);
+$httpsRedirectSel->setSelected(true === $config['use_https'] ? 'true' : $config['use_https']);
+
+// If the setup is called over http disable https options to prevent user from being locked out
+if (!rex_request::isHttps()) {
+    $httpsRedirectSel->setAttribute('disabled', 'disabled');
+}
+
+$content .= '<legend>' . rex_i18n::msg('setup_402') . '</legend>';
+
+$formElements = [];
+
+$n = [];
+$n['label'] = '<label for="rex-form-serveraddress">' . rex_i18n::msg('server') . '</label>';
+$n['field'] = '<input class="form-control" type="text" id="rex-form-serveraddress" name="serveraddress" value="' . rex_escape($config['server']) . '" autofocus />';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-form-servername">' . rex_i18n::msg('servername') . '</label>';
+$n['field'] = '<input class="form-control" type="text" id="rex-form-servername" name="servername" value="' . rex_escape($config['servername']) . '" />';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-form-error-email">' . rex_i18n::msg('error_email') . '</label>';
+$n['field'] = '<input class="form-control" type="text" id="rex-form-error-email" name="error_email" value="' . rex_escape($config['error_email']) . '" />';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-form-timezone">' . rex_i18n::msg('setup_412') . '</label>';
+$n['field'] = $timezone_sel->get();
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/form.php');
+
+$content .= '</fieldset><fieldset><legend>' . rex_i18n::msg('setup_403') . '</legend>';
+
+$formElements = [];
+
+$n = [];
+$n['label'] = '<label for=rex-form-mysql-host">MySQL Host</label>';
+$n['field'] = '<input class="form-control" type="text" id="rex-form-mysql-host" name="mysql_host" value="' . rex_escape($config['db'][1]['host']) . '" />';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-form-db-user-login">Login</label>';
+$n['field'] = '<input class="form-control" type="text" id="rex-form-db-user-login" name="redaxo_db_user_login" value="' . rex_escape($config['db'][1]['login']) . '" />';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-form-db-user-pass">' . rex_i18n::msg('setup_409') . '</label>';
+$n['field'] = '<input class="form-control" type="password" id="rex-form-db-user-pass" name="redaxo_db_user_pass" value="' . rex_escape($config['db'][1]['password']) . '" />';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-form-dbname">' . rex_i18n::msg('setup_408') . '</label>';
+$n['field'] = '<input class="form-control" type="text" value="' . rex_escape($config['db'][1]['name']) . '" id="rex-form-dbname" name="dbname" />';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/form.php');
+
+$formElements = [];
+$n = [];
+$n['label'] = '<label>' . rex_i18n::msg('setup_411') . '</label>';
+$n['field'] = '<input type="checkbox" name="redaxo_db_create" value="1"' . $db_create_checked . ' />';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/checkbox.php');
+
+$content .= '</fieldset><fieldset><legend>' . rex_i18n::msg('setup_security') . '</legend>';
+
+$formElements = [];
+
+if (!rex_request::isHttps()) {
+    $n = [];
+    $n['field'] = '<label class="form-control-static"><i class="fa fa-warning"></i> '.rex_i18n::msg('https_only_over_https').'</label>';
+    $formElements[] = $n;
+}
+
+$n = [];
+$n['label'] = '<label>'.rex_i18n::msg('https_activate_redirect_for').'</label>';
+$n['field'] = $httpsRedirectSel->get();
+$formElements[] = $n;
+
+$n = [];
+$n['field'] = '<p>'.rex_i18n::msg('hsts_more_information').'</p>';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/form.php');
+
+$content .= '</fieldset>';
+
+$formElements = [];
+
+$n = [];
+$n['field'] = '<button class="btn btn-setup" type="submit" value="' . rex_i18n::msg('system_update') . '">' . $submit_message . '</button>';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$buttons = $fragment->parse('core/form/submit.php');
+
+echo $headline;
+echo implode('', $error_array);
+
+$fragment = new rex_fragment();
+$fragment->setVar('title', rex_i18n::msg('setup_416'), false);
+$fragment->setVar('body', $content, false);
+$fragment->setVar('buttons', $buttons, false);
+$content = $fragment->parse('core/page/section.php');
+
+echo '<form action="' . rex_url::backendController() . '" method="post">' . $content . '</form>';

--- a/redaxo/src/core/pages/setup.step5.php
+++ b/redaxo/src/core/pages/setup.step5.php
@@ -1,0 +1,242 @@
+<?php
+
+$tables_complete = ('' == rex_setup_importer::verifyDbSchema()) ? true : false;
+
+$createdb = rex_post('createdb', 'int', '');
+
+$supportsUtf8mb4 = rex_setup_importer::supportsUtf8mb4();
+$existingUtf8mb4 = false;
+$utf8mb4 = false;
+if ($supportsUtf8mb4) {
+    $utf8mb4 = rex_post('utf8mb4', 'bool', true);
+    $existingUtf8mb4 = $utf8mb4;
+    if ($tables_complete) {
+        $data = rex_sql::factory()->getArray('SELECT value FROM '.rex::getTable('config').' WHERE namespace="core" AND `key`="utf8mb4"');
+        $existingUtf8mb4 = isset($data[0]['value']) ? json_decode($data[0]['value']) : false;
+    }
+}
+
+// rex_sql will only work after rex_setup::checkDb() succeeded
+$security = rex_setup::checkDbSecurity();
+
+$headline = rex_view::title(rex_i18n::msg('setup_500'));
+
+$content = '
+            <fieldset class="rex-js-setup-step-5">
+                <input type="hidden" name="page" value="setup" />
+                <input type="hidden" name="step" value="6" />
+                <input type="hidden" name="lang" value="' . rex_escape($lang) . '" />
+            ';
+
+$submit_message = rex_i18n::msg('setup_511');
+if (count($errors) > 0) {
+    $errors[] = rex_view::error(rex_i18n::msg('setup_503'));
+    $headline .= implode('', $errors);
+    $submit_message = rex_i18n::msg('setup_512');
+}
+
+if ($security) {
+    $headline .= $security;
+}
+
+$dbchecked = array_fill(0, 6, '');
+switch ($createdb) {
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+        $dbchecked[$createdb] = ' checked="checked"';
+        break;
+    default:
+        $dbchecked[0] = ' checked="checked"';
+}
+
+// Vorhandene Exporte auslesen
+$sel_export = new rex_select();
+$sel_export->setName('import_name');
+$sel_export->setId('rex-form-import-name');
+$sel_export->setSize(1);
+$sel_export->setStyle('class="form-control selectpicker rex-js-import-name"');
+$sel_export->setAttribute('onclick', 'checkInput(\'createdb_3\')');
+$export_dir = rex_backup::getDir();
+$exports_found = false;
+
+if (is_dir($export_dir)) {
+    $export_sqls = [];
+
+    if ($handle = opendir($export_dir)) {
+        while (false !== ($file = readdir($handle))) {
+            if ('.' == $file || '..' == $file) {
+                continue;
+            }
+
+            $isSql = ('.sql' == substr($file, strlen($file) - 4));
+            if ($isSql) {
+                // cut .sql
+                $export_sqls[] = substr($file, 0, -4);
+                $exports_found = true;
+            }
+        }
+        closedir($handle);
+    }
+
+    foreach ($export_sqls as $sql_export) {
+        $sel_export->addOption($sql_export, $sql_export);
+    }
+}
+
+$formElements = [];
+
+$n = [];
+$n['label'] = '<label for="rex-form-createdb-0">' . rex_i18n::msg('setup_504') . '</label>';
+$n['field'] = '<input type="radio" id="rex-form-createdb-0" name="createdb" value="0"' . $dbchecked[0] . ' />';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-form-createdb-1">' . rex_i18n::msg('setup_505') . '</label>';
+$n['field'] = '<input type="radio" id="rex-form-createdb-1" name="createdb" value="1"' . $dbchecked[1] . ' />';
+$n['note'] = rex_i18n::msg('setup_505_note');
+$formElements[] = $n;
+
+if ($tables_complete) {
+    $n = [];
+    $n['label'] = '<label for="rex-form-createdb-2">' . rex_i18n::msg('setup_506') . '</label>';
+    $n['field'] = '<input type="radio" id="rex-form-createdb-2" name="createdb" value="2"' . $dbchecked[2] . ' />';
+    $n['note'] = rex_i18n::msg('setup_506_note');
+    $formElements[] = $n;
+}
+
+$n = [];
+$n['label'] = '<label for="rex-form-createdb-4">' . rex_i18n::msg('setup_514') . '</label>';
+$n['field'] = '<input type="radio" id="rex-form-createdb-4" name="createdb" value="4"' . $dbchecked[4] . ' />';
+$n['note'] = rex_i18n::msg('setup_514_note');
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$mode = $fragment->parse('core/form/radio.php');
+
+if ($exports_found) {
+    $formElements = [];
+    $n = [];
+    $n['label'] = '<label for="rex-form-createdb-3">' . rex_i18n::msg('setup_507') . '</label>';
+    $n['field'] = '<input type="radio" id="rex-form-createdb-3" name="createdb" value="3"' . $dbchecked[3] . ' />';
+    $formElements[] = $n;
+
+    $fragment = new rex_fragment();
+    $fragment->setVar('elements', $formElements, false);
+    $mode .= $fragment->parse('core/form/radio.php');
+
+    $formElements = [];
+    $n = [];
+    $n['field'] = $sel_export->get();
+    $n['note'] = rex_i18n::msg('backup_version_warning');
+    $formElements[] = $n;
+
+    $fragment = new rex_fragment();
+    $fragment->setVar('elements', $formElements, false);
+    $mode .= $fragment->parse('core/form/form.php');
+}
+
+$formElements = [];
+
+$n = [];
+$n['label'] = '<label for="rex-form-utf8mb4">'.rex_i18n::msg('setup_charset_utf8mb4').'</label>';
+$n['field'] = '<input type="radio" id="rex-form-utf8mb4" name="utf8mb4" value="1"'.($utf8mb4 ? ' checked' : '').($supportsUtf8mb4 ? '' : ' disabled').' />';
+$n['note'] = rex_i18n::msg('setup_charset_utf8mb4_note');
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-form-utf8">'.rex_i18n::msg('setup_charset_utf8').'</label>';
+$n['field'] = '<input type="radio" id="rex-form-utf8" name="utf8mb4" value="0"'.($utf8mb4 ? '' : ' checked').' />';
+$n['note'] = rex_i18n::msg('setup_charset_utf8_note');
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$charset = $fragment->parse('core/form/radio.php');
+
+$formElements = [];
+
+$sql = rex_sql::factory();
+
+$n = [];
+$n['label'] = '<label>'.rex_i18n::msg('version').'</label>';
+$n['field'] = '<p class="form-control-static">'.$sql->getDbType().' '.$sql->getDbVersion().'</p>';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label>'.rex_i18n::msg('mode').'</label>';
+$n['field'] = $mode;
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label>'.rex_i18n::msg('charset').'</label>';
+$n['field'] = $charset;
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/form.php');
+
+$content .= '</fieldset>';
+
+$formElements = [];
+
+$n = [];
+$n['field'] = '<button class="btn btn-setup" type="submit" value="' . $submit_message . '">' . $submit_message . '</button>';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$buttons = $fragment->parse('core/form/submit.php');
+
+$content .= '</form>';
+
+$content .= '
+            <script type="text/javascript">
+                 <!--
+                jQuery(function($) {
+                    var $container = $(".rex-js-setup-step-5");
+
+                    // when opening backup dropdown -> mark corresponding radio button as checked
+                    $container.find(".rex-js-import-name").click(function () {
+                        $container.find("[name=createdb][value=3]").prop("checked", true);
+                    });
+
+                    if (!$container.find("[name=utf8mb4][value=1]").prop("disabled")) {
+                        // when changing mode -> reset disabled state
+                        $container.find("[name=createdb]").click(function () {
+                            $container.find("[name=utf8mb4]").prop("disabled", false);
+                        });
+
+                        // when selecting "existing db" -> select current charset and disable radios
+                        $container.find("[name=createdb][value=2]").click(function () {
+                            $container.find("[name=utf8mb4][value='.((int) $existingUtf8mb4).']").prop("checked", true);
+                            $container.find("[name=utf8mb4]").prop("disabled", true);
+                        });
+
+                        // when selecting "update db" -> select utf8mb4 charset
+                        $container.find("[name=createdb][value=4]").click(function () {
+                            $container.find("[name=utf8mb4][value=1]").prop("checked", true);
+                        });
+
+                        // when selecting "import backup" -> disable radios
+                        $container.find("[name=createdb][value=3]").click(function () {
+                            $container.find("[name=utf8mb4]").prop("disabled", true);
+                        });
+                    }
+                });
+                 //-->
+            </script>';
+
+echo $headline;
+echo implode('', $error_array);
+
+$fragment = new rex_fragment();
+$fragment->setVar('title', rex_i18n::msg('setup_501'), false);
+$fragment->setVar('body', $content, false);
+$fragment->setVar('buttons', $buttons, false);
+$content = $fragment->parse('core/page/section.php');
+
+echo '<form action="' . rex_url::backendController() . '" method="post">' . $content . '</form>';

--- a/redaxo/src/core/pages/setup.step6.php
+++ b/redaxo/src/core/pages/setup.step6.php
@@ -1,0 +1,116 @@
+<?php
+
+$user_sql = rex_sql::factory();
+$user_sql->setQuery('select * from ' . rex::getTablePrefix() . 'user LIMIT 1');
+
+$headline = rex_view::title(rex_i18n::msg('setup_600'));
+
+$submit_message = rex_i18n::msg('setup_610');
+if (count($errors) > 0) {
+    $submit_message = rex_i18n::msg('setup_611');
+    $headline .= implode('', $errors);
+}
+
+$content = '';
+
+$content .= '
+        <fieldset>
+            <input class="rex-js-javascript" type="hidden" name="javascript" value="0" />
+            <input type="hidden" name="page" value="setup" />
+            <input type="hidden" name="step" value="7" />
+            <input type="hidden" name="lang" value="' . rex_escape($lang) . '" />
+            ';
+
+$redaxo_user_login = rex_post('redaxo_user_login', 'string');
+$redaxo_user_pass = rex_post('redaxo_user_pass', 'string');
+
+if ($user_sql->getRows() > 0) {
+    $formElements = [];
+    $n = [];
+
+    $checked = '';
+    if (!isset($_REQUEST['redaxo_user_login'])) {
+        $checked = 'checked="checked"';
+    }
+
+    $n['label'] = '<label>' . rex_i18n::msg('setup_609') . '</label>';
+    $n['field'] = '<input class="rex-js-noadmin" type="checkbox" name="noadmin" value="1" ' . $checked . ' />';
+    $formElements[] = $n;
+
+    $fragment = new rex_fragment();
+    $fragment->setVar('elements', $formElements, false);
+    $content .= $fragment->parse('core/form/checkbox.php');
+}
+
+$formElements = [];
+
+$n = [];
+$n['label'] = '<label for="rex-form-redaxo-user-login">' . rex_i18n::msg('setup_607') . '</label>';
+$n['field'] = '<input class="form-control" type="text" value="' . rex_escape($redaxo_user_login) . '" id="rex-form-redaxo-user-login" name="redaxo_user_login" autofocus />';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-form-redaxo-user-pass">' . rex_i18n::msg('setup_608') . '</label>';
+$n['field'] = '<input class="form-control rex-js-redaxo-user-pass" type="password" value="' . rex_escape($redaxo_user_pass) . '" id="rex-form-redaxo-user-pass" name="redaxo_user_pass" />';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= '<div class="rex-js-login-data">' . $fragment->parse('core/form/form.php') . '</div>';
+
+$content .= '</fieldset>';
+
+$formElements = [];
+
+$n = [];
+$n['field'] = '<button class="btn btn-setup" type="submit" value="' . $submit_message . '">' . $submit_message . '</button>';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$buttons = $fragment->parse('core/form/submit.php');
+
+$content .= '
+
+    <script type="text/javascript">
+         <!--
+        jQuery(function($) {
+            $(".rex-js-createadminform")
+                .submit(function(){
+                    var pwInp = $(".rex-js-redaxo-user-pass");
+                    if(pwInp.val() != "") {
+                        $(".rex-js-createadminform").append(\'<input type="hidden" name="\'+pwInp.attr("name")+\'" value="\'+Sha1.hash(pwInp.val())+\'" />\');
+                        pwInp.removeAttr("name");
+                    }
+            });
+
+            $(".rex-js-javascript").val("1");
+
+            $(".rex-js-createadminform .rex-js-noadmin").on("change",function (){
+
+                if($(this).is(":checked")) {
+                    $(".rex-js-login-data").each(function() {
+                        $(this).css("display","none");
+                    })
+                } else {
+                    $(".rex-js-login-data").each(function() {
+                        $(this).css("display","block");
+                    })
+                }
+
+            }).trigger("change");
+
+        });
+     //-->
+    </script>';
+
+echo $headline;
+
+$fragment = new rex_fragment();
+$fragment->setVar('title', rex_i18n::msg('setup_606'), false);
+$fragment->setVar('body', $content, false);
+$fragment->setVar('buttons', $buttons, false);
+$content = $fragment->parse('core/page/section.php');
+
+echo '<form class="rex-js-createadminform" action="' . rex_url::backendController() . '" method="post" autocomplete="off">' . $content . '</form>';
+

--- a/redaxo/src/core/pages/setup.step6.php
+++ b/redaxo/src/core/pages/setup.step6.php
@@ -113,4 +113,3 @@ $fragment->setVar('buttons', $buttons, false);
 $content = $fragment->parse('core/page/section.php');
 
 echo '<form class="rex-js-createadminform" action="' . rex_url::backendController() . '" method="post" autocomplete="off">' . $content . '</form>';
-

--- a/redaxo/src/core/pages/setup.step7.php
+++ b/redaxo/src/core/pages/setup.step7.php
@@ -1,0 +1,31 @@
+<?php
+
+$configFile = rex_path::coreData('config.yml');
+$config = array_merge(
+    rex_file::getConfig(rex_path::core('default.config.yml')),
+    rex_file::getConfig($configFile)
+);
+$config['setup'] = false;
+
+if (rex_file::putConfig($configFile, $config)) {
+    $errmsg = '';
+    rex_file::delete(rex_path::coreCache('config.yml.cache'));
+} else {
+    $errmsg = rex_i18n::msg('setup_701');
+}
+
+$headline = rex_view::title(rex_i18n::msg('setup_700'));
+
+$content = '<h3>' . rex_i18n::msg('setup_703') . '</h3>';
+$content .= rex_i18n::rawMsg('setup_704', '<a href="' . rex_url::backendController() . '">', '</a>');
+$content .= '<p>' . rex_i18n::msg('setup_705') . '</p>';
+
+$buttons = '<a class="btn btn-setup" href="' . rex_url::backendController() . '">' . rex_i18n::msg('setup_706') . '</a>';
+
+echo $headline;
+
+$fragment = new rex_fragment();
+$fragment->setVar('heading', rex_i18n::msg('setup_702'), false);
+$fragment->setVar('body', $content, false);
+$fragment->setVar('buttons', $buttons, false);
+echo $fragment->parse('core/page/section.php');


### PR DESCRIPTION
die große lange setup page in einzelne teilseiten aufgeteilt.

ich habe dabei nur die einzelnen logiken extrahiert die die pages rendern (damit die steuerungslogik klarer wird wg. early returns etc. in der pages/setup.php

die eigentlichen validierungslogiken hab ich bewusst in der pages/setup.php belassen damit nicht auch noch die logik verändert werden müssen. so wird bereits genug code bewegt