### PR TITLE
Cache löschen: auch Opcache leeren

### DIFF
--- a/redaxo/src/core/functions/function_rex_other.php
+++ b/redaxo/src/core/functions/function_rex_other.php
@@ -25,6 +25,10 @@ function rex_delete_cache()
 
     rex_clang::reset();
 
+    if (function_exists('opcache_reset')) {
+        opcache_reset();
+    }
+
     // ----- EXTENSION POINT
     return rex_extension::registerPoint(new rex_extension_point('CACHE_DELETED', rex_i18n::msg('delete_cache_message')));
 }


### PR DESCRIPTION
Schlage vor, dass wenn man den Cache löscht, auch der Opcache geleert wird.

Komme von: https://friendsofredaxo.slack.com/archives/C1BAXLN2F/p1583144983472800