### PR TITLE
Systemeinstellungen: Editor nicht nullen

### DIFF
--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -68,12 +68,6 @@ if ($func && !$csrfToken->isValid()) {
         }
     }
 
-    if (empty($settings['editor'])) {
-        $settings['editor'] = null;
-    }
-    $config['editor'] = $settings['editor'];
-    rex::setProperty('editor', $config['editor']);
-
     foreach (rex_system_setting::getAll() as $setting) {
         $key = $setting->getKey();
         if (isset($settings[$key])) {


### PR DESCRIPTION
Seit https://github.com/redaxo/redaxo/pull/3639 hat die Editor-Einstellung einen eigenen Block.
Bei der Speicherroutine des oberen Block müssen diese Zeilen daher weg, sonst wird beim Speichern oben der Editor immer genullt.