### PR TITLE
tests: remove unnecessary file creation

### DIFF
--- a/redaxo/src/addons/tests/bin/setup.php
+++ b/redaxo/src/addons/tests/bin/setup.php
@@ -24,8 +24,6 @@ $REX['REDAXO'] = true;
 $REX['HTDOCS_PATH'] = '../';
 $REX['BACKEND_FOLDER'] = 'redaxo';
 
-file_put_contents('data/config.yml', "error_email: info@redaxo.org\n");
-
 // bootstrap core
 require 'src/core/boot.php';
 


### PR DESCRIPTION
ist mir grad mal aufgefallen, da ich in letzter Zeit mal die tests lokal habe laufen lassen, dass eine `redaxo/data/config.yml` angelegt wurde mit dem Inhalt `error_email: info@redaxo.org`.

schätze die kann also weg