### PR TITLE
use is_file() instead of file_exists() which is up to 100x faster

### DIFF
--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -484,7 +484,7 @@ class rex_backup
 
     private static function importScript($filename, $importType, $eventType)
     {
-        if (file_exists($filename)) {
+        if (is_file($filename)) {
             require $filename;
         }
     }

--- a/redaxo/src/addons/backup/lib/cronjob.php
+++ b/redaxo/src/addons/backup/lib/cronjob.php
@@ -21,9 +21,9 @@ class rex_cronjob_export extends rex_cronjob
         $blacklist_tables = explode('|', $this->getParam('blacklist_tables'));
         $whitelist_tables = array_diff($tables, $blacklist_tables);
 
-        if (file_exists($dir . $file . $ext)) {
+        if (is_file($dir . $file . $ext)) {
             $i = 1;
-            while (file_exists($dir . $file . '_' . $i . $ext)) {
+            while (is_file($dir . $file . '_' . $i . $ext)) {
                 ++$i;
             }
             $file = $file . '_' . $i;

--- a/redaxo/src/addons/backup/lib/tar.php
+++ b/redaxo/src/addons/backup/lib/tar.php
@@ -44,7 +44,7 @@ class rex_backup_tar extends tar
         unset($this->directories);
 
         // If the tar file doesn't exist...
-        if (!file_exists($filename)) {
+        if (!is_file($filename)) {
             return false;
         }
 
@@ -66,7 +66,7 @@ class rex_backup_tar extends tar
     public function addFile($filename)
     {
         // Make sure the file we are adding exists!
-        if (!file_exists($filename)) {
+        if (!is_file($filename)) {
             return false;
         }
 
@@ -112,7 +112,7 @@ class rex_backup_tar extends tar
      */
     public function addDirectory($dirname)
     {
-        if (!file_exists($dirname)) {
+        if (!is_file($dirname)) {
             return false;
         }
 
@@ -317,7 +317,7 @@ class rex_backup_tar extends tar
             foreach ($this->files as $item) {
                 // jan: wenn probleme mit der ordnergenerierung -> ordner manuell einstellen
 
-                if (!file_exists(dirname($item['name']))) {
+                if (!is_file(dirname($item['name']))) {
                     rex_dir::create(dirname($item['name']));
                 }
                 if ($h = @fopen($item['name'], 'w+')) {

--- a/redaxo/src/addons/backup/lib/tar.php
+++ b/redaxo/src/addons/backup/lib/tar.php
@@ -112,7 +112,7 @@ class rex_backup_tar extends tar
      */
     public function addDirectory($dirname)
     {
-        if (!is_file($dirname)) {
+        if (!is_dir($dirname)) {
             return false;
         }
 

--- a/redaxo/src/addons/backup/pages/export.php
+++ b/redaxo/src/addons/backup/pages/export.php
@@ -54,9 +54,9 @@ if ($export && !$csrfToken->isValid()) {
         $ext = 'sql' == $exporttype ? '.sql' : '.tar.gz';
         $export_path = rex_backup::getDir() . '/';
 
-        if (file_exists($export_path . $filename . $ext)) {
+        if (is_file($export_path . $filename . $ext)) {
             $i = 1;
-            while (file_exists($export_path . $filename . '_' . $i . $ext)) {
+            while (is_file($export_path . $filename . '_' . $i . $ext)) {
                 ++$i;
             }
             $filename = $filename . '_' . $i;

--- a/redaxo/src/addons/backup/vendor/tar.php
+++ b/redaxo/src/addons/backup/vendor/tar.php
@@ -442,7 +442,7 @@ class tar {
    * @return bool
    */
   public function addDirectory($dirname) {
-    if(!is_file($dirname))
+    if(!is_dir($dirname))
       return false;
 
     // Get directory information

--- a/redaxo/src/addons/backup/vendor/tar.php
+++ b/redaxo/src/addons/backup/vendor/tar.php
@@ -350,7 +350,7 @@ class tar {
     unset($this->numDirectories);
 
     // If the tar file doesn't exist...
-    if(!file_exists($filename))
+    if(!is_file($filename))
       return false;
 
     $this->filename = $filename;
@@ -368,7 +368,7 @@ class tar {
    */
   public function appendTar($filename) {
     // If the tar file doesn't exist...
-    if(!file_exists($filename))
+    if(!is_file($filename))
       return false;
 
     $this->__readTar($filename);
@@ -442,7 +442,7 @@ class tar {
    * @return bool
    */
   public function addDirectory($dirname) {
-    if(!file_exists($dirname))
+    if(!is_file($dirname))
       return false;
 
     // Get directory information
@@ -470,7 +470,7 @@ class tar {
    */
   public function addFile($filename) {
     // Make sure the file we are adding exists!
-    if(!file_exists($filename))
+    if(!is_file($filename))
       return false;
 
     // Make sure there are no other files in the archive that have this same filename

--- a/redaxo/src/addons/be_style/lib/scss_compiler.php
+++ b/redaxo/src/addons/be_style/lib/scss_compiler.php
@@ -62,11 +62,11 @@ class rex_scss_compiler
             $path_parts = pathinfo($path);
             $underscore_file = $path_parts['dirname'] . '/_' . $path_parts['basename'];
 
-            if (file_exists($underscore_file)) {
+            if (is_file($underscore_file)) {
                 $path = $underscore_file;
             }
 
-            if (!file_exists($path)) {
+            if (!is_file($path)) {
                 return null;
             }
 

--- a/redaxo/src/addons/be_style/update.php
+++ b/redaxo/src/addons/be_style/update.php
@@ -9,7 +9,7 @@ $addon->includeFile(__DIR__.'/install.php');
 foreach ($addon->getInstalledPlugins() as $plugin) {
     $file = __DIR__.'/plugins/'.$plugin->getName().'/install.php';
 
-    if (file_exists($file)) {
+    if (is_file($file)) {
         $plugin->includeFile($file);
     }
 }

--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -57,7 +57,7 @@ class rex_api_install_core_update extends rex_api_function
                 foreach (rex_finder::factory($temppath . 'addons')->dirsOnly() as $dir) {
                     $addonkey = $dir->getBasename();
                     $addonPath = $dir->getRealPath() . '/';
-                    if (!file_exists($addonPath . rex_package::FILE_PACKAGE)) {
+                    if (!is_file($addonPath . rex_package::FILE_PACKAGE)) {
                         continue;
                     }
 
@@ -83,11 +83,11 @@ class rex_api_install_core_update extends rex_api_function
             //    }
             //}
             $this->checkRequirements($temppath, $version['version'], $updateAddonsConfig);
-            if (file_exists($temppath . 'core/update.php')) {
+            if (is_file($temppath . 'core/update.php')) {
                 include $temppath . 'core/update.php';
             }
             foreach ($updateAddons as $addonkey => $addon) {
-                if ($addon->isInstalled() && file_exists($file = $temppath . 'addons/' . $addonkey . '/' . rex_package::FILE_UPDATE)) {
+                if ($addon->isInstalled() && is_file($file = $temppath . 'addons/' . $addonkey . '/' . rex_package::FILE_UPDATE)) {
                     try {
                         $addon->includeFile($file);
                         if ($msg = $addon->getProperty('updatemsg', '')) {

--- a/redaxo/src/addons/install/lib/package/package_download.php
+++ b/redaxo/src/addons/install/lib/package/package_download.php
@@ -84,6 +84,6 @@ abstract class rex_install_package_download
             return $success;
         }
 
-        return file_exists("phar://$file/" . $this->addonkey);
+        return is_file("phar://$file/" . $this->addonkey);
     }
 }

--- a/redaxo/src/addons/install/lib/package/package_download.php
+++ b/redaxo/src/addons/install/lib/package/package_download.php
@@ -84,6 +84,6 @@ abstract class rex_install_package_download
             return $success;
         }
 
-        return is_file("phar://$file/" . $this->addonkey);
+        return is_dir("phar://$file/" . $this->addonkey);
     }
 }

--- a/redaxo/src/addons/install/lib/package/package_update.php
+++ b/redaxo/src/addons/install/lib/package/package_update.php
@@ -44,7 +44,7 @@ class rex_install_package_update extends rex_install_package_download
 
         // ---- check package.yml
         $packageFile = $temppath . rex_package::FILE_PACKAGE;
-        if (!file_exists($packageFile)) {
+        if (!is_file($packageFile)) {
             return rex_i18n::msg('package_missing_yml_file');
         }
         try {
@@ -58,7 +58,7 @@ class rex_install_package_update extends rex_install_package_download
         }
 
         // ---- include update.php
-        if ($this->addon->isInstalled() && file_exists($temppath . rex_package::FILE_UPDATE)) {
+        if ($this->addon->isInstalled() && is_file($temppath . rex_package::FILE_UPDATE)) {
             try {
                 $this->addon->includeFile('../.new.' . $this->addonkey . '/' . rex_package::FILE_UPDATE);
             } catch (rex_functional_exception $e) {

--- a/redaxo/src/addons/media_manager/lib/effects/effect_insert_image.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_insert_image.php
@@ -13,7 +13,7 @@ class rex_effect_insert_image extends rex_effect_abstract
 
         // -------------------------------------- CONFIG
         $brandimage = rex_path::media($this->params['brandimage']);
-        if (!is_file($brandimage) || !is_file($brandimage)) {
+        if (!is_file($brandimage)) {
             return;
         }
 

--- a/redaxo/src/addons/media_manager/lib/effects/effect_insert_image.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_insert_image.php
@@ -13,7 +13,7 @@ class rex_effect_insert_image extends rex_effect_abstract
 
         // -------------------------------------- CONFIG
         $brandimage = rex_path::media($this->params['brandimage']);
-        if (!file_exists($brandimage) || !is_file($brandimage)) {
+        if (!is_file($brandimage) || !is_file($brandimage)) {
             return;
         }
 

--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -86,7 +86,7 @@ class rex_managed_media
             return;
         }
 
-        if (!$this->sourcePath || !file_exists($this->sourcePath)) {
+        if (!$this->sourcePath || !is_file($this->sourcePath)) {
             throw new rex_media_manager_not_found_exception(sprintf('Source path "%s" does not exist.', $this->sourcePath));
         }
 
@@ -219,7 +219,7 @@ class rex_managed_media
 
     public function exists(): bool
     {
-        return $this->asImage || file_exists($this->sourcePath);
+        return $this->asImage || is_file($this->sourcePath);
     }
 
     /**

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -169,7 +169,7 @@ class rex_media_manager
     {
         $cache_file = $this->getCacheFilename();
 
-        if (!file_exists($cache_file)) {
+        if (!is_file($cache_file)) {
             return false;
         }
 
@@ -185,7 +185,7 @@ class rex_media_manager
             return true;
         }
 
-        if (!file_exists($mediapath)) {
+        if (!is_file($mediapath)) {
             return false;
         }
 

--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -44,7 +44,7 @@ function rex_mediapool_filename($FILENAME, $doSubindexing = true)
     if ($doSubindexing || $FILENAME != $NFILENAME) {
         // ----- datei schon vorhanden -> namen aendern -> _1 ..
         $cnt = 0;
-        while (file_exists(rex_path::media($NFILENAME)) || rex_media::get($NFILENAME)) {
+        while (is_file(rex_path::media($NFILENAME)) || rex_media::get($NFILENAME)) {
             ++$cnt;
             $NFILENAME = $NFILE_NAME . '_' . $cnt . $NFILE_EXT;
         }
@@ -289,7 +289,7 @@ function rex_mediapool_syncFile($physical_filename, $category_id, $title, $files
 {
     $abs_file = rex_path::media($physical_filename);
 
-    if (!file_exists($abs_file)) {
+    if (!is_file($abs_file)) {
         return false;
     }
 

--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -301,7 +301,7 @@ class rex_media
      */
     public function fileExists()
     {
-        return file_exists(rex_path::media($this->getFileName()));
+        return is_file(rex_path::media($this->getFileName()));
     }
 
     // allowed filetypes

--- a/redaxo/src/addons/mediapool/pages/media.detail.php
+++ b/redaxo/src/addons/mediapool/pages/media.detail.php
@@ -149,7 +149,7 @@ if ($isImage) {
         $width = '';
     }
 
-    if (!file_exists(rex_path::media($fname))) {
+    if (!is_file(rex_path::media($fname))) {
         $sidebar = '<i class="rex-mime rex-mime-error"></i><span class="sr-only">' . $fname . '</span>';
     } else {
         $sidebar = '

--- a/redaxo/src/addons/mediapool/pages/media.list.php
+++ b/redaxo/src/addons/mediapool/pages/media.list.php
@@ -297,7 +297,7 @@ $panel = '
                     }
 
                     // wenn datei fehlt
-                    if (!file_exists(rex_path::media($file_name))) {
+                    if (!is_file(rex_path::media($file_name))) {
                         $thumbnail = '<i class="rex-mime rex-mime-error" title="' . rex_i18n::msg('pool_file_does_not_exist') . '"></i><span class="sr-only">' . $file_name . '</span>';
                     } else {
                         $file_ext = substr(strrchr($file_name, '.'), 1);

--- a/redaxo/src/addons/mediapool/pages/sync.php
+++ b/redaxo/src/addons/mediapool/pages/sync.php
@@ -32,7 +32,7 @@ if ($PERMALL) {
     // Extra - filesize/width/height DB-Filesystem Sync
     foreach ($db_files as $db_file) {
         $path = rex_path::media($db_file['filename']);
-        if (!file_exists($path)) {
+        if (!is_file($path)) {
             continue;
         }
 

--- a/redaxo/src/addons/phpmailer/install.php
+++ b/redaxo/src/addons/phpmailer/install.php
@@ -19,6 +19,6 @@ if ($addon->hasConfig('log')) {
 
 $oldBackUpFolder = rex_path::addonData('phpmailer', 'mail_backup');
 $logFolder = rex_path::addonData('phpmailer', 'mail_log');
-if (is_file($oldBackUpFolder) && !is_file($logFolder)) {
+if (is_dir($oldBackUpFolder) && !is_dir($logFolder)) {
     rename($oldBackUpFolder, $logFolder);
 }

--- a/redaxo/src/addons/phpmailer/install.php
+++ b/redaxo/src/addons/phpmailer/install.php
@@ -19,6 +19,6 @@ if ($addon->hasConfig('log')) {
 
 $oldBackUpFolder = rex_path::addonData('phpmailer', 'mail_backup');
 $logFolder = rex_path::addonData('phpmailer', 'mail_log');
-if (file_exists($oldBackUpFolder) && !file_exists($logFolder)) {
+if (is_file($oldBackUpFolder) && !is_file($logFolder)) {
     rename($oldBackUpFolder, $logFolder);
 }

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -200,7 +200,7 @@ class rex_mailer extends PHPMailer
 
         $count = 1;
         $archiveFile = $dir.'/'.date('Y-m-d_H_i_s').'.html';
-        while (file_exists($archiveFile)) {
+        while (is_file($archiveFile)) {
             $archiveFile = $dir.'/'.date('Y-m-d_H_i_s').'_'.(++$count).'.html';
         }
 

--- a/redaxo/src/addons/structure/lib/structure_element.php
+++ b/redaxo/src/addons/structure/lib/structure_element.php
@@ -130,7 +130,7 @@ abstract class rex_structure_element
 
             $startId = rex_article::getSiteStartArticleId();
             $file = rex_path::addonCache('structure', $startId . '.1.article');
-            if (!rex::isBackend() && file_exists($file)) {
+            if (!rex::isBackend() && is_file($file)) {
                 // da getClassVars() eine statische Methode ist, können wir hier nicht mit $this->getId() arbeiten!
                 $genVars = rex_file::getCache($file);
                 unset($genVars['last_update_stamp']);

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -88,7 +88,7 @@ class rex_template
             return false;
         }
 
-        if (!file_exists($file)) {
+        if (!is_file($file)) {
             // Generated Datei erzeugen
             if (!$this->generate()) {
                 throw new rex_exception('Unable to generate rexTemplate with id "' . $this->getId() . '"');

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content.php
@@ -93,7 +93,7 @@ class rex_article_content extends rex_article_content_base
             $article_content_file = rex_path::addonCache('structure', $this->article_id . '.' . $this->clang . '.content');
 
             $generated = true;
-            if (!file_exists($article_content_file)) {
+            if (!is_file($article_content_file)) {
                 $generated = rex_content_service::generateArticleContent($this->article_id, $this->clang);
                 if (true !== $generated) {
                     // fehlermeldung ausgeben

--- a/redaxo/src/addons/structure/update.php
+++ b/redaxo/src/addons/structure/update.php
@@ -27,7 +27,7 @@ $addon->includeFile(__DIR__.'/install.php');
 foreach ($addon->getInstalledPlugins() as $plugin) {
     $file = __DIR__.'/plugins/'.$plugin->getName().'/install.php';
 
-    if (file_exists($file)) {
+    if (is_file($file)) {
         $plugin->includeFile($file);
     }
 }

--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -318,7 +318,7 @@ class rex_autoload
          */
         $contents = @php_strip_whitespace($path);
         if (!$contents) {
-            if (!file_exists($path)) {
+            if (!is_file($path)) {
                 $message = 'File at "%s" does not exist, check your classmap definitions';
             } elseif (!is_readable($path)) {
                 $message = 'File at "%s" is not readable, check its permissions';

--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -327,7 +327,7 @@ class rex_be_controller
 
                 case 'path':
                 case 'subpath':
-                    if (file_exists($path = $package->getPath($value))) {
+                    if (is_file($path = $package->getPath($value))) {
                         $value = $path;
                     }
                     // no break

--- a/redaxo/src/core/lib/clang/clang.php
+++ b/redaxo/src/core/lib/clang/clang.php
@@ -267,7 +267,7 @@ class rex_clang
         }
 
         $file = rex_path::coreCache('clang.cache');
-        if (!file_exists($file)) {
+        if (!is_file($file)) {
             rex_clang_service::generateCache();
         }
         foreach (rex_file::getCache($file) as $id => $data) {

--- a/redaxo/src/core/lib/config.php
+++ b/redaxo/src/core/lib/config.php
@@ -315,7 +315,7 @@ class rex_config
     private static function loadFromFile()
     {
         // delete cache-file, will be regenerated on next request
-        if (file_exists(self::$cacheFile)) {
+        if (is_file(self::$cacheFile)) {
             self::$data = rex_file::getCache(self::$cacheFile);
             return true;
         }

--- a/redaxo/src/core/lib/console/assets_sync.php
+++ b/redaxo/src/core/lib/console/assets_sync.php
@@ -105,7 +105,7 @@ class rex_command_assets_sync extends rex_console_command
                 $hasError = true;
                 $io->text("<error>Not readable:</error> <comment>$f1FileShort</comment>");
             }
-            if (file_exists($f2File) && !is_writable($f2File)) {
+            if (is_file($f2File) && !is_writable($f2File)) {
                 ++$errored;
                 $hasError = true;
                 $io->text("<error>Not writable:</error> <comment>$f2FileShort</comment>");
@@ -115,7 +115,7 @@ class rex_command_assets_sync extends rex_console_command
                 continue;
             }
 
-            if (!file_exists($f2File)) {
+            if (!is_file($f2File)) {
                 rex_file::copy($f1File, $f2File);
                 ++$created;
                 if ($io->isVerbose()) {

--- a/redaxo/src/core/lib/packages/package.php
+++ b/redaxo/src/core/lib/packages/package.php
@@ -241,7 +241,7 @@ abstract class rex_package implements rex_package_interface
     {
         extract($__context, EXTR_SKIP);
 
-        if (file_exists($this->getPath($__file))) {
+        if (is_file($this->getPath($__file))) {
             return include $this->getPath($__file);
         }
 
@@ -254,7 +254,7 @@ abstract class rex_package implements rex_package_interface
     public function loadProperties()
     {
         $file = $this->getPath(self::FILE_PACKAGE);
-        if (!file_exists($file)) {
+        if (!is_file($file)) {
             $this->propertiesLoaded = true;
             return;
         }

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -149,7 +149,7 @@ class rex_response
     {
         self::cleanOutputBuffers();
 
-        if (!file_exists($file)) {
+        if (!is_file($file)) {
             header('HTTP/1.1 ' . self::HTTP_NOT_FOUND);
             exit;
         }

--- a/redaxo/src/core/lib/setup/import.php
+++ b/redaxo/src/core/lib/setup/import.php
@@ -178,7 +178,7 @@ class rex_setup_importer
         if (!is_dir(rex_path::addon('backup'))) {
             $err_msg .= rex_i18n::msg('setup_510') . '<br />';
         } else {
-            if (file_exists($import_sql)) {
+            if (is_file($import_sql)) {
                 rex_i18n::addDirectory(rex_path::addon('backup', 'lang/'));
 
                 // DB Import
@@ -188,7 +188,7 @@ class rex_setup_importer
                 }
 
                 // Archiv optional importieren
-                if (true === $state_db['state'] && null !== $import_archiv && file_exists($import_archiv)) {
+                if (true === $state_db['state'] && null !== $import_archiv && is_file($import_archiv)) {
                     $state_archiv = rex_backup::importFiles($import_archiv);
                     if (false === $state_archiv['state']) {
                         $err_msg .= $state_archiv['message'] . '<br />';

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -62,7 +62,7 @@ class rex_file
     public static function put($file, $content)
     {
         return rex_timer::measure(__METHOD__, static function () use ($file, $content) {
-            if (!rex_dir::create(dirname($file)) || file_exists($file) && !is_writable($file)) {
+            if (!rex_dir::create(dirname($file)) || is_file($file) && !is_writable($file)) {
                 return false;
             }
 
@@ -125,7 +125,7 @@ class rex_file
                     rex_dir::create($dstdir);
                 }
 
-                if (rex_dir::isWritable($dstdir) && (!file_exists($dstfile) || is_writable($dstfile)) && copy($srcfile, $dstfile)) {
+                if (rex_dir::isWritable($dstdir) && (!is_file($dstfile) || is_writable($dstfile)) && copy($srcfile, $dstfile)) {
                     @chmod($dstfile, rex::getFilePerm());
                     touch($dstfile, filemtime($srcfile), fileatime($srcfile));
                     return true;
@@ -158,7 +158,7 @@ class rex_file
     public static function delete($file)
     {
         return rex_timer::measure(__METHOD__, static function () use ($file) {
-            if (file_exists($file)) {
+            if (is_file($file)) {
                 return unlink($file);
             }
             return true;

--- a/redaxo/src/core/lib/util/log_file.php
+++ b/redaxo/src/core/lib/util/log_file.php
@@ -45,7 +45,7 @@ class rex_log_file implements Iterator
     public function __construct($path, $maxFileSize = null)
     {
         $this->path = $path;
-        if (!file_exists($path)) {
+        if (!is_file($path)) {
             rex_file::put($path, '');
         }
         if ($maxFileSize && filesize($path) > $maxFileSize) {
@@ -83,7 +83,7 @@ class rex_log_file implements Iterator
         if ($this->pos < 0) {
             // position is before file start -> look for next file
             $path2 = $this->path . '.2';
-            if ($this->second || !$this->file2 && !file_exists($path2)) {
+            if ($this->second || !$this->file2 && !is_file($path2)) {
                 // already in file2 or file2 does not exist -> mark currentLine as invalid
                 $this->currentLine = null;
                 $this->key = null;

--- a/redaxo/src/core/lib/util/stream.php
+++ b/redaxo/src/core/lib/util/stream.php
@@ -54,7 +54,7 @@ class rex_stream
             $hash = substr(sha1($content), 0, 7);
             $path = rex_path::coreCache('stream/'.$path.'/'.$hash);
 
-            if (!file_exists($path)) {
+            if (!is_file($path)) {
                 rex_file::put($path, $content);
             }
 

--- a/redaxo/src/core/pages/system.log.redaxo.php
+++ b/redaxo/src/core/pages/system.log.redaxo.php
@@ -22,7 +22,7 @@ if ('delLog' == $func) {
         $error = rex_i18n::msg('syslog_delete_error');
     }
 }
-if ('download' == $func && file_exists($logFile)) {
+if ('download' == $func && is_file($logFile)) {
     rex_response::sendFile($logFile, 'application/octet-stream', 'attachment');
     exit;
 }
@@ -85,7 +85,7 @@ if ($url = rex_editor::factory()->getUrl($logFile, 0)) {
     $formElements[] = $n;
 }
 
-if (file_exists($logFile)) {
+if (is_file($logFile)) {
     $url = rex_url::currentBackendPage(['func' => 'download']);
     $n = [];
     $n['field'] = '<a class="btn btn-save" href="'. $url .'">' . rex_i18n::msg('syslog_download', basename($logFile)) . '</a>';


### PR DESCRIPTION
inspiriert von https://bugs.php.net/bug.php?id=78285

benchmark:
```php
<?php
$t0 = hrtime(true);
for ($i = 0; $i < 1000; $i++) {
    is_file(__FILE__);
}
$t1 = hrtime(true);
for ($i = 0; $i < 1000; $i++) {
    file_exists(__FILE__);
}
$t2 = hrtime(true);
printf("is_file      took %f ms\n", ($t1 - $t0)/10e6);
printf("file_exists took %f ms\n", ($t2 - $t1)/10e6);
```

ergibt auf meinem laptop
```sh
$ php perf.php
is_file      took 0.058450 ms
file_exists took 5.852210 ms

$ php perf.php
is_file      took 0.047010 ms
file_exists took 6.005810 ms

$ php -v
PHP 7.3.0 (cli) (built: Dec  6 2018 02:17:00) ( ZTS MSVC15 (Visual C++ 2017) x86
 )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.0-dev, Copyright (c) 1998-2018 Zend Technologies
    with blackfire v1.24.1~win-x32-zts73, https://blackfire.io, by Blackfire
```

related https://github.com/symfony/symfony/issues/36493