### PR TITLE
Installer: command install:update

### DIFF
--- a/redaxo/src/addons/install/lib/command/update.php
+++ b/redaxo/src/addons/install/lib/command/update.php
@@ -69,12 +69,12 @@ class rex_command_install_update extends rex_console_command
         try {
             $message = $install->run($addonKey, $fileId);
         } catch (rex_exception $exception) {
-            $io->error($exception->getMessage());
+            $io->error($this->decodeMessage($exception->getMessage()));
             return 1;
         }
 
         if ('' !== $message) {
-            $io->error($message);
+            $io->error($this->decodeMessage($message));
             return 1;
         }
 

--- a/redaxo/src/addons/install/lib/command/update.php
+++ b/redaxo/src/addons/install/lib/command/update.php
@@ -25,7 +25,6 @@ class rex_command_install_update extends rex_console_command
         /** @var string $addonKey */
         $addonKey = $input->getArgument('addonkey');
 
-
         if (!rex_addon::exists($addonKey)) {
             $io->error(sprintf('AddOn "%s" does not exist!', $addonKey));
             return 1;

--- a/redaxo/src/addons/install/lib/command/update.php
+++ b/redaxo/src/addons/install/lib/command/update.php
@@ -1,0 +1,85 @@
+<?php
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @package redaxo\install
+ *
+ * @internal
+ */
+class rex_command_install_update extends rex_console_command
+{
+    protected function configure()
+    {
+        $this->setDescription('Updates an AddOn from redaxo.org')
+            ->addArgument('addonkey', InputArgument::REQUIRED, 'AddOn key, e.g. "yform"')
+            ->addArgument('version', InputArgument::OPTIONAL, 'Version, e.g. "3.2.1"');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = $this->getStyle($input, $output);
+
+        /** @var string $addonKey */
+        $addonKey = $input->getArgument('addonkey');
+
+
+        if (!rex_addon::exists($addonKey)) {
+            $io->error(sprintf('AddOn "%s" does not exist!', $addonKey));
+            return 1;
+        }
+
+        $packages = rex_install_packages::getUpdatePackages();
+
+        if (!isset($packages[$addonKey])) {
+            $io->error(sprintf('No Updates available for AddOn "%s"!', $addonKey));
+            return 1;
+        }
+        $package = $packages[$addonKey];
+        $files = $package['files'];
+
+        $version = $input->getArgument('version');
+
+        if (null === $version) {
+            $versions = [];
+            foreach ($files as $fileMeta) {
+                $versions[] = $fileMeta['version'];
+            }
+
+            $version = $io->choice('Please choose a version', $versions);
+        }
+
+        // search fileId by version
+        $fileId = null;
+        foreach ($files as $fId => $fileMeta) {
+            if ($fileMeta['version'] !== $version) {
+                continue;
+            }
+            $fileId = $fId;
+            break;
+        }
+
+        if (!$fileId || !isset($files[$fileId])) {
+            $io->error(sprintf('Version "%s" does not exist or is below the current version!', $version));
+            return 1;
+        }
+
+        $install = new rex_install_package_update();
+        try {
+            $message = $install->run($addonKey, $fileId);
+        } catch (rex_exception $exception) {
+            $io->error($exception->getMessage());
+            return 1;
+        }
+
+        if ('' !== $message) {
+            $io->error($message);
+            return 1;
+        }
+
+        $io->success(sprintf('AddOn "%s" successfully updated to version "%s".', $addonKey, $version));
+        return 0;
+    }
+}

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -24,6 +24,7 @@ requires:
         extensions: [zlib]
     redaxo: ^5.5.0
 
+
 console_commands:
     install:download: rex_command_install_download
     install:list: rex_command_install_list

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -24,11 +24,6 @@ requires:
         extensions: [zlib]
     redaxo: ^5.5.0
 
-
-conflicts:
-    packages:
-        sked: '*'
-
 console_commands:
     install:download: rex_command_install_download
     install:list: rex_command_install_list

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -25,6 +25,10 @@ requires:
     redaxo: ^5.5.0
 
 
+conflicts:
+    packages:
+        sked: '*'
+
 console_commands:
     install:download: rex_command_install_download
     install:list: rex_command_install_list

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -28,3 +28,4 @@ requires:
 console_commands:
     install:download: rex_command_install_download
     install:list: rex_command_install_list
+    install:update: rex_command_install_update


### PR DESCRIPTION
_die command maschine hat wieder zugeschlagen._

command `install:update` updated ein AddOn mit Updates von redaxo.org.

`redaxo/bin/console install:update <addonkey> <version>`:
- addonkey: z.B. "yform"
- version: z.B. "1.2.3"

Die Versionsangabe ist optional, wenn keine angegeben ist, werden mögliche Versionen zur Auswahl gestellt (gleich wie im Backend auch sind).

refs #2080 