### PR TITLE
rex_sql_table: column sorting korrigiert

### DIFF
--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -975,17 +975,31 @@ class rex_sql_table
             }
         }
 
-        foreach ($this->positions as $name => $after) {
-            $insert = [$name => $this->columns[$name]];
+        while ($count = count($this->positions)) {
+            foreach ($this->positions as $name => $after) {
+                $insert = [$name => $this->columns[$name]];
 
-            if (self::FIRST === $after) {
-                $columns = $insert + $columns;
+                if (self::FIRST === $after) {
+                    $columns = $insert + $columns;
+                    unset($this->positions[$name]);
 
-                continue;
+                    continue;
+                }
+
+                if (!isset($columns[$after])) {
+                    continue;
+                }
+
+                $offset = array_search($after, array_keys($columns));
+                assert(is_int($offset));
+                ++$offset;
+                $columns = array_slice($columns, 0, $offset) + $insert + array_slice($columns, $offset);
+                unset($this->positions[$name]);
             }
 
-            $offset = array_search($after, array_keys($columns)) + 1;
-            $columns = array_slice($columns, 0, $offset) + $insert + array_slice($columns, $offset);
+            if ($count === count($this->positions)) {
+                throw new LogicException('Columns can not be sorted because some explicit positions do not exist.');
+            }
         }
 
         $this->columns = $columns;

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -555,6 +555,7 @@ class rex_sql_table_test extends TestCase
         $table = rex_sql_table::get(self::TABLE);
         $table
             ->ensureColumn(new rex_sql_column('title', 'varchar(255)', false, 'Default title'))
+            ->ensureColumn(new rex_sql_column('teaser', 'varchar(255)', false))
             ->ensureColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment'), rex_sql_table::FIRST)
             ->ensureColumn(new rex_sql_column('status', 'tinyint(1)'))
             ->ensureColumn(new rex_sql_column('timestamp', 'datetime', true))
@@ -565,7 +566,7 @@ class rex_sql_table_test extends TestCase
             ->ensure();
 
         static::assertTrue($table->exists());
-        static::assertSame(['id', 'title', 'description', 'status', 'timestamp'], array_keys($table->getColumns()));
+        static::assertSame(['id', 'title', 'description', 'teaser', 'status', 'timestamp'], array_keys($table->getColumns()));
         static::assertTrue($table->hasIndex('i_status_timestamp'));
         static::assertTrue($table->hasIndex('i_description'));
 
@@ -577,11 +578,12 @@ class rex_sql_table_test extends TestCase
             ->ensureColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment'))
             ->ensureColumn(new rex_sql_column('status', 'tinyint(1)'))
             ->ensureColumn(new rex_sql_column('title', 'varchar(20)', false), 'timestamp')
+            ->ensureColumn(new rex_sql_column('teaser', 'varchar(255)', false), 'status')
             ->setPrimaryKey(['id', 'title'])
             ->ensureIndex(new rex_sql_index('i_status_timestamp', ['status', 'timestamp'], rex_sql_index::UNIQUE))
             ->ensure();
 
-        $expectedOrder = ['timestamp', 'title', 'id', 'status', 'description'];
+        $expectedOrder = ['timestamp', 'title', 'id', 'status', 'teaser', 'description'];
 
         static::assertSame($expectedOrder, array_keys($table->getColumns()));
         static::assertTrue($table->hasIndex('i_status_timestamp'));


### PR DESCRIPTION
Die Columns wurden zwar in den DB richtig sortiert, nur im table-objekt waren sie danach nicht richtig.