### PR TITLE
hide password in setup

### DIFF
--- a/redaxo/src/addons/structure/pages/index.php
+++ b/redaxo/src/addons/structure/pages/index.php
@@ -169,7 +169,7 @@ if ($KAT->getRows() > 0) {
         $status_icon = $catStatusTypes[$KAT->getValue('status')][2];
 
         if ($structureContext->hasCategoryPermission()) {
-            if ($structureContext->hasCategoryPermission() && rex::getUser()->hasPerm('publishCategory[]')) {
+            if (rex::getUser()->hasPerm('publishCategory[]')) {
                 $kat_status = '<a class="' . $status_class . '" href="' . $structureContext->getContext()->getUrl(['category-id' => $i_category_id, 'catstart' => $structureContext->getCatStart()] + rex_api_category_status::getUrlParams()) . '"><i class="rex-icon ' . $status_icon . '"></i> ' . $kat_status . '</a>';
             } else {
                 $kat_status = '<span class="' . $status_class . ' text-muted"><i class="rex-icon ' . $status_icon . '"></i> ' . $kat_status . '</span>';

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -275,6 +275,7 @@ https_only_frontend = nur für Frontend aktivieren
 https_only_backend = nur für Backend aktivieren
 https_activate = für Frontend und Backend aktiveren
 
+setup_password_hint = Zur Vergabe eines neuen Passwortes dieses eintragen. Sonst Feld leer lassen.
 hsts_more_information = HSTS sollte in den Hostingeinstellungen der Domain/s (empfohlen) aktiviert werden, kann aber auch in der config.yml von REDAXO nachträglich aktiviert werden. Weitere Informationen in der REDAXO-Doku.
 
 # redaxo\include\pages\addon.php

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -275,7 +275,7 @@ https_only_frontend = nur für Frontend aktivieren
 https_only_backend = nur für Backend aktivieren
 https_activate = für Frontend und Backend aktiveren
 
-setup_password_hint = Zur Vergabe eines neuen Passwortes dieses eintragen. Sonst Feld leer lassen.
+setup_password_hint = Zur Vergabe eines neuen Passwortes dieses eintragen. Sonst unverändert lassen.
 hsts_more_information = HSTS sollte in den Hostingeinstellungen der Domain/s (empfohlen) aktiviert werden, kann aber auch in der config.yml von REDAXO nachträglich aktiviert werden. Weitere Informationen in der REDAXO-Doku.
 
 # redaxo\include\pages\addon.php

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -275,7 +275,7 @@ https_only_frontend = Activate only for frontend
 https_only_backend = Activate only for backend
 https_activate = Activate for frontend and backend
 
-setup_password_hint = Enter a new password or leave the input empty otherwise.
+setup_password_hint = Enter a new password or leave the input unchanged otherwise.
 hsts_more_information = It is recommended to activate HSTS in your domain/s hosting settings, but can also be activated in REDAXOs config.yml at a later stage. More information is available in the REDAXO documentation
 
 # redaxo\include\pages\addon.php

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -275,6 +275,7 @@ https_only_frontend = Activate only for frontend
 https_only_backend = Activate only for backend
 https_activate = Activate for frontend and backend
 
+setup_password_hint = Enter a new password or leave the input empty otherwise.
 hsts_more_information = It is recommended to activate HSTS in your domain/s hosting settings, but can also be activated in REDAXOs config.yml at a later stage. More information is available in the REDAXO documentation
 
 # redaxo\include\pages\addon.php

--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -10,6 +10,11 @@ class rex_setup
     public const MIN_PHP_VERSION = REX_MIN_PHP_VERSION;
     public const MIN_MYSQL_VERSION = '5.5.3';
 
+    /**
+     * no-password placeholder required to support empty passwords/clearing the password
+     */
+    public const DEFAULT_DUMMY_PASSWORD = '-REDAXO-DEFAULT-DUMMY-PASSWORD-';
+
     private static $MIN_PHP_EXTENSIONS = ['fileinfo', 'pcre', 'pdo', 'pdo_mysql', 'session', 'tokenizer'];
 
     /**

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -88,8 +88,8 @@ if ($step > 4) {
         $config['db'][1]['host'] = trim(rex_post('mysql_host', 'string'));
         $config['db'][1]['login'] = trim(rex_post('redaxo_db_user_login', 'string'));
 
-        $passwd = rex_post('redaxo_db_user_pass', 'string');
-        if ($passwd) {
+        $passwd = rex_post('redaxo_db_user_pass', 'string', rex_setup::DEFAULT_DUMMY_PASSWORD);
+        if ($passwd != rex_setup::DEFAULT_DUMMY_PASSWORD) {
             $config['db'][1]['password'] = $passwd;
         }
         $config['db'][1]['name'] = trim(rex_post('dbname', 'string'));

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -87,7 +87,11 @@ if ($step > 4) {
         $config['timezone'] = rex_post('timezone', 'string');
         $config['db'][1]['host'] = trim(rex_post('mysql_host', 'string'));
         $config['db'][1]['login'] = trim(rex_post('redaxo_db_user_login', 'string'));
-        $config['db'][1]['password'] = rex_post('redaxo_db_user_pass', 'string');
+
+        $passwd = rex_post('redaxo_db_user_pass', 'string');
+        if ($passwd) {
+            $config['db'][1]['password'] = $passwd;
+        }
         $config['db'][1]['name'] = trim(rex_post('dbname', 'string'));
         $config['use_https'] = rex_post('use_https', 'string');
 

--- a/redaxo/src/core/pages/setup.step4.php
+++ b/redaxo/src/core/pages/setup.step4.php
@@ -83,7 +83,11 @@ $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="rex-form-db-user-pass">' . rex_i18n::msg('setup_409') . '</label>';
-$n['field'] = '<input class="form-control" type="password" id="rex-form-db-user-pass" name="redaxo_db_user_pass" value="' . rex_escape($config['db'][1]['password']) . '" />';
+$n['field'] = '<input class="form-control" type="password" id="rex-form-db-user-pass" name="redaxo_db_user_pass" value="" />';
+$formElements[] = $n;
+
+$n = [];
+$n['field'] = '<p>'.rex_i18n::msg('setup_password_hint').'</p>';
 $formElements[] = $n;
 
 $n = [];

--- a/redaxo/src/core/pages/setup.step4.php
+++ b/redaxo/src/core/pages/setup.step4.php
@@ -83,7 +83,7 @@ $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="rex-form-db-user-pass">' . rex_i18n::msg('setup_409') . '</label>';
-$n['field'] = '<input class="form-control" type="password" id="rex-form-db-user-pass" name="redaxo_db_user_pass" value="" />';
+$n['field'] = '<input class="form-control" type="password" id="rex-form-db-user-pass" name="redaxo_db_user_pass" value="'. rex_setup::DEFAULT_DUMMY_PASSWORD .'" />';
 $formElements[] = $n;
 
 $n = [];


### PR DESCRIPTION
closes https://github.com/redaxo/redaxo/issues/2712

Das passwort Eingabefeld wird nicht mehr vorgefüllt.
Wenn man ein neues Passwort eingibt wird dieses benutzt, ansonsten bleibt das "vorherige" bestehen.