### PR TITLE
Slice-Message nicht verwerfen

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/pages/content.edit.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.edit.php
@@ -7,9 +7,8 @@ assert(isset($slice_id) && is_int($slice_id));
 assert(isset($template_attributes) && is_array($template_attributes));
 assert(isset($slice_revision) && is_int($slice_revision));
 assert(isset($function) && is_string($function));
-
-$info = '';
-$warning = '';
+assert(isset($info) && is_string($info));
+assert(isset($warning) && is_string($warning));
 
 $apiFunc = rex_api_function::factory();
 if ($apiFunc && $result = $apiFunc->getResult()) {


### PR DESCRIPTION
Beim Speichern eines Slices, erscheint seit 5.9 nicht mehr die Erfolgsmeldung im Block.
Ausgelöst durch https://github.com/redaxo/redaxo/commit/a82804e57ecdfe4f996041fe05c68f07e159a4fc#diff-817fc14243239fae826c8273436ff958

https://friendsofredaxo.slack.com/archives/C1BAXLN2F/p1583258965133600