### PR TITLE
Weitere Stellen mit rex_timer messen

### DIFF
--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -35,7 +35,7 @@ register_shutdown_function(static function () {
         }
 
         foreach ($timings['timings'] as $i => $timing) {
-            if ($timing['end'] - $timing['start'] > 0.001) {
+            if ($timing['end'] - $timing['start'] >= 0.001) {
                 $clockwork->getTimeline()->addEvent($label.'_'.$i, $label, $timing['start'], $timing['end']);
             }
         }

--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -408,11 +408,15 @@ class rex_be_controller
             $currentPage->setHasLayout(false);
         }
 
-        require rex_path::core('layout/top.php');
+        rex_timer::measure('Layout: top.php', function () {
+            require rex_path::core('layout/top.php');
+        });
 
         self::includePath($currentPage->getPath());
 
-        require rex_path::core('layout/bottom.php');
+        rex_timer::measure('Layout: bottom.php', function () {
+            require rex_path::core('layout/bottom.php');
+        });
     }
 
     /**
@@ -454,20 +458,22 @@ class rex_be_controller
      */
     private static function includePath($path, array $context = [])
     {
-        $pattern = '@' . preg_quote(rex_path::src('addons/'), '@') . '([^/\\\]+)(?:[/\\\]plugins[/\\\]([^/\\\]+))?@';
+        return rex_timer::measure('Page: '.rex_path::relative($path, rex_path::src()), function () use ($path, $context) {
+            $pattern = '@' . preg_quote(rex_path::src('addons/'), '@') . '([^/\\\]+)(?:[/\\\]plugins[/\\\]([^/\\\]+))?@';
 
-        if (!preg_match($pattern, $path, $matches)) {
-            $__context = $context;
-            $__path = $path;
-            unset($context, $path, $pattern, $matches);
-            extract($__context, EXTR_SKIP);
-            return include $__path;
-        }
+            if (!preg_match($pattern, $path, $matches)) {
+                $__context = $context;
+                $__path = $path;
+                unset($context, $path, $pattern, $matches);
+                extract($__context, EXTR_SKIP);
+                return include $__path;
+            }
 
-        $package = rex_addon::get($matches[1]);
-        if (isset($matches[2])) {
-            $package = $package->getPlugin($matches[2]);
-        }
-        return $package->includeFile(str_replace($package->getPath(), '', $path), $context);
+            $package = rex_addon::get($matches[1]);
+            if (isset($matches[2])) {
+                $package = $package->getPlugin($matches[2]);
+            }
+            return $package->includeFile(str_replace($package->getPath(), '', $path), $context);
+        });
     }
 }

--- a/redaxo/src/core/lib/fragment.php
+++ b/redaxo/src/core/lib/fragment.php
@@ -107,9 +107,11 @@ class rex_fragment
         foreach (self::$fragmentDirs as $fragDir) {
             $fragment = $fragDir . $filename;
             if (is_readable($fragment)) {
-                ob_start();
-                require $fragment;
-                $content = ob_get_clean();
+                $content = rex_timer::measure('Fragment: '.$filename, function () use ($fragment) {
+                    ob_start();
+                    require $fragment;
+                    return ob_get_clean();
+                });
 
                 if ($this->decorator) {
                     $this->decorator->setVar('rexDecoratedContent', $content, false);


### PR DESCRIPTION
Ich weiß nicht, wie weit wir hier gehen wollen (es hat ja auch minimalen Einfluss auf die normalen Aufrufe ohne Debug-Modus, und es macht den Code weniger gut lesbar finde ich).

Aber mal so als Idee, paar weitere Stellen zu messen.

Aktuell: Layout-Dateien, Fragmente, Pages
Fürs Frontend wären dann noch die einzelnen Templates und Module interessant.

![Screenshot 2020-04-10 11 17 45](https://user-images.githubusercontent.com/330436/78980124-87277700-7b1d-11ea-83a0-02665524b8e7.png)

