### PR TITLE
phpunit: auch v8 und v9 zulassen

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -55,7 +55,6 @@
       <path value="$PROJECT_DIR$/vendor/symfony/event-dispatcher-contracts" />
       <path value="$PROJECT_DIR$/vendor/friendsofredaxo/linter" />
       <path value="$PROJECT_DIR$/vendor/seld/jsonlint" />
-      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-intl-idn" />
       <path value="$PROJECT_DIR$/vendor/symfony/dependency-injection" />
       <path value="$PROJECT_DIR$/vendor/phpspec/prophecy" />
       <path value="$PROJECT_DIR$/vendor/symfony/framework-bundle" />
@@ -63,7 +62,6 @@
       <path value="$PROJECT_DIR$/vendor/nikic/php-parser" />
       <path value="$PROJECT_DIR$/vendor/symfony/http-kernel" />
       <path value="$PROJECT_DIR$/vendor/symfony/options-resolver" />
-      <path value="$PROJECT_DIR$/vendor/symfony/mime" />
       <path value="$PROJECT_DIR$/vendor/vimeo/psalm" />
       <path value="$PROJECT_DIR$/vendor/phpstan/phpstan" />
       <path value="$PROJECT_DIR$/vendor/symfony/cache" />
@@ -81,11 +79,15 @@
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-php70" />
       <path value="$PROJECT_DIR$/vendor/symfony/routing" />
       <path value="$PROJECT_DIR$/vendor/netresearch/jsonmapper" />
-      <path value="$PROJECT_DIR$/vendor/symfony/debug" />
       <path value="$PROJECT_DIR$/vendor/doctrine/instantiator" />
       <path value="$PROJECT_DIR$/vendor/symfony/http-foundation" />
       <path value="$PROJECT_DIR$/vendor/phpmyadmin/sql-parser" />
       <path value="$PROJECT_DIR$/vendor/friendsofphp/php-cs-fixer" />
+      <path value="$PROJECT_DIR$/vendor/symfony/deprecation-contracts" />
+      <path value="$PROJECT_DIR$/vendor/psr/event-dispatcher" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-invoker" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/type" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/code-unit" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />

--- a/.idea/redaxo.iml
+++ b/.idea/redaxo.iml
@@ -51,6 +51,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpstan/phpstan-phpunit" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-code-coverage" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-file-iterator" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-invoker" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-text-template" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-timer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-token-stream" />
@@ -58,6 +59,8 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/psalm/plugin-phpunit" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/psalm/plugin-symfony" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/psr/cache" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/psr/event-dispatcher" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/code-unit" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/code-unit-reverse-lookup" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/comparator" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/diff" />
@@ -68,13 +71,14 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/object-reflector" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/recursion-context" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/resource-operations" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/type" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/version" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/seld/jsonlint" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/cache" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/cache-contracts" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/config" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/debug" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/dependency-injection" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/deprecation-contracts" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/error-handler" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/event-dispatcher" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/event-dispatcher-contracts" />
@@ -83,9 +87,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/framework-bundle" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/http-foundation" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/http-kernel" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/mime" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/options-resolver" />
-      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-intl-idn" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php70" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/process" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/routing" />

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,3 +72,7 @@ jobs:
             php: 7.4
         -   <<: *TEST_MYSQL
             php: nightly
+            install:
+                - composer install --prefer-dist --ignore-platform-reqs
+                - mysql -e 'create database redaxo5;'
+                - php .tools/bin/setup

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "phpstan/phpstan": "0.12.31",
         "phpstan/extension-installer": "1.0.4",
         "phpstan/phpstan-phpunit": "0.12.11",
-        "phpunit/phpunit": "7.5.20",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
         "psalm/plugin-phpunit": "0.10.1",
         "psalm/plugin-symfony": "1.3.0",
         "vimeo/psalm": "3.12.1"
@@ -90,9 +90,6 @@
     ],
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true,
-        "platform": {
-            "php": "7.1.3"
-        }
+        "sort-packages": true
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
      bootstrap=".tools/bootstrap.php"
-     forceCoversAnnotation="true"
      beStrictAboutCoversAnnotation="true"
      beStrictAboutOutputDuringTests="true"
      beStrictAboutTodoAnnotatedTests="true"

