### PR TITLE
Update AntiXSS und escapte script-tags erlauben

### DIFF
--- a/redaxo/src/core/composer.json
+++ b/redaxo/src/core/composer.json
@@ -11,7 +11,7 @@
         "symfony/polyfill-mbstring": "^1.14",
         "symfony/var-dumper": "^4.4",
         "symfony/yaml": "^4.4",
-        "voku/anti-xss": "^4.1"
+        "voku/anti-xss": "^4.1.24"
     },
 
     "replace": {

--- a/redaxo/src/core/composer.lock
+++ b/redaxo/src/core/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f225af4b93069da62baa4d8013300512",
+    "content-hash": "065388d87eff58785f9434cced194a5e",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -441,12 +441,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "5f81a65d531dc88975b8fe32331cfb8a79c34fe3"
+                "reference": "f0eca1ac3194cc94726f0bb366672f38629272b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5f81a65d531dc88975b8fe32331cfb8a79c34fe3",
-                "reference": "5f81a65d531dc88975b8fe32331cfb8a79c34fe3",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/f0eca1ac3194cc94726f0bb366672f38629272b4",
+                "reference": "f0eca1ac3194cc94726f0bb366672f38629272b4",
                 "shasum": ""
             },
             "conflict": {
@@ -497,8 +497,8 @@
                 "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
                 "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2",
                 "ezsystems/ezplatform-user": ">=1,<1.0.1",
-                "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.13.1|>=6,<6.7.9.1|>=6.8,<6.13.5.1|>=7,<7.2.4.1|>=7.3,<7.3.2.1",
-                "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.6|>=5.4,<5.4.12.3|>=2011,<2017.12.4.3|>=2018.6,<2018.6.1.4|>=2018.9,<2018.9.1.3",
+                "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.14.1|>=6,<6.7.9.1|>=6.8,<6.13.6.2|>=7,<7.2.4.1|>=7.3,<7.3.2.1|>=7.5,<7.5.6.2",
+                "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.6|>=5.4,<5.4.14.1|>=2011,<2017.12.7.2|>=2018.6,<2018.6.1.4|>=2018.9,<2018.9.1.3|>=2019.3,<2019.3.4.2",
                 "ezsystems/repository-forms": ">=2.3,<2.3.2.1",
                 "ezyang/htmlpurifier": "<4.1.1",
                 "firebase/php-jwt": "<2",
@@ -693,7 +693,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2020-03-02T07:11:48+00:00"
+            "time": "2020-03-03T17:52:54+00:00"
         },
         {
             "name": "symfony/console",
@@ -1319,16 +1319,16 @@
         },
         {
             "name": "voku/anti-xss",
-            "version": "4.1.22",
+            "version": "4.1.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/anti-xss.git",
-                "reference": "4c23b8b88430834ee3eaee30d2bc373ef1ba19eb"
+                "reference": "4c032aa1aedbf4934418520c61c00b8fad6ca8d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/anti-xss/zipball/4c23b8b88430834ee3eaee30d2bc373ef1ba19eb",
-                "reference": "4c23b8b88430834ee3eaee30d2bc373ef1ba19eb",
+                "url": "https://api.github.com/repos/voku/anti-xss/zipball/4c032aa1aedbf4934418520c61c00b8fad6ca8d5",
+                "reference": "4c032aa1aedbf4934418520c61c00b8fad6ca8d5",
                 "shasum": ""
             },
             "require": {
@@ -1372,20 +1372,20 @@
                 "security",
                 "xss"
             ],
-            "time": "2020-02-06T14:46:13+00:00"
+            "time": "2020-03-08T00:12:04+00:00"
         },
         {
             "name": "voku/portable-ascii",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "a3801f5facf187a28cc2cae7b98a540c36406dc4"
+                "reference": "9fd2b224c71448b5f84aef9d499a1428d79776a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/a3801f5facf187a28cc2cae7b98a540c36406dc4",
-                "reference": "a3801f5facf187a28cc2cae7b98a540c36406dc4",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/9fd2b224c71448b5f84aef9d499a1428d79776a2",
+                "reference": "9fd2b224c71448b5f84aef9d499a1428d79776a2",
                 "shasum": ""
             },
             "require": {
@@ -1421,20 +1421,20 @@
                 "clean",
                 "php"
             ],
