### PR TITLE
Passwortregeln: "min 0" ignorieren

### DIFF
--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -39,12 +39,14 @@ class rex_password_policy
         $parts = [];
 
         foreach ($this->options as $key => $options) {
-            if (isset($options['min'], $options['max'])) {
+            if (isset($options['min'], $options['max']) && $options['min']) {
                 $constraint = rex_i18n::msg('password_rule_between', $options['min'], $options['max']);
             } elseif (isset($options['max'])) {
                 $constraint = rex_i18n::msg('password_rule_max', $options['max']);
-            } else {
+            } elseif (isset($options['min']) && $options['min']) {
                 $constraint = rex_i18n::msg('password_rule_min', $options['min']);
+            } else {
+                continue;
             }
 
             $parts[] = rex_i18n::msg('password_rule_'.$key, $constraint);

--- a/redaxo/src/core/tests/login/password_policy_test.php
+++ b/redaxo/src/core/tests/login/password_policy_test.php
@@ -50,4 +50,27 @@ class rex_password_policy_test extends TestCase
         yield [$options, false, 'AB7=E8#fg9?'];
         yield [$options, false, 'abcdef123!%ABuegrouwouewhifggreigeioger'];
     }
+
+    public function testGetRule(): void
+    {
+        $getRule = new ReflectionMethod(rex_password_policy::class, 'getRule');
+        $getRule->setAccessible(true);
+
+        $policy = new rex_password_policy(['length' => ['min' => 5, 'max' => 25]]);
+        $rule = $getRule->invoke($policy);
+
+        static::assertStringContainsString('5', $rule);
+        static::assertStringContainsString('25', $rule);
+
+        $policy = new rex_password_policy(['length' => ['min' => 0, 'max' => 25]]);
+        $rule = $getRule->invoke($policy);
+
+        static::assertStringNotContainsString('0', $rule);
+        static::assertStringContainsString('25', $rule);
+
+        $policy = new rex_password_policy(['length' => ['min' => 0]]);
+        $rule = $getRule->invoke($policy);
+
+        static::assertSame('', $rule);
+    }
 }


### PR DESCRIPTION
In unserer Default-Config haben wir manche Regeln nur mit "min 0", zur leichteren Anpassung:
https://github.com/redaxo/redaxo/blob/fc198811bbfb6447c9a54c34aa59e3a974671fa7/redaxo/src/core/default.config.yml#L33-L37

Vorher sah dann die Meldung aber so aus:

![Screenshot 2020-06-30 23 52 49](https://user-images.githubusercontent.com/330436/86180625-d2559280-bb2c-11ea-8cf1-c74c3539a5d8.png)

Dieser PR ändert es in:

![Screenshot 2020-06-30 23 52 28](https://user-images.githubusercontent.com/330436/86180641-da153700-bb2c-11ea-9cd8-94f2746c8ef7.png)
