### PR TITLE
GithubAction: dont run jobs on forks, because we are not allowed to commit

### DIFF
--- a/.github/workflows/cs-fix.yml
+++ b/.github/workflows/cs-fix.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest
+    # dont run jobs on forks, because we are not allowed to commit
     if: github.event.pull_request.draft == false && github.repository == 'redaxo/redaxo'
 
     steps:

--- a/.github/workflows/cs-fix.yml
+++ b/.github/workflows/cs-fix.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.repository == 'redaxo/redaxo'
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -8,7 +8,7 @@ jobs:
     build:
 
         runs-on: ubuntu-latest
-        if: github.event.pull_request.draft == false
+        if: github.event.pull_request.draft == false && github.repository == 'redaxo/redaxo'
         
         services:
             mysql:

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -8,7 +8,7 @@ jobs:
     build:
 
         runs-on: ubuntu-latest
-        if: github.event.pull_request.draft == false && github.repository == 'redaxo/redaxo'
+        if: github.event.pull_request.draft == false
         
         services:
             mysql:


### PR DESCRIPTION
inspired by https://github.community/t5/GitHub-Actions/Stop-github-actions-running-on-a-fork/m-p/51555#M8236

damit wir niemanden abschrecken da der PR nie grün wird, oder sich jemand verausgabt den Build grün zu bekommen, obwohl es in forks technisch aktuell gar nicht möglich ist

-> weniger verwirrung