-            "time": "2020-02-06T21:46:48+00:00"
+            "time": "2020-03-06T02:47:42+00:00"
         },
         {
             "name": "voku/portable-utf8",
-            "version": "5.4.40",
+            "version": "5.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-utf8.git",
-                "reference": "1b558059a84d566843c8d0a2ba1d9c3051764565"
+                "reference": "e34247dce28f9aebebd2d752d8813b91de689aec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/1b558059a84d566843c8d0a2ba1d9c3051764565",
-                "reference": "1b558059a84d566843c8d0a2ba1d9c3051764565",
+                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/e34247dce28f9aebebd2d752d8813b91de689aec",
+                "reference": "e34247dce28f9aebebd2d752d8813b91de689aec",
                 "shasum": ""
             },
             "require": {
@@ -1495,7 +1495,7 @@
                 "utf-8",
                 "utf8"
             ],
-            "time": "2020-02-22T23:18:32+00:00"
+            "time": "2020-03-06T01:23:48+00:00"
         }
     ],
     "packages-dev": [],

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -221,6 +221,7 @@ class rex_string
         if (!$antiXss) {
             $antiXss = new voku\helper\AntiXSS();
             $antiXss->removeEvilAttributes(['style']);
+            $antiXss->removeNeverAllowedStrAfterwards(['&lt;script&gt;', '&lt;/script&gt;']);
         }
 
         return $antiXss->xss_clean($html);

--- a/redaxo/src/core/tests/util/markdown_test.php
+++ b/redaxo/src/core/tests/util/markdown_test.php
@@ -21,6 +21,20 @@ class rex_markdown_test extends TestCase
             ['', ''],
             ['<p>foo <em>bar</em> <strong>baz</strong></p>', 'foo _bar_ **baz**'],
             ["<p>foo<br />\nbar</p>\n<p>baz</p>", "foo\nbar\n\nbaz"],
+            [
+                <<<'HTML'
+
+<pre><code class="language-php">    &lt;script&gt;foo()&lt;/script&gt;</code></pre>
+HTML
+                ,
+                <<<'MD'
+<script> foo() </script>
+
+```php
+    <script>foo()</script>
+```
+MD
+            ],
         ];
     }
 

--- a/redaxo/src/core/tests/util/string_test.php
+++ b/redaxo/src/core/tests/util/string_test.php
@@ -98,6 +98,10 @@ class rex_string_test extends TestCase
 <a href="javascript:alert(1)">Foo</a>
 <a href="index.php" onclick="alert(1)">Foo</a>
 <img src="foo.jpg" onmouseover="alert(1)"/>
+
+<pre><code>
+    &lt;script&gt; foo() &lt;/script&gt;
+</code></pre>
 INPUT;
 
         $expected = <<<'EXPECTED'
@@ -108,6 +112,10 @@ INPUT;
 <a href="(1)">Foo</a>
 <a href="index.php">Foo</a>
 <img src="foo.jpg" />
+
+<pre><code>
+    &lt;script&gt; foo() &lt;/script&gt;
+</code></pre>
 EXPECTED;
 
         static::assertSame($expected, rex_string::sanitizeHtml($input));

