### PR TITLE
psalm: add symfony plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
         "friendsofphp/php-cs-fixer": "^2.16",
         "friendsofredaxo/linter": "^1.2",
         "phpstan/phpstan": "^0.12.11",
+        "psalm/plugin-symfony": "^1.2.1",
         "vimeo/psalm": "^3.10.1"
     },
     "autoload-dev": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -42,6 +42,7 @@
     </stubs>
     <plugins>
         <plugin filename="psalm-utils.php" />
+        <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin" />
     </plugins>
     <issueHandlers>
         <InvalidGlobal>

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -22,7 +22,6 @@ class rex_command_install_download extends rex_console_command
     {
         $io = $this->getStyle($input, $output);
 
-        /** @var string $addonKey */
         $addonKey = $input->getArgument('addonkey');
 
         if (rex_addon::exists($addonKey)) {

--- a/redaxo/src/addons/install/lib/command/update.php
+++ b/redaxo/src/addons/install/lib/command/update.php
@@ -22,7 +22,6 @@ class rex_command_install_update extends rex_console_command
     {
         $io = $this->getStyle($input, $output);
 
-        /** @var string $addonKey */
         $addonKey = $input->getArgument('addonkey');
 
         if (!rex_addon::exists($addonKey)) {

--- a/redaxo/src/core/lib/console/package/activate.php
+++ b/redaxo/src/core/lib/console/package/activate.php
@@ -22,7 +22,6 @@ class rex_command_package_activate extends rex_console_command
     {
         $io = $this->getStyle($input, $output);
 
-        /** @var string $packageId */
         $packageId = $input->getArgument('package-id');
 
         // the package manager don't know new packages in the addon folder

--- a/redaxo/src/core/lib/console/package/deactivate.php
+++ b/redaxo/src/core/lib/console/package/deactivate.php
@@ -22,7 +22,6 @@ class rex_command_package_deactivate extends rex_console_command
     {
         $io = $this->getStyle($input, $output);
 
-        /** @var string $packageId */
         $packageId = $input->getArgument('package-id');
 
         // the package manager don't know new packages in the addon folder

--- a/redaxo/src/core/lib/console/package/delete.php
+++ b/redaxo/src/core/lib/console/package/delete.php
@@ -22,7 +22,6 @@ class rex_command_package_delete extends rex_console_command
     {
         $io = $this->getStyle($input, $output);
 
-        /** @var string $packageId */
         $packageId = $input->getArgument('package-id');
 
         // the package manager don't know new packages in the addon folder

--- a/redaxo/src/core/lib/console/package/install.php
+++ b/redaxo/src/core/lib/console/package/install.php
@@ -24,7 +24,6 @@ class rex_command_package_install extends rex_console_command
     {
         $io = $this->getStyle($input, $output);
 
-        /** @var string $packageId */
         $packageId = $input->getArgument('package-id');
 
         // the package manager don't know new packages in the addon folder

--- a/redaxo/src/core/lib/console/package/uninstall.php
+++ b/redaxo/src/core/lib/console/package/uninstall.php
@@ -22,7 +22,6 @@ class rex_command_package_uninstall extends rex_console_command
     {
         $io = $this->getStyle($input, $output);
 
-        /** @var string $packageId */
         $packageId = $input->getArgument('package-id');
 
         // the package manager don't know new packages in the addon folder


### PR DESCRIPTION
Das Plugin analysiert nun die Consolen-Argumente/Optionen.