--- a/psalm.xml
+++ b/psalm.xml
@@ -59,6 +59,8 @@
         <DeprecatedMethod>
             <errorLevel type="info">
                 <referencedMethod name="rex_string::versionCompare"/>
+                <referencedMethod name="PHPUnit\Framework\Assert::assertDirectoryNotExists"/>
+                <referencedMethod name="PHPUnit\Framework\Assert::assertFileNotExists"/>
             </errorLevel>
         </DeprecatedMethod>
         <InternalMethod errorLevel="info" />

--- a/redaxo/src/addons/media_manager/tests/media_manager_test.php
+++ b/redaxo/src/addons/media_manager/tests/media_manager_test.php
@@ -63,9 +63,9 @@ class rex_media_manager_test extends TestCase
         $url = rex_media_manager::getUrl($type, $file, $timestamp);
 
         if (false === $expectedBuster) {
-            static::assertNotContains('buster=', $url);
+            static::assertStringNotContainsString('buster=', $url);
         } else {
-            static::assertContains('buster='.$expectedBuster, $url);
+            static::assertStringContainsString('buster='.$expectedBuster, $url);
         }
     }
 

--- a/redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
+++ b/redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_article_content_test extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         // fake article
         $article_file = rex_path::addonCache('structure', '1.1.article');
@@ -46,7 +46,7 @@ class rex_article_content_test extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // delete all fake structure cache files
         $finder = rex_finder::factory(rex_path::addonCache('structure'))

--- a/redaxo/src/addons/structure/tests/article_test.php
+++ b/redaxo/src/addons/structure/tests/article_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_article_test extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         // generate classVars and add test column
         rex_article::getClassVars();
@@ -22,7 +22,7 @@ class rex_article_test extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // reset static properties
         $class = new ReflectionClass(rex_article::class);

--- a/redaxo/src/addons/structure/tests/category_test.php
+++ b/redaxo/src/addons/structure/tests/category_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_category_test extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         // generate classVars and add test column
         rex_category::getClassVars();
@@ -22,7 +22,7 @@ class rex_category_test extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // reset static properties
         $class = new ReflectionClass(rex_article::class);

