### PR TITLE
Template-Lösch-Fehler korrigiert

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -42,7 +42,7 @@ if ('delete' == $function) {
 
         if ($del->getRows() > 0 || rex_template::getDefaultId() == $template_id) {
             $template_in_use_message = '';
-            $templatename = $del->getValue('template.name');
+            $templatename = $del->getRows() ? $del->getValue('template.name') : null;
             while ($del->hasNext()) {
                 $aid = $del->getValue('article.id');
                 $clang_id = $del->getValue('article.clang_id');


### PR DESCRIPTION
fixes #3730

Der Fehler entstand, wenn man das Default-Template löschen wollte, und es aber bei keinem Artikel hinterlegt ist.