### PR TITLE
Addonverwaltung: Whoops vermeiden, wenn Version nicht gesetzt

### DIFF
--- a/redaxo/src/core/pages/packages.php
+++ b/redaxo/src/core/pages/packages.php
@@ -183,10 +183,13 @@ if ('' == $subpage) {
             $class = ' mark';
         }
 
-        $version = ('' != trim($package->getVersion())) ? ' <span class="rex-' . $type . '-version">' . trim($package->getVersion()) . '</span>' : '';
+        $version = '';
+        if ('' !== trim($package->getVersion())) {
+            $version = ' <span class="rex-' . $type . '-version">' . trim($package->getVersion()) . '</span>';
 
-        if (rex_version::isUnstable($package->getVersion())) {
-            $version = '<i class="rex-icon rex-icon-unstable-version" title="'. rex_i18n::msg('unstable_version') .'"></i> '. $version;
+            if (rex_version::isUnstable($package->getVersion())) {
+                $version = '<i class="rex-icon rex-icon-unstable-version" title="'. rex_i18n::msg('unstable_version') .'"></i> '. $version;
+            }
         }
 
         $license = '';


### PR DESCRIPTION
fixes #3449


Addons ohne Version lassen sich nicht installieren, deswegen muss man es an den anderen Stellen nicht berücksichtigen, denke ich.