### PR TITLE
fix accesskey shortcuts

### DIFF
--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -1,5 +1,5 @@
 package: mediapool
-version: '2.8.0'
+version: '2.8.1-dev'
 author: 'Jan Kristinus'
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/mediapool/pages/sync.php
+++ b/redaxo/src/addons/mediapool/pages/sync.php
@@ -146,7 +146,7 @@ if ($PERMALL) {
             <script type="text/javascript">
                 jQuery(document).ready(function($){
                     $("input[name=\'sync_files[]\']").change(function() {
-                        $(this).closest(\'form\').find("[type=\'submit\']").attr("disabled", $("input[name=\'sync_files[]\']:checked").size() == 0);
+                        $(this).closest(\'form\').find("[type=\'submit\']").attr("disabled", $("input[name=\'sync_files[]\']:checked").length == 0);
                     }).change();
                     $("#rex-js-checkie").change(function() {
                         $("input[name=\'sync_files[]\']").change();

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -411,7 +411,7 @@ jQuery(function($){
         var key = String.fromCharCode(event.which);
         var haystack = $("input[accesskey='"+ key +"'], button[accesskey='"+ key +"']");
 
-        if(haystack.size() > 0)
+        if(haystack.length > 0)
         {
             $(haystack.get(0)).click();
             return false;
@@ -420,7 +420,7 @@ jQuery(function($){
         {
             haystack = $("a[accesskey='"+ key +"']");
 
-            if(haystack.size() > 0)
+            if(haystack.length > 0)
             {
                 var hit = $(haystack.get(0));
                 if(hit.attr("onclick") != undefined)


### PR DESCRIPTION
fixes #3457 

.size() gibt es in jQuery net mehr

> Note: This method has been removed in jQuery 3.0. Use the .length property instead.

siehe [jquery docs](https://api.jquery.com/size/)


dieser fehler ist vermutlich seit #3095 vorhanden.

