### PR TITLE
console: sync packages with filesystem

### DIFF
--- a/redaxo/src/core/lib/console/package/activate.php
+++ b/redaxo/src/core/lib/console/package/activate.php
@@ -23,7 +23,11 @@ class rex_command_package_activate extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+
+        // the package manager don't know new packages in the addon folder
+        // so we need to make them available
         rex_package_manager::synchronizeWithFileSystem();
+
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/lib/console/package/activate.php
+++ b/redaxo/src/core/lib/console/package/activate.php
@@ -23,6 +23,7 @@ class rex_command_package_activate extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+        rex_package_manager::synchronizeWithFileSystem();
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/lib/console/package/deactivate.php
+++ b/redaxo/src/core/lib/console/package/deactivate.php
@@ -23,6 +23,7 @@ class rex_command_package_deactivate extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+        rex_package_manager::synchronizeWithFileSystem();
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/lib/console/package/deactivate.php
+++ b/redaxo/src/core/lib/console/package/deactivate.php
@@ -23,7 +23,11 @@ class rex_command_package_deactivate extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+
+        // the package manager don't know new packages in the addon folder
+        // so we need to make them available
         rex_package_manager::synchronizeWithFileSystem();
+
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/lib/console/package/delete.php
+++ b/redaxo/src/core/lib/console/package/delete.php
@@ -23,7 +23,11 @@ class rex_command_package_delete extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+
+        // the package manager don't know new packages in the addon folder
+        // so we need to make them available
         rex_package_manager::synchronizeWithFileSystem();
+
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/lib/console/package/delete.php
+++ b/redaxo/src/core/lib/console/package/delete.php
@@ -23,6 +23,7 @@ class rex_command_package_delete extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+        rex_package_manager::synchronizeWithFileSystem();
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/lib/console/package/install.php
+++ b/redaxo/src/core/lib/console/package/install.php
@@ -25,6 +25,7 @@ class rex_command_package_install extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+        rex_package_manager::synchronizeWithFileSystem();
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/lib/console/package/install.php
+++ b/redaxo/src/core/lib/console/package/install.php
@@ -25,7 +25,11 @@ class rex_command_package_install extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+
+        // the package manager don't know new packages in the addon folder
+        // so we need to make them available
         rex_package_manager::synchronizeWithFileSystem();
+
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/lib/console/package/uninstall.php
+++ b/redaxo/src/core/lib/console/package/uninstall.php
@@ -23,6 +23,7 @@ class rex_command_package_uninstall extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+        rex_package_manager::synchronizeWithFileSystem();
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/lib/console/package/uninstall.php
+++ b/redaxo/src/core/lib/console/package/uninstall.php
@@ -23,7 +23,11 @@ class rex_command_package_uninstall extends rex_console_command
         $io = $this->getStyle($input, $output);
 
         $packageId = $input->getArgument('package-id');
+
+        // the package manager don't know new packages in the addon folder
+        // so we need to make them available
         rex_package_manager::synchronizeWithFileSystem();
+
         $package = rex_package::get($packageId);
         if (!$package instanceof rex_package) {
             $io->error('Package "'.$packageId.'" doesn\'t exists!');

--- a/redaxo/src/core/pages/packages.php
+++ b/redaxo/src/core/pages/packages.php
@@ -95,6 +95,8 @@ if ('license' == $subpage) {
 
 // ----------------- OUT
 if ('' == $subpage) {
+    // the package manager don't know new packages in the addon folder
+    // so we need to make them available
     rex_package_manager::synchronizeWithFileSystem();
 
     $toolbar = '


### PR DESCRIPTION
wenn man ein AddOn in den `src/addons/` ordner legt, kennen die `package:` commands dieses nicht, da dies noch nicht, wie auf Addon-Page passiert, gesynct ist.