### PR TITLE
rex::getConsole() befüllen vor Laden der Addons

### DIFF
--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -7,6 +7,12 @@ require __DIR__.'/boot.php';
 // force debug mode to enable output of notices/warnings and dump() function
 rex::setProperty('debug', true);
 
+rex::setProperty('lang', 'en_gb');
+rex_i18n::setLocale('en_gb');
+
+$application = new rex_console_application();
+rex::setProperty('console', $application);
+
 rex_addon::initialize(!rex::isSetup());
 
 if (!rex::isSetup()) {
@@ -14,13 +20,6 @@ if (!rex::isSetup()) {
         rex_package::require($packageId)->enlist();
     }
 }
-
-$application = new rex_console_application();
-
-rex::setProperty('console', $application);
-
-rex::setProperty('lang', 'en_gb');
-rex_i18n::setLocale('en_gb');
 
 $application->setCommandLoader(new rex_console_command_loader());
 


### PR DESCRIPTION
fixes #3693

Wir fragen bei dem Cache-Handling der package.yml zwar `rex::getConsole()` ab, aber das war zu dem Zeitpunkt noch gar nicht befüllt.