### PR TITLE
PHPMailer:: setzen der default Verschlüsselung

### DIFF
--- a/redaxo/src/addons/phpmailer/package.yml
+++ b/redaxo/src/addons/phpmailer/package.yml
@@ -36,6 +36,7 @@ default_config:
     encoding: '8bit'
     priority: 0
     smtpsecure: ''
+    security_mode: false
     smtpauth: false
     username: ''
     password: ''


### PR DESCRIPTION
auf manuelle Auswahl. DF User scheinen mit Auto ein Problem zu haben, daher schlage ich als Default-Setting jetzt manuell vor. 
closes: https://github.com/redaxo/redaxo/issues/3006

Bestehende Settings werden nicht verändert

<img width="612" alt="Bildschirmfoto 2020-03-01 um 11 39 17" src="https://user-images.githubusercontent.com/791247/75624096-5dd80a80-5bb1-11ea-8c00-ac08649c0e33.png">
