### PR TITLE
Installer: added rex_install

### DIFF
--- a/redaxo/src/addons/install/lib/install.php
+++ b/redaxo/src/addons/install/lib/install.php
@@ -50,7 +50,8 @@ class rex_install
     }
 
     /**
-     * Updates an AddOn from redaxo.org.
+     * Updates an already downloaded AddOn from redaxo.org with a newer version.
+     * The AddOn is not required to be installed beforehand.
      *
      * @param string $addonKey e.g. "yform"
      * @param string $version  e.g. "3.2.1"

--- a/redaxo/src/addons/install/lib/install.php
+++ b/redaxo/src/addons/install/lib/install.php
@@ -61,7 +61,7 @@ class rex_install
     public function updateAddon(string $addonKey, string $version): void
     {
         if (!rex_addon::exists($addonKey)) {
-            throw new rex_exception(sprintf('AddOn "%s" don\'t exists!', $addonKey));
+            throw new rex_exception(sprintf('AddOn "%s" does not exist!', $addonKey));
         }
 
         $packages = rex_install_packages::getUpdatePackages();

--- a/redaxo/src/addons/install/lib/install.php
+++ b/redaxo/src/addons/install/lib/install.php
@@ -11,19 +11,17 @@ class rex_install
      * @param string $addonKey e.g. "yform"
      * @param string $version  e.g. "3.2.1"
      *
-     * @throws rex_functional_exception
-     *
-     * @return bool|string
+     * @throws rex_exception
      */
-    public function downloadAddon(string $addonKey, string $version)
+    public function downloadAddon(string $addonKey, string $version): void
     {
         if (rex_addon::exists($addonKey)) {
-            throw new rex_functional_exception(sprintf('AddOn "%s" already exists!', $addonKey));
+            throw new rex_exception(sprintf('AddOn "%s" already exists!', $addonKey));
         }
 
         $packages = rex_install_packages::getAddPackages();
         if (!isset($packages[$addonKey])) {
-            throw new rex_functional_exception(sprintf('AddOn "%s" does not exist!', $addonKey));
+            throw new rex_exception(sprintf('AddOn "%s" does not exist!', $addonKey));
         }
         $package = $packages[$addonKey];
         $files = $package['files'];
@@ -39,17 +37,15 @@ class rex_install
         }
 
         if (!$fileId || !isset($files[$fileId])) {
-            throw new rex_functional_exception(sprintf('Version "%s" not found!', $version));
+            throw new rex_exception(sprintf('Version "%s" not found!', $version));
         }
 
         $install = new rex_install_package_add();
         $message = $install->run($addonKey, $fileId);
 
         if ('' !== $message) {
-            return $message;
+            throw new rex_exception($message);
         }
-
-        return true;
     }
 
     /**
@@ -58,20 +54,18 @@ class rex_install
      * @param string $addonKey e.g. "yform"
      * @param string $version  e.g. "3.2.1"
      *
-     * @throws rex_functional_exception
-     *
-     * @return bool|string
+     * @throws rex_exception
      */
-    public function updateAddon(string $addonKey, string $version)
+    public function updateAddon(string $addonKey, string $version): void
     {
         if (!rex_addon::exists($addonKey)) {
-            throw new rex_functional_exception(sprintf('AddOn "%s" don\'t exists!', $addonKey));
+            throw new rex_exception(sprintf('AddOn "%s" don\'t exists!', $addonKey));
         }
 
         $packages = rex_install_packages::getUpdatePackages();
 
         if (!isset($packages[$addonKey])) {
-            throw new rex_functional_exception(sprintf('No Updates available for AddOn "%s"!', $addonKey));
+            throw new rex_exception(sprintf('No Updates available for AddOn "%s"!', $addonKey));
         }
         $package = $packages[$addonKey];
         $files = $package['files'];
@@ -87,16 +81,14 @@ class rex_install
         }
 
         if (!$fileId || !isset($files[$fileId])) {
-            throw new rex_functional_exception(sprintf('Version "%s" does not exist or is below the current version!', $version));
+            throw new rex_exception(sprintf('Version "%s" does not exist or is below the current version!', $version));
         }
 
         $install = new rex_install_package_update();
         $message = $install->run($addonKey, $fileId);
 
         if ('' !== $message) {
-            return $message;
+            throw new rex_exception($message);
         }
-
-        return true;
     }
 }

