### PR TITLE
Systemreport: SQL-Fehler abfangen

### DIFF
--- a/redaxo/src/core/lib/system_report.php
+++ b/redaxo/src/core/lib/system_report.php
@@ -54,18 +54,23 @@ class rex_system_report
                 continue;
             }
 
-            $sql = rex_sql::factory($dbId);
-
             $dbData = [];
-            $dbData['Version'] = $sql->getDbType().' '.$sql->getDbVersion();
 
-            if (1 === $dbId) {
-                $dbData['Character set'] = rex::getConfig('utf8mb4') ? 'utf8mb4' : 'utf8';
-            }
+            try {
+                $sql = rex_sql::factory($dbId);
 
-            $security = rex_setup::checkDbSecurity();
-            if ($security) {
-                $dbData['Warning'] = implode('<br/>', $security);
+                $dbData['Version'] = $sql->getDbType().' '.$sql->getDbVersion();
+
+                if (1 === $dbId) {
+                    $dbData['Character set'] = rex::getConfig('utf8mb4') ? 'utf8mb4' : 'utf8';
+
+                    $security = rex_setup::checkDbSecurity();
+                    if ($security) {
+                        $dbData['Warning'] = implode('<br/>', $security);
+                    }
+                }
+            } catch (rex_sql_exception $exception) {
+                $dbData['Warning'] = $exception->getMessage();
             }
 
             if (1 === $dbId) {


### PR DESCRIPTION
Das ist insbesondere wichtig, da der Systembericht ja auch in Whoops verwendet wird, und wenn es da dann zu einem Fehler kommt, kommt die einfache Oops-Seite.

fixes #3566

![Screenshot 2020-04-26 13 04 53](https://user-images.githubusercontent.com/330436/80305683-8b5ec000-87be-11ea-9767-50afccef34af.png)