--- a/redaxo/src/core/vendor/composer/installed.json
+++ b/redaxo/src/core/vendor/composer/installed.json
@@ -451,12 +451,12 @@
         "source": {
             "type": "git",
             "url": "https://github.com/Roave/SecurityAdvisories.git",
-            "reference": "5f81a65d531dc88975b8fe32331cfb8a79c34fe3"
+            "reference": "f0eca1ac3194cc94726f0bb366672f38629272b4"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5f81a65d531dc88975b8fe32331cfb8a79c34fe3",
-            "reference": "5f81a65d531dc88975b8fe32331cfb8a79c34fe3",
+            "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/f0eca1ac3194cc94726f0bb366672f38629272b4",
+            "reference": "f0eca1ac3194cc94726f0bb366672f38629272b4",
             "shasum": ""
         },
         "conflict": {
@@ -507,8 +507,8 @@
             "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
             "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2",
             "ezsystems/ezplatform-user": ">=1,<1.0.1",
-            "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.13.1|>=6,<6.7.9.1|>=6.8,<6.13.5.1|>=7,<7.2.4.1|>=7.3,<7.3.2.1",
-            "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.6|>=5.4,<5.4.12.3|>=2011,<2017.12.4.3|>=2018.6,<2018.6.1.4|>=2018.9,<2018.9.1.3",
+            "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.14.1|>=6,<6.7.9.1|>=6.8,<6.13.6.2|>=7,<7.2.4.1|>=7.3,<7.3.2.1|>=7.5,<7.5.6.2",
+            "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.6|>=5.4,<5.4.14.1|>=2011,<2017.12.7.2|>=2018.6,<2018.6.1.4|>=2018.9,<2018.9.1.3|>=2019.3,<2019.3.4.2",
             "ezsystems/repository-forms": ">=2.3,<2.3.2.1",
             "ezyang/htmlpurifier": "<4.1.1",
             "firebase/php-jwt": "<2",
@@ -685,7 +685,7 @@
             "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
             "zfr/zfr-oauth2-server-module": "<0.1.2"
         },
