### PR TITLE
root composer.json

### DIFF
--- a/.tools/bin/update-requirements
+++ b/.tools/bin/update-requirements
@@ -95,6 +95,10 @@ find redaxo/src/addons/tests/vendor -name "phpstan.neon.dist" -type f -delete
 find redaxo/src/addons/tests/vendor -name "phpunit.xml" -type f -delete
 find redaxo/src/addons/tests/vendor -name "psalm.xml" -type f -delete
 
+printf "\nUpdate root vendor\n"
+.tools/bin/update-root-composer
+composer update
+
 printf "\nUpdate redaxo/src/core/assets/jquery.min.js\n"
 curl -# https://cdn.jsdelivr.net/gh/jquery/jquery@3/dist/jquery.js > redaxo/src/core/assets/jquery.js
 curl -# https://cdn.jsdelivr.net/gh/jquery/jquery@3/dist/jquery.min.js > redaxo/src/core/assets/jquery.min.js

--- a/.tools/bin/update-requirements
+++ b/.tools/bin/update-requirements
@@ -95,7 +95,7 @@ find redaxo/src/addons/tests/vendor -name "phpstan.neon.dist" -type f -delete
 find redaxo/src/addons/tests/vendor -name "phpunit.xml" -type f -delete
 find redaxo/src/addons/tests/vendor -name "psalm.xml" -type f -delete
 
-printf "\nUpdate root vendor\n"
+printf "\nUpdate root composer.json and vendor/\n"
 .tools/bin/update-root-composer
 composer update
 

--- a/.tools/bin/update-root-composer
+++ b/.tools/bin/update-root-composer
@@ -4,6 +4,8 @@
 $replace = [];
 
 $baseDir = dirname(__DIR__, 2);
