### PR TITLE
fix rex_module::getKey()

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -42,14 +42,17 @@ class rex_module
 
     public function getKey(): ?string
     {
+        // key will never be empty string in the db
         if ('' === $this->key) {
-            $this -
+            $this-
 
             $sql = rex_sql::factory();
             $sql->setQuery('select `key` from '. rex::getTable('module') .' where id=?', [$this->module_id]);
 
             if (1 == $sql->getRows()) {
                 $this->key = $sql->getValue('key');
+            } else {
+                $this->key = null;
             }
         }
 

--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -44,7 +44,6 @@ class rex_module
     {
         // key will never be empty string in the db
         if ('' === $this->key) {
-            $this -
 
             $sql = rex_sql::factory();
             $sql->setQuery('select `key` from '. rex::getTable('module') .' where id=?', [$this->module_id]);

--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -39,16 +39,16 @@ class rex_module
         return $this->module_id;
     }
 
-    public function getKey(): string
+    public function getKey(): ?string
     {
         if (null === $this->key) {
-            $this->key = '';
+            $this->key = null;
 
             $sql = rex_sql::factory();
             $sql->setQuery('select `key` from '. rex::getTable('module') .' where id=?', [$this->module_id]);
 
             if (1 == $sql->getRows()) {
-                $this->key = $sql->getValue('key') ?? '';
+                $this->key = $sql->getValue('key');
             }
         }
 

--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -52,7 +52,7 @@ class rex_module
             } else {
                 $this->key = null;
             }
-            assert($this->key !== '');
+            assert('' !== $this->key);
         }
 
         return $this->key;

--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -10,13 +10,14 @@ class rex_module
      */
     private $module_id;
     /**
-     * @var string
+     * @var string|null
      */
     private $key;
 
     public function __construct(int $module_id)
     {
         $this->module_id = $module_id;
+        $this->key = '';
     }
 
     public static function forKey(string $module_key): ?self
@@ -41,8 +42,8 @@ class rex_module
 
     public function getKey(): ?string
     {
-        if (null === $this->key) {
-            $this->key = null;
+        if ('' === $this->key) {
+            $this-
 
             $sql = rex_sql::factory();
             $sql->setQuery('select `key` from '. rex::getTable('module') .' where id=?', [$this->module_id]);

--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -43,7 +43,7 @@ class rex_module
     public function getKey(): ?string
     {
         if ('' === $this->key) {
-            $this-
+            $this -
 
             $sql = rex_sql::factory();
             $sql->setQuery('select `key` from '. rex::getTable('module') .' where id=?', [$this->module_id]);

--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -48,7 +48,7 @@ class rex_module
             $sql->setQuery('select `key` from '. rex::getTable('module') .' where id=?', [$this->module_id]);
 
             if (1 == $sql->getRows()) {
-                $this->key = $sql->getValue('key');
+                $this->key = $sql->getValue('key') ?? '';
             }
         }
 

--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -44,7 +44,7 @@ class rex_module
     {
         // key will never be empty string in the db
         if ('' === $this->key) {
-            $this-
+            $this -
 
             $sql = rex_sql::factory();
             $sql->setQuery('select `key` from '. rex::getTable('module') .' where id=?', [$this->module_id]);

--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -44,7 +44,6 @@ class rex_module
     {
         // key will never be empty string in the db
         if ('' === $this->key) {
-
             $sql = rex_sql::factory();
             $sql->setQuery('select `key` from '. rex::getTable('module') .' where id=?', [$this->module_id]);
 

--- a/redaxo/src/addons/structure/plugins/content/lib/api_module.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_module.php
@@ -52,6 +52,7 @@ class rex_module
             } else {
                 $this->key = null;
             }
+            assert($this->key !== '');
         }
 
         return $this->key;

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -28,12 +28,7 @@ class rex_template
         return rex_config::get('structure/content', 'default_template_id', 1);
     }
 
-    /**
-     * @param string $template_key
-     *
-     * @return null|self
-     */
-    public static function forKey($template_key)
+    public static function forKey(string $template_key): ?self
     {
         $sql = rex_sql::factory()->setQuery(
             'SELECT `id` FROM '.rex::getTable('template').' WHERE `key` = :key',

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -56,6 +56,7 @@ class rex_template
 
     public function getKey(): ?string
     {
+        // key will never be empty string in the db
         if ('' === $this->key) {
             $sql = rex_sql::factory()->setQuery(
                 'SELECT `key` FROM '.rex::getTable('template').' WHERE `id` = :id',

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -58,13 +58,10 @@ class rex_template
         return $this->id;
     }
 
-    /**
-     * @return string
-     */
-    public function getKey()
+    public function getKey(): ?string
     {
         if (null === $this->key) {
-            $this->key = '';
+            $this->key = null;
 
             $sql = rex_sql::factory()->setQuery(
                 'SELECT `key` FROM '.rex::getTable('template').' WHERE `id` = :id',

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -68,6 +68,7 @@ class rex_template
             } else {
                 $this->key = null;
             }
+            assert($this->key !== '');
         }
 
         return $this->key;

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -57,7 +57,6 @@ class rex_template
     public function getKey(): ?string
     {
         if ('' === $this->key) {
-
             $sql = rex_sql::factory()->setQuery(
                 'SELECT `key` FROM '.rex::getTable('template').' WHERE `id` = :id',
                 ['id' => $this->id]

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -57,7 +57,6 @@ class rex_template
     public function getKey(): ?string
     {
         if ('' === $this->key) {
-            $this->key = null;
 
             $sql = rex_sql::factory()->setQuery(
                 'SELECT `key` FROM '.rex::getTable('template').' WHERE `id` = :id',

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -68,7 +68,7 @@ class rex_template
             } else {
                 $this->key = null;
             }
-            assert($this->key !== '');
+            assert('' !== $this->key);
         }
 
         return $this->key;

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -13,13 +13,14 @@ class rex_template
      */
     private $id;
     /**
-     * @var string
+     * @var string|null
      */
     private $key;
 
     public function __construct($template_id)
     {
         $this->id = (int) $template_id;
+        $this->key = '';
     }
 
     public static function getDefaultId()
@@ -60,7 +61,7 @@ class rex_template
 
     public function getKey(): ?string
     {
-        if (null === $this->key) {
+        if ('' === $this->key) {
             $this->key = null;
 
             $sql = rex_sql::factory()->setQuery(
@@ -70,6 +71,8 @@ class rex_template
 
             if (1 == $sql->getRows()) {
                 $this->key = $sql->getValue('key');
+            } else {
+                $this->key = null;
             }
         }
 


### PR DESCRIPTION
Wenn man REX_MODULE_KEY verwendet und es keiner gesetzt wurde, dann kommt aus der Datenbank `null` zurück und da der typehint einen string erwartet kracht es hier.

Dirk hat das gleiche Problem bei `REX_TEMPLATE_KEY` gemeldet, ich kann es aber nicht reproduzieren. Für mich müsste eigentlich wenn an beiden Stellen fliegen, da die ziemlich identisch sind...


**TypeError:** Return value of rex_module::getKey() must be of the type string, null returned
**File:** redaxo/src/addons/structure/plugins/content/lib/api_module.php
**Line:** 55

<details>
<summary>Stacktrace</summary>

| Function                                     | File                                                                       | Line     |
| -------------------------------------------- | -------------------------------------------------------------------------- | -------- |
| rex_module->getKey                           | redaxo/src/addons/structure/plugins/content/lib/article_content_base.php   | 504      |
| rex_article_content_base->replaceVars        | redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php | 77       |
| rex_article_content_editor->outputSlice      | redaxo/src/addons/structure/plugins/content/lib/article_content_base.php   | 356      |
| rex_article_content_base->getArticle         | redaxo/src/addons/structure/plugins/content/lib/article_content.php        | 83       |
| rex_article_content->getArticle              | redaxo/src/addons/structure/plugins/content/pages/content.edit.php         | 34       |
| include                                      | redaxo/src/core/lib/packages/package.php                                   | 245      |
| rex_package->includeFile                     | redaxo/src/core/lib/be/controller.php                                      | 471      |
| rex_be_controller::includePath               | redaxo/src/core/lib/be/controller.php                                      | 428      |
| rex_be_controller::includeCurrentPageSubPath | redaxo/src/addons/structure/plugins/content/pages/content.php              | 427      |
| include                                      | redaxo/src/core/lib/packages/package.php                                   | 245      |
| rex_package->includeFile                     | redaxo/src/core/lib/be/controller.php                                      | 471      |
| rex_be_controller::includePath               | redaxo/src/core/lib/be/controller.php                                      | 413      |
| rex_be_controller::includeCurrentPage        | redaxo/src/core/backend.php                                                | 216      |
| require                                      | redaxo/src/core/boot.php                                                   | 137      |
| require                                      | redaxo/index.php                                                           | 9        |

</details>
<details>
<summary>System report (REDAXO 5.10.0-beta2, PHP 7.4.1)</summary>

| REDAXO        |              |
| ------------: | :----------- |
|       Version | 5.10.0-beta2 |


| PHP           |            |
| ------------: | :--------- |
|       Version | 7.4.1      |
|       OPcache | no         |
|        Xdebug | no         |


| Database      |              |
| ------------: | :----------- |
|       Version | MySQL 5.7.26 |
| Character set | utf8mb4      |


| Server        |            |
| ------------: | :--------- |
|            OS | Darwin     |
|          SAPI | cgi-fcgi   |
|     Webserver | Apache     |


| Request       |                      |
| ------------: | :------------------- |
|       Browser | Chrome/80.0.3987.122 |
|      Protocol | HTTP/1.1             |
|         HTTPS | yes                  |


| Packages            |              |
| ------------------: | :----------- |
|              backup | 2.6.0-beta2  |
|            be_style | 2.10.0-beta2 |
| be_style/customizer | 2.10.0-beta2 |
|     be_style/redaxo | 2.10.0-beta2 |
|       clear_content | 1.0.3        |
|             install | 2.7.0-beta2  |
|       media_manager | 2.9.0-beta2  |
|           mediapool | 2.8.0-beta2  |
|            metainfo | 2.7.0-beta2  |
|               mform | 5.2.4        |
|          mform/docs | 1.0          |
|           phpmailer | 2.8.0-beta2  |
|             project | dev          |
|           structure | 2.10.0-beta2 |
|   structure/content | 2.10.0-beta2 |
|               users | 2.6.1-beta2  |
|               yform | 3.3.1        |
|          yform/docs | 3.3.1        |
|         yform/email | 3.3.1        |
|       yform/manager | 3.3.1        |
|            yrewrite | 2.6          |

</details>