### PR TITLE
Console: config:set allow boolean string

### DIFF
--- a/redaxo/src/core/lib/console/config/set.php
+++ b/redaxo/src/core/lib/console/config/set.php
@@ -49,7 +49,7 @@ EOF
             throw new InvalidArgumentException('No new value specified');
         }
 
-        if ('bool' === $type || 'boolean' === $type) {
+        if (!$unset && ('bool' === $type || 'boolean' === $type)) {
             $value = 'true' === $value || 'on' === $value ? true : $value;
             $value = 'false' === $value || 'off' === $value ? false : $value;
         }

--- a/redaxo/src/core/lib/console/config/set.php
+++ b/redaxo/src/core/lib/console/config/set.php
@@ -28,9 +28,15 @@ class rex_command_config_set extends rex_console_command
         $key = $input->getArgument('config-key');
         $value = $input->getArgument('value');
         $unset = $input->getOption('unset');
+        $type = $input->getOption('type');
 
         if (null === $value && false === $unset) {
             throw new InvalidArgumentException('No new value specified');
+        }
+
+        if ($type === 'bool' || $type === 'boolean') {
+            $value = $value === 'true' ? true : $value;
+            $value = $value === 'false' ? false : $value;
         }
 
         $path = explode('.', $key);
@@ -44,7 +50,7 @@ class rex_command_config_set extends rex_console_command
                 $config[$pathPart] = [];
             }
             if ($i === count($path) - 1) {
-                $config[$pathPart] = $unset ? null : rex_type::cast($value, $input->getOption('type'));
+                $config[$pathPart] = $unset ? null : rex_type::cast($value, $type);
                 break;
             }
             $config = &$config[$pathPart];

--- a/redaxo/src/core/lib/console/config/set.php
+++ b/redaxo/src/core/lib/console/config/set.php
@@ -34,9 +34,9 @@ class rex_command_config_set extends rex_console_command
             throw new InvalidArgumentException('No new value specified');
         }
 
-        if ($type === 'bool' || $type === 'boolean') {
-            $value = $value === 'true' ? true : $value;
-            $value = $value === 'false' ? false : $value;
+        if ('bool' === $type || 'boolean' === $type) {
+            $value = 'true' === $value ? true : $value;
+            $value = 'false' === $value ? false : $value;
         }
 
         $path = explode('.', $key);

--- a/redaxo/src/core/lib/console/config/set.php
+++ b/redaxo/src/core/lib/console/config/set.php
@@ -35,8 +35,8 @@ class rex_command_config_set extends rex_console_command
         }
 
         if ('bool' === $type || 'boolean' === $type) {
-            $value = 'true' === $value ? true : $value;
-            $value = 'false' === $value ? false : $value;
+            $value = 'true' === $value || 'on' === $value ? true : $value;
+            $value = 'false' === $value || 'off' === $value ? false : $value;
         }
 
         $path = explode('.', $key);

--- a/redaxo/src/core/lib/console/config/set.php
+++ b/redaxo/src/core/lib/console/config/set.php
@@ -18,7 +18,22 @@ class rex_command_config_set extends rex_console_command
             ->addArgument('config-key', InputArgument::REQUIRED, 'config path separated by periods, e.g. "setup" or "db.1.host"')
             ->addArgument('value', InputArgument::OPTIONAL, 'new value for config key, e.g. "somestring" or "1"')
             ->addOption('type', 't', InputOption::VALUE_REQUIRED, 'php type of new value, e.g. "bool" or "int"', 'string')
-            ->addOption('unset', null, InputOption::VALUE_NONE, 'sets the config key to null');
+            ->addOption('unset', null, InputOption::VALUE_NONE, 'sets the config key to null')
+            ->setHelp(<<<'EOF'
+Set config variables in config.yml.
+
+Example: enable setup
+  <info>%command.full_name% --type boolean setup true</info>
+
+Example: set password min length to 8
+  <info>%command.full_name% --type integer password_policy.length.min 8</info>
+
+Example: set error email
+  <info>%command.full_name% error_email mail@example.org</info>
+
+EOF
+            )
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/redaxo/src/core/tests/console/config/set_test.php
+++ b/redaxo/src/core/tests/console/config/set_test.php
@@ -1,0 +1,37 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+class rex_command_config_set_test extends TestCase
+{
+    /**
+     * @dataProvider dataSetBoolean
+     */
+    public function testSetBoolean($expectedValue, $value)
+    {
+        $commandTester = new CommandTester(new rex_command_config_set());
+        $commandTester->execute([
+            'type' => 'bool',
+            'config-key' => 'test',
+            'value' => $value,
+        ]);
+        $config = rex_file::getConfig(rex_path::coreData('config.yml'));
+        static::assertIsBool($config['test']);
+        static::assertEquals($expectedValue, $config['test']);
+        static::assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function dataSetBoolean()
+    {
+        return [
+            [true, '1'],
+            [false, '0'],
+            [true, 'true'],
+            [false, 'false'],
+        ];
+    }
+}

--- a/redaxo/src/core/tests/console/config/set_test.php
+++ b/redaxo/src/core/tests/console/config/set_test.php
@@ -32,6 +32,8 @@ class rex_command_config_set_test extends TestCase
             [false, '0'],
             [true, 'true'],
             [false, 'false'],
+            [true, 'on'],
+            [false, 'off'],
         ];
     }
 }

--- a/redaxo/src/core/tests/console/config/set_test.php
+++ b/redaxo/src/core/tests/console/config/set_test.php
@@ -15,7 +15,7 @@ class rex_command_config_set_test extends TestCase
     {
         $commandTester = new CommandTester(new rex_command_config_set());
         $commandTester->execute([
-            'type' => 'bool',
+            '--type' => 'bool',
             'config-key' => 'test',
             'value' => $value,
         ]);


### PR DESCRIPTION
closes #3673 

aktuell lässt sich ein boolesches `false` nur durch  
`php redaxo/bin/console config:set --type="bool" debug.enabled 0`
setzen.

Ich würde als Anwender erwarten, dass ich ein `false` auch "ausgeschrieben" setzen kann.
`php redaxo/bin/console config:set --type="bool" debug.enabled false`