### PR TITLE
remove html markup from checkPhpSecurity() & checkDbSecurity()

### DIFF
--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -531,7 +531,7 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
             $phpEol = rex_setup::checkPhpSecurity();
             if (!empty($phpEol)) {
                 foreach ($phpEol as $warning) {
-                    $this->io->warning(rex_view::warning($warning));
+                    $this->io->warning($warning);
                 }
             } else {
                 $this->io->success('PHP version ok');

--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -256,7 +256,7 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         $sql = rex_sql::factory();
         $dbEol = rex_setup::checkDbSecurity();
         if (!empty($dbEol)) {
-            foreach($dbEol as $warning) {
+            foreach ($dbEol as $warning) {
                 $io->warning($warning);
             }
         } else {
@@ -530,7 +530,7 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         if (0 == count($errors)) {
             $phpEol = rex_setup::checkPhpSecurity();
             if (!empty($phpEol)) {
-                foreach($phpEol as $warning) {
+                foreach ($phpEol as $warning) {
                     $this->io->warning(rex_view::warning($warning));
                 }
             } else {

--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -256,7 +256,9 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         $sql = rex_sql::factory();
         $dbEol = rex_setup::checkDbSecurity();
         if (!empty($dbEol)) {
-            $io->warning($this->decodeMessage($dbEol));
+            foreach($dbEol as $warning) {
+                $io->warning($warning);
+            }
         } else {
             $io->block('Database version: '.$sql->getDbType(). ' '.$sql->getDbVersion());
         }
@@ -528,7 +530,9 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         if (0 == count($errors)) {
             $phpEol = rex_setup::checkPhpSecurity();
             if (!empty($phpEol)) {
-                $this->io->warning($this->decodeMessage($phpEol));
+                foreach($phpEol as $warning) {
+                    $this->io->warning(rex_view::warning($warning));
+                }
             } else {
                 $this->io->success('PHP version ok');
             }

--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -156,32 +156,32 @@ class rex_setup
     /**
      * Basic php security checks. Returns a human readable strings on error.
      *
-     * @return string
+     * @return string[]
      */
     public static function checkPhpSecurity()
     {
-        $security = '';
+        $security = [];
 
         if (PHP_SAPI !== 'cli' && !rex_request::isHttps()) {
-            $security .= rex_view::warning(rex_i18n::msg('setup_security_no_https'));
+            $security[] = rex_view::warning(rex_i18n::msg('setup_security_no_https'));
         }
 
         if (function_exists('apache_get_modules') && in_array('mod_security', apache_get_modules())) {
-            $security .= rex_view::warning(rex_i18n::msg('setup_security_warn_mod_security'));
+            $security[] = rex_view::warning(rex_i18n::msg('setup_security_warn_mod_security'));
         }
 
         if ('0' !== ini_get('session.auto_start')) {
-            $security .= rex_view::warning(rex_i18n::msg('setup_session_autostart_warning'));
+            $security[] = rex_view::warning(rex_i18n::msg('setup_session_autostart_warning'));
         }
 
         if (1 == version_compare(PHP_VERSION, '7.2', '<') && time() > strtotime('1 Dec 2019')) {
-            $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION));
+            $security[] = rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION);
         } elseif (1 == version_compare(PHP_VERSION, '7.3', '<') && time() > strtotime('30 Nov 2020')) {
-            $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION));
+            $security[] = rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION);
         } elseif (1 == version_compare(PHP_VERSION, '7.4', '<') && time() > strtotime('6 Dec 2021')) {
-            $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION));
+            $security[] = rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION);
         } elseif (1 == version_compare(PHP_VERSION, '8.0', '<') && time() > strtotime('28 Nov 2022')) {
-            $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION));
+            $security[] = rex_i18n::msg('setup_security_deprecated_php', PHP_VERSION);
         }
 
         return $security;
