### PR TITLE
WIP: initial clockwork console integration

### DIFF
--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -1,4 +1,5 @@
 <?php
+
 // XXX
 if (rex::getConsole()) {
     rex_sql::setFactoryClass(rex_sql_debug::class);

--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -1,4 +1,13 @@
 <?php
+// XXX
+if (rex::getConsole()) {
+    rex_sql::setFactoryClass(rex_sql_debug::class);
+    rex_extension::setFactoryClass(rex_extension_debug::class);
+
+    rex_logger::setFactoryClass(rex_logger_debug::class);
+    rex_api_function::setFactoryClass(rex_api_function_debug::class);
+    return;
+}
 
 // collect only data in debug mode with http requests outside of the debug addon
 if (!rex::isDebugMode() || !rex_server('REQUEST_URI') || 'debug' === rex_get(rex_api_function::REQ_CALL_PARAM)) {

--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -48,7 +48,21 @@ class rex_console_application extends Application
             $this->loadPackages($command);
         }
 
-        return parent::doRunCommand($command, $input, $output);
+        $exitCode = parent::doRunCommand($command, $input, $output);
+
+        $clockwork = rex_debug_clockwork::getInstance();
+        $clockwork->resolveAsCommand(
+            $command->getName(),
+            $exitCode,
+            // XXX convert to the correct types, see https://github.com/itsgoingd/clockwork/issues/394
+            $command->getDefinition()->getArguments(),
+            $command->getDefinition()->getOptions(),
+            $command->getDefinition()->getArgumentDefaults(),
+            $command->getDefinition()->getOptionDefaults()
+        )
+        ->storeRequest();
+
+        return $exitCode;
     }
 
     private function loadPackages(rex_console_command $command)


### PR DESCRIPTION
ich hatte lokal es versucht via `rex_factory_trait` in der `rex_console_application` eine integration zu bauen - aber das ging nicht, da die boot.php der addons zu spät zieht aktuell um die factory-class auszutauschen.

daher hab ich jetzt erstmal generell versucht wie die integration mit clockwork aussieht.

das ganze sieht in der UI dann so aus:
![grafik](https://user-images.githubusercontent.com/120441/81818971-fdf5cc80-952e-11ea-892f-0546c5033d27.png)


related upstream issues:
- https://github.com/itsgoingd/clockwork/issues/394
- https://github.com/itsgoingd/clockwork/issues/395

closes https://github.com/redaxo/redaxo/issues/3581

**Todos**
- [ ] integration mit clockwork finalisieren (hier passen die argumente/optionen noch nicht
- [ ] schauen, wie wir das ganze ins debug addon bekommen könnten, statt wie hier aktuell noch in core klassen