### PR TITLE
removed unnecessary bc code

### DIFF
--- a/redaxo/src/addons/structure/lib/service_article.php
+++ b/redaxo/src/addons/structure/lib/service_article.php
@@ -915,10 +915,6 @@ class rex_article_service
             return rex::getUser()->getLogin();
         }
 
-        if (method_exists(rex::class, 'getEnvironment')) {
-            return rex::getEnvironment();
-        }
-
-        return 'frontend';
+        return rex::getEnvironment();
     }
 }

--- a/redaxo/src/addons/structure/lib/service_category.php
+++ b/redaxo/src/addons/structure/lib/service_category.php
@@ -588,10 +588,6 @@ class rex_category_service
             return rex::getUser()->getLogin();
         }
 
-        if (method_exists(rex::class, 'getEnvironment')) {
-            return rex::getEnvironment();
-        }
-
-        return 'frontend';
+        return rex::getEnvironment();
     }
 }

--- a/redaxo/src/addons/structure/plugins/content/lib/content_service.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/content_service.php
@@ -344,10 +344,6 @@ class rex_content_service
             return rex::getUser()->getLogin();
         }
 
-        if (method_exists(rex::class, 'getEnvironment')) {
-            return rex::getEnvironment();
-        }
-
-        return 'frontend';
+        return rex::getEnvironment();
     }
 }


### PR DESCRIPTION
dieser code war nötig für BC zu alten REX versionen.. mitlerweile sind die min redaxo versionen aber aktuell genug

`rex::getEnvironment()` gibts seit R5.4