### PR TITLE
$imagick->setResolution wurde ignoriert

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php
@@ -65,6 +65,7 @@ class rex_effect_convert2img extends rex_effect_abstract
 
         if (class_exists(Imagick::class)) {
             $imagick = new Imagick();
+            $imagick->setResolution($density, $density);
             $imagick->readImage($from_path.'[0]');
 
             if ('' != $color) {
@@ -73,7 +74,6 @@ class rex_effect_convert2img extends rex_effect_abstract
                 $imagick->mergeImageLayers(Imagick::LAYERMETHOD_FLATTEN);
             }
 
-            $imagick->setResolution($density, $density);
             $imagick->setImageColorspace(Imagick::COLORSPACE_RGB);
             $imagick->setImageFormat($convert_to['ext']);
 


### PR DESCRIPTION
man muss die Resolution setzen bevor das man Bild einlest, ansonsten wird diese Methode ignoriert