### PR TITLE
Normalizer direkt nutzen

### DIFF
--- a/redaxo/src/core/composer.json
+++ b/redaxo/src/core/composer.json
@@ -7,6 +7,7 @@
         "ramsey/http-range": "dev-legacy",
         "roave/security-advisories": "dev-master",
         "symfony/console": "^4.4",
+        "symfony/polyfill-intl-normalizer": "^1.14",
         "symfony/polyfill-mbstring": "^1.14",
         "symfony/var-dumper": "^4.4",
         "symfony/yaml": "^4.4",

--- a/redaxo/src/core/composer.lock
+++ b/redaxo/src/core/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c567e700ff4b865f29968e69f559d285",
+    "content-hash": "f225af4b93069da62baa4d8013300512",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -441,12 +441,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "71174ad65ddde2852b10107ebf2f75d04eb47b43"
+                "reference": "5f81a65d531dc88975b8fe32331cfb8a79c34fe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/71174ad65ddde2852b10107ebf2f75d04eb47b43",
-                "reference": "71174ad65ddde2852b10107ebf2f75d04eb47b43",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5f81a65d531dc88975b8fe32331cfb8a79c34fe3",
+                "reference": "5f81a65d531dc88975b8fe32331cfb8a79c34fe3",
                 "shasum": ""
             },
             "conflict": {
@@ -565,7 +565,7 @@
                 "serluck/phpwhois": "<=4.2.6",
                 "shopware/shopware": "<5.3.7",
                 "silverstripe/admin": ">=1.0.3,<1.0.4|>=1.1,<1.1.1",
-                "silverstripe/assets": ">=1,<1.3.5",
+                "silverstripe/assets": ">=1,<1.3.5|>=1.4,<1.4.4",
                 "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
                 "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
@@ -693,7 +693,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2020-02-29T00:01:08+00:00"
+            "time": "2020-03-02T07:11:48+00:00"
         },
         {
             "name": "symfony/console",

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -31,25 +31,7 @@ class rex_string
      */
     public static function normalizeEncoding($string)
     {
-        static $normalizer;
-
-        if (null === $normalizer) {
-            if (function_exists('normalizer_normalize')) {
-                $normalizer = static function ($string) {
-                    return normalizer_normalize($string, Normalizer::FORM_C);
-                };
-            } else {
-                $normalizer = static function ($string) {
-                    return str_replace(
-                        ["A\xcc\x88", "a\xcc\x88", "O\xcc\x88", "o\xcc\x88", "U\xcc\x88", "u\xcc\x88"],
-                        ['Ä', 'ä', 'Ö', 'ö', 'Ü', 'ü'],
-                        $string
-                    );
-                };
-            }
-        }
-
-        return $normalizer($string);
+        return Normalizer::normalize($string, Normalizer::FORM_C);
     }
 
     /**

--- a/redaxo/src/core/vendor/composer/installed.json
+++ b/redaxo/src/core/vendor/composer/installed.json
@@ -451,12 +451,12 @@
         "source": {
             "type": "git",
             "url": "https://github.com/Roave/SecurityAdvisories.git",
-            "reference": "71174ad65ddde2852b10107ebf2f75d04eb47b43"
+            "reference": "5f81a65d531dc88975b8fe32331cfb8a79c34fe3"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/71174ad65ddde2852b10107ebf2f75d04eb47b43",
-            "reference": "71174ad65ddde2852b10107ebf2f75d04eb47b43",
+            "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5f81a65d531dc88975b8fe32331cfb8a79c34fe3",
+            "reference": "5f81a65d531dc88975b8fe32331cfb8a79c34fe3",
             "shasum": ""
         },
         "conflict": {
@@ -575,7 +575,7 @@
             "serluck/phpwhois": "<=4.2.6",
             "shopware/shopware": "<5.3.7",
             "silverstripe/admin": ">=1.0.3,<1.0.4|>=1.1,<1.1.1",
-            "silverstripe/assets": ">=1,<1.3.5",
+            "silverstripe/assets": ">=1,<1.3.5|>=1.4,<1.4.4",
             "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
             "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
             "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
@@ -685,7 +685,7 @@
             "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
             "zfr/zfr-oauth2-server-module": "<0.1.2"
         },
-        "time": "2020-02-29T00:01:08+00:00",
+        "time": "2020-03-02T07:11:48+00:00",
         "type": "metapackage",
         "notification-url": "https://packagist.org/downloads/",
         "license": [


### PR DESCRIPTION
Da wir das polyfill-intl-normalizer-Paket inzwischen sowieso drin haben, habe ich es als explizite Abhängigkeit reingesetzt, und daher die Fallback-Variante entfernt