### PR TITLE
Default-Config in package.yml ermöglichen

### DIFF
--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -100,6 +100,14 @@ class rex_api_install_core_update extends rex_api_function
                         throw new rex_functional_exception($addonkey . ': SQL error: ' . $e->getMessage(), $e);
                     }
                 }
+
+                if ($addon->isInstalled()) {
+                    foreach ($addon->getProperty('default_config', []) as $key => $value) {
+                        if (!$addon->hasConfig($key)) {
+                            $addon->setConfig($key, $value);
+                        }
+                    }
+                }
             }
 
             // create backup

--- a/redaxo/src/addons/install/lib/package/package_update.php
+++ b/redaxo/src/addons/install/lib/package/package_update.php
@@ -72,6 +72,14 @@ class rex_install_package_update extends rex_install_package_download
             }
         }
 
+        if ($this->addon->isInstalled() && isset($config['default_config'])) {
+            foreach ($config['default_config'] as $key => $value) {
+                if (!$this->addon->hasConfig($key)) {
+                    $this->addon->setConfig($key, $value);
+                }
+            }
+        }
+
         // ---- backup
         $assets = $this->addon->getAssetsPath();
         $installConfig = rex_file::getCache(rex_addon::get('install')->getDataPath('config.json'));

--- a/redaxo/src/addons/media_manager/install.php
+++ b/redaxo/src/addons/media_manager/install.php
@@ -11,22 +11,6 @@
 
 $addon = rex_addon::get('media_manager');
 
-if (!$addon->hasConfig('jpg_quality')) {
-    $addon->setConfig('jpg_quality', 85);
-}
-
-if (!$addon->hasConfig('png_compression')) {
-    $addon->setConfig('png_compression', 5);
-}
-
-if (!$addon->hasConfig('webp_quality')) {
-    $addon->setConfig('webp_quality', 85);
-}
-
-if (!$addon->hasConfig('interlace')) {
-    $addon->setConfig('interlace', ['jpg']);
-}
-
 rex_sql_table::get(rex::getTable('media_manager_type'))
     ->ensurePrimaryIdColumn()
     ->ensureColumn(new rex_sql_column('status', 'int(10) unsigned'))

--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -232,22 +232,22 @@ class rex_managed_media
         $format = $this->format;
         $format = 'jpeg' === $format ? 'jpg' : $format;
 
-        $interlace = $this->getImageProperty(self::PROP_INTERLACE, $addon->getConfig('interlace', ['jpg']));
+        $interlace = $this->getImageProperty(self::PROP_INTERLACE, $addon->getConfig('interlace'));
         imageinterlace($this->image['src'], in_array($format, $interlace) ? 1 : 0);
 
         ob_start();
         if ('jpg' == $format) {
-            $quality = $this->getImageProperty(self::PROP_JPG_QUALITY, $addon->getConfig('jpg_quality', 85));
+            $quality = $this->getImageProperty(self::PROP_JPG_QUALITY, $addon->getConfig('jpg_quality'));
             imagejpeg($this->image['src'], null, $quality);
         } elseif ('png' == $format) {
-            $compression = $this->getImageProperty(self::PROP_PNG_COMPRESSION, $addon->getConfig('png_compression', 5));
+            $compression = $this->getImageProperty(self::PROP_PNG_COMPRESSION, $addon->getConfig('png_compression'));
             imagepng($this->image['src'], null, $compression);
         } elseif ('gif' == $format) {
             imagegif($this->image['src']);
         } elseif ('wbmp' == $format) {
             imagewbmp($this->image['src']);
         } elseif ('webp' == $format) {
-            $quality = $this->getImageProperty(self::PROP_WEBP_QUALITY, $addon->getConfig('webp_quality', 85));
+            $quality = $this->getImageProperty(self::PROP_WEBP_QUALITY, $addon->getConfig('webp_quality'));
             imagewebp($this->image['src'], null, $quality);
         }
         return ob_get_clean();

--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -16,5 +16,10 @@ page:
 requires:
     php:
         extensions: [gd]
-    redaxo: ^5.9.1-dev
+    redaxo: ^5.10.0-dev
 
+default_config:
+    jpg_quality: 80
+    png_compression: 5
+    webp_quality: 85
+    interlace: [jpg]

--- a/redaxo/src/addons/media_manager/pages/settings.php
+++ b/redaxo/src/addons/media_manager/pages/settings.php
@@ -90,7 +90,7 @@ $select->setId('rex-media-manager-interlace');
 $select->setAttribute('class', 'form-control selectpicker');
 $select->setMultiple(true);
 $select->addOptions(['jpg', 'png', 'gif'], true);
