### PR TITLE
Optional explizit Passwortänderung erfordern

### DIFF
--- a/redaxo/src/addons/users/lang/de_de.lang
+++ b/redaxo/src/addons/users/lang/de_de.lang
@@ -26,6 +26,7 @@ user_options = Optionen
 user_extras = Extras
 last_login = Letzter Login
 user_caption = Liste der angelegten Benutzer
+user_password_change_required = Passwort muss nach Login ausgetauscht werden
 user_status = User ist aktiv
 startpage = Startseite
 

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -267,6 +267,7 @@ if ($warnings) {
         }
     }
 } else {
+    // default value for new users (for existing users it is replaced after reading the user from db)
     $passwordChangeRequired = true;
 }
 
@@ -287,7 +288,8 @@ $SHOW = true;
 if ('' != $FUNC_ADD || $user_id > 0) {
     $SHOW = false;
 
-    $self = false;
+    // whether the user is editing his own account
+    $self = $user && $user->getId() == $user_id;
 
     $statuschecked = '';
     if ('' != $FUNC_ADD) {
@@ -359,8 +361,6 @@ if ('' != $FUNC_ADD || $user_id > 0) {
         $sel_role->setSelected($userrole);
         $sel_be_sprache->setSelected($userperm_be_sprache);
         $sel_startpage->setSelected($userperm_startpage);
-
-        $self = rex::getUser()->getValue('login') == $sql->getValue(rex::getTablePrefix() . 'user.login');
 
         if (rex::getUser()->isAdmin()) {
             $disabled = $self ? ' disabled="disabled"' : '';

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -23,6 +23,7 @@ if (0 != $user_id) {
 
 // Allgemeine Infos
 $userpsw = rex_post('userpsw', 'string');
+$passwordChangeRequired = rex_post('password_change_required', 'bool');
 $userlogin = rex_post('userlogin', 'string');
 $username = rex_request('username', 'string');
 $userdesc = rex_request('userdesc', 'string');
@@ -157,6 +158,8 @@ if ($warnings) {
         $updateuser->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords($user, $passwordHash));
     }
 
+    $updateuser->setValue('password_change_required', (int) $passwordChangeRequired);
+
     $updateuser->update();
 
     $info = rex_i18n::msg('user_data_updated');
@@ -216,6 +219,7 @@ if ($warnings) {
         $adduser->addGlobalUpdateFields();
         $adduser->setDateTimeValue('password_changed', time());
         $adduser->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords(null, $userpswHash));
+        $adduser->setValue('password_change_required', (int) $passwordChangeRequired);
         if (isset($userstatus) && 1 == $userstatus) {
             $adduser->setValue('status', 1);
         } else {
@@ -262,6 +266,8 @@ if ($warnings) {
             $warnings[] = rex_i18n::msg('user_missing_password');
         }
     }
+} else {
+    $passwordChangeRequired = true;
 }
 
 // ---------------------------------- ERR MSG
@@ -280,6 +286,8 @@ $SHOW = true;
 
 if ('' != $FUNC_ADD || $user_id > 0) {
     $SHOW = false;
+
+    $self = false;
 
     $statuschecked = '';
     if ('' != $FUNC_ADD) {
@@ -318,6 +326,7 @@ if ('' != $FUNC_ADD || $user_id > 0) {
             $sql->setQuery('select * from ' . rex::getTablePrefix() . 'user where id=' . $user_id);
 
             if (1 == $sql->getRows()) {
+                $passwordChangeRequired = (bool) $sql->getValue('password_change_required');
                 $useradmin = $sql->getValue('admin');
                 $userstatus = $sql->getValue(rex::getTablePrefix() . 'user.status');
                 $userrole = $sql->getValue(rex::getTablePrefix() . 'user.role');
@@ -408,6 +417,27 @@ if ('' != $FUNC_ADD || $user_id > 0) {
     $n['field'] = '<input class="form-control" type="password" id="rex-js-user-password" name="userpsw" autocomplete="new-password"/>';
 
     $formElements[] = $n;
+
+    $fragment = new rex_fragment();
+    $fragment->setVar('flush', true);
+    $fragment->setVar('group', true);
+    $fragment->setVar('elements', $formElements, false);
+    $content .= $fragment->parse('core/form/form.php');
+
+    $formElements = [];
+
+    $n = [];
+    $n['label'] = '<label for="rex-user-password-change-required">' . rex_i18n::msg('user_password_change_required') . '</label>';
+    $checked = $passwordChangeRequired && !$self ? ' checked="checked"' : '';
+    $disabled = $self ? ' disabled="disabled"' : '';
+    $n['field'] = '<input type="checkbox" id="rex-user-password-change-required" name="password_change_required" value="1" ' . $checked . $disabled . ' />';
+    $formElements[] = $n;
+
+    $fragment = new rex_fragment();
+    $fragment->setVar('elements', $formElements, false);
+    $content .= $fragment->parse('core/form/checkbox.php');
+
+    $formElements = [];
 
     $n = [];
     $n['label'] = '<label for="rex-user-name">' . rex_i18n::msg('name') . '</label>';

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -202,10 +202,10 @@ if ($user = rex::getUser()) {
     if (rex::getProperty('login')->requiresPasswordChange()) {
         // profile is available for everyone, no additional checks required
         rex_be_controller::setCurrentPage('profile');
-    } else {
-        // --- page pruefen und benoetigte rechte checken
-        rex_be_controller::checkPagePermissions($user);
     }
+
+    // --- page pruefen und benoetigte rechte checken
+    rex_be_controller::checkPagePermissions($user);
 }
 $page = rex_be_controller::getCurrentPage();
 rex_view::setJsProperty('page', $page);

--- a/redaxo/src/core/install.php
+++ b/redaxo/src/core/install.php
@@ -42,6 +42,7 @@ $table
     ->ensureGlobalColumns()
     ->ensureColumn(new rex_sql_column('password_changed', 'datetime'))
     ->ensureColumn(new rex_sql_column('previous_passwords', 'text'))
+    ->ensureColumn(new rex_sql_column('password_change_required', 'tinyint(1)'))
     ->ensureColumn(new rex_sql_column('lasttrydate', 'datetime'))
     ->ensureColumn(new rex_sql_column('lastlogin', 'datetime', true))
     ->ensureColumn(new rex_sql_column('session_id', 'varchar(255)', true))

--- a/redaxo/src/core/lib/console/user/create.php
+++ b/redaxo/src/core/lib/console/user/create.php
@@ -21,6 +21,7 @@ class rex_command_user_create extends rex_console_command
             ->addArgument('password', InputArgument::OPTIONAL, 'Password')
             ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Name')
             ->addOption('admin', null, InputOption::VALUE_NONE, 'Grant admin permissions')
+            ->addOption('password-change-required', null, InputOption::VALUE_NONE, 'Require password change after login')
         ;
     }
 
@@ -80,6 +81,7 @@ class rex_command_user_create extends rex_console_command
         $user->addGlobalUpdateFields('console');
         $user->setDateTimeValue('password_changed', time());
         $user->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords(null, $passwordHash));
+        $user->setValue('password_change_required', (int) $input->getOption('password-change-required'));
         $user->setValue('status', '1');
         $user->insert();
 

--- a/redaxo/src/core/lib/console/user/set_password.php
+++ b/redaxo/src/core/lib/console/user/set_password.php
@@ -3,6 +3,7 @@
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -18,6 +19,7 @@ class rex_command_user_set_password extends rex_console_command
             ->setDescription('Sets a new password for a user')
             ->addArgument('user', InputArgument::REQUIRED, 'Username')
             ->addArgument('password', InputArgument::OPTIONAL, 'Password')
+            ->addOption('password-change-required', null, InputOption::VALUE_NONE, 'Require password change after login')
         ;
     }
 
@@ -71,6 +73,7 @@ class rex_command_user_set_password extends rex_console_command
             ->addGlobalUpdateFields('console')
             ->setDateTimeValue('password_changed', time())
             ->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords($user, $passwordHash))
+            ->setValue('password_change_required', (int) $input->getOption('password-change-required'))
             ->update();
 
         rex_extension::registerPoint(new rex_extension_point('PASSWORD_UPDATED', '', [

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -111,13 +111,14 @@ class rex_backend_login extends rex_login
                 $this->impersonator = rex_user::fromSql($this->impersonator);
             }
 
-            if (
-                ($loggedInViaCookie || $this->userLogin) &&
-                $forceRenewAfter = $this->passwordPolicy->getForceRenewAfter()
-            ) {
-                $datetime = (new DateTimeImmutable())->sub($forceRenewAfter);
-                if (strtotime($this->user->getValue('password_changed')) < $datetime->getTimestamp()) {
+            if ($loggedInViaCookie || $this->userLogin) {
+                if ($this->user->getValue('password_change_required')) {
                     $this->setSessionVar(self::SESSION_PASSWORD_CHANGE_REQUIRED, true);
+                } elseif ($forceRenewAfter = $this->passwordPolicy->getForceRenewAfter()) {
+                    $datetime = (new DateTimeImmutable())->sub($forceRenewAfter);
+                    if (strtotime($this->user->getValue('password_changed')) < $datetime->getTimestamp()) {
+                        $this->setSessionVar(self::SESSION_PASSWORD_CHANGE_REQUIRED, true);
+                    }
                 }
             }
         } else {

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -107,6 +107,7 @@ if (rex_post('upd_psw_button', 'bool')) {
         $updateuser->setWhere(['id' => $user_id]);
         $updateuser->setValue('password', $userpsw_new_1);
         $updateuser->addGlobalUpdateFields();
+        $updateuser->setValue('password_change_required', 0);
         $updateuser->setDateTimeValue('password_changed', time());
         $updateuser->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords($user, $userpsw_new_1));
 


### PR DESCRIPTION
Als Admin kann man optional explizit eine Passwortänderung bei einem User anfordern.
Sobald der sich dann einloggt, muss er das Passwort ändern (genauso wie bei der Passworterneuerung über die Passwortregeln).
Geht bei neuen und vorhandenen Benutzern.

![Screenshot 2020-04-08 17 07 39](https://user-images.githubusercontent.com/330436/78800212-7a8b0d80-79bb-11ea-9435-52ddfb799bf7.png)

Bei neuen Benutzern ist die Checkbox default angehakt.