### PR TITLE
ungenutzte Sprachkeys überprüfen

### DIFF
--- a/.tools/bin/check-i18n
+++ b/.tools/bin/check-i18n
@@ -36,7 +36,7 @@ class rex_check_i18n
         @
         (?<complete>
             \s*
-            (?>rex_i18n::|->)(?>msg|msgInLocale|rawMsg|rawMsgInLocale|hasMsg|hasMsgOrFallback|addMsg|translate|translateArray)\(
+            (?>rex_i18n::|->)(?>i18n|msg|msgInLocale|rawMsg|rawMsgInLocale|hasMsg|hasMsgOrFallback|addMsg|translate|translateArray)\(
                 \s*
                 (?>\'|")
                 (?<key>.*?)
@@ -62,12 +62,11 @@ class rex_check_i18n
         /** @var \SplFileInfo $file */
         foreach ($this->iterator as $file) {
             $filepath = $file->getPathname();
-            $content = \rex_file::get($filepath);
+            $content = rex_file::get($filepath);
 
-            if ('lang' === $file->getExtension() && preg_match_all('/^([^=\s]+)\h*=\h*(\S.*)(?<=\S)/m', $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
-                $path = str_replace(rex_path::src(), '', $filepath);
+            if ('lang' === $file->getExtension() && preg_match_all('/^([^=\s]+)\h*=\h*(\S.*)(?<=\S)/m', $content, $matches, PREG_SET_ORDER)) {
                 foreach ($matches as $match) {
-                    $this->i18nMsg[$match[1][0]] = $path.'#L'.$match[1][1];
+                    $this->i18nMsg[$match[1]] = $file->getPath();
                 }
             }
 
@@ -79,19 +78,45 @@ class rex_check_i18n
         }
     }
 
-    public function check()
+    private function modify()
     {
-        $this->parse();
-
         $unused = [];
-        foreach ($this->i18nMsg as $i18nKey => $i18nFile) {
+        foreach ($this->i18nMsg as $i18nKey => $langDir) {
             if (!isset($this->i18nInUse[$i18nKey])) {
-                $unused[$i18nKey] = $i18nFile;
+                $unused[$langDir][] = $i18nKey;
             }
         }
 
-        echo 'These keys can be deleted.'."\n";
-        print_r($unused);
+        foreach ($unused as $langDir => $i18nKeys) {
+            $langFiles = rex_finder::factory($langDir)->recursive()->filesOnly()->ignoreFiles(['.*']);
+            foreach ($langFiles as $langFile) {
+                $content = rex_file::get($langFile);
+
+                // Leere Zeilen würden verloren gehen
+                // if (preg_match_all('/^([^=\s]+)\h*=\h*(\S.*)(?<=\S)/m', $content, $matches, PREG_SET_ORDER)) {
+                //     print_r($matches);
+                // }
+
+                $newContent = [];
+                $lines = explode("\n", $content);
+                foreach ($lines as $line) {
+                    $parts = explode('=', $line);
+
+                    if (in_array(trim($parts[0]), $i18nKeys)) {
+                        continue;
+                    }
+
+                    $newContent[] = $line;
+                }
+                rex_file::put($langFile, implode("\n", $newContent));
+            }
+        }
+    }
+
+    public function check()
+    {
+        $this->parse();
+        $this->modify();
     }
 }
 

--- a/.tools/bin/check-i18n
+++ b/.tools/bin/check-i18n
@@ -105,7 +105,8 @@ if (isset($argv[1])) {
     }
 }
 if (!is_dir($dir)) {
-    exit('Folder "' . $dir . '" not found!'.PHP_EOL);
+    echo('Folder "' . $dir . '" not found!'.PHP_EOL);
+    exit(1);
 }
 
 $check = new rex_check_i18n($dir);

--- a/.tools/bin/check-i18n
+++ b/.tools/bin/check-i18n
@@ -4,7 +4,7 @@
 /**
  * @author Thomas Blum
  *
- * This command checks for removable keys in i18n lamg files.
+ * This command checks for removable keys in i18n .lang files.
  *
  * Examples:
  *

--- a/.tools/bin/check-i18n
+++ b/.tools/bin/check-i18n
@@ -36,7 +36,7 @@ class rex_check_i18n
         @
         (?<complete>
             \s*
-            (?>rex_i18n::|->)(?>i18n|msg|msgInLocale|rawMsg|rawMsgInLocale|hasMsg|hasMsgOrFallback|addMsg|translate|translateArray)\(
+            (?>rex_i18n::|->)(?>i18n|msgInLocale|rawMsgInLocale|hasMsgOrFallback|translateArray|addMsg|rawMsg|hasMsg|msg|translate)\(
                 \s*
                 (?>\'|")
                 (?<key>.*?)

--- a/.tools/bin/check-i18n
+++ b/.tools/bin/check-i18n
@@ -130,7 +130,7 @@ if (isset($argv[1])) {
     }
 }
 if (!is_dir($dir)) {
-    echo('Folder "' . $dir . '" not found!'.PHP_EOL);
+    echo 'Folder "' . $dir . '" not found!'.PHP_EOL;
     exit(1);
 }
 

--- a/.tools/bin/check-i18n
+++ b/.tools/bin/check-i18n
@@ -1,0 +1,112 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * @author Thomas Blum
+ *
+ * This command checks for removable keys in i18n lamg files.
+ *
+ * Examples:
+ *
+ * bin/check-i18n
+ * bin/check-i18n core
+ * bin/check-i18n -addonName-
+ */
+
+unset($REX);
+$REX['REDAXO'] = true;
+$REX['HTDOCS_PATH'] = './';
+$REX['BACKEND_FOLDER'] = 'redaxo';
+$REX['LOAD_PAGE'] = false;
+
+require $REX['BACKEND_FOLDER'] . '/src/core/boot.php';
+require $REX['BACKEND_FOLDER'] . '/src/core/packages.php';
+
+// avoid PREG_JIT_STACKLIMIT_ERROR, changelog parts can be long
+ini_set('pcre.jit', 0);
+
+/**
+ * @package redaxo\core
+ *
+ * @internal
+ */
+class rex_check_i18n
+{
+    private const PATTERN = '
+        @
+        (?<complete>
+            \s*
+            (?>rex_i18n::|->)(?>msg|msgInLocale|rawMsg|rawMsgInLocale|hasMsg|hasMsgOrFallback|addMsg|translate|translateArray)\(
+                \s*
+                (?>\'|")
+                (?<key>.*?)
+                (?>\'|")
+                .*?
+            \)
+        )
+        @isx';
+
+    private $dir;
+    private $iterator;
+    private $i18nInUse;
+    private $i18nMsg;
+
+    public function __construct($dir)
+    {
+        $this->dir = $dir;
+        $this->iterator = rex_finder::factory($this->dir)->recursive()->filesOnly()->ignoreFiles(['.*']);
+    }
+
+    private function parse()
+    {
+        /** @var \SplFileInfo $file */
+        foreach ($this->iterator as $file) {
+            $filepath = $file->getPathname();
+            $content = \rex_file::get($filepath);
+
+            if ('lang' === $file->getExtension() && preg_match_all('/^([^=\s]+)\h*=\h*(\S.*)(?<=\S)/m', $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+                $path = str_replace(rex_path::src(), '', $filepath);
+                foreach ($matches as $match) {
+                    $this->i18nMsg[$match[1][0]] = $path.'#L'.$match[1][1];
+                }
+            }
+
+            if (preg_match_all(self::PATTERN, $content, $matches, PREG_SET_ORDER)) {
+                foreach ($matches as $match) {
+                    $this->i18nInUse[$match['key']] = '';
+                }
+            }
+        }
+    }
+
+    public function check()
+    {
+        $this->parse();
+
+        $unused = [];
+        foreach ($this->i18nMsg as $i18nKey => $i18nFile) {
+            if (!isset($this->i18nInUse[$i18nKey])) {
+                $unused[$i18nKey] = $i18nFile;
+            }
+        }
+
+        echo 'These keys can be deleted.'."\n";
+        print_r($unused);
+    }
+}
+
+$dir = rex_path::src();
+if (isset($argv[1])) {
+    $dir = rtrim($argv[1], DIRECTORY_SEPARATOR);
+    if ('core' === $dir) {
+        $dir = rex_path::core();
+    } else {
+        $dir = rex_path::addon($dir);
+    }
+}
+if (!is_dir($dir)) {
+    exit('Folder "' . $dir . '" not found!'.PHP_EOL);
+}
+
+$check = new rex_check_i18n($dir);
+$check->check();

--- a/.tools/bin/check-i18n
+++ b/.tools/bin/check-i18n
@@ -36,43 +36,78 @@ class rex_check_i18n
         @
         (?<complete>
             \s*
-            (?>rex_i18n::|->)(?>i18n|msgInLocale|rawMsgInLocale|hasMsgOrFallback|translateArray|addMsg|rawMsg|hasMsg|msg|translate)\(
-                \s*
-                (?>\'|")
-                (?<key>.*?)
-                (?>\'|")
-                .*?
+            (?>::|->)(?>i18n|msgInLocale|rawMsgInLocale|hasMsgOrFallback|translateArray|addMsg|rawMsg|hasMsg|msg|translate)\(
+                (?<params>
+                    \s*
+                    (?>\'|")
+                    (?<key>.*?(?>\'\s*\$)?)
+                    (?>\'|")
+                    .*?
+                )
             \)
         )
         @isx';
 
     private $dir;
-    private $iterator;
-    private $i18nInUse;
-    private $i18nMsg;
+    private $i18nInUse = [];
+    private $i18nMsg = [];
 
     public function __construct($dir)
     {
         $this->dir = $dir;
-        $this->iterator = rex_finder::factory($this->dir)->recursive()->filesOnly()->ignoreFiles(['.*']);
     }
 
     private function parse()
     {
+        $files = rex_finder::factory(rex_path::src())->recursive()->filesOnly()->ignoreFiles(['.*']);
         /** @var \SplFileInfo $file */
-        foreach ($this->iterator as $file) {
+        foreach ($files as $file) {
             $filepath = $file->getPathname();
             $content = rex_file::get($filepath);
 
-            if ('lang' === $file->getExtension() && preg_match_all('/^([^=\s]+)\h*=\h*(\S.*)(?<=\S)/m', $content, $matches, PREG_SET_ORDER)) {
-                foreach ($matches as $match) {
-                    $this->i18nMsg[$match[1]] = $file->getPath();
-                }
+            if ('lang' === $file->getExtension()) {
+                continue;
             }
 
             if (preg_match_all(self::PATTERN, $content, $matches, PREG_SET_ORDER)) {
                 foreach ($matches as $match) {
-                    $this->i18nInUse[$match['key']] = '';
+                    $params = explode(',', $match['params']);
+                    $key = str_replace(['"', "'"], '', $params[0]);
+                    if (false !== strpos($key, '.')) {
+                        $varParts = explode('.', $key);
+                        foreach ($varParts as $index => $varPart) {
+                            $varPart = trim($varPart);
+                            if ('$' === substr($varPart, 0, 1)) {
+                                $varPart = '<regexVar>';
+                            }
+                            $varParts[$index] = $varPart;
+                        }
+                        $key = implode('', $varParts);
+                    }
+                    $this->i18nInUse[$key] = '';
+                }
+            }
+        }
+
+        $keys = [];
+        foreach ($this->i18nInUse as $key => $value) {
+            if (false !== strpos($key, '<regexVar>')) {
+                $keys[] = $key;
+            }
+        }
+        print_r($keys);
+    }
+
+    private function loadI18n()
+    {
+        $files = rex_finder::factory($this->dir)->recursive()->filesOnly()->ignoreFiles(['.*']);
+        /** @var \SplFileInfo $file */
+        foreach ($files as $file) {
+            $filepath = $file->getPathname();
+            $content = rex_file::get($filepath);
+            if ('lang' === $file->getExtension() && preg_match_all('/^([^=\s]+)\h*=\h*(\S.*)(?<=\S)/m', $content, $matches, PREG_SET_ORDER)) {
+                foreach ($matches as $match) {
+                    $this->i18nMsg[$match[1]] = $file->getPath();
                 }
             }
         }
@@ -83,9 +118,24 @@ class rex_check_i18n
         $unused = [];
         foreach ($this->i18nMsg as $i18nKey => $langDir) {
             if (!isset($this->i18nInUse[$i18nKey])) {
+                foreach ($this->i18nInUse as $inUseKey => $inUseValue) {
+                    if ('addon_'.$inUseKey === $i18nKey ||
+                        'plugin_'.$inUseKey === $i18nKey ||
+                        'package_'.$inUseKey === $i18nKey) {
+                        continue 2;
+                    }
+
+                    if (false !== strpos($inUseKey, '<regexVar>')) {
+                        $pattern = '@^'.str_replace('<regexVar>', '[$a-zA-Z0-9]*', $inUseKey).'$@';
+                        if (preg_match($pattern, $i18nKey)) {
+                            continue 2;
+                        }
+                    }
+                }
                 $unused[$langDir][] = $i18nKey;
             }
         }
+        print_r($unused);
 
         foreach ($unused as $langDir => $i18nKeys) {
             $langFiles = rex_finder::factory($langDir)->recursive()->filesOnly()->ignoreFiles(['.*']);
@@ -116,6 +166,7 @@ class rex_check_i18n
     public function check()
     {
         $this->parse();
+        $this->loadI18n();
         $this->modify();
     }
 }


### PR DESCRIPTION
close #3747 

Ein erster Entwurf.

### Mögliche Probleme

- [ ] **Permissions**
   - https://github.com/redaxo/redaxo/blob/master/redaxo/src/core/lib/login/perm.php#L35

---

- [ ] **Via Variable übersetzt**
  - https://github.com/redaxo/redaxo/blob/master/redaxo/src/core/lib/form/elements/prio.php#L33-L34
  - https://github.com/redaxo/redaxo/blob/master/redaxo/src/core/lib/form/elements/prio.php#L84
  - **vorgeschlagene Lösung**
    - > Ich denke wir sollten die properties komplett entfernen und an den ~5 stellen überall direkt rex_i18n aufrufen

- [ ] **Vars mit Prefix**
  - https://github.com/redaxo/redaxo/blob/02fd86dfb681bc541fb214d6a8c8f00f17fcd19f/redaxo/src/core/lib/packages/manager.php#L190
  - > `$this->i18n` im package-manager kann immer `addon_*` oder `plugin_*` oder `package_*` sein.