@@ -190,47 +190,47 @@ class rex_setup
     /**
      * Basic database security checks. Returns a human readable strings on error.
      *
-     * @return string
+     * @return string[]
      */
     public static function checkDbSecurity()
     {
         $sql = rex_sql::factory();
         $dbVersion = $sql->getDbVersion();
         $dbType = $sql->getDbType();
-        $security = '';
+        $security = [];
 
         if (rex_sql::MARIADB === $dbType) {
             // https://en.wikipedia.org/wiki/MariaDB#Versioning
             if (1 == version_compare($dbVersion, '5.2', '<') && time() > strtotime('1 Feb 2015')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '5.3', '<') && time() > strtotime('1 Nov 2015')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '5.5', '<') && time() > strtotime('1 Mar 2017')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '10.0', '<') && time() > strtotime('1 Apr 2020')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '10.1', '<') && time() > strtotime('1 Mar 2019')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '10.2', '<') && time() > strtotime('1 Oct 2020')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '10.3', '<') && time() > strtotime('1 May 2022')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '10.4', '<') && time() > strtotime('1 May 2023')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '10.5', '<') && time() > strtotime('1 Jun 2024')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mariadb', $dbVersion);
             }
             // 10.5 is not yet released
         } elseif (rex_sql::MYSQL === $dbType) {
             // https://en.wikipedia.org/wiki/MySQL#Release_history
             if (1 == version_compare($dbVersion, '5.5', '<') && time() > strtotime('1 Dec 2013')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mysql', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mysql', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '5.6', '<') && time() > strtotime('1 Dec 2018')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mysql', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mysql', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '5.7', '<') && time() > strtotime('1 Feb 2021')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mysql', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mysql', $dbVersion);
             } elseif (1 == version_compare($dbVersion, '8.0', '<') && time() > strtotime('1 Oct 2023')) {
-                $security .= rex_view::warning(rex_i18n::msg('setup_security_deprecated_mysql', $dbVersion));
+                $security[] = rex_i18n::msg('setup_security_deprecated_mysql', $dbVersion);
             }
             // EOL 8.0 is April 2026
         }

--- a/redaxo/src/core/pages/setup.step3.php
+++ b/redaxo/src/core/pages/setup.step3.php
@@ -45,7 +45,7 @@ $security .= '<script>
 
 </script>';
 
-foreach(rex_setup::checkPhpSecurity() as $warning) {
+foreach (rex_setup::checkPhpSecurity() as $warning) {
     $security .= rex_view::warning($warning);
 }
 

--- a/redaxo/src/core/pages/setup.step3.php
+++ b/redaxo/src/core/pages/setup.step3.php
@@ -45,7 +45,9 @@ $security .= '<script>
 
 </script>';
 
-$security .= rex_setup::checkPhpSecurity();
+foreach(rex_setup::checkPhpSecurity() as $warning) {
+    $security .= rex_view::warning($warning);
+}
 
 echo rex_view::title(rex_i18n::msg('setup_300'));
 

--- a/redaxo/src/core/pages/setup.step5.php
+++ b/redaxo/src/core/pages/setup.step5.php
@@ -32,7 +32,7 @@ if (count($errors) > 0) {
     $submit_message = rex_i18n::msg('setup_512');
 }
 
-foreach(rex_setup::checkDbSecurity() as $message) {
+foreach (rex_setup::checkDbSecurity() as $message) {
     $headline .= rex_view::warning($message);
 }
 

--- a/redaxo/src/core/pages/setup.step5.php
+++ b/redaxo/src/core/pages/setup.step5.php
@@ -16,9 +16,6 @@ if ($supportsUtf8mb4) {
     }
 }
 
-// rex_sql will only work after rex_setup::checkDb() succeeded
-$security = rex_setup::checkDbSecurity();
-
 $headline = rex_view::title(rex_i18n::msg('setup_500'));
 
 $content = '
@@ -35,8 +32,8 @@ if (count($errors) > 0) {
     $submit_message = rex_i18n::msg('setup_512');
 }
 
-if ($security) {
-    $headline .= $security;
+foreach(rex_setup::checkDbSecurity() as $message) {
+    $headline .= rex_view::warning($message);
 }
 
 $dbchecked = array_fill(0, 6, '');


### PR DESCRIPTION
`rex_setup` ohne rendering, stattdessn nur die logik