### PR TITLE
Core-Update: Doppel-rename statt löschen+rename

### DIFF
--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -138,7 +138,7 @@ class rex_api_install_core_update extends rex_api_function
             error_clear_last();
             $pathOld = rex_path::src('core.old');
             // move current core to temp path
-            if (@rename($pathCore, $pathOld)) {
+            if (!@rename($pathCore, $pathOld)) {
                 $message = $pathCore.' could not be moved to '.$pathOld;
                 $message .= ($error = error_get_last()) ? ': '.$error['message'] : '.';
                 throw new rex_functional_exception($message);

--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -137,12 +137,15 @@ class rex_api_install_core_update extends rex_api_function
             // move temp dirs to permanent destination
             error_clear_last();
             $pathOld = rex_path::src('core.old');
+            // move current core to temp path
             if (@rename($pathCore, $pathOld)) {
                 $message = $pathCore.' could not be moved to '.$pathOld;
                 $message .= ($error = error_get_last()) ? ': '.$error['message'] : '.';
                 throw new rex_functional_exception($message);
             }
+            // move new core to main core path
             if (@rename($temppath . 'core', $pathCore)) {
+                // remove temp path of old core
                 rex_dir::delete($pathOld);
             } else {
                 // revert to old core


### PR DESCRIPTION
fixes #3291

Bei @alexplusde hatte das so scheinbar geholfen, auch wenn ich immer noch nicht wirklich kapiere, weshalb.