### PR TITLE
rex_sql: lastInsertId zwischenspeichern

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -70,7 +70,11 @@ class rex_sql implements Iterator
     /** @var int */
     protected $DBID; // ID der Verbindung
 
-    /** @var string */
+    /**
+      * Store the lastInsertId per rex_sql object, so rex_sql objects don't override each other because of the shared static PDO instance.
+      *
+      * @var string
+      */
     private $lastInsertId = '0'; // compatibility to PDO, which uses string '0' as default
 
     /** @var self[] */

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -70,6 +70,9 @@ class rex_sql implements Iterator
     /** @var int */
     protected $DBID; // ID der Verbindung
 
+    /** @var string */
+    private $lastInsertId = '0'; // compatibility to PDO, which uses string '0' as default
+
     /** @var self[] */
     protected $records;
 
@@ -348,6 +351,7 @@ class rex_sql implements Iterator
 
             $this->stmt->execute($params);
             $this->rows = $this->stmt->rowCount();
+            $this->lastInsertId = self::$pdo[$this->DBID]->lastInsertId();
         } catch (PDOException $e) {
             throw new rex_sql_exception('Error while executing statement "' . $this->query . '" using params ' . json_encode($params) . '! ' . $e->getMessage(), $e, $this);
         } finally {
@@ -409,6 +413,7 @@ class rex_sql implements Iterator
             });
 
             $this->rows = $this->stmt->rowCount();
+            $this->lastInsertId = self::$pdo[$this->DBID]->lastInsertId();
         } catch (PDOException $e) {
             throw new rex_sql_exception('Error while executing statement "' . $query . '"! ' . $e->getMessage(), $e, $this);
         } finally {
@@ -1057,6 +1062,7 @@ class rex_sql implements Iterator
         $this->wherevar = '';
         $this->counter = 0;
         $this->rows = 0;
+        $this->lastInsertId = '0';
 
         return $this;
     }
@@ -1111,7 +1117,7 @@ class rex_sql implements Iterator
      */
     public function getLastId()
     {
-        return self::$pdo[$this->DBID]->lastInsertId();
+        return $this->lastInsertId;
     }
 
     /**

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -71,10 +71,10 @@ class rex_sql implements Iterator
     protected $DBID; // ID der Verbindung
 
     /**
-      * Store the lastInsertId per rex_sql object, so rex_sql objects don't override each other because of the shared static PDO instance.
-      *
-      * @var string
-      */
+     * Store the lastInsertId per rex_sql object, so rex_sql objects don't override each other because of the shared static PDO instance.
+     *
+     * @var string
+     */
     private $lastInsertId = '0'; // compatibility to PDO, which uses string '0' as default
 
     /** @var self[] */

--- a/redaxo/src/core/tests/sql/sql_test.php
+++ b/redaxo/src/core/tests/sql/sql_test.php
@@ -459,6 +459,39 @@ class rex_sql_test extends TestCase
         static::assertEquals(1, $sql->getRows());
     }
 
+    public function testGetLastId(): void
+    {
+        $sql = rex_sql::factory();
+
+        static::assertSame('0', $sql->getLastId(), 'Initial value for LastId');
+
+        $sql->setTable(self::TABLE);
+        $sql->setValue('col_int', 5);
+        $sql->setValue('col_str', 'abc');
+        $sql->setValue('col_text', 'mytext');
+        $sql->insert();
+
+        static::assertSame('1', $sql->getLastId(), 'LastId after ->insert()');
+
+        $sql->setTable(self::TABLE);
+        $sql->setWhere(['id' => 1]);
+        $sql->setValue('col_int', 6);
+        $sql->update();
+
+        static::assertSame('0', $sql->getLastId(), 'LastId after ->update()');
+
+        $sql->setQuery('INSERT INTO '.self::TABLE.' SET col_int = 3');
+
+        static::assertSame('2', $sql->getLastId(), 'LastId after second INSERT query');
+
+        $secondSql = rex_sql::factory();
+        $secondSql->setQuery('SELECT * FROM '.self::TABLE);
+
+        static::assertSame('0', $secondSql->getLastId(), 'LastId after SELECT query');
+        static::assertSame('2', $sql->getLastId(), 'LastId still the same in other sql object');
+
+    }
+
     public function testGetTables()
     {
         $tables = rex_sql::factory()->getTables();

--- a/redaxo/src/core/tests/sql/sql_test.php
+++ b/redaxo/src/core/tests/sql/sql_test.php
@@ -489,7 +489,6 @@ class rex_sql_test extends TestCase
 
         static::assertSame('0', $secondSql->getLastId(), 'LastId after SELECT query');
         static::assertSame('2', $sql->getLastId(), 'LastId still the same in other sql object');
-
     }
 
     public function testGetTables()


### PR DESCRIPTION
fixes #3828

Ich habe es grob mit Blackfire getestet, und es scheint keinerlei Auswirkung zu haben (auch bei 1000 Queries nicht).