### PR TITLE
console: wrong user - no hard exit

### DIFF
--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -19,9 +19,7 @@ class rex_console_application extends Application
     public function doRun(InputInterface $input, OutputInterface $output)
     {
         try {
-            if (!$this->checkConsoleUser($input, $output)) {
-                return 1;
-            }
+            $this->checkConsoleUser($input, $output);
             return parent::doRun($input, $output);
         } catch (\Exception $e) {
             // catch and rethrow \Exceptions first to only catch fatal errors below (\Exception implements \Throwable)


### PR DESCRIPTION
refs #3287 

ich weiß net warum das doch so drin gelandet ist.... Bin mir sicher wir hatten das in Hannover anders besprochen ; bin bestimmt einfach wieder verpeilt gewesen oder habe gefroren, wer weiß :stuck_out_tongue_winking_eye: 

aktuell sorgt der check dafür, dass ein hard exit gemacht wird, wenn der console user nicht der owner der files ist.