-        "time": "2020-03-02T07:11:48+00:00",
+        "time": "2020-03-03T17:52:54+00:00",
         "type": "metapackage",
         "notification-url": "https://packagist.org/downloads/",
         "license": [
@@ -1349,17 +1349,17 @@
     },
     {
         "name": "voku/anti-xss",
-        "version": "4.1.22",
-        "version_normalized": "4.1.22.0",
+        "version": "4.1.24",
+        "version_normalized": "4.1.24.0",
         "source": {
             "type": "git",
             "url": "https://github.com/voku/anti-xss.git",
-            "reference": "4c23b8b88430834ee3eaee30d2bc373ef1ba19eb"
+            "reference": "4c032aa1aedbf4934418520c61c00b8fad6ca8d5"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/voku/anti-xss/zipball/4c23b8b88430834ee3eaee30d2bc373ef1ba19eb",
-            "reference": "4c23b8b88430834ee3eaee30d2bc373ef1ba19eb",
+            "url": "https://api.github.com/repos/voku/anti-xss/zipball/4c032aa1aedbf4934418520c61c00b8fad6ca8d5",
+            "reference": "4c032aa1aedbf4934418520c61c00b8fad6ca8d5",
             "shasum": ""
         },
         "require": {
@@ -1369,7 +1369,7 @@
         "require-dev": {
             "phpunit/phpunit": "~6.0 || ~7.0"
         },
-        "time": "2020-02-06T14:46:13+00:00",
+        "time": "2020-03-08T00:12:04+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
@@ -1408,17 +1408,17 @@
     },
     {
         "name": "voku/portable-ascii",
-        "version": "1.4.8",
-        "version_normalized": "1.4.8.0",
+        "version": "1.4.9",
+        "version_normalized": "1.4.9.0",
         "source": {
             "type": "git",
             "url": "https://github.com/voku/portable-ascii.git",
-            "reference": "a3801f5facf187a28cc2cae7b98a540c36406dc4"
+            "reference": "9fd2b224c71448b5f84aef9d499a1428d79776a2"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/voku/portable-ascii/zipball/a3801f5facf187a28cc2cae7b98a540c36406dc4",
-            "reference": "a3801f5facf187a28cc2cae7b98a540c36406dc4",
+            "url": "https://api.github.com/repos/voku/portable-ascii/zipball/9fd2b224c71448b5f84aef9d499a1428d79776a2",
+            "reference": "9fd2b224c71448b5f84aef9d499a1428d79776a2",
             "shasum": ""
         },
         "require": {
@@ -1430,7 +1430,7 @@
         "suggest": {
             "ext-intl": "Use Intl for transliterator_transliterate() support"
         },
-        "time": "2020-02-06T21:46:48+00:00",
+        "time": "2020-03-06T02:47:42+00:00",
         "type": "library",
         "installation-source": "dist",
         "autoload": {
@@ -1459,17 +1459,17 @@
     },
     {
         "name": "voku/portable-utf8",
-        "version": "5.4.40",
-        "version_normalized": "5.4.40.0",
+        "version": "5.4.41",
+        "version_normalized": "5.4.41.0",
         "source": {
             "type": "git",
             "url": "https://github.com/voku/portable-utf8.git",
-            "reference": "1b558059a84d566843c8d0a2ba1d9c3051764565"
+            "reference": "e34247dce28f9aebebd2d752d8813b91de689aec"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/voku/portable-utf8/zipball/1b558059a84d566843c8d0a2ba1d9c3051764565",
-            "reference": "1b558059a84d566843c8d0a2ba1d9c3051764565",
+            "url": "https://api.github.com/repos/voku/portable-utf8/zipball/e34247dce28f9aebebd2d752d8813b91de689aec",
+            "reference": "e34247dce28f9aebebd2d752d8813b91de689aec",
             "shasum": ""
         },
         "require": {
@@ -1492,7 +1492,7 @@
             "ext-json": "Use JSON for string detection",
             "ext-mbstring": "Use Mbstring for best performance"
         },
-        "time": "2020-02-22T23:18:32+00:00",
+        "time": "2020-03-06T01:23:48+00:00",
         "type": "library",
         "installation-source": "dist",
         "autoload": {

--- a/redaxo/src/core/vendor/voku/anti-xss/CHANGELOG.md
+++ b/redaxo/src/core/vendor/voku/anti-xss/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 4.1.24 (2020-03-08)
+
+- allow to change the "_never_allowed_str_afterwards" (issue #56)
+- fix false-positive (issue #55)
+
+### 4.1.23 (2020-03-06)
+
+- use some more bad strings from "https://github.com/s0md3v/AwesomeXSS"
+- optimize some regex (use strpos before the regex)
+
+
 ### 4.1.22 (2020-02-06)
 
 - fix false-positive (issue #54)

--- a/redaxo/src/core/vendor/voku/anti-xss/src/voku/helper/AntiXSS.php
+++ b/redaxo/src/core/vendor/voku/anti-xss/src/voku/helper/AntiXSS.php
@@ -65,7 +65,7 @@ final class AntiXSS
     /**
      * @var string[]
      */
-    private static $_never_allowed_str_afterwards = [
+    private $_never_allowed_str_afterwards = [
         '&lt;script&gt;',
         '&lt;/script&gt;',
     ];
@@ -535,12 +535,18 @@ final class AntiXSS
                     if ($tmpAntiXss->isXssFound() === true) {
                         $this->_xss_found = true;
 
-                        $str = \str_ireplace($matchInner, UTF8::rawurldecode($urlPartClean), $str);
+                        $urlPartClean = \str_replace(['&lt;', '&gt;'], ['voku::anti-xss::lt', 'voku::anti-xss::gt'], $urlPartClean);
+                        $urlPartClean = UTF8::rawurldecode($urlPartClean);
+                        $urlPartClean = \str_replace(['voku::anti-xss::lt', 'voku::anti-xss::gt'], ['&lt;', '&gt;'], $urlPartClean);
+
+                        $str = \str_ireplace($matchInner, $urlPartClean, $str);
                     }
                 }
             }
         } else {
+            $str = \str_replace(['&lt;', '&gt;'], ['voku::anti-xss::lt', 'voku::anti-xss::gt'], $str);
             $str = $this->_entity_decode(UTF8::rawurldecode($str));
+            $str = \str_replace(['voku::anti-xss::lt', 'voku::anti-xss::gt'], ['&lt;', '&gt;'], $str);
         }
 
         return $str;
@@ -629,7 +635,7 @@ final class AntiXSS
         // backup the string (for later comparision)
         $str_backup = $str;
 
-        // corrects words before the browser will do it
+        // correct words before the browser will do it
         $str = $this->_compact_exploded_javascript($str);
 
         // remove disallowed javascript calls in links, images etc.
@@ -767,7 +773,7 @@ final class AntiXSS
         }
 
         return (string) \str_ireplace(
-            self::$_never_allowed_str_afterwards,
+            $this->_never_allowed_str_afterwards,
             $this->_replacement,
             $str
         );
@@ -900,9 +906,7 @@ final class AntiXSS
         if (\strpos($str, '=') !== false) {
             $out = '';
             if (\preg_match_all('#\s*[\p{L}0-9_\-\[\]]+\s*=\s*(["\'])(?:[^\1]*?)\\1#ui', $str, $matches)) {
-                foreach ($matches[0] as $match) {
-                    $out .= $match;
-                }
+                $out = \implode('', $matches[0]);
             }
         } else {
             $out = $str;
@@ -1067,7 +1071,7 @@ final class AntiXSS
                         $patternTmp .= $callTmp . ':|';
                     }
                 }
-                $pattern = '#' . $search . '=.*(?:' . $patternTmp . 'window\.|\(?document\)?\.|\.cookie|(?:%3C|<)\s*s\s*c\s*r\s*i\s*p\s*t\s*|d\s*a\s*t\s*a\s*:)#ius';
+                $pattern = '#' . $search . '=.*(?:' . $patternTmp . '\(?window\)?\.|\(?history\)?\.|\(?location\)?\.|\(?document\)?\.|\(?cookie\)?\.|\(?ScriptElement\)?\.|d\s*a\s*t\s*a\s*:)#ius';
                 $matchInner = [];
                 \preg_match($pattern, $match[1], $matchInner);
                 if (\count($matchInner) > 0) {
@@ -1505,11 +1509,46 @@ final class AntiXSS
      */
     private function _sanitize_naughty_javascript($str)
     {
-        $str = (string) \preg_replace(
-            '#(alert|prompt|confirm|cmd|passthru|eval|exec|expression|system|fopen|fsockopen|file|file_get_contents|readfile|unlink)(\s*)\((.*)\)#uisU',
-            '\\1\\2&#40;\\3&#41;',
-            $str
-        );
+        if (\strpos($str, '(') !== false) {
+            $patterns = [
+                'alert',
+                'prompt',
+                'confirm',
+                'cmd',
+                'passthru',
+                'eval',
+                'exec',
+                'execScript',
+                'setTimeout',
+                'setInterval',
+                'setImmediate',
+                'expression',
+                'system',
+                'fopen',
+                'fsockopen',
+                'file',
+                'file_get_contents',
+                'readfile',
+                'unlink',
+            ];
+
+            $found = false;
+            foreach ($patterns as $pattern) {
+                if (\strpos($str, $pattern) !== false) {
+                    $found = true;
+
+                    break;
+                }
+            }
+
+            if ($found === true) {
+                $str = (string) \preg_replace(
+                    '#(' . \implode('|', $patterns) . ')(\s*)\((.*)\)#uisU',
+                    '\\1\\2&#40;\\3&#41;',
+                    $str
+                );
+            }
+        }
 
         return (string) $str;
     }
@@ -1640,6 +1679,27 @@ final class AntiXSS
     }
 
     /**
+     * Add some strings to the "_never_allowed_str_afterwards"-array.
+     *
+     * @param string[] $strings
+     *
+     * @return $this
+     */
+    public function addNeverAllowedStrAfterwards(array $strings): self
+    {
+        if ($strings === []) {
+            return $this;
+        }
+
+        $this->_never_allowed_str_afterwards = \array_merge(
+            $strings,
+            $this->_never_allowed_str_afterwards
+        );
+
+        return $this;
+    }
+
+    /**
      * Check if the "AntiXSS->xss_clean()"-method found an XSS attack in the last run.
      *
      * @return bool|null will return null if the "xss_clean()" wan't running at all
@@ -1731,6 +1791,32 @@ final class AntiXSS
         $this->_never_allowed_on_events_afterwards = \array_diff(
             $this->_never_allowed_on_events_afterwards,
             \array_intersect($strings, $this->_never_allowed_on_events_afterwards)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Remove some strings from the "_never_allowed_str_afterwards"-array.
+     *
+     * <p>
+     * <br />
+     * WARNING: Use this method only if you have a really good reason.
+     * </p>
+     *
+     * @param string[] $strings
+     *
+     * @return $this
+     */
+    public function removeNeverAllowedStrAfterwards(array $strings): self
+    {
+        if ($strings === []) {
+            return $this;
+        }
+
+        $this->_never_allowed_str_afterwards = \array_diff(
+            $this->_never_allowed_str_afterwards,
+            \array_intersect($strings, $this->_never_allowed_str_afterwards)
         );
 
         return $this;

--- a/redaxo/src/core/vendor/voku/portable-ascii/CHANGELOG.md
+++ b/redaxo/src/core/vendor/voku/portable-ascii/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.4.9 (2020-03-06)
+
+- ASCII::to_slugify() -> fix php warning from empty "separator"
+
 ### 1.4.8 (2020-02-06)
 
 - small optimization for "ASCII::to_ascii()" performance

--- a/redaxo/src/core/vendor/voku/portable-ascii/src/voku/helper/ASCII.php
+++ b/redaxo/src/core/vendor/voku/portable-ascii/src/voku/helper/ASCII.php
@@ -879,7 +879,7 @@ final class ASCII
         $str = (string) \preg_replace('/[\\-_\\s]+/', $separator, $str);
 
         $l = \strlen($separator);
-        if (\strpos($str, $separator) === 0) {
+        if ($l && \strpos($str, $separator) === 0) {
             $str = (string) \substr($str, $l);
         }
 

--- a/redaxo/src/core/vendor/voku/portable-utf8/CHANGELOG.md
+++ b/redaxo/src/core/vendor/voku/portable-utf8/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 5.4.41 (2020-03-06)
+
+- fix "UTF8::is_utf8*" -> detecting when last byte is incomplete multibyte character | big thanks @daniel-jeffery 
+
 ### 5.4.40 (2020-02-23)
 
 - fix php notices (run all tests with E_ALL ^ E_USER_WARNING)

--- a/redaxo/src/core/vendor/voku/portable-utf8/src/voku/helper/UTF8.php
+++ b/redaxo/src/core/vendor/voku/portable-utf8/src/voku/helper/UTF8.php
@@ -7918,6 +7918,7 @@ final class UTF8
      *                  <p>An array containing chunks of chars from the input.</p>
      *
      * @noinspection SuspiciousBinaryOperationInspection
+     * @noinspection OffsetOperationsInspection
      */
     public static function str_split(
         $input,
@@ -13482,7 +13483,7 @@ final class UTF8
             }
         }
 
-        if (!self::pcre_utf8_support()) {
+        if (self::$SUPPORT['pcre_utf8']) {
             // If even just the first character can be matched, when the /u
             // modifier is used, then it's valid UTF-8. If the UTF-8 is somehow
             // invalid, nothing at all will match, even if the string contains
@@ -13597,7 +13598,7 @@ final class UTF8
             }
         }
 
-        return true;
+        return $mState === 0;
     }
 
     /**


### PR DESCRIPTION
Das Problem, auf welches ich in https://github.com/redaxo/redaxo/pull/3428 gestoßen bin, wurde gefixt:
https://github.com/voku/anti-xss/issues/55

Außerdem konnte man aktuell im Markdown auch in Code-Blöcken keine script-Tags notieren.
Das ist nun möglich:
https://github.com/voku/anti-xss/issues/56