### PR TITLE
console: added install:download

### DIFF
--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -25,7 +25,7 @@ class rex_command_install_download extends rex_console_command
         $addonKey = $input->getArgument('addonkey');
 
         if (rex_addon::exists($addonKey)) {
-            $io->error(sprintf('AddOn "%s" already exist!', $addonKey));
+            $io->error(sprintf('AddOn "%s" already exists!', $addonKey));
             return 1;
         }
 

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -14,7 +14,7 @@ class rex_command_install_download extends rex_console_command
     protected function configure()
     {
         $this->setDescription('Download an AddOn from redaxo.org')
-            ->addArgument('addonkey', InputArgument::REQUIRED, 'AddOn key e.g. "yform"')
+            ->addArgument('addonkey', InputArgument::REQUIRED, 'AddOn key, e.g. "yform"')
             ->addArgument('version', InputArgument::OPTIONAL, 'version e.g. "3.2.1"');
     }
 

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @package redaxo/install
+ * @package redaxo\install
  *
  * @internal
  */

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -37,7 +37,7 @@ class rex_command_install_download extends rex_console_command
         if (null === $version) {
             $versions = [];
             foreach ($files as $fId => $fileMeta) {
-                $versions[$fId] = $fileMeta['version'];
+                $versions[] = $fileMeta['version'];
             }
 
             $version = $io->choice('Please choose a version', $versions);

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -24,7 +24,7 @@ class rex_command_install_download extends rex_console_command
 
         $addonKey = $input->getArgument('addonkey');
 
-        $packages = rex_install_packages::getAddPackages($addonKey);
+        $packages = rex_install_packages::getAddPackages();
         if (!isset($packages[$addonKey])) {
             $io->error(sprintf('AddOn "%s" does not exist!', $addonKey));
             return 1;

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -24,6 +24,11 @@ class rex_command_install_download extends rex_console_command
 
         $addonKey = $input->getArgument('addonkey');
 
+        if (rex_addon::exists($addonKey)) {
+            $io->error(sprintf('AddOn "%s" already exist!', $addonKey));
+            return 1;
+        }
+
         $packages = rex_install_packages::getAddPackages();
         if (!isset($packages[$addonKey])) {
             $io->error(sprintf('AddOn "%s" does not exist!', $addonKey));

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -9,8 +9,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
-class rex_command_install_download extends rex_console_command {
-
+class rex_command_install_download extends rex_console_command
+{
     protected function configure()
     {
         $this->setDescription('Download an AddOn from redaxo.org')
@@ -45,7 +45,7 @@ class rex_command_install_download extends rex_console_command {
 
         // search fileId by version
         $fileId = null;
-        foreach($files as $fId => $fileMeta) {
+        foreach ($files as $fId => $fileMeta) {
             if ($fileMeta['version'] !== $version) {
                 continue;
             }

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -1,0 +1,77 @@
+<?php
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @package redaxo/install
+ *
+ * @internal
+ */
+class rex_command_install_download extends rex_console_command {
+
+    protected function configure()
+    {
+        $this->setDescription('Download an AddOn from redaxo.org')
+            ->addArgument('addonkey', InputArgument::REQUIRED, 'AddOn key e.g. "yform"')
+            ->addArgument('version', InputArgument::OPTIONAL, 'version e.g. "3.2.1"');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = $this->getStyle($input, $output);
+
+        $addonKey = $input->getArgument('addonkey');
+
+        $packages = rex_install_packages::getAddPackages($addonKey);
+        if (!isset($packages[$addonKey])) {
+            $io->error(sprintf('AddOn "%s" does not exist!', $addonKey));
+            return 1;
+        }
+        $package = $packages[$addonKey];
+        $files = $package['files'];
+
+        $version = $input->getArgument('version');
+
+        if (null === $version) {
+            $versions = [];
+            foreach ($files as $fId => $fileMeta) {
+                $versions[$fId] = $fileMeta['version'];
+            }
+
+            $version = $io->choice('Please choose a version', $versions);
+        }
+
+        // search fileId by version
+        $fileId = null;
+        foreach($files as $fId => $fileMeta) {
+            if ($fileMeta['version'] !== $version) {
+                continue;
+            }
+            $fileId = $fId;
+            break;
+        }
+
+        if (!$fileId || !isset($files[$fileId])) {
+            $io->error(sprintf('Version "%s" not found!', $version));
+            return 1;
+        }
+
+        $install = new rex_install_package_add();
+        try {
+            $message = $install->run($addonKey, $fileId);
+        } catch (rex_exception $exception) {
+            $io->error($exception->getMessage());
+            return 1;
+        }
+
+        if ('' !== $message) {
+            $io->error($message);
+            return 1;
+        }
+
+        $io->success(sprintf('AddOn "%s" with version "%s" successfully downloaded', $addonKey, $version));
+        return 0;
+    }
+}

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -15,7 +15,7 @@ class rex_command_install_download extends rex_console_command
     {
         $this->setDescription('Download an AddOn from redaxo.org')
             ->addArgument('addonkey', InputArgument::REQUIRED, 'AddOn key, e.g. "yform"')
-            ->addArgument('version', InputArgument::OPTIONAL, 'version e.g. "3.2.1"');
+            ->addArgument('version', InputArgument::OPTIONAL, 'Version, e.g. "3.2.1"');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -41,7 +41,7 @@ class rex_command_install_download extends rex_console_command
 
         if (null === $version) {
             $versions = [];
-            foreach ($files as $fId => $fileMeta) {
+            foreach ($files as $fileMeta) {
                 $versions[] = $fileMeta['version'];
             }
 

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -76,7 +76,7 @@ class rex_command_install_download extends rex_console_command
             return 1;
         }
 
-        $io->success(sprintf('AddOn "%s" with version "%s" successfully downloaded', $addonKey, $version));
+        $io->success(sprintf('AddOn "%s" with version "%s" successfully downloaded.', $addonKey, $version));
         return 0;
     }
 }

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -27,3 +27,4 @@ requires:
 
 console_commands:
     install:list: rex_command_install_list
+    install:download: rex_command_install_download

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -26,5 +26,5 @@ requires:
 
 
 console_commands:
-    install:list: rex_command_install_list
     install:download: rex_command_install_download
+    install:list: rex_command_install_list


### PR DESCRIPTION
und da isser der `install:download` command um AddOns aus dem Installer via console zu **downloaden**.

`redaxo/bin/console install:download <addonkey> <version>`.

Version ist optional, wenn keine angegeben wird, werden alle verfügbaren Versionen aufgelistet und man per choice() eins auswählen.