-$select->setSelected($addon->getConfig('interlace', ['jpg']));
+$select->setSelected($addon->getConfig('interlace'));
 
 $n = [];
 $n['label'] = '<label for="rex-media-manager-interlace">' . $addon->i18n('interlace') . '</label>';

--- a/redaxo/src/addons/phpmailer/install.php
+++ b/redaxo/src/addons/phpmailer/install.php
@@ -10,35 +10,6 @@
 
 $addon = rex_addon::get('phpmailer');
 
-if (!$addon->hasConfig()) {
-    $addon->setConfig('from', '');
-    $addon->setConfig('test_address', '');
-    $addon->setConfig('fromname', 'Mailer');
-    $addon->setConfig('confirmto', '');
-    $addon->setConfig('bcc', '');
-    $addon->setConfig('mailer', 'mail');
-    $addon->setConfig('host', 'localhost');
-    $addon->setConfig('port', 25);
-    $addon->setConfig('charset', 'utf-8');
-    $addon->setConfig('wordwrap', 120);
-    $addon->setConfig('encoding', '8bit');
-    $addon->setConfig('priority', 0);
-    $addon->setConfig('smtpsecure', '');
-    $addon->setConfig('smtpauth', false);
-    $addon->setConfig('username', '');
-    $addon->setConfig('password', '');
-    $addon->setConfig('smtp_debug', '0');
-    $addon->setConfig('logging', 0);
-    $addon->setConfig('archive', false);
-} else {
-    if (!$addon->hasConfig('logging')) {
-        $addon->setConfig('logging', 0);
-    }
-    if (!$addon->hasConfig('archive')) {
-        $addon->setConfig('archive', false);
-    }
-}
-
 if ($addon->hasConfig('log')) {
     if ($addon->getConfig('log')) {
         $addon->setConfig('archive', true);

--- a/redaxo/src/addons/phpmailer/package.yml
+++ b/redaxo/src/addons/phpmailer/package.yml
@@ -19,4 +19,25 @@ pages:
         perm: admin
 
 requires:
-    redaxo: ^5.9.0
+    redaxo: ^5.10.0-dev
+
+default_config:
+    from: ''
+    test_address: ''
+    fromname: 'Mailer'
+    confirmto: ''
+    bcc: ''
+    mailer: 'mail'
+    host: 'localhost'
+    port: 25
+    charset: 'utf-8'
+    wordwrap: 120
+    encoding: '8bit'
+    priority: 0
+    smtpsecure: ''
+    smtpauth: false
+    username: ''
+    password: ''
+    smtp_debug: '0'
+    logging: 0
+    archive: false

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -159,6 +159,12 @@ abstract class rex_package_manager
                 self::generatePackageOrder();
             }
 
+            foreach ($this->package->getProperty('default_config', []) as $key => $value) {
+                if (!$this->package->hasConfig($key)) {
+                    $this->package->setConfig($key, $value);
+                }
+            }
+
             // copy assets
             $assets = $this->package->getPath('assets');
             if (is_dir($assets)) {

--- a/redaxo/src/core/lib/packages/package.php
+++ b/redaxo/src/core/lib/packages/package.php
@@ -107,10 +107,6 @@ abstract class rex_package implements rex_package_interface
      */
     public function getConfig($key = null, $default = null)
     {
-        if (1 === func_num_args()) {
-            $default = self::getProperty('default_config')[$key] ?? null;
-        }
-
         return rex_config::get($this->getPackageId(), $key, $default);
     }
 

--- a/redaxo/src/core/lib/packages/package.php
+++ b/redaxo/src/core/lib/packages/package.php
@@ -107,6 +107,10 @@ abstract class rex_package implements rex_package_interface
      */
     public function getConfig($key = null, $default = null)
     {
+        if (1 === func_num_args()) {
+            $default = self::getProperty('default_config')[$key] ?? null;
+        }
+
         return rex_config::get($this->getPackageId(), $key, $default);
     }
 


### PR DESCRIPTION
Idee ist, dass man bei der Installation nicht jeden Config-Wert prüfen muss, und ggf. initialisieren, sondern, dass man einfach in der package.yml die Default hinterlegen kann.

Diese Default-Werte werden gar nicht in der DB gespeichert. Wobei mir in dem Moment, wo ich es gerade schreibe, auffällt, dass das vielleicht doch nicht so eine gute Idee ist.
So lassen sie Default-Werte schwieriger ändern.
Also sollte ich die ggf. doch besser bei Installation auch in die DB schreiben.
Edit: Erledigt!

Aber erst mal grundsätzlich: Wollen wir überhaupt sowas?