### PR TITLE
Artikel-Content-Generierung: Exception bei Fehlern

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_content.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content.php
@@ -92,18 +92,11 @@ class rex_article_content extends rex_article_content_base
 
             $article_content_file = rex_path::addonCache('structure', $this->article_id . '.' . $this->clang . '.content');
 
-            $generated = true;
             if (!file_exists($article_content_file)) {
-                $generated = rex_content_service::generateArticleContent($this->article_id, $this->clang);
-                if (true !== $generated) {
-                    // fehlermeldung ausgeben
-                    echo $generated;
-                }
+                rex_content_service::generateArticleContent($this->article_id, $this->clang);
             }
 
-            if (true === $generated) {
-                require $article_content_file;
-            }
+            require $article_content_file;
 
             // ----- end: article caching
             $CONTENT = ob_get_clean();

--- a/redaxo/src/addons/structure/plugins/content/lib/content_service.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/content_service.php
@@ -321,7 +321,9 @@ class rex_content_service
      * @param int $article_id Id des zu generierenden Artikels
      * @param int $clang      ClangId des Artikels
      *
-     * @return bool|string TRUE bei Erfolg, FALSE wenn eine ungütlige article_id übergeben wird, sonst eine Fehlermeldung
+     * @throws rex_exception
+     *
+     * @return true
      */
     public static function generateArticleContent($article_id, $clang = null)
     {
@@ -334,7 +336,7 @@ class rex_content_service
             $CONT->setCLang($_clang);
             $CONT->setEval(false); // Content nicht ausführen, damit in Cachedatei gespeichert werden kann
             if (!$CONT->setArticleId($article_id)) {
-                return false;
+                throw new rex_exception(sprintf('Article %d does not exist.', $article_id));
             }
 
             // --------------------------------------------------- Artikelcontent speichern
@@ -349,7 +351,7 @@ class rex_content_service
             ]));
 
             if (false === rex_file::put($article_content_file, $article_content)) {
-                return rex_i18n::msg('article_could_not_be_generated') . ' ' . rex_i18n::msg('check_rights_in_directory') . rex_path::addonCache('structure');
+                throw new rex_exception(sprintf('Article %d could not be generated, check the directory permissions for "%s".', $article_id, rex_path::addonCache('structure')));
             }
         }
 


### PR DESCRIPTION
Vorher wurde da im Frontend einfach eine Fehlermeldung ausgegeben per `echo`, die den vollen Pfad zum Cache-Ordner enthielt. Da man das ja nicht machen sollte, sehe ich das als Bugfix.