### PR TITLE
fix AssertionError

### DIFF
--- a/redaxo/src/core/lib/form/elements/container.php
+++ b/redaxo/src/core/lib/form/elements/container.php
@@ -68,6 +68,9 @@ class rex_form_container_element extends rex_form_element
     protected function prepareInnerFields()
     {
         $values = $this->getValue();
+        if (null === $values) {
+            return;
+        }
         if (is_string($values)) {
             $values = json_decode($values, true);
             if (!$this->multiple) {


### PR DESCRIPTION
Paar Zeilen weiter das `assert()` löste sonst teils aus.
Daher nun ein schnelles Abbrechen bei `null`, da die Methode da sowieso nichts macht.