### PR TITLE
take mysql comments into account in `rex_sql_column`

### DIFF
--- a/redaxo/src/core/lib/sql/column.php
+++ b/redaxo/src/core/lib/sql/column.php
@@ -29,6 +29,10 @@ class rex_sql_column
      * @var null|string
      */
     private $extra;
+    /**
+     * @var null|string
+     */
+    private $comment;
 
     /**
      * @var bool
@@ -41,14 +45,16 @@ class rex_sql_column
      * @param bool        $nullable
      * @param null|string $default
      * @param null|string $extra
+     * @param null|string $comment
      */
-    public function __construct($name, $type, $nullable = false, $default = null, $extra = null)
+    public function __construct($name, $type, $nullable = false, $default = null, $extra = null, $comment = null)
     {
         $this->name = $name;
         $this->type = $type;
         $this->nullable = $nullable;
         $this->default = $default;
         $this->extra = $extra;
+        $this->comment = $comment;
     }
 
     /**
@@ -172,6 +178,26 @@ class rex_sql_column
     }
 
     /**
+     * @param null|string $comment
+     *
+     * @return $this
+     */
+    public function setComment($comment)
+    {
+        $this->comment = $comment;
+
+        return $this->setModified(true);
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
      * @return bool
      */
     public function equals(self $column)
@@ -181,6 +207,7 @@ class rex_sql_column
             $this->type === $column->type &&
             $this->nullable === $column->nullable &&
             $this->default === $column->default &&
-            $this->extra === $column->extra;
+            $this->extra === $column->extra &&
+            $this->comment === $column->comment;
     }
 }

--- a/redaxo/src/core/lib/sql/schema_dumper.php
+++ b/redaxo/src/core/lib/sql/schema_dumper.php
@@ -71,7 +71,12 @@ class rex_sql_schema_dumper
         $parameters = [];
         $nonDefault = false;
 
-        if (null !== $column->getExtra()) {
+        if (null !== $column->getComment()) {
+            $parameters[] = $this->scalar($column->getComment());
+            $nonDefault = true;
+        }
+
+        if ($nonDefault || null !== $column->getExtra()) {
             $parameters[] = $this->scalar($column->getExtra());
             $nonDefault = true;
         }

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1680,7 +1680,7 @@ class rex_sql implements Iterator
      * @throws rex_sql_exception
      *
      * @return array Ein mehrdimensionales Array das die Metadaten enthaelt
-     * @psalm-return list<array{name: string, type: string, null: 'YES'|'NO', key: string, default: null|string, extra: string, comment: string}>
+     * @psalm-return list<array{name: string, type: string, null: 'YES'|'NO', key: string, default: null|string, extra: string, comment: null|string}>
      */
     public static function showColumns($table, $DBID = 1)
     {

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1696,7 +1696,7 @@ class rex_sql implements Iterator
                 'key' => (string) $col->getValue('Key'),
                 'default' => null === $col->getValue('Default') ? null : (string) $col->getValue('Default'),
                 'extra' => (string) $col->getValue('Extra'),
-                'comment' => (string) $col->getValue('Comment'),
+                'comment' => null === $col->getValue('Comment') ? null : (string) $col->getValue('Comment'),
             ];
         }
 

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1680,12 +1680,12 @@ class rex_sql implements Iterator
      * @throws rex_sql_exception
      *
      * @return array Ein mehrdimensionales Array das die Metadaten enthaelt
