### PR TITLE
MP: Fallback für alte MM-Versionen entfernt

### DIFF
--- a/redaxo/src/addons/mediapool/pages/media.detail.php
+++ b/redaxo/src/addons/mediapool/pages/media.detail.php
@@ -137,13 +137,8 @@ if ($isImage) {
     $img_max = rex_url::media($fname);
 
     if (rex_addon::get('media_manager')->isAvailable() && 'svg' != rex_file::extension($fname)) {
-        if (method_exists(rex_media_manager::class, 'getUrl')) {
-            $imgn = rex_media_manager::getUrl('rex_mediapool_detail', $encoded_fname, $gf->getDateTimeValue('updatedate'));
-            $img_max = rex_media_manager::getUrl('rex_mediapool_maximized', $encoded_fname, $gf->getDateTimeValue('updatedate'));
-        } else {
-            $imgn = rex_url::backendController(['rex_mediapool_detail' => $type, 'rex_media_file' => $encoded_fname]);
-            $img_max = rex_url::backendController(['rex_mediapool_maximized' => $type, 'rex_media_file' => $encoded_fname]);
-        }
+        $imgn = rex_media_manager::getUrl('rex_mediapool_detail', $encoded_fname, $gf->getDateTimeValue('updatedate'));
+        $img_max = rex_media_manager::getUrl('rex_mediapool_maximized', $encoded_fname, $gf->getDateTimeValue('updatedate'));
 
         $width = '';
     }

--- a/redaxo/src/addons/mediapool/pages/media.list.php
+++ b/redaxo/src/addons/mediapool/pages/media.list.php
@@ -251,12 +251,8 @@ $panel = '
 
                 if (!rex_addon::get('media_manager')->isAvailable()) {
                     $media_manager_url = null;
-                } elseif (method_exists(rex_media_manager::class, 'getUrl')) {
-                    $media_manager_url = [rex_media_manager::class, 'getUrl'];
                 } else {
-                    $media_manager_url = static function ($type, $file, $timestamp) {
-                        return rex_url::backendController(['rex_media_type' => $type, 'rex_media_file' => $file]);
-                    };
+                    $media_manager_url = [rex_media_manager::class, 'getUrl'];
                 }
 
                 $panel .= '<tbody>';


### PR DESCRIPTION
Der MP benötigt inzwischen R5.10, somit brauchen wir den Fallback für alte MM-Versionen nicht mehr.