### PR TITLE
Mediapool: filename unique + bessere Dateinamensgenerierung

### DIFF
--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -43,12 +43,9 @@ function rex_mediapool_filename($FILENAME, $doSubindexing = true)
 
     if ($doSubindexing || $FILENAME != $NFILENAME) {
         // ----- datei schon vorhanden -> namen aendern -> _1 ..
-        if (file_exists(rex_path::media($NFILENAME))) {
-            $cnt = 1;
-            while (file_exists(rex_path::media($NFILE_NAME . '_' . $cnt . $NFILE_EXT))) {
-                ++$cnt;
-            }
-
+        $cnt = 0;
+        while (file_exists(rex_path::media($NFILENAME)) || rex_media::get($NFILENAME)) {
+            ++$cnt;
             $NFILENAME = $NFILE_NAME . '_' . $cnt . $NFILE_EXT;
         }
     }

--- a/redaxo/src/addons/mediapool/install.php
+++ b/redaxo/src/addons/mediapool/install.php
@@ -22,6 +22,7 @@ rex_sql_table::get(rex::getTable('media'))
     ->ensureGlobalColumns()
     ->ensureColumn(new rex_sql_column('revision', 'int(10) unsigned'))
     ->ensureIndex(new rex_sql_index('category_id', ['category_id']))
+    ->ensureIndex(new rex_sql_index('filename', ['filename'], rex_sql_index::UNIQUE))
     ->ensure();
 
 rex_sql_table::get(rex::getTable('media_category'))


### PR DESCRIPTION
fixes #3412

* Die `filename`-Spalte hat nun einen Unique-Index (somit gleichzeitig ein kleiner Schritt für #2786 @alexplusde)
* Bei der suche nach einem freien Dateinamen wird nicht mehr nur nach den physischen Dateien geschaut, sondern auch nach den Datensätzen aus rex_media