### PR TITLE
Templateausführung messen

### DIFF
--- a/redaxo/src/addons/structure/package.yml
+++ b/redaxo/src/addons/structure/package.yml
@@ -24,4 +24,4 @@ pages:
 system_plugins: [content]
 
 requires:
-    redaxo: ^5.5.0
+    redaxo: ^5.11.0-dev

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -438,9 +438,10 @@ class rex_article_content_base
             ob_implicit_flush(0);
 
             $TEMPLATE = new rex_template($this->template_id);
-            $tplContent = $this->replaceCommonVars($TEMPLATE->getTemplate());
 
-            rex_timer::measure('Template: '.($TEMPLATE->getKey() ?? $TEMPLATE->getId()), function () use ($tplContent) {
+            rex_timer::measure('Template: '.($TEMPLATE->getKey() ?? $TEMPLATE->getId()), function () use ($TEMPLATE) {
+                $tplContent = $this->replaceCommonVars($TEMPLATE->getTemplate());
+
                 require rex_stream::factory('template/' . $this->template_id, $tplContent);
             });
 

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -439,7 +439,10 @@ class rex_article_content_base
 
             $TEMPLATE = new rex_template($this->template_id);
             $tplContent = $this->replaceCommonVars($TEMPLATE->getTemplate());
-            require rex_stream::factory('template/' . $this->template_id, $tplContent);
+
+            rex_timer::measure('Template: '.($TEMPLATE->getKey() ?? $TEMPLATE->getId()), function () use ($tplContent) {
+                require rex_stream::factory('template/' . $this->template_id, $tplContent);
+            });
 
             $CONTENT = ob_get_clean();
 

--- a/redaxo/src/addons/structure/plugins/content/lib/var_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/var_template.php
@@ -53,6 +53,7 @@ class rex_var_template extends rex_var
 
     /**
      * @param int|string $id
+     *
      * @return false|string
      */
     public static function getTemplateOutput(string $path, $id, ?rex_timer $timer)

--- a/redaxo/src/addons/structure/plugins/content/lib/var_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/var_template.php
@@ -29,6 +29,8 @@ class rex_var_template extends rex_var
     }
 
     /**
+     * @internal
+     *
      * @return string
      */
     public static function getTemplateStream($id, rex_article_content_base $article = null)
@@ -44,13 +46,15 @@ class rex_var_template extends rex_var
     }
 
     /**
+     * @internal
+     *
      * @param int|string $id
      *
      * @return false|string
      */
-    public static function getTemplateOutput($id, rex_timer $timer, $includeTemplate)
+    public static function getTemplateOutput($id, ?rex_timer $timer = null)
     {
-        if (rex::isDebugMode()) {
+        if ($timer && rex::isDebugMode()) {
             $timer->stop();
             $tmpl = new rex_template($id);
             rex_timer::measured('Template: '.($tmpl->getKey() ?? $tmpl->getId()), $timer);

--- a/redaxo/src/addons/structure/plugins/content/package.yml
+++ b/redaxo/src/addons/structure/plugins/content/package.yml
@@ -35,7 +35,7 @@ pages:
             actions: { title: translate:actions }
 
 requires:
-    redaxo: ^5.5.0
+    redaxo: ^5.11.0-dev
 
 conflicts:
     packages:

--- a/redaxo/src/core/lib/util/timer.php
+++ b/redaxo/src/core/lib/util/timer.php
@@ -65,6 +65,11 @@ class rex_timer
         }
     }
 
+    /**
+     * Saves the measurement of the given timer.
+     *
+     * This method should be used only if the measured code can not be wrapped inside a callable, otherwise use `measure()`.
+     */
     public static function measured(string $label, self $timer): void
     {
         $duration = self::$serverTimings[$label]['sum'] ?? 0;

--- a/redaxo/src/core/lib/util/timer.php
+++ b/redaxo/src/core/lib/util/timer.php
@@ -70,15 +70,20 @@ class rex_timer
         } finally {
             $timer->stop();
 
-            $duration = self::$serverTimings[$label]['sum'] ?? 0;
-            $duration += $timer->getDelta(self::MILLISEC);
-
-            self::$serverTimings[$label]['sum'] = $duration;
-            self::$serverTimings[$label]['timings'][] = [
-                'start' => $timer->start,
-                'end' => microtime(true),
-            ];
+            self::measured($label, $timer);
         }
+    }
+
+    public static function measured(string $label, self $timer): void
+    {
+        $duration = self::$serverTimings[$label]['sum'] ?? 0;
+        $duration += $timer->getDelta(self::MILLISEC);
+
+        self::$serverTimings[$label]['sum'] = $duration;
+        self::$serverTimings[$label]['timings'][] = [
+            'start' => $timer->start,
+            'end' => microtime(true),
+        ];
     }
 
     /**


### PR DESCRIPTION
In der REX_VAR war es recht tricky, aber habe eine funktionierende Variante gefunden.
`rex_timer::measure()` kann dort nicht verwendet werden, da sonst das `require ..` statement in der closure wäre, und somit nicht mehr im gleichen Variablen-Scope wie das äußere Template.

![Screenshot 2020-04-13 12 43 11](https://user-images.githubusercontent.com/330436/79115274-b9d3a880-7d85-11ea-8798-f91efcb60962.png)