--- a/redaxo/src/addons/install/lib/install.php
+++ b/redaxo/src/addons/install/lib/install.php
@@ -6,7 +6,8 @@
 class rex_install
 {
     /**
-     * Download an AddOn from redaxo.org.
+     * Downloads and unzips a AddOn from redaxo.org into the AddOns folder.
+     * Installation and Activation needs to be triggered in a separate step.
      *
      * @param string $addonKey e.g. "yform"
      * @param string $version  e.g. "3.2.1"

--- a/redaxo/src/addons/install/lib/install.php
+++ b/redaxo/src/addons/install/lib/install.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @package redaxo\install
+ */
+class rex_install {
+
+    /**
+     * Download an AddOn from redaxo.org
+     *
+     * @param string $addonKey e.g. "yform"
+     * @param string $version e.g. "3.2.1"
+     * @return bool|string
+     * @throws rex_functional_exception
+     */
+    public function downloadAddon(string $addonKey, string $version) {
+        if (rex_addon::exists($addonKey)) {
+            throw new rex_functional_exception(sprintf('AddOn "%s" already exists!', $addonKey));
+        }
+
+        $packages = rex_install_packages::getAddPackages();
+        if (!isset($packages[$addonKey])) {
+           throw new rex_functional_exception(sprintf('AddOn "%s" does not exist!', $addonKey));
+        }
+        $package = $packages[$addonKey];
+        $files = $package['files'];
+
+        // search fileId by version
+        $fileId = null;
+        foreach ($files as $fId => $fileMeta) {
+            if ($fileMeta['version'] !== $version) {
+                continue;
+            }
+            $fileId = $fId;
+            break;
+        }
+
+        if (!$fileId || !isset($files[$fileId])) {
+            throw new rex_functional_exception(sprintf('Version "%s" not found!', $version));
+        }
+
+        $install = new rex_install_package_add();
+        $message = $install->run($addonKey, $fileId);
+
+        if ('' !== $message) {
+            return $message;
+        }
+
+        return true;
+    }
+
+    /**
+     * Updates an AddOn from redaxo.org
+     *
+     * @param string $addonKey e.g. "yform"
+     * @param string $version e.g. "3.2.1"
+     * @return bool|string
+     * @throws rex_functional_exception
+     */
+    public function updateAddon(string $addonKey, string $version) {
+        if (!rex_addon::exists($addonKey)) {
+            throw new rex_functional_exception(sprintf('AddOn "%s" don\'t exists!', $addonKey));
+        }
+
+        $packages = rex_install_packages::getUpdatePackages();
+
+        if (!isset($packages[$addonKey])) {
+            throw new rex_functional_exception(sprintf('No Updates available for AddOn "%s"!', $addonKey));
+        }
+        $package = $packages[$addonKey];
+        $files = $package['files'];
+
+        // search fileId by version
+        $fileId = null;
+        foreach ($files as $fId => $fileMeta) {
+            if ($fileMeta['version'] !== $version) {
+                continue;
+            }
+            $fileId = $fId;
+            break;
+        }
+
+        if (!$fileId || !isset($files[$fileId])) {
+            throw new rex_functional_exception(sprintf('Version "%s" does not exist or is below the current version!', $version));
+        }
+
+        $install = new rex_install_package_update();
+        $message = $install->run($addonKey, $fileId);
+
+        if ('' !== $message) {
+            return $message;
+        }
+
+        return true;
+    }
+}

--- a/redaxo/src/addons/install/lib/install.php
+++ b/redaxo/src/addons/install/lib/install.php
@@ -3,24 +3,27 @@
 /**
  * @package redaxo\install
  */
-class rex_install {
-
+class rex_install
+{
     /**
-     * Download an AddOn from redaxo.org
+     * Download an AddOn from redaxo.org.
      *
      * @param string $addonKey e.g. "yform"
-     * @param string $version e.g. "3.2.1"
-     * @return bool|string
+     * @param string $version  e.g. "3.2.1"
+     *
      * @throws rex_functional_exception
+     *
+     * @return bool|string
      */
-    public function downloadAddon(string $addonKey, string $version) {
+    public function downloadAddon(string $addonKey, string $version)
+    {
         if (rex_addon::exists($addonKey)) {
             throw new rex_functional_exception(sprintf('AddOn "%s" already exists!', $addonKey));
         }
 
         $packages = rex_install_packages::getAddPackages();
         if (!isset($packages[$addonKey])) {
-           throw new rex_functional_exception(sprintf('AddOn "%s" does not exist!', $addonKey));
+            throw new rex_functional_exception(sprintf('AddOn "%s" does not exist!', $addonKey));
         }
         $package = $packages[$addonKey];
         $files = $package['files'];
@@ -50,14 +53,17 @@ class rex_install {
     }
 
     /**
-     * Updates an AddOn from redaxo.org
+     * Updates an AddOn from redaxo.org.
      *
      * @param string $addonKey e.g. "yform"
-     * @param string $version e.g. "3.2.1"
-     * @return bool|string
+     * @param string $version  e.g. "3.2.1"
+     *
      * @throws rex_functional_exception
+     *
+     * @return bool|string
      */
-    public function updateAddon(string $addonKey, string $version) {
+    public function updateAddon(string $addonKey, string $version)
+    {
         if (!rex_addon::exists($addonKey)) {
             throw new rex_functional_exception(sprintf('AddOn "%s" don\'t exists!', $addonKey));
         }

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -1,5 +1,5 @@
 package: install
-version: '2.7.0'
+version: '2.8.0-dev'
 author: Gregor Harlan
 supportpage: www.redaxo.org/de/forum
 


### PR DESCRIPTION
eine kleine Klasse, abgeleitet aus den Commands, damit man einfacher in Skripten AddOns downloaden und updaten kann.

(use-case für mich; vereinfachen der demos)

Beispiele für die Doku
```php
$installer = new rex_install();

// lade yform in der Version 3.2.1 herunter.
$installer->downloadAddon('yform', '3.2.1');

// update yform auf die Version 3.2.1
$installer->updateAddon('yform', '3.2.1');
```

