### PR TITLE
console: install:download - decode html

### DIFF
--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -68,12 +68,12 @@ class rex_command_install_download extends rex_console_command
         try {
             $message = $install->run($addonKey, $fileId);
         } catch (rex_exception $exception) {
-            $io->error($exception->getMessage());
+            $io->error($this->decodeMessage($exception->getMessage()));
             return 1;
         }
 
         if ('' !== $message) {
-            $io->error($message);
+            $io->error($this->decodeMessage($message));
             return 1;
         }
 


### PR DESCRIPTION
im `install:download` wird noch eine html-formatierte Fehlermeldung ausgegeben.

refs #3353 