### PR TITLE
structure: wrong i18n keys

### DIFF
--- a/redaxo/src/addons/structure/package.yml
+++ b/redaxo/src/addons/structure/package.yml
@@ -1,5 +1,5 @@
 package: structure
-version: '2.10.0'
+version: '2.10.1-dev'
 author: Markus Staab
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/structure/plugins/content/package.yml
+++ b/redaxo/src/addons/structure/plugins/content/package.yml
@@ -1,5 +1,5 @@
 package: structure/content
-version: '2.10.0'
+version: '2.10.1-dev'
 author: Markus Staab
 supportpage: www.redaxo.org/de/forum/
 

--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -578,10 +578,10 @@ if ($OUT) {
     $list->setColumnLayout(rex_i18n::msg('header_template_functions'), ['<th class="rex-table-action" colspan="2">###VALUE###</th>', '<td class="rex-table-action">###VALUE###</td>']);
     $list->setColumnParams(rex_i18n::msg('header_template_functions'), ['function' => 'edit', 'template_id' => '###id###']);
 
-    $list->addColumn(rex_i18n::msg('template_delete'), '<i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('delete'));
-    $list->setColumnLayout(rex_i18n::msg('template_delete'), ['', '<td class="rex-table-action">###VALUE###</td>']);
-    $list->setColumnParams(rex_i18n::msg('template_delete'), ['function' => 'delete', 'template_id' => '###id###'] + $csrfToken->getUrlParams());
-    $list->addLinkAttribute(rex_i18n::msg('template_delete'), 'data-confirm', rex_i18n::msg('confirm_delete_template'));
+    $list->addColumn(rex_i18n::msg('delete_template'), '<i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('delete'));
+    $list->setColumnLayout(rex_i18n::msg('delete_template'), ['', '<td class="rex-table-action">###VALUE###</td>']);
+    $list->setColumnParams(rex_i18n::msg('delete_template'), ['function' => 'delete', 'template_id' => '###id###'] + $csrfToken->getUrlParams());
+    $list->addLinkAttribute(rex_i18n::msg('delete_template'), 'data-confirm', rex_i18n::msg('confirm_delete_template'));
 
     $list->setNoRowsMessage(rex_i18n::msg('templates_not_found'));
 


### PR DESCRIPTION
Beim weiterentwickeln des debug-addons ist mir aufgefallen, dass hier ein Dreher bei den i18n-keys drin war.

es gibt nur i18n-key mit `delete_template` aber nicht `template_delete`.

(In der Liste der getriggerten ExtensionPoints)
![image](https://user-images.githubusercontent.com/21292755/76641591-1b6be180-6552-11ea-97d2-f5f765b4ebcf.png)
