### PR TITLE
Benutzer erstellen: Fehler bei neuen Passwortregeln

### DIFF
--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -113,7 +113,7 @@ if ($save && ($FUNC_ADD || $FUNC_UPDATE || $FUNC_APPLY)) {
         $warnings[] = rex_i18n::msg('invalid_email');
     }
 
-    if ($userpsw && (true !== $msg = $passwordPolicy->check($userpsw, $user_id))) {
+    if ($userpsw && (true !== $msg = $passwordPolicy->check($userpsw, $user_id ?: null))) {
         if (rex::getUser()->isAdmin()) {
             $msg .= ' '.rex_i18n::msg('password_admin_notice');
         }


### PR DESCRIPTION
Wenn man die neuen Passwortregeln nutzt, die Checks gegen die vorher verwendeten Passwörter machen, dann kann man aktuell keinen neuen Benutzer anlegen.
Grund: Die Benutzerseite arbeitet mit id=0 für Benutzeranlage, die Passwort-Rules-Api erfordert dort aber `null`.