### PR TITLE
Einfache Möglichkeit, aus Template/Module auf Fehlerseite zu leiten

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -43,15 +43,23 @@ if (rex::isBackend()) {
         $article = new rex_article_content();
         $article->setCLang(rex_clang::getCurrentId());
 
-        if ($article->setArticleId(rex_article::getCurrentId())) {
-            $content .= $article->getArticleTemplate();
-        } else {
+        if (!$article->setArticleId(rex_article::getCurrentId())) {
             $fragment = new rex_fragment([
                 'content' => '<p><b>Kein Startartikel selektiert - No starting Article selected.</b><br />Please click here to enter <a href="' . rex_url::backendController() . '">redaxo</a>.</p>',
             ]);
             $content .= $fragment->parse('core/fe_ooops.php');
             rex_response::sendPage($content);
             exit;
+        }
+
+        try {
+            $content .= $article->getArticleTemplate();
+        } catch (rex_article_not_found_exception $exception) {
+            $article = new rex_article_content();
+            $article->setCLang(rex_clang::getCurrentId());
+            $article->setArticleId(rex_article::getNotfoundArticleId());
+
+            $content .= $article->getArticleTemplate();
         }
 
         $art_id = $article->getArticleId();

--- a/redaxo/src/addons/structure/plugins/content/lib/article_not_found_exception.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_not_found_exception.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @package redaxo\structure\content
+ */
+class rex_article_not_found_exception extends rex_exception
+{
+    public function __construct(?string $message = null, ?Exception $previous = null)
+    {
+        parent::__construct($message ?? 'Article not found.', $previous);
+    }
+}


### PR DESCRIPTION
Im Moment ist es nicht so leicht, aus dem Template oder sogar erst aus einem Modul heraus umzuschwenken auf den 404-Artikel (mit 404 Statuscode).

Man könnte auf den Fehlerartikel weiterleiten. Das wäre aber ja eine 30x-Weiterleitung auf eine 404-Seite, und es würde sich somit die Adresse im Browser ändern.
Ich möchte aber den Fall lösen, dass die Adresse stehen bleiben soll, und aber die 404-Seite mit 404-Code erscheinen soll.

Aktuell müsste man dazu den Output Buffer leeren, und dann selbst per `rex_article_content` stattdessen den Fehlerartikel ausgeben, und dann müsste man eventuell auch noch per exit abbrechen.

Mit diesem PR wäre es stattdessen möglich im Template/Module die neue `rex_article_not_found_exception` zu werfen, und das content-Plugin würde dann darauf reagieren und umschwenken auf den Fehlerartikel.

Ein typischer Fall dafür ist die Detailseite zu einem YForm-Datensatz. Wenn da eine ungültige ID übergeben wird, bzw. ein ungültiger Slug bei Benutzung des URL-Addons, möchte man teilweise auf den 404-Artikel schwenken. Und dieser Check geschieht in der Regel im Module.