### PR TITLE
assets:sync: compare file hash additional to the filemtime

### DIFF
--- a/redaxo/src/core/lib/console/assets_sync.php
+++ b/redaxo/src/core/lib/console/assets_sync.php
@@ -125,7 +125,7 @@ class rex_command_assets_sync extends rex_console_command
                 continue;
             }
 
-            if ($f1Fileinfo->getMtime() > filemtime($f2File)) {
+            if ($f1Fileinfo->getMtime() > filemtime($f2File) && md5_file($f1File) != md5_file($f2File)) {
                 rex_file::copy($f1File, $f2File);
                 ++$updated;
                 if ($io->isVerbose()) {


### PR DESCRIPTION
closes https://github.com/redaxo/redaxo/issues/3714

Getestet indem man 
- eine datei verändert
- speichert (damit sich die filemtime ändert)
- die datei vom inhalt her wieder auf den stand von zuvor zurück verändert
- erneut speichert

-> jetzt hat man dateien die inhaltlich identisch sind, aber mit gleichem content-hash.
-> vor dem PR wurden diese dateien kopiert. Jetzt nach der Änderung nicht mehr