### PR TITLE
Debug-Timeline: EPs über normalen rex_timer-Mechanismus

### DIFF
--- a/redaxo/src/addons/debug/lib/extension_debug.php
+++ b/redaxo/src/addons/debug/lib/extension_debug.php
@@ -16,15 +16,9 @@ class rex_extension_debug extends rex_extension
         $coreTimer = rex::getProperty('timer');
         $absDur = $coreTimer->getFormattedDelta();
 
-        $rnd = mt_rand();
-        rex_debug::getInstance()->startEvent($rnd, 'EP: '. $extensionPoint->getName());
-
         $timer = new rex_timer();
         $res = parent::registerPoint($extensionPoint);
         $epDur = $timer->getFormattedDelta();
-
-        rex_debug::getInstance()
-            ->endEvent($rnd);
 
         $memory = rex_formatter::bytes(memory_get_usage(true), [3]);
 

--- a/redaxo/src/core/lib/extension.php
+++ b/redaxo/src/core/lib/extension.php
@@ -37,8 +37,12 @@ abstract class rex_extension
 
         $name = $extensionPoint->getName();
 
-        foreach ([self::EARLY, self::NORMAL, self::LATE] as $level) {
-            if (isset(self::$extensions[$name][$level]) && is_array(self::$extensions[$name][$level])) {
+        rex_timer::measure('EP: '.$name, function () use ($extensionPoint, $name) {
+            foreach ([self::EARLY, self::NORMAL, self::LATE] as $level) {
+                if (!isset(self::$extensions[$name][$level]) || !is_array(self::$extensions[$name][$level])) {
+                    continue;
+                }
+
                 foreach (self::$extensions[$name][$level] as $extensionAndParams) {
                     [$extension, $params] = $extensionAndParams;
                     $extensionPoint->setExtensionParams($params);
@@ -49,7 +53,7 @@ abstract class rex_extension
                     }
                 }
             }
-        }
+        });
 
         return $extensionPoint->getSubject();
     }

--- a/redaxo/src/core/lib/extension.php
+++ b/redaxo/src/core/lib/extension.php
@@ -37,7 +37,7 @@ abstract class rex_extension
 
         $name = $extensionPoint->getName();
 
-        rex_timer::measure('EP: '.$name, function () use ($extensionPoint, $name) {
+        rex_timer::measure('EP: '.$name, static function () use ($extensionPoint, $name) {
             foreach ([self::EARLY, self::NORMAL, self::LATE] as $level) {
                 if (!isset(self::$extensions[$name][$level]) || !is_array(self::$extensions[$name][$level])) {
                     continue;

--- a/redaxo/src/core/lib/login/user.php
+++ b/redaxo/src/core/lib/login/user.php
@@ -32,8 +32,6 @@ class rex_user
 
     /**
      * Class name for user roles.
-     *
-     * @var class-string<rex_user_role_interface>
      */
     protected static $roleClass;
 


### PR DESCRIPTION
Aktuell haben die EPs eine Sonderrolle, und sind nicht von der 1ms-Grenze betroffen.

Bin mir unsicher, ob das gut ist oder nicht.
Einerseits sieht man in der Timeline so ganz gut, wie der EP-Ablauf aussieht.
Anderseits können das manchmal aber auch recht viele werden, und es stellt sich mir die Frage, warum gerade die EPs da eine Sonderrolle bekommen. Und sie haben ja auch noch eine separate Seite mit Details, wo alle gelistet sind.

Daher zur Diskussion hier eine Änderung, sodass die EPs auch über den normalen Mechanismus gehen, wie die anderen Stellen.
So kann aber passieren, dass gar kein EP mehr auftaucht:

![Screenshot 2020-04-10 13 21 56](https://user-images.githubusercontent.com/330436/78987569-b2ff2880-7b2e-11ea-9bc6-04fb02efeab3.png)

Wie gesagt: bin mir unsicher, ob wir das so ändern sollten, oder nicht.