### PR TITLE
add save/apply button titles

### DIFF
--- a/redaxo/src/addons/media_manager/pages/settings.php
+++ b/redaxo/src/addons/media_manager/pages/settings.php
@@ -107,7 +107,7 @@ $n['field'] = '<a class="btn btn-abort" href="' . rex_url::currentBackendPage() 
 $formElements[] = $n;
 
 $n = [];
-$n['field'] = '<button class="btn btn-apply rex-form-aligned" type="submit" name="sendit" value="1"' . rex::getAccesskey(rex_i18n::msg('update'), 'apply') . '>' . rex_i18n::msg('update') . '</button>';
+$n['field'] = '<button class="btn btn-apply rex-form-aligned" type="submit" name="sendit" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('update') . '</button>';
 $formElements[] = $n;
 
 $fragment = new rex_fragment();

--- a/redaxo/src/addons/media_manager/pages/settings.php
+++ b/redaxo/src/addons/media_manager/pages/settings.php
@@ -107,7 +107,7 @@ $n['field'] = '<a class="btn btn-abort" href="' . rex_url::currentBackendPage() 
 $formElements[] = $n;
 
 $n = [];
-$n['field'] = '<button class="btn btn-apply rex-form-aligned" type="submit" name="sendit" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('update') . '</button>';
+$n['field'] = '<button class="btn btn-apply rex-form-aligned" type="submit" name="sendit" value="1"' . rex::getAccesskey(rex_i18n::msg('save_and_goon_tooltip'), 'apply') . '>' . rex_i18n::msg('update') . '</button>';
 $formElements[] = $n;
 
 $fragment = new rex_fragment();

