### PR TITLE
rex_sql_table: Teils falsche Spaltenreihenfolge bei ensureGlobalColumns

### DIFF
--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -82,7 +82,7 @@ require_once rex_path::core('functions/function_rex_globals.php');
 require_once rex_path::core('functions/function_rex_other.php');
 
 // ----------------- VERSION
-rex::setProperty('version', '5.10.0');
+rex::setProperty('version', '5.10.1-dev');
 
 $cacheFile = rex_path::coreCache('config.yml.cache');
 $configFile = rex_path::coreData('config.yml');

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -658,10 +658,20 @@ class rex_sql_table
             $previous = $name;
         }
 
+        $implicitReversedPositions = array_flip($this->positions);
+
         foreach ($positions as $name => $after) {
             // unset is necessary to add new position as last array element
             unset($this->positions[$name]);
             $this->positions[$name] = $after;
+
+            if (isset($implicitReversedPositions[$after])) {
+                // move the implicitly after `$after` positioned column
+                // after the one that was explicitly positioned at that position
+                $this->positions[$implicitReversedPositions[$after]] = $name;
+                $implicitReversedPositions[$name] = $implicitReversedPositions[$after];
+                unset($implicitReversedPositions[$after]);
+            }
         }
 
         $this->alter();

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -600,6 +600,26 @@ class rex_sql_table_test extends TestCase
         static::assertTrue($table->hasIndex('i_description'));
     }
 
+    public function testEnsureWithEnsureGlobalColumns(): void
+    {
+        $expectedOrder = ['id', 'title', 'createdate', 'createuser', 'updatedate', 'updateuser', 'revision'];
+
+        for ($i = 1; $i <= 2; ++$i) {
+            $table = rex_sql_table::get(self::TABLE);
+            $table
+                ->ensurePrimaryIdColumn()
+                ->ensureColumn(new rex_sql_column('title', 'varchar(255)'))
+                ->ensureGlobalColumns()
+                ->ensureColumn(new rex_sql_column('revision', 'tinyint(1)'))
+                ->ensure();
+
+            rex_sql_table::clearInstance(self::TABLE);
+            $table = rex_sql_table::get(self::TABLE);
+
+            static::assertSame($expectedOrder, array_keys($table->getColumns()), "Column order does not match expected order (\$i = $i)");
+        }
+    }
+
     public function testRenameNonExistingTable()
     {
         $this->expectException(rex_exception::class);


### PR DESCRIPTION
```php
            rex_sql_table::get($table)
                ->ensurePrimaryIdColumn()
                ->ensureColumn(new rex_sql_column('title', 'varchar(255)'))
                ->ensureGlobalColumns()
                ->ensureColumn(new rex_sql_column('revision', 'tinyint(1)'))
                ->ensure();
```

Bei diesem Code wechselt bei jeder Ausführung die `revision`-Spalte die Position.
Sie wechselt immer zwischen ganz hinten nach `updateuser` und der Position nach der ersten "global column", also nach `createdate`.