### PR TITLE
assets:sync: use shorter description and moved extensive description …

### DIFF
--- a/redaxo/src/core/lib/console/assets_sync.php
+++ b/redaxo/src/core/lib/console/assets_sync.php
@@ -16,7 +16,9 @@ class rex_command_assets_sync extends rex_console_command
     protected function configure()
     {
         $this
-            ->setDescription('Sync folders and files of /assets with /redaxo/src/addons/my-addon/assets (or plugin) respectively /redaxo/src/core/assets folders');
+            ->setDescription('Sync assets within the assets-dir with the sources-dir')
+            ->setHelp('Sync folders and files of /assets with /redaxo/src/addons/my-addon/assets (or plugin) respectively /redaxo/src/core/assets folders')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
…into help

closes https://github.com/redaxo/redaxo/issues/3676

getestet:

```bash
staabm@staabm_laptop MINGW64 /c/xampp7.3/htdocs/redaxo (master)
$ php redaxo/bin/console
REDAXO 5.11.0

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for mor
e verbose output and 3 for debug

Available commands:
  help                   Displays help for a command
  list                   Lists commands
 assets
  assets:sync            Sync assets within the assets-dir with the sources-dir
 be_style
  be_style:compile       [styles:compile] Converts Backend SCSS files to CSS
 cache
  cache:clear            Clears the redaxo core cache
 config
  config:get             Get config variables
  config:set             Set config variables
 cronjob
  cronjob:run            Executes cronjobs of the "script" environment
 db
  db:connection-options  Dumps the db connection options for the mysql cli tool
  db:dump-schema         Dumps the schema of db tables as php code
  db:set-connection      Sets database connection credentials.
...

$ php redaxo/bin/console help assets:sync
Description:
  Sync assets within the assets-dir with the sources-dir

Usage:
  assets:sync

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for mor
e verbose output and 3 for debug

Help:
  Sync folders and files of /assets with /redaxo/src/addons/my-addon/assets (or plugin) re
spectively /redaxo/src/core/assets folders
```