### PR TITLE
Installer: Temp-Dateien besser löschen, Abbruch bei Entpack-Fehler

### DIFF
--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -172,10 +172,11 @@ class rex_api_install_core_update extends rex_api_function
             $message = $e->getMessage();
         } catch (rex_sql_exception $e) {
             $message = 'SQL error: ' . $e->getMessage();
+        } finally {
+            rex_file::delete($archivefile);
+            rex_dir::delete($temppath);
         }
 
-        rex_file::delete($archivefile);
-        rex_dir::delete($temppath);
         if ($message) {
             $message = $installAddon->i18n('warning_core_not_updated') . '<br />' . $message;
             $success = false;

--- a/redaxo/src/addons/install/lib/api/api_package_upload.php
+++ b/redaxo/src/addons/install/lib/api/api_package_upload.php
@@ -52,10 +52,12 @@ class rex_api_install_package_upload extends rex_api_function
             rex_install_webservice::post(rex_install_packages::getPath('?package=' . $addonkey . '&file_id=' . rex_request('file', 'int', 0)), ['file' => $file], $archive);
         } catch (rex_functional_exception $e) {
             throw new rex_api_exception($e->getMessage());
+        } finally {
+            if ($archive) {
+                rex_file::delete($archive);
+            }
         }
-        if ($archive) {
-            rex_file::delete($archive);
-        }
+
         unset($_REQUEST['file']);
         rex_install_packages::deleteCache();
         return new rex_api_result(true, rex_i18n::msg('install_info_addon_uploaded', $addonkey));

--- a/redaxo/src/addons/install/lib/package/package_download.php
+++ b/redaxo/src/addons/install/lib/package/package_download.php
@@ -28,14 +28,18 @@ abstract class rex_install_package_download
 
         $message = '';
         $this->archive = $archivefile;
-        if ($this->file['checksum'] != md5_file($archivefile)) {
-            $message = rex_i18n::msg('install_warning_zip_wrong_checksum');
-        } elseif (!$this->isCorrectFormat($archivefile)) {
-            $message = rex_i18n::msg('install_warning_zip_wrong_format');
-        } elseif (is_string($msg = $this->doAction())) {
-            $message = $msg;
+
+        try {
+            if ($this->file['checksum'] != md5_file($archivefile)) {
+                $message = rex_i18n::msg('install_warning_zip_wrong_checksum');
+            } elseif (!$this->isCorrectFormat($archivefile)) {
+                $message = rex_i18n::msg('install_warning_zip_wrong_format');
+            } elseif (is_string($msg = $this->doAction())) {
+                $message = $msg;
+            }
+        } finally {
+            rex_file::delete($archivefile);
         }
-        rex_file::delete($archivefile);
 
         return $message;
     }


### PR DESCRIPTION
fixes #2286
Zumindest bei Alex trat der Fehler aus dem Issue genau dann auf, wenn der Tempordner noch aus einem früheren Versuch existierte.
Das sollte nun nicht mehr passieren.