### PR TITLE
cli-setup: rename option from 'existing' to 'skip'

### DIFF
--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -280,12 +280,12 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         $createdbOptions = [
             'normal' => 'Setup database',
             'override' => 'Setup database and overwrite it if it exitsts already (Caution - All existing data will be deleted!)',
-            'existing' => 'Database already exists (Continue without database import)',
+            'skip' => 'Database already exists (Continue without database import)',
             'update' => 'Update database (Update from previous version)',
             'import' => 'Import existing database export',
         ];
         if (!$tables_complete) {
-            unset($createdbOptions['existing']);
+            unset($createdbOptions['skip']);
         }
         if (0 === count($backups)) {
             unset($createdbOptions['import']);
@@ -318,7 +318,7 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
             }
             $error = rex_setup_importer::loadExistingImport($import_name);
             $io->success('Database successfully imported using file "'.$import_name.'"');
-        } elseif ('existing' == $createdb && $tables_complete) {
+        } elseif ('skip' == $createdb && $tables_complete) {
             $error = rex_setup_importer::databaseAlreadyExists();
             $io->success('Skipping database setup');
         } elseif ('override' == $createdb) {


### PR DESCRIPTION
feels more natural. 'skip' better transports the meaning of the action beeing taken

## Todo
- [ ] BC mit `existing` keyword, damit bereits bestehende automatisierungen/skripts weiter funktionieren


## vorher
```
Step 5 of 6 / Database
======================

 Database version: MariaDB 10.1.37

 Choose database setup [ normal ]:
  [normal  ] Setup database
  [override] Setup database and overwrite it if it exitsts already (Caution - All existing data will be deleted!)
  [existing] Database already exists (Continue without database import)
  [update  ] Update database (Update from previous version)
 > existing

                                                                                                                        
 [OK] Using "existing" database setup                                                                                   
                                                                                                                        

                                                                                                                        
 [OK] Skipping database setup                                                                                                                                      
```

## nachher
```
Step 5 of 6 / Database
======================

 Database version: MariaDB 10.1.37

 Choose database setup [ normal ]:
  [normal  ] Setup database
  [override] Setup database and overwrite it if it exitsts already (Caution - All existing data will be deleted!)
  [skip    ] Database already exists (Continue without database import)
  [update  ] Update database (Update from previous version)
 > skip

                                                                                                                        
 [OK] Using "skip" database setup                                                                                       
                                                                                                                        

                                                                                                                        
 [OK] Skipping database setup                                                                                                                                                                                                         ```