### PR TITLE
Unstable-Warnung auch für Addon-Erstinstallation

### DIFF
--- a/redaxo/src/addons/install/pages/packages.add.php
+++ b/redaxo/src/addons/install/pages/packages.add.php
@@ -72,12 +72,19 @@ if ($addonkey && isset($addons[$addonkey]) && !rex_addon::exists($addonkey)) {
             <tbody>';
 
     foreach ($addon['files'] as $fileId => $file) {
-        $content .= '
+        $content .= '        
+            $version = rex_escape($file['version']);
+            $description = $markdown($file['description']);
+
+            if (class_exists(rex_version::class) && rex_version::isUnstable($version)) {
+                $version = '<i class="rex-icon rex-icon-unstable-version" title="'. rex_i18n::msg('unstable_version') .'"></i> '. $version;
+                $description = rex_view::warning(rex_i18n::msg('unstable_version')) . $description;
+            }
             <tr>
                 <td class="rex-table-icon"><i class="rex-icon rex-icon-package"></i></td>
-                <td data-title="' . $package->i18n('version') . '">' . rex_escape($file['version']) . '</td>
+                <td data-title="' . $package->i18n('version') . '">' . $version . '</td>
                 <td data-title="' . $package->i18n('published_on') . '">' . rex_escape(rex_formatter::strftime($file['created'])) . '</td>
-                <td data-title="' . $package->i18n('description') . '">' . $markdown($file['description']) . '</td>
+                <td data-title="' . $package->i18n('description') . '">' . $description . '</td>
                 <td class="rex-table-action"><a href="' . rex_url::currentBackendPage(['addonkey' => $addonkey, 'file' => $fileId] + rex_api_install_package_add::getUrlParams()) . '" data-pjax="false"><i class="rex-icon rex-icon-download"></i> ' . $package->i18n('download') . '</a></td>
             </tr>';
     }

--- a/redaxo/src/addons/install/pages/packages.add.php
+++ b/redaxo/src/addons/install/pages/packages.add.php
@@ -71,15 +71,15 @@ if ($addonkey && isset($addons[$addonkey]) && !rex_addon::exists($addonkey)) {
             </thead>
             <tbody>';
 
-    foreach ($addon['files'] as $fileId => $file) {
-        $content .= '        
-            $version = rex_escape($file['version']);
-            $description = $markdown($file['description']);
+    foreach ($addon['files'] as $fileId => $file) {  
+        $version = rex_escape($file['version']);
+        $description = $markdown($file['description']);
 
-            if (class_exists(rex_version::class) && rex_version::isUnstable($version)) {
-                $version = '<i class="rex-icon rex-icon-unstable-version" title="'. rex_i18n::msg('unstable_version') .'"></i> '. $version;
-                $description = rex_view::warning(rex_i18n::msg('unstable_version')) . $description;
-            }
+        if (class_exists(rex_version::class) && rex_version::isUnstable($version)) {
+            $version = '<i class="rex-icon rex-icon-unstable-version" title="'. rex_i18n::msg('unstable_version') .'"></i> '. $version;
+            $description = rex_view::warning(rex_i18n::msg('unstable_version')) . $description;
+        }
+        $content .= '      
             <tr>
                 <td class="rex-table-icon"><i class="rex-icon rex-icon-package"></i></td>
                 <td data-title="' . $package->i18n('version') . '">' . $version . '</td>

--- a/redaxo/src/addons/install/pages/packages.add.php
+++ b/redaxo/src/addons/install/pages/packages.add.php
@@ -71,7 +71,7 @@ if ($addonkey && isset($addons[$addonkey]) && !rex_addon::exists($addonkey)) {
             </thead>
             <tbody>';
 
-    foreach ($addon['files'] as $fileId => $file) {  
+    foreach ($addon['files'] as $fileId => $file) {
         $version = rex_escape($file['version']);
         $description = $markdown($file['description']);
 


### PR DESCRIPTION
Beim Update eines Addons erscheint eine Warnung bei Entwicklungsversionen.
Diese Ausgabe fehlt bei der Erstinstallation eines Addons.