### PR TITLE
sys-report: throw a meaningfull error instead of a type-error because…

### DIFF
--- a/redaxo/src/core/pages/system.report.html.php
+++ b/redaxo/src/core/pages/system.report.html.php
@@ -13,6 +13,9 @@ foreach ($report as $title => $group) {
 
     foreach ($group as $label => $value) {
         if (rex_system_report::TITLE_PACKAGES === $title || rex_system_report::TITLE_REDAXO === $title) {
+            if ($value === null) {
+                throw new rex_exception('Package '. $label .' does not define a proper version in its package.yml');
+            }
             if (rex_version::isUnstable($value)) {
                 $value = '<i class="rex-icon rex-icon-unstable-version" title="'. rex_i18n::msg('unstable_version') .'"></i> '. rex_escape($value);
             }

--- a/redaxo/src/core/pages/system.report.html.php
+++ b/redaxo/src/core/pages/system.report.html.php
@@ -13,7 +13,7 @@ foreach ($report as $title => $group) {
 
     foreach ($group as $label => $value) {
         if (rex_system_report::TITLE_PACKAGES === $title || rex_system_report::TITLE_REDAXO === $title) {
-            if ($value === null) {
+            if (null === $value) {
                 throw new rex_exception('Package '. $label .' does not define a proper version in its package.yml');
             }
             if (rex_version::isUnstable($value)) {


### PR DESCRIPTION
… of a null-version

wenn ein update fehlschlägt und z.b. ein leerer addon ordner übrig bleibt, der keine package.yml enthält bekommt man bisher folgenden error bei aufruf des sys-reports:

```
TypeError thrown with message "Argument 1 passed to rex_version::isUnstable() must be of the type string, null given, called in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\pages\system.report.html.php on line 19"

Stacktrace:
#13 TypeError in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\util\version.php:15
#12 rex_version:isUnstable in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\pages\system.report.html.php:19
#11 include in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:469
#10 rex_be_controller:{closure} in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\util\timer.php:60
#9 rex_timer:measure in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:477
#8 rex_be_controller:includePath in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:432
#7 rex_be_controller:includeCurrentPageSubPath in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\pages\system.php:9
#6 include in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:469
#5 rex_be_controller:{closure} in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\util\timer.php:60
#4 rex_timer:measure in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:477
#3 rex_be_controller:includePath in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:415
#2 rex_be_controller:includeCurrentPage in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\backend.php:235
#1 require in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\boot.php:137
#0 require in C:\xampp7.3\htdocs\redaxo\redaxo\index.php:9
```

diesen error kann man auch aus anderen gründen bekommen.. wurde im slack schon das ein oder andere mal gemeldet, wo wir nicht wussten warum..

nach dieser Änderung jetzt dann

```
rex_exception thrown with message "Package yform does not define a proper version in its package.yml"

Stacktrace:
#12 rex_exception in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\pages\system.report.html.php:17
#11 include in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:469
#10 rex_be_controller:{closure} in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\util\timer.php:60
#9 rex_timer:measure in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:477
#8 rex_be_controller:includePath in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:432
#7 rex_be_controller:includeCurrentPageSubPath in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\pages\system.php:9
#6 include in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:469
#5 rex_be_controller:{closure} in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\util\timer.php:60
#4 rex_timer:measure in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:477
#3 rex_be_controller:includePath in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\lib\be\controller.php:415
#2 rex_be_controller:includeCurrentPage in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\backend.php:235
#1 require in C:\xampp7.3\htdocs\redaxo\redaxo\src\core\boot.php:137
#0 require in C:\xampp7.3\htdocs\redaxo\redaxo\index.php:9
```

![grafik](https://user-images.githubusercontent.com/120441/86530518-9bc7a100-beb9-11ea-968f-44ff81e27946.png)


damit wird nicht das urspr. problem gelöst, aber zumindest bekommt der redaxo admin eine exception mit genaueren angaben zum problem bzw. welches package der verursacher ist