### PR TITLE
Debug: remove unnecessary check

### DIFF
--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -1,7 +1,7 @@
 <?php
 
 // collect only data in debug mode with http requests outside of the debug addon
-if (!rex::isDebugMode() || !(rex_server('REQUEST_URI') || rex::getConsole()) || 'debug' === rex_get(rex_api_function::REQ_CALL_PARAM)) {
+if (!rex::isDebugMode() || 'debug' === rex_get(rex_api_function::REQ_CALL_PARAM)) {
     return;
 }
 


### PR DESCRIPTION
`!(rex_server('REQUEST_URI') || rex::getConsole())` wird nicht mehr benötigt, da wir keinen anderen Zugriffspunkte außer console und web-sapi haben.