### PR TITLE
debug() expanded design fix

### DIFF
--- a/redaxo/src/core/lib/var_dumper.php
+++ b/redaxo/src/core/lib/var_dumper.php
@@ -61,6 +61,11 @@ abstract class rex_var_dumper
                         background-color: transparent;
                         color: #eeffff;
                     ',
+                    'expanded' =>  $styleAll . '
+                        white-space: pre;
+                        background: unset;
+                        color: inherit;
+                    ',
                     'const' => $styleAll . 'color: #F78C6C; font-weight: 700;',
                     'ellipsis' => $styleAll . 'color: #eeffff;',
                     'index' => $styleAll . 'color: #C3E88D;',

--- a/redaxo/src/core/lib/var_dumper.php
+++ b/redaxo/src/core/lib/var_dumper.php
@@ -61,7 +61,7 @@ abstract class rex_var_dumper
                         background-color: transparent;
                         color: #eeffff;
                     ',
-                    'expanded' =>  $styleAll . '
+                    'expanded' => $styleAll . '
                         white-space: pre;
                         background: unset;
                         color: inherit;


### PR DESCRIPTION
Bei Verwendung von UiKit im Front- und Backend wurde die Ausgabe von `<samp>` von uikit übernommen. Durch Zuordnung eines eigenen Stils für `expanded` kann das gelöst werden.  

fixes https://github.com/redaxo/redaxo/issues/3627

vorher: 

<img width="541" alt="Bildschirmfoto 2020-05-15 um 16 21 05" src="https://user-images.githubusercontent.com/791247/82065999-1ef52380-96cf-11ea-8373-9bdc5263af30.png">


Nachher: 

<img width="233" alt="Bildschirmfoto 2020-05-15 um 16 31 48" src="https://user-images.githubusercontent.com/791247/82066009-23214100-96cf-11ea-8ba4-135d323a5cbb.png">