--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -468,7 +468,7 @@ function rex_mediapool_Mediaform($form_title, $button_title, $rex_file_category,
 
     $add_submit = '';
     if ($close_form && '' != $opener_input_field) {
-        $add_submit = '<button class="btn btn-save" type="submit" name="saveandexit" value="' . rex_i18n::msg('pool_file_upload_get') . '"' . rex::getAccesskey(rex_i18n::msg('pool_file_upload_get'), 'save') . '>' . rex_i18n::msg('pool_file_upload_get') . '</button>';
+        $add_submit = '<button class="btn btn-save" type="submit" name="saveandexit" value="' . rex_i18n::msg('pool_file_upload_get') . '"' . rex::getAccesskey(rex_i18n::msg('save_and_close_tooltip'), 'save') . '>' . rex_i18n::msg('pool_file_upload_get') . '</button>';
     }
 
     $panel = '';

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
@@ -451,7 +451,7 @@ class rex_article_content_editor extends rex_article_content
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-apply" type="submit" name="btn_update" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('update_block') . '</button>';
+        $n['field'] = '<button class="btn btn-apply" type="submit" name="btn_update" value="1"' . rex::getAccesskey(rex_i18n::msg('save_and_goon_tooltip'), 'apply') . '>' . rex_i18n::msg('update_block') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
@@ -447,11 +447,11 @@ class rex_article_content_editor extends rex_article_content
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save" type="submit" name="btn_save" value="1"' . rex::getAccesskey(rex_i18n::msg('save_block'), 'save') . '>' . rex_i18n::msg('save_block') . '</button>';
+        $n['field'] = '<button class="btn btn-save" type="submit" name="btn_save" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'save') . '>' . rex_i18n::msg('save_block') . '</button>';
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-apply" type="submit" name="btn_update" value="1"' . rex::getAccesskey(rex_i18n::msg('update_block'), 'apply') . '>' . rex_i18n::msg('update_block') . '</button>';
+        $n['field'] = '<button class="btn btn-apply" type="submit" name="btn_update" value="1"' . rex::getAccesskey(rex_i18n::msg('save_and_close_tooltip'), 'apply') . '>' . rex_i18n::msg('update_block') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
@@ -447,11 +447,11 @@ class rex_article_content_editor extends rex_article_content
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save" type="submit" name="btn_save" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'save') . '>' . rex_i18n::msg('save_block') . '</button>';
+        $n['field'] = '<button class="btn btn-save" type="submit" name="btn_save" value="1"' . rex::getAccesskey(rex_i18n::msg('save_and_close_tooltip'), 'save') . '>' . rex_i18n::msg('save_block') . '</button>';
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-apply" type="submit" name="btn_update" value="1"' . rex::getAccesskey(rex_i18n::msg('save_and_close_tooltip'), 'apply') . '>' . rex_i18n::msg('update_block') . '</button>';
+        $n['field'] = '<button class="btn btn-apply" type="submit" name="btn_update" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('update_block') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
@@ -199,7 +199,7 @@ if ('add' == $function || 'edit' == $function) {
 
         $btn_update = '';
         if ('add' != $function) {
-            $btn_update = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('save_action_and_continue') . '</button>';
+            $btn_update = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_and_goon_tooltip'), 'apply') . '>' . rex_i18n::msg('save_action_and_continue') . '</button>';
         }
 
         if ('' != $success) {

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
@@ -199,7 +199,7 @@ if ('add' == $function || 'edit' == $function) {
 
         $btn_update = '';
         if ('add' != $function) {
-            $btn_update = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_action_and_continue'), 'apply') . '>' . rex_i18n::msg('save_action_and_continue') . '</button>';
+            $btn_update = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('save_action_and_continue') . '</button>';
         }
 
         if ('' != $success) {
@@ -365,7 +365,7 @@ if ('add' == $function || 'edit' == $function) {
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit"' . rex::getAccesskey(rex_i18n::msg('save_action_and_quit'), 'save') . '>' . rex_i18n::msg('save_action_and_quit') . '</button>';
+        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit"' . rex::getAccesskey(rex_i18n::msg('save_and_close_tooltip'), 'save') . '>' . rex_i18n::msg('save_action_and_quit') . '</button>';
         $formElements[] = $n;
 
         if ('' != $btn_update) {

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
@@ -200,7 +200,7 @@ if ('add' == $function || 'edit' == $function) {
 
         $btn_update = '';
         if ('add' != $function) {
-            $btn_update = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('save_module_and_continue') . '</button>';
+            $btn_update = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_and_goon_tooltip'), 'apply') . '>' . rex_i18n::msg('save_module_and_continue') . '</button>';
         }
 
         if ('' != $success) {

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
@@ -200,7 +200,7 @@ if ('add' == $function || 'edit' == $function) {
 
         $btn_update = '';
         if ('add' != $function) {
-            $btn_update = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_module_and_continue'), 'apply') . '>' . rex_i18n::msg('save_module_and_continue') . '</button>';
+            $btn_update = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('save_module_and_continue') . '</button>';
         }
 
         if ('' != $success) {
@@ -259,7 +259,7 @@ if ('add' == $function || 'edit' == $function) {
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit"' . rex::getAccesskey(rex_i18n::msg('save_module_and_quit'), 'save') . '>' . rex_i18n::msg('save_module_and_quit') . '</button>';
+        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit"' . rex::getAccesskey(rex_i18n::msg('save_and_close_tooltip'), 'save') . '>' . rex_i18n::msg('save_module_and_quit') . '</button>';
         $formElements[] = $n;
 
         if ('' != $btn_update) {

--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -463,7 +463,7 @@ if ('add' == $function || 'edit' == $function) {
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('save_template_and_continue') . '</button>';
+        $n['field'] = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_and_goon_tooltip'), 'apply') . '>' . rex_i18n::msg('save_template_and_continue') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();

--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -459,11 +459,11 @@ if ('add' == $function || 'edit' == $function) {
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit"' . rex::getAccesskey(rex_i18n::msg('save_template_and_quit'), 'save') . '>' . rex_i18n::msg('save_template_and_quit') . '</button>';
+        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit"' . rex::getAccesskey(rex_i18n::msg('save_and_close_tooltip'), 'save') . '>' . rex_i18n::msg('save_template_and_quit') . '</button>';
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_template_and_continue'), 'apply') . '>' . rex_i18n::msg('save_template_and_continue') . '</button>';
+        $n['field'] = '<button class="btn btn-apply" type="submit" name="goon" value="1"' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('save_template_and_continue') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -293,11 +293,11 @@ if ('' != $FUNC_ADD || $user_id > 0) {
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="FUNC_UPDATE" value="1" ' . rex::getAccesskey(rex_i18n::msg('user_save'), 'save') . '>' . rex_i18n::msg('user_save') . '</button>';
+        $n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="FUNC_UPDATE" value="1" ' . rex::getAccesskey(rex_i18n::msg('save_and_close_tooltip'), 'save') . '>' . rex_i18n::msg('user_save') . '</button>';
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-apply" type="submit" name="FUNC_APPLY" value="1" ' . rex::getAccesskey(rex_i18n::msg('user_apply'), 'apply') . '>' . rex_i18n::msg('user_apply') . '</button>';
+        $n['field'] = '<button class="btn btn-apply" type="submit" name="FUNC_APPLY" value="1" ' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('user_apply') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -297,7 +297,7 @@ if ('' != $FUNC_ADD || $user_id > 0) {
         $formElements[] = $n;
 
         $n = [];
-        $n['field'] = '<button class="btn btn-apply" type="submit" name="FUNC_APPLY" value="1" ' . rex::getAccesskey(rex_i18n::msg('save_tooltip'), 'apply') . '>' . rex_i18n::msg('user_apply') . '</button>';
+        $n['field'] = '<button class="btn btn-apply" type="submit" name="FUNC_APPLY" value="1" ' . rex::getAccesskey(rex_i18n::msg('save_and_goon_tooltip'), 'apply') . '>' . rex_i18n::msg('user_apply') . '</button>';
         $formElements[] = $n;
 
         $fragment = new rex_fragment();

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -11,7 +11,7 @@ datetimeformat = %d. %b. %Y, %H:%M
 timeformat = %H:%M
 ctrl = Mehrfachauswahl mit <kbd>STRG</kbd> bzw. <kbd>CMD</kbd>
 translatable = Übersetzbar via <code>translate:i18n_key</code>
-save_tooltip = Speichern und weiter bearbeiten
+save_and_goon_tooltip = Speichern und weiter bearbeiten
 save_and_close_tooltip = Speichern und schließen
 
 # Allgemein

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -11,6 +11,8 @@ datetimeformat = %d. %b. %Y, %H:%M
 timeformat = %H:%M
 ctrl = Mehrfachauswahl mit <kbd>STRG</kbd> bzw. <kbd>CMD</kbd>
 translatable = Übersetzbar via <code>translate:i18n_key</code>
+save_tooltip = Speichern auf dieser Seite
+save_and_close_tooltip = Speichern und zurück
 
 # Allgemein
 abort = abbrechen

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -11,8 +11,8 @@ datetimeformat = %d. %b. %Y, %H:%M
 timeformat = %H:%M
 ctrl = Mehrfachauswahl mit <kbd>STRG</kbd> bzw. <kbd>CMD</kbd>
 translatable = Übersetzbar via <code>translate:i18n_key</code>
-save_tooltip = Speichern auf dieser Seite
-save_and_close_tooltip = Speichern und zurück
+save_tooltip = Speichern und weiter bearbeiten
+save_and_close_tooltip = Speichern und schließen
 
 # Allgemein
 abort = abbrechen

--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -131,7 +131,7 @@ class rex_form extends rex_form_base
                 if ('save' === $name) {
                     $attr['title'] = rex_i18n::msg('save_and_close_tooltip');
                 } elseif ('apply' === $name) {
-                    $attr['title'] = rex_i18n::msg('save_tooltip');
+                    $attr['title'] = rex_i18n::msg('save_and_goon_tooltip');
                 }
                 $controlElements[$name] = $this->addField(
                     'button',

--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -128,6 +128,11 @@ class rex_form extends rex_form_base
                 if ('abort' === $name || 'delete' === $name) {
                     $attr['formnovalidate'] = 'formnovalidate';
                 }
+                if ('save' === $name) {
+                    $attr['title'] = rex_i18n::msg('save_tooltip');
+                } elseif ('apply' === $name) {
+                    $attr['title'] = rex_i18n::msg('save_and_close_tooltip');
+                }
                 $controlElements[$name] = $this->addField(
                     'button',
                     $name,

--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -129,9 +129,9 @@ class rex_form extends rex_form_base
                     $attr['formnovalidate'] = 'formnovalidate';
                 }
                 if ('save' === $name) {
-                    $attr['title'] = rex_i18n::msg('save_tooltip');
-                } elseif ('apply' === $name) {
                     $attr['title'] = rex_i18n::msg('save_and_close_tooltip');
+                } elseif ('apply' === $name) {
+                    $attr['title'] = rex_i18n::msg('save_tooltip');
                 }
                 $controlElements[$name] = $this->addField(
                     'button',


### PR DESCRIPTION
Generischen Tooltip hinzufügen, den wir auf allen "übernehmen"/"speichern" knöpfen nutzen können.

Button labels selbst wurden nicht angepasst, da wir uns nicht auf labels einigen konnten die besser sind als die bisherigen

![image](https://user-images.githubusercontent.com/120441/75109713-45eb0e80-5626-11ea-855f-c1494ed51ddd.png)

![image](https://user-images.githubusercontent.com/120441/75109716-526f6700-5626-11ea-9e04-cf06e42a41cb.png)




closes https://github.com/redaxo/redaxo/issues/772