### PR TITLE
trigger github-actions when PR leaves DRAFT state

### DIFF
--- a/.github/workflows/csfix.yml
+++ b/.github/workflows/csfix.yml
@@ -2,6 +2,7 @@ name: php-cs-fixer
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
     - '**.php'
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,7 @@ on:
     - bugfix
     - temp
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
     - '*'
 

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -1,6 +1,8 @@
 name: Visual Regression Testing
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
     build:


### PR DESCRIPTION
see 
- https://github.community/t5/GitHub-Actions/Don-t-run-actions-on-draft-pull-requests/m-p/55316/highlight/true#M9508
- https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request

> Note: By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened. To trigger workflows for more activity types, use the types keyword.