### PR TITLE
Redaxo-Log-Eintrag um Success erweitern

### DIFF
--- a/redaxo/src/core/pages/system.log.redaxo.php
+++ b/redaxo/src/core/pages/system.log.redaxo.php
@@ -59,7 +59,7 @@ foreach (new LimitIterator($file, 0, 100) as $entry) {
     $data = $entry->getData();
 
     $class = strtolower($data[0]);
-    $class = ('notice' == $class || 'warning' == $class) ? $class : 'error';
+    $class = ('notice' == $class || 'warning' == $class || 'success' == $class) ? $class : 'error';
 
     $path = '';
     if (isset($data[2])) {


### PR DESCRIPTION
Erweiterung der Redaxo-Log-Darstellung um Success (grün).
Bisher:
```
rex_logger::factory()->log('Error', 'Error-Eintrag');
rex_logger::factory()->log('Notice', 'Notice-Eintrag');
rex_logger::factory()->log('Warning', 'Warning-Eintrag');
```
Neu: 
`rex_logger::factory()->log('Success', 'Success-Eintrag');`

![Bildschirmfoto 2020-06-02 um 15 56 50](https://user-images.githubusercontent.com/16903055/83528823-dcfb1880-a4e9-11ea-9891-de9aee1c3e99.png)
