### PR TITLE
Remove nikic/php-parser dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.16.4",
         "friendsofredaxo/linter": "1.2.6",
-        "nikic/php-parser": "4.9.1",
         "phpstan/phpstan": "0.12.42",
         "phpstan/extension-installer": "1.0.5",
         "phpstan/phpstan-phpunit": "0.12.16",


### PR DESCRIPTION
Hatten wir früher auf eine alte version fixiert, wg bugs. Sind mittlerweile in der upstream lib gefixed