### PR TITLE
disable `html_errors`

### DIFF
--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -33,9 +33,9 @@ if ('cli' !== PHP_SAPI) {
 
 // set arg_separator to get valid html output if session.use_trans_sid is activated
 ini_set('arg_separator.output', '&amp;');
-// make Whoops link to the php.net manual on exception pages, when not configured differently
-if (ini_get('html_errors') && !ini_get('docref_root')) {
-    ini_set('docref_root', "https://php.net/manual/");
+// disable html_erors to avoid html in exceptions and log files
+if (ini_get('html_errors')) {
+    ini_set('html_errors', '0');
 }
 
 require_once __DIR__ . '/lib/util/path.php';

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -33,7 +33,7 @@ if ('cli' !== PHP_SAPI) {
 
 // set arg_separator to get valid html output if session.use_trans_sid is activated
 ini_set('arg_separator.output', '&amp;');
-// disable html_erors to avoid html in exceptions and log files
+// disable html_errors to avoid html in exceptions and log files
 if (ini_get('html_errors')) {
     ini_set('html_errors', '0');
 }

--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -250,10 +250,6 @@ abstract class rex_error_handler
             isset($debug['throw_always_exception']) &&
             (true === $debug['throw_always_exception'] || $errno === ($errno & $debug['throw_always_exception']))
         ) {
-            if (ini_get('html_errors')) {
-                $errstr = htmlspecialchars_decode($errstr);
-            }
-
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
         }
 
@@ -266,15 +262,11 @@ abstract class rex_error_handler
             if ('cli' === PHP_SAPI) {
                 echo self::getErrorType($errno) . ": $errstr in $file on line $errline";
             } else {
-                if (!ini_get('html_errors')) {
-                    $errstr = rex_escape($errstr);
-                }
-
                 $file = rex_escape($file);
                 if ($url = rex_editor::factory()->getUrl($errfile, $errline)) {
                     $file = '<a href="'.rex_escape($url).'">'.$file.'</a>';
                 }
-                echo '<div><b>' . self::getErrorType($errno) . '</b>: '.$errstr." in <b>$file</b> on line <b>$errline</b></div>";
+                echo '<div><b>' . self::getErrorType($errno) . '</b>: '.rex_escape($errstr)." in <b>$file</b> on line <b>$errline</b></div>";
             }
         }
 

--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -250,6 +250,10 @@ abstract class rex_error_handler
             isset($debug['throw_always_exception']) &&
             (true === $debug['throw_always_exception'] || $errno === ($errno & $debug['throw_always_exception']))
         ) {
+            if (ini_get('html_errors')) {
+                $errstr = htmlspecialchars_decode($errstr);
+            }
+
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
         }
 


### PR DESCRIPTION
Ich glaube, dass das nicht 100% korrekt ist, aber es ist aus meiner Sicht schwierig hier 100% korrekt zu sein.
Und ich denke, dass das meist die korrekten Ergebnisse liefert.

Vorher:

<img width="1557" alt="Screenshot 2020-03-03 11 29 32" src="https://user-images.githubusercontent.com/330436/75767330-ef2ab680-5d42-11ea-87c9-67a8e26b240e.png">

Nachher

<img width="1557" alt="Screenshot 2020-03-03 11 29 57" src="https://user-images.githubusercontent.com/330436/75767350-f4880100-5d42-11ea-80d7-b74be5ff9ed1.png">