+// list of core addons with a composer.lock.
+// intentionally not using a wildcard because other non-system-addons might be contained
 $dirs = [
     $baseDir.'/redaxo/src/addons/be_style',
     $baseDir.'/redaxo/src/addons/debug',

--- a/.tools/bin/update-root-composer
+++ b/.tools/bin/update-root-composer
@@ -1,0 +1,29 @@
+#!/usr/bin/env php
+<?php
+
+$replace = [];
+
+$baseDir = dirname(__DIR__, 2);
+$dirs = [
+    $baseDir.'/redaxo/src/addons/be_style',
+    $baseDir.'/redaxo/src/addons/debug',
+    $baseDir.'/redaxo/src/addons/phpmailer',
+    $baseDir.'/redaxo/src/core',
+];
+
+foreach ($dirs as $dir) {
+    $packages = json_decode(file_get_contents($dir.'/composer.lock'), true)['packages'];
+
+    foreach ($packages as $package) {
+        if (is_dir($dir.'/vendor/'.$package['name'])) {
+            $replace[$package['name']] = $package['version'];
+        }
+    }
+}
+
+ksort($replace);
+
+$file = $baseDir.'/composer.json';
+$content = json_decode(file_get_contents($file), true);
+$content['replace'] = $replace;
+file_put_contents($file, json_encode($content, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");

--- a/.tools/bootstrap.php
+++ b/.tools/bootstrap.php
@@ -1,9 +1,4 @@
 <?php
 
-unset($REX);
-$REX['REDAXO'] = false;
-$REX['HTDOCS_PATH'] = './';
-$REX['BACKEND_FOLDER'] = 'redaxo';
-$REX['LOAD_PAGE'] = false;
-
-require $REX['BACKEND_FOLDER'] . '/src/core/boot.php';
+// Simulate existance of this constant (normally defined in core/boot.php)
+define('REX_MIN_PHP_VERSION', '7.1.3');

--- a/.tools/bootstrap.php
+++ b/.tools/bootstrap.php
@@ -1,4 +1,0 @@
-<?php
-
-// Simulate existance of this constant (normally defined in core/boot.php)
-define('REX_MIN_PHP_VERSION', '7.1.3');

--- a/.tools/bootstrap.php
+++ b/.tools/bootstrap.php
@@ -7,19 +7,3 @@ $REX['BACKEND_FOLDER'] = 'redaxo';
 $REX['LOAD_PAGE'] = false;
 
 require $REX['BACKEND_FOLDER'] . '/src/core/boot.php';
-
-// include all functions, which might otherwise only be conditionally included
-$finder = rex_finder::factory('redaxo/src/')
-    ->recursive()
-    // ignore files, which dont contain declarations but execute logic
-    ->ignoreFiles('function_rex_category.php')
-    ->filesOnly();
-/** @var SplFileInfo $file */
-foreach ($finder as $path => $file) {
-    if (false !== strpos($file->getPath(), 'functions') && '.php' === substr($path, -4)) {
-        require_once $file->getRealPath();
-    }
-}
-
-// manually include functions which dont match the expectations of a "functions" folder
-require_once 'redaxo/src/addons/metainfo/extensions/extension_cleanup.php';

--- a/.tools/constants.php
+++ b/.tools/constants.php
@@ -1,0 +1,6 @@
+<?php
+
+// For static analysis we do not boot redaxo.
+// But to avoid errors about non-existing constants (usually defined while booting redaxo), we define them here.
+
+define('REX_MIN_PHP_VERSION', json_decode(file_get_contents(__DIR__.'/../composer.json'), true)['config']['platform']['php']);

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,8 @@
             "redaxo/src/core/functions/function_rex_escape.php",
             "redaxo/src/core/functions/function_rex_globals.php",
             "redaxo/src/core/functions/function_rex_other.php",
-            "redaxo/src/core/vendor/autoload.php"
+            "redaxo/src/core/vendor/autoload.php",
+            ".tools/constants.php"
         ]
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,8 @@
 {
+    "name": "redaxo/source",
+    "type": "library",
+    "description": "REDAXO CMS source repository (for static analysis)",
+    "license": "MIT",
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
         "friendsofredaxo/linter": "^1.2",
@@ -6,16 +10,78 @@
         "psalm/plugin-symfony": "^1.2.1",
         "vimeo/psalm": "^3.10.1"
     },
+    "replace": {
+        "erusev/parsedown": "1.7.4",
+        "erusev/parsedown-extra": "0.8.1",
+        "filp/whoops": "2.7.1",
+        "itsgoingd/clockwork": "v4.1.2",
+        "phpmailer/phpmailer": "v6.1.5",
+        "psr/container": "1.0.0",
+        "psr/http-message": "1.0.1",
+        "psr/log": "1.1.3",
+        "ramsey/collection": "0.3.0",
+        "ramsey/http-range": "dev-legacy",
+        "scssphp/scssphp": "1.1.0",
+        "symfony/console": "v4.4.8",
+        "symfony/polyfill-ctype": "v1.15.0",
+        "symfony/polyfill-intl-grapheme": "v1.15.0",
+        "symfony/polyfill-intl-normalizer": "v1.15.0",
+        "symfony/polyfill-mbstring": "v1.15.0",
+        "symfony/polyfill-php72": "v1.15.0",
+        "symfony/polyfill-php73": "v1.15.0",
+        "symfony/service-contracts": "v1.1.8",
+        "symfony/var-dumper": "v4.4.8",
+        "symfony/yaml": "v4.4.8",
+        "voku/anti-xss": "4.1.24",
+        "voku/portable-ascii": "1.4.10",
+        "voku/portable-utf8": "5.4.41"
+    },
+    "autoload": {
+        "classmap": [
+            "redaxo/src/addons/backup/lib/",
+            "redaxo/src/addons/backup/vendor/",
+            "redaxo/src/addons/be_style/lib/",
+            "redaxo/src/addons/be_style/vendor/scssphp/",
+            "redaxo/src/addons/cronjob/lib/",
+            "redaxo/src/addons/cronjob/plugins/article_status/lib/",
+            "redaxo/src/addons/cronjob/plugins/optimize_tables/lib/",
+            "redaxo/src/addons/debug/lib/",
+            "redaxo/src/addons/debug/vendor/",
+            "redaxo/src/addons/install/lib/",
+            "redaxo/src/addons/media_manager/lib/",
+            "redaxo/src/addons/mediapool/lib/",
+            "redaxo/src/addons/metainfo/lib/",
+            "redaxo/src/addons/phpmailer/lib/",
+            "redaxo/src/addons/phpmailer/vendor/",
+            "redaxo/src/addons/structure/lib/",
+            "redaxo/src/addons/structure/plugins/content/lib/",
+            "redaxo/src/addons/structure/plugins/history/lib/",
+            "redaxo/src/addons/structure/plugins/version/lib/",
+            "redaxo/src/addons/users/lib/",
+            "redaxo/src/core/lib/"
+        ],
+        "files": [
+            "redaxo/src/addons/mediapool/functions/function_rex_mediapool.php",
+            "redaxo/src/addons/metainfo/extensions/extension_cleanup.php",
+            "redaxo/src/addons/metainfo/functions/function_metainfo.php",
+            "redaxo/src/addons/structure/functions/function_rex_url.php",
+            "redaxo/src/core/functions/function_rex_escape.php",
+            "redaxo/src/core/functions/function_rex_globals.php",
+            "redaxo/src/core/functions/function_rex_other.php",
+            "redaxo/src/core/vendor/autoload.php"
+        ]
+    },
     "autoload-dev": {
         "classmap": [
             "redaxo/src/addons/media_manager/tests/",
             "redaxo/src/addons/mediapool/tests/",
             "redaxo/src/addons/structure/tests/",
             "redaxo/src/addons/structure/plugins/content/tests/",
+            "redaxo/src/addons/tests/lib/",
+            "redaxo/src/addons/tests/vendor/",
             "redaxo/src/core/tests/"
         ]
     },
-
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,7 +16,6 @@ parameters:
         - redaxo/src/addons/structure
         - redaxo/src/addons/tests
         - redaxo/src/addons/users
-    bootstrap: .tools/bootstrap.php
     excludes_analyse:
         - redaxo/src/addons/be_style/vendor/
         - redaxo/src/addons/debug/vendor/

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-    autoloader=".tools/bootstrap.php"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"


### PR DESCRIPTION
Behebt diese Probleme:
- Lokal gab es vorher bei phpstan bei mir immer Fehler, wenn nicht alle Addons/Plugins aktiviert waren
- Für die Analyse wurde für symfony/yaml zum Beispiel die Dateien aus `/vendor` statt aus `redaxo/core/vendor` genommen, es wurde also unter Umständen mit anderen Versionen analysiert, als die eigentlich in Redaxo liegen

Und der PR stellt das Repo nun unter `redaxo/source` zur Verfügung.