### PR TITLE
Module: Einfache Var-Ersetzungen vor den richtigen REX_VARs

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -484,7 +484,6 @@ class rex_article_content_base
     protected function replaceVars(rex_sql $sql, $content)
     {
         $content = $this->replaceCommonVars($content);
-        $content = $this->replaceObjectVars($sql, $content);
         $content = str_replace(
             [
                 'REX_MODULE_ID',
@@ -500,6 +499,8 @@ class rex_article_content_base
             ],
             $content
         );
+
+        $content = $this->replaceObjectVars($sql, $content);
 
         return $content;
     }


### PR DESCRIPTION
In https://github.com/redaxo/redaxo/pull/571 wurde die Reihenfolge eigentlich schon mal getauscht, seitdem werden `REX_ARTICLE_ID` etc. vor den eigentlichen REX_VARs wie `REX_VALUE[x]` ersetzt.

Dabei wurden aber nicht die zusätzlichen einfachen Vars der Slices mit nach oben verschoben.
Das hole ich nun nach.

Einserseits will man die innerhalb der echten Vars nutzen können: `REX_CONFIG["REX_MODULE_ID.foo"]`

Andererseits sollen sie gerade nicht im Inhalt der Values ersetzt werden. Aktuell wird ja erst `REX_VALUE[]` ersetzt, und dann `REX_MODULE_ID` etc. Wenn der Redakteur also in einem Block `REX_MODULE_ID` verwendet, wird es auch ersetzt.
Wenn er den Block dann wieder öffnet, sogar auch im Textfeld, es erscheint also nicht mehr der eingegebene Text.