-     * @psalm-return list<array{name: string, type: string, null: 'YES'|'NO', key: string, default: null|string, extra: string}>
+     * @psalm-return list<array{name: string, type: string, null: 'YES'|'NO', key: string, default: null|string, extra: string, comment: string}>
      */
     public static function showColumns($table, $DBID = 1)
     {
         $sql = self::factory($DBID);
-        $sql->setQuery('SHOW COLUMNS FROM ' . $sql->escapeIdentifier($table));
+        $sql->setQuery('SHOW FULL COLUMNS FROM ' . $sql->escapeIdentifier($table));
 
         $columns = [];
         foreach ($sql as $col) {
@@ -1696,6 +1696,7 @@ class rex_sql implements Iterator
                 'key' => (string) $col->getValue('Key'),
                 'default' => null === $col->getValue('Default') ? null : (string) $col->getValue('Default'),
                 'extra' => (string) $col->getValue('Extra'),
+                'comment' => (string) $col->getValue('Comment'),
             ];
         }
 

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -925,7 +925,7 @@ class rex_sql_table
         }
 
         return sprintf(
-            '%s %s %s %s %s',
+            '%s %s %s %s %s %s',
             $this->sql->escapeIdentifier($column->getName()),
             $column->getType(),
             $default,

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -101,7 +101,8 @@ class rex_sql_table
                 $type,
                 'YES' === $column['null'],
                 $column['default'],
-                $column['extra'] ?: null
+                $column['extra'] ?: null,
+                $column['comment'] ?: null
             );
 
             $this->columnsExisting[$column['name']] = $column['name'];
@@ -918,13 +919,19 @@ class rex_sql_table
             $default = 'DEFAULT '.$this->sql->escape($column->getDefault());
         }
 
+        $comment = $column->getComment();
+        if ($comment) {
+            $comment = 'COMMENT '. $this->sql->escape($comment);
+        }
+
         return sprintf(
             '%s %s %s %s %s',
             $this->sql->escapeIdentifier($column->getName()),
             $column->getType(),
             $default,
             $column->isNullable() ? '' : 'NOT NULL',
-            $column->getExtra()
+            $column->getExtra(),
+            $comment
         );
     }
 

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -920,7 +920,7 @@ class rex_sql_table
         }
 
         $comment = $column->getComment();
-        if ($comment) {
+        if (null !== $comment && '' !== $comment) {
             $comment = 'COMMENT '. $this->sql->escape($comment);
         }
 

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -24,7 +24,7 @@ class rex_sql_table_test extends TestCase
         $table = rex_sql_table::get(self::TABLE);
 
         $table
-            ->addColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment'))
+            ->addColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment', 'comment for id col'))
             ->addColumn(new rex_sql_column('title', 'varchar(255)', true, 'Default title'))
             ->setPrimaryKey('id')
             ->addIndex(new rex_sql_index('i_title', ['title']))
@@ -72,6 +72,7 @@ class rex_sql_table_test extends TestCase
         static::assertFalse($id->isNullable());
         static::assertNull($id->getDefault());
         static::assertSame('auto_increment', $id->getExtra());
+        static::assertSame('comment for id col', $id->getComment());
 
         $title = $table->getColumn('title');
 

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -215,7 +215,7 @@ class rex_sql_table_test extends TestCase
         $table = rex_sql_table::get(self::TABLE);
 
         static::assertEquals($id, $table->getColumn('id'));
-        static::assertSame(null, $table->getColumn('id')->getComment());
+        static::assertNull($table->getColumn('id')->getComment());
     }
 
     public function testEnsureColumn()

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -24,7 +24,7 @@ class rex_sql_table_test extends TestCase
         $table = rex_sql_table::get(self::TABLE);
 
         $table
-            ->addColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment', 'comment for id col'))
+            ->addColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment', 'initial comment for id col'))
             ->addColumn(new rex_sql_column('title', 'varchar(255)', true, 'Default title'))
             ->setPrimaryKey('id')
             ->addIndex(new rex_sql_index('i_title', ['title']))
@@ -72,7 +72,7 @@ class rex_sql_table_test extends TestCase
         static::assertFalse($id->isNullable());
         static::assertNull($id->getDefault());
         static::assertSame('auto_increment', $id->getExtra());
-        static::assertSame('comment for id col', $id->getComment());
+        static::assertSame('initial comment for id col', $id->getComment());
 
         $title = $table->getColumn('title');
 
