### PR TITLE
added google chrome workaround for slow clear-site-data bug

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -93,7 +93,7 @@ if (rex::isSetup()) {
         $advertisedChrome = preg_match('/(Chrome|CriOS)\//i', $userAgent);
         $nonChrome = preg_match('/(Aviator|ChromePlus|coc_|Dragon|Edge|Flock|Iron|Kinza|Maxthon|MxNitro|Nichrome|OPR|Perk|Rockmelt|Seznam|Sleipnir|Spark|UBrowser|Vivaldi|WebExplorer|YaBrowser)/i', $userAgent);
         if($advertisedChrome && !$nonChrome) {
-            // Browser is likely Google Chrome which currently seems to be super slow when clearing site data
+            // Browser is likely Google Chrome which currently seems to be super slow when clearing 'cache' from site data
             // https://bugs.chromium.org/p/chromium/issues/detail?id=762417
             rex_response::setHeader('Clear-Site-Data', '"storage", "executionContexts"');
         } else {

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -88,7 +88,17 @@ if (rex::isSetup()) {
         $login->setLogout(true);
         $login->checkLogin();
         rex_csrf_token::removeAll();
-        rex_response::setHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
+
+        $userAgent = rex_server('HTTP_USER_AGENT');
+        $advertisedChrome = preg_match('/(Chrome|CriOS)\//i', $userAgent);
+        $nonChrome = preg_match('/(Aviator|ChromePlus|coc_|Dragon|Edge|Flock|Iron|Kinza|Maxthon|MxNitro|Nichrome|OPR|Perk|Rockmelt|Seznam|Sleipnir|Spark|UBrowser|Vivaldi|WebExplorer|YaBrowser)/i', $userAgent);
+        if($advertisedChrome && !$nonChrome) {
+            // Browser is likely Google Chrome which currently seems to be super slow when clearing site data
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=762417
+            rex_response::setHeader('Clear-Site-Data', '"storage", "executionContexts"');
+        } else {
+            rex_response::setHeader('Clear-Site-Data', '"cache", "storage", "executionContexts"');
+        }
 
         // Currently browsers like Safari do not support the header Clear-Site-Data.
         // we dont kill/regenerate the session so e.g. the frontend will not get logged out

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -92,7 +92,7 @@ if (rex::isSetup()) {
         $userAgent = rex_server('HTTP_USER_AGENT');
         $advertisedChrome = preg_match('/(Chrome|CriOS)\//i', $userAgent);
         $nonChrome = preg_match('/(Aviator|ChromePlus|coc_|Dragon|Edge|Flock|Iron|Kinza|Maxthon|MxNitro|Nichrome|OPR|Perk|Rockmelt|Seznam|Sleipnir|Spark|UBrowser|Vivaldi|WebExplorer|YaBrowser)/i', $userAgent);
-        if($advertisedChrome && !$nonChrome) {
+        if ($advertisedChrome && !$nonChrome) {
             // Browser is likely Google Chrome which currently seems to be super slow when clearing 'cache' from site data
             // https://bugs.chromium.org/p/chromium/issues/detail?id=762417
             rex_response::setHeader('Clear-Site-Data', '"storage", "executionContexts"');

--- a/redaxo/src/core/lib/login/user.php
+++ b/redaxo/src/core/lib/login/user.php
@@ -30,8 +30,6 @@ class rex_user
 
     /**
      * Class name for user roles.
-     *
-     * @var class-string<rex_user_role_interface>
      */
     protected static $roleClass;
 


### PR DESCRIPTION
refs https://bugs.chromium.org/p/chromium/issues/detail?id=762417

closes https://github.com/redaxo/redaxo/issues/3352

mittels browser detect wird der cache von google chrome nicht mehr geleert wg. des im issue genannten chrome bugs.

getestet in Chrome Canary und Firefox Nightly