### PR TITLE
Addons: PHP-Mindestversion setzen

### DIFF
--- a/redaxo/src/addons/backup/package.yml
+++ b/redaxo/src/addons/backup/package.yml
@@ -19,5 +19,6 @@ page:
 
 requires:
     php:
+        version: '>=7.1'
         extensions: [ctype]
     redaxo: ^5.9.0

--- a/redaxo/src/addons/be_style/package.yml
+++ b/redaxo/src/addons/be_style/package.yml
@@ -12,4 +12,5 @@ console_commands:
     styles:compile: rex_be_style_command_compile
 
 requires:
+    php: '>=7.1'
     redaxo: ^5.10.0

--- a/redaxo/src/addons/cronjob/package.yml
+++ b/redaxo/src/addons/cronjob/package.yml
@@ -18,6 +18,7 @@ pages:
         perm: admin[]
 
 requires:
+    php: '>=7.1'
     redaxo: ^5.9.0
 
 console_commands:

--- a/redaxo/src/addons/debug/package.yml
+++ b/redaxo/src/addons/debug/package.yml
@@ -4,3 +4,6 @@ author: Markus Staab
 supportpage: www.redaxo.org/de/forum/
 
 load: early
+
+requires:
+    php: '>=7.1'

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -21,6 +21,7 @@ page:
 
 requires:
     php:
+        version: '>=7.1'
         extensions: [zlib]
     redaxo: ^5.7.0
 

--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -13,8 +13,10 @@ page:
         settings: { title: 'translate:media_manager_subpage_config' }
         overview: { title: 'translate:media_manager_subpage_desc', subPath: README.md }
         clear_cache: { title: 'translate:media_manager_subpage_clear_cache', itemclass: 'pull-right', linkclass: 'btn btn-delete', href: { page: media_manager/types, func: clear_cache } }
+
 requires:
     php:
+        version: '>=7.1'
         extensions: [gd]
     redaxo: ^5.10.0
 

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -30,4 +30,5 @@ allowed_doctypes: [bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, mp4, 
 image_extensions: [bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]
 
 requires:
+    php: '>=7.1'
     redaxo: ^5.10.0

--- a/redaxo/src/addons/metainfo/package.yml
+++ b/redaxo/src/addons/metainfo/package.yml
@@ -15,6 +15,7 @@ page:
         clangs: { title: 'translate:clangs' }
 
 requires:
+    php: '>=7.1'
     redaxo: '^5.6.0'
     packages:
         structure: '^2.0.0'

--- a/redaxo/src/addons/phpmailer/package.yml
+++ b/redaxo/src/addons/phpmailer/package.yml
@@ -20,6 +20,7 @@ pages:
         perm: admin
 
 requires:
+    php: '>=7.1'
     redaxo: ^5.10.0
 
 default_config:

--- a/redaxo/src/addons/structure/package.yml
+++ b/redaxo/src/addons/structure/package.yml
@@ -24,4 +24,5 @@ pages:
 system_plugins: [content]
 
 requires:
+    php: '>=7.1'
     redaxo: ^5.5.0

--- a/redaxo/src/addons/users/package.yml
+++ b/redaxo/src/addons/users/package.yml
@@ -17,4 +17,5 @@ page:
         roles: { title: 'translate:roles', perm: admin }
 
 requires:
+    php: '>=7.1'
     redaxo: ^5.5.0


### PR DESCRIPTION
Aufgefallen war das Problem bei einigen, da ich den Installer ja auch einzeln zur Verfügung gestellt habe für R>=5.7. Und R5.7 ist noch kompatibel zu PHP>=5.5, aber die einzeln veröffentlichte Installer-Version benötigt schon PHP>=7.1.