### PR TITLE
touch(): Fehler unterdrücken

### DIFF
--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -127,7 +127,7 @@ class rex_file
 
                 if (rex_dir::isWritable($dstdir) && (!file_exists($dstfile) || is_writable($dstfile)) && copy($srcfile, $dstfile)) {
                     @chmod($dstfile, rex::getFilePerm());
-                    touch($dstfile, filemtime($srcfile), fileatime($srcfile));
+                    @touch($dstfile, filemtime($srcfile), fileatime($srcfile));
                     return true;
                 }
             }


### PR DESCRIPTION
fixes #595

touch() lässt sich nur nutzen, wenn man der Owner der Datei ist.