@@ -162,6 +162,42 @@ class rex_sql_table_test extends TestCase
         static::assertEquals($description, $table->getColumn('description'));
 
         static::assertSame(['pid', 'id', 'name', 'title', 'description'], array_keys($table->getColumns()));
+    }
+
+    public function testAddColumnComment()
+    {
+        $table = $this->createTable();
+
+        $title = new rex_sql_column('title', 'varchar(20)', false, null, null, 'new title comment');
+        $table
+            ->ensureColumn($title)
+            ->alter();
+
+        static::assertSame($title, $table->getColumn('title'));
+
+        rex_sql_table::clearInstance(self::TABLE);
+        $table = rex_sql_table::get(self::TABLE);
+
+        static::assertEquals($title, $table->getColumn('title'));
+        static::assertSame('new title comment', $table->getColumn('title')->getComment());
+    }
+
+    public function testChangeColumnComment()
+    {
+        $table = $this->createTable();
+
+        $id = new rex_sql_column('id', 'int(11)', false, null, 'auto_increment', 'changed id comment');
+        $table
+            ->ensureColumn($id)
+            ->alter();
+
+        static::assertSame($id, $table->getColumn('id'));
+
+        rex_sql_table::clearInstance(self::TABLE);
+        $table = rex_sql_table::get(self::TABLE);
+
+        static::assertEquals($id, $table->getColumn('id'));
+        static::assertSame('changed id comment', $table->getColumn('id')->getComment());
     }
 
     public function testEnsureColumn()

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -147,7 +147,7 @@ class rex_sql_table_test extends TestCase
     {
         $table = $this->createTable();
 
-        $description = new rex_sql_column('description', 'text', true);
+        $description = new rex_sql_column('description', 'text', true, null, null, 'description comment');
         $table
             ->addColumn($description)
             ->addColumn(new rex_sql_column('name', 'varchar(255)'), 'id')

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -200,6 +200,24 @@ class rex_sql_table_test extends TestCase
         static::assertSame('changed id comment', $table->getColumn('id')->getComment());
     }
 
+    public function testRemoveColumnComment()
+    {
+        $table = $this->createTable();
+
+        $id = new rex_sql_column('id', 'int(11)', false, null, 'auto_increment', null);
+        $table
+            ->ensureColumn($id)
+            ->alter();
+
+        static::assertSame($id, $table->getColumn('id'));
+
+        rex_sql_table::clearInstance(self::TABLE);
+        $table = rex_sql_table::get(self::TABLE);
+
+        static::assertEquals($id, $table->getColumn('id'));
+        static::assertSame(null, $table->getColumn('id')->getComment());
+    }
+
     public function testEnsureColumn()
     {
         $table = $this->createTable();


### PR DESCRIPTION
refs https://github.com/redaxo/redaxo/issues/3700

in der CLI getestet:
```bash
$ php redaxo/bin/console db:dump-schema rex_webvitals
rex_sql_table::get(rex::getTable('webvitals'))
    ->ensureColumn(new rex_sql_column('id', 'int(11)', false, null, 'auto_increment'))
    ->ensureColumn(new rex_sql_column('uri', 'text'))
    ->ensureColumn(new rex_sql_column('article_id', 'int(11)'))
    ->ensureColumn(new rex_sql_column('clang', 'int(11)'))
    ->ensureColumn(new rex_sql_column('cls', 'int(11)', true, null, null, 'cumulative layout shift'))
    ->ensureColumn(new rex_sql_column('fid', 'int(11)', true, null, null, 'first input delay'))
    ->ensureColumn(new rex_sql_column('lcp', 'int(11)', true, null, null, 'largest contentful paint'))
    ->ensureColumn(new rex_sql_column('ttfb', 'int(11)', true, null, null, 'time to first byte'))
    ->setPrimaryKey('id')
    ->ensure();


 [OK] Generated schema for table "rex_webvitals".
```

tabellen kommentare würde ich in einem separaten PR sehen