--- a/redaxo/src/core/tests/console/config/set_test.php
+++ b/redaxo/src/core/tests/console/config/set_test.php
@@ -10,13 +10,13 @@ class rex_command_config_set_test extends TestCase
 {
     private $initialConfig;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $configPath = rex_path::coreData('config.yml');
         $this->initialConfig = file_get_contents($configPath);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $configPath = rex_path::coreData('config.yml');
         file_put_contents($configPath, $this->initialConfig);

--- a/redaxo/src/core/tests/extension_test.php
+++ b/redaxo/src/core/tests/extension_test.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_extension_test extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -13,7 +13,7 @@ class rex_backend_login_test extends TestCase
     private $password = 'test1234';
     private $cookiekey = 'mycookie';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (rex::getUser()) {
             $this->skipped = true;
@@ -31,7 +31,7 @@ class rex_backend_login_test extends TestCase
         $adduser->insert();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->skipped) {
             return;

--- a/redaxo/src/core/tests/sql/sql_select_test.php
+++ b/redaxo/src/core/tests/sql/sql_select_test.php
@@ -9,7 +9,7 @@ class rex_sql_select_test extends TestCase
 {
     public const TABLE = 'rex_tests';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -30,7 +30,7 @@ class rex_sql_select_test extends TestCase
         $this->insertRow();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -10,7 +10,7 @@ class rex_sql_table_test extends TestCase
     public const TABLE = 'rex_sql_table_test';
     public const TABLE2 = 'rex_sql_table_test2';
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $sql = rex_sql::factory();
         $sql->setQuery('DROP TABLE IF EXISTS `' . self::TABLE2 . '`');

--- a/redaxo/src/core/tests/sql/sql_test.php
+++ b/redaxo/src/core/tests/sql/sql_test.php
@@ -10,7 +10,7 @@ class rex_sql_test extends TestCase
     public const TABLE = 'rex_tests_table';
     public const VIEW = 'rex_tests_view';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +31,7 @@ class rex_sql_test extends TestCase
         $sql->setQuery('CREATE VIEW `' . self::VIEW . '` AS SELECT * FROM `'.self::TABLE.'`');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/redaxo/src/core/tests/util/dir_test.php
+++ b/redaxo/src/core/tests/util/dir_test.php
@@ -7,14 +7,14 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_dir_test extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         rex_dir::create($this->getPath());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/redaxo/src/core/tests/util/file_test.php
+++ b/redaxo/src/core/tests/util/file_test.php
@@ -7,14 +7,14 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_file_test extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         rex_dir::create($this->getPath());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/redaxo/src/core/tests/util/finder_test.php
+++ b/redaxo/src/core/tests/util/finder_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_finder_test extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -23,7 +23,7 @@ class rex_finder_test extends TestCase
         rex_file::put($this->getPath('dir1/Thumbs.db'), '');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/redaxo/src/core/tests/util/i18n_test.php
+++ b/redaxo/src/core/tests/util/i18n_test.php
@@ -17,7 +17,7 @@ class rex_i18n_test extends TestCase
 {
     private $previousLocale;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->previousLocale = rex_i18n::setLocale('de_de', false);
 
@@ -37,7 +37,7 @@ LANG;
         rex_file::put($this->getPath().'/en_gb.lang', $content."\nmy=EN");
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         rex_dir::delete($this->getPath());
         rex_i18n::setLocale($this->previousLocale, false);

--- a/redaxo/src/core/tests/util/log_file_test.php
+++ b/redaxo/src/core/tests/util/log_file_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_log_file_test extends TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         rex_dir::delete($this->getPath());
     }

--- a/redaxo/src/core/tests/util/socket_proxy_test.php
+++ b/redaxo/src/core/tests/util/socket_proxy_test.php
@@ -9,13 +9,13 @@ class rex_socket_proxy_test extends TestCase
 {
     private $proxy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->proxy = rex::getProperty('socket_proxy');
         rex::setProperty('socket_proxy', null);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         rex::setProperty('socket_proxy', $this->proxy);
     }

--- a/redaxo/src/core/tests/util/socket_test.php
+++ b/redaxo/src/core/tests/util/socket_test.php
@@ -9,13 +9,13 @@ class rex_socket_test extends TestCase
 {
     private $proxy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->proxy = rex::getProperty('socket_proxy');
         rex::setProperty('socket_proxy', null);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         rex::setProperty('socket_proxy', $this->proxy);
     }

--- a/redaxo/src/core/tests/util/sortable_iterator_test.php
+++ b/redaxo/src/core/tests/util/sortable_iterator_test.php
@@ -7,12 +7,12 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_sortable_iterator_test extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/redaxo/src/core/tests/util/timer_test.php
+++ b/redaxo/src/core/tests/util/timer_test.php
@@ -9,14 +9,14 @@ class rex_timer_test extends TestCase
 {
     private $orgDebug;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // rex_timer internals depend on debug mode..
         $this->orgDebug = rex::getProperty('debug');
         rex::setProperty('debug', true);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         rex::setProperty('debug', $this->orgDebug);
     }

--- a/redaxo/src/core/tests/var/var_config_test.php
+++ b/redaxo/src/core/tests/var/var_config_test.php
@@ -2,13 +2,13 @@
 
 class rex_var_config_test extends rex_var_base_test
 {
-    public function setUp()
+    public function setUp(): void
     {
         rex::setConfig('myCoreConfig', 'myCoreConfigValue');
         rex_addon::get('project')->setConfig('myPackageConfig', 'myPackageConfigValue');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         rex::removeConfig('myCoreConfig');
         rex_addon::get('project')->removeConfig('tests');

--- a/redaxo/src/core/tests/var/var_property_test.php
+++ b/redaxo/src/core/tests/var/var_property_test.php
@@ -2,13 +2,13 @@
 
 class rex_var_property_test extends rex_var_base_test
 {
-    public function setUp()
+    public function setUp(): void
     {
         rex::setProperty('myCoreProperty', 'myCorePropertyValue');
         rex_addon::get('project')->setProperty('myPackageProperty', 'myPackagePropertyValue');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         rex::removeProperty('myCoreProperty');
         rex_addon::get('project')->removeProperty('tests');


### PR DESCRIPTION
Ich denke bei PHPUnit brauchen wir keine fixe Version.
Und die neueren Versionen sind besser auf die neueren PHP-Versionen abgestimmt.
-> mal schauen, ob die aktuellen probleme bei den php8-tests dadurch gelöst werden.