### PR TITLE
Setup: Passwortregeln berücksichtigen

### DIFF
--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -267,6 +267,11 @@ if (7 === $step) {
             $errors[] = rex_view::error(rex_i18n::msg('setup_602'));
         }
 
+        $passwordPolicy = rex_backend_password_policy::factory(rex::getProperty('password_policy', []));
+        if (true !== $msg = $passwordPolicy->check($redaxo_user_pass)) {
+            $errors[] = rex_view::error($msg);
+        }
+
         if (0 == count($errors)) {
             $ga = rex_sql::factory();
             $ga->setQuery('select * from ' . rex::getTablePrefix() . 'user where login = ? ', [$redaxo_user_login]);
@@ -276,7 +281,7 @@ if (7 === $step) {
             } else {
                 // the server side encryption of pw is only required
                 // when not already encrypted by client using javascript
-                $redaxo_user_pass = rex_login::passwordHash($redaxo_user_pass, rex_post('javascript', 'boolean'));
+                $redaxo_user_pass = rex_login::passwordHash($redaxo_user_pass);
 
                 $user = rex_sql::factory();
                 // $user->setDebug();

--- a/redaxo/src/core/pages/setup.step6.php
+++ b/redaxo/src/core/pages/setup.step6.php
@@ -18,7 +18,6 @@ $content = '';
 
 $content .= '
         <fieldset>
-            <input class="rex-js-javascript" type="hidden" name="javascript" value="0" />
             ';
 
 $redaxo_user_login = rex_post('redaxo_user_login', 'string');
@@ -51,7 +50,7 @@ $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="rex-form-redaxo-user-pass">' . rex_i18n::msg('setup_608') . '</label>';
-$n['field'] = '<input class="form-control rex-js-redaxo-user-pass" type="password" value="' . rex_escape($redaxo_user_pass) . '" id="rex-form-redaxo-user-pass" name="redaxo_user_pass" />';
+$n['field'] = '<input class="form-control" type="password" value="' . rex_escape($redaxo_user_pass) . '" id="rex-form-redaxo-user-pass" name="redaxo_user_pass" />';
 $formElements[] = $n;
 
 $fragment = new rex_fragment();
@@ -75,17 +74,6 @@ $content .= '
     <script type="text/javascript">
          <!--
         jQuery(function($) {
-            $(".rex-js-createadminform")
-                .submit(function(){
-                    var pwInp = $(".rex-js-redaxo-user-pass");
-                    if(pwInp.val() != "") {
-                        $(".rex-js-createadminform").append(\'<input type="hidden" name="\'+pwInp.attr("name")+\'" value="\'+Sha1.hash(pwInp.val())+\'" />\');
-                        pwInp.removeAttr("name");
-                    }
-            });
-
-            $(".rex-js-javascript").val("1");
-
             $(".rex-js-createadminform .rex-js-noadmin").on("change",function (){
 
                 if($(this).is(":checked")) {


### PR DESCRIPTION
Beim Setzen eines Passworts werden überall die Passwortregeln geprüft, nur im Web-Setup nicht (im Console-Setup schon).
Ich denke, wir sollte die auch im Web-Setup testen.

Ich musste dafür an der Stelle das Prehashing rausnehmen (so, wie wir es auch schon an den anderen Stellen gemacht haben). Beim Login ist es weiterhin drin.