### PR TITLE
Min-PHP erhöhen auf 7.3

### DIFF
--- a/.github/workflows/cs-check.yml
+++ b/.github/workflows/cs-check.yml
@@ -23,7 +23,7 @@ jobs:
           - name: Setup PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: 7.1
+                php-version: 7.3
                 extensions: intl
                 coverage: none # disable xdebug, pcov
                 tools: cs2pr

--- a/.github/workflows/cs-fix.yml
+++ b/.github/workflows/cs-fix.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.1
+        php-version: 7.3
         coverage: none # disable xdebug, pcov
         tools: cs2pr
 

--- a/.github/workflows/rexlint.yml
+++ b/.github/workflows/rexlint.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.1
+                  php-version: 7.3
                   extensions: intl
                   coverage: none # disable xdebug, pcov
             - name: Get Composer Cache Directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
                 - php .tools/bin/setup
             script: vendor/bin/phpunit
             php: 7.3
-            dist: bionic
+            dist: xenial
             env:
                 - DB=mariadb
             addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ jobs:
                 - mysql -e 'create database redaxo5;'
                 - php .tools/bin/setup
             script: vendor/bin/phpunit
-            php: 7.1
+            php: 7.3
             dist: trusty
             env:
                 - DB=mariadb
             addons:
                 mariadb: 10.1
         -   <<: *TEST
-            php: 7.3
+            php: 7.4
             addons:
                 mariadb: 10.4
         -   <<: *TEST
@@ -57,17 +57,13 @@ jobs:
                 - mysql --version
         -   &TEST_MYSQL
             <<: *TEST
-            php: 7.1
+            php: 7.3
             dist: bionic
             env:
                 - DB=mysql5
             services:
                 - mysql
             addons: {}
-        -   <<: *TEST_MYSQL
-            php: 7.2
-        -   <<: *TEST_MYSQL
-            php: 7.3
         -   <<: *TEST_MYSQL
             php: 7.4
         -   <<: *TEST_MYSQL

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
                 - php .tools/bin/setup
             script: vendor/bin/phpunit
             php: 7.3
-            dist: trusty
+            dist: bionic
             env:
                 - DB=mariadb
             addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ jobs:
                 - php .tools/bin/setup
             script: vendor/bin/phpunit
             php: 7.3
-            dist: xenial
+            dist: trusty
             env:
                 - DB=mariadb
             addons:
                 mariadb: 10.1
         -   <<: *TEST
-            php: 7.4
+            php: 7.3
             addons:
                 mariadb: 10.4
         -   <<: *TEST

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "phpstan/phpstan": "0.12.42",
         "phpstan/extension-installer": "1.0.5",
         "phpstan/phpstan-phpunit": "0.12.16",
-        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
+        "phpunit/phpunit": "^9.3",
         "psalm/plugin-phpunit": "0.10.1",
         "psalm/plugin-symfony": "1.4.1",
         "vimeo/psalm": "3.12.2"

--- a/redaxo/src/addons/backup/package.yml
+++ b/redaxo/src/addons/backup/package.yml
@@ -19,6 +19,6 @@ page:
 
 requires:
     php:
-        version: '>=7.1'
+        version: '>=7.3'
         extensions: [ctype]
     redaxo: ^5.9.0

--- a/redaxo/src/addons/be_style/composer.json
+++ b/redaxo/src/addons/be_style/composer.json
@@ -5,7 +5,7 @@
 
     "config": {
         "platform": {
-            "php": "7.1.3"
+            "php": "7.3.0"
         }
     }
 }

--- a/redaxo/src/addons/be_style/package.yml
+++ b/redaxo/src/addons/be_style/package.yml
@@ -12,5 +12,5 @@ console_commands:
     styles:compile: rex_be_style_command_compile
 
 requires:
-    php: '>=7.1'
+    php: '>=7.3'
     redaxo: ^5.10.0

--- a/redaxo/src/addons/cronjob/package.yml
+++ b/redaxo/src/addons/cronjob/package.yml
@@ -18,7 +18,7 @@ pages:
         perm: admin[]
 
 requires:
-    php: '>=7.1'
+    php: '>=7.3'
     redaxo: ^5.9.0
 
 console_commands:

--- a/redaxo/src/addons/debug/package.yml
+++ b/redaxo/src/addons/debug/package.yml
@@ -14,5 +14,5 @@ page:
     linkAttr: { target: _blank }
 
 requires:
-    php: '>=7.1'
+    php: '>=7.3'
     redaxo: ^5.11.0

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -21,7 +21,7 @@ page:
 
 requires:
     php:
-        version: '>=7.1'
+        version: '>=7.3'
         extensions: [zlib]
     redaxo: ^5.7.0
 

--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -16,7 +16,7 @@ page:
 
 requires:
     php:
-        version: '>=7.1'
+        version: '>=7.3'
         extensions: [gd]
     redaxo: ^5.10.0
 

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -30,5 +30,5 @@ allowed_doctypes: [bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, mp4, 
 image_extensions: [bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]
 
 requires:
-    php: '>=7.1'
+    php: '>=7.3'
     redaxo: ^5.10.0

--- a/redaxo/src/addons/metainfo/package.yml
+++ b/redaxo/src/addons/metainfo/package.yml
@@ -15,7 +15,7 @@ page:
         clangs: { title: 'translate:clangs' }
 
 requires:
-    php: '>=7.1'
+    php: '>=7.3'
     redaxo: '^5.6.0'
     packages:
         structure: '^2.0.0'

--- a/redaxo/src/addons/phpmailer/composer.json
+++ b/redaxo/src/addons/phpmailer/composer.json
@@ -3,7 +3,7 @@
 
     "config": {
         "platform": {
-            "php": "7.1.3"
+            "php": "7.3.0"
         }
     }
 }

--- a/redaxo/src/addons/phpmailer/package.yml
+++ b/redaxo/src/addons/phpmailer/package.yml
@@ -20,7 +20,7 @@ pages:
         perm: admin
 
 requires:
-    php: '>=7.1'
+    php: '>=7.3'
     redaxo: ^5.10.0
 
 default_config:

--- a/redaxo/src/addons/structure/package.yml
+++ b/redaxo/src/addons/structure/package.yml
@@ -24,5 +24,5 @@ pages:
 system_plugins: [content]
 
 requires:
-    php: '>=7.1'
+    php: '>=7.3'
     redaxo: ^5.11.0

--- a/redaxo/src/addons/users/package.yml
+++ b/redaxo/src/addons/users/package.yml
@@ -17,5 +17,5 @@ page:
         roles: { title: 'translate:roles', perm: admin }
 
 requires:
-    php: '>=7.1'
+    php: '>=7.3'
     redaxo: ^5.11.0

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -9,7 +9,7 @@
  * @global boolean $REX['LOAD_PAGE']      [Optional] Wether the front controller should be loaded or not. Default value is false.
  */
 
-define('REX_MIN_PHP_VERSION', '7.1.3');
+define('REX_MIN_PHP_VERSION', '7.3');
 
 if (version_compare(PHP_VERSION, REX_MIN_PHP_VERSION) < 0) {
     throw new Exception('PHP version >=' . REX_MIN_PHP_VERSION . ' needed!');

--- a/redaxo/src/core/composer.json
+++ b/redaxo/src/core/composer.json
@@ -23,7 +23,7 @@
         "optimize-autoloader": true,
         "sort-packages": true,
         "platform": {
-            "php": "7.1.3"
+            "php": "7.3.0"
         }
     },
 

--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -3,8 +3,8 @@
 // don't use REX_MIN_PHP_VERSION or rex_setup::MIN_MYSQL_VERSION here!
 // while updating the core, the constants contain the old min versions from previous core version
 
-if (PHP_VERSION_ID < 70103) {
-    throw new rex_functional_exception(rex_i18n::msg('setup_301', PHP_VERSION, '7.1.3'));
+if (PHP_VERSION_ID < 70300) {
+    throw new rex_functional_exception(rex_i18n::msg('setup_301', PHP_VERSION, '7.3'));
 }
 
 $minMysqlVersion = '5.6';


### PR DESCRIPTION
Ich schlage vor, nun mal wieder die PHP-Version zu erhöhen, und zwar direkt um zwei Versionen auf min. 7.3.
PHP 7.2 erhält noch 2 Monate Sicherheitsfixes: https://www.php.net/supported-versions.php
Ich würde die aber trotzdem schon weglassen. Ich habe ja auch schon öfters gesagt, dass ich lieber seltenerer größere Sprünge mache, als kontinuierlich kleine.

Aus meiner Sicht brauchen wir auch nicht vorher eine Version mit Warnung rausbringen. Man sieht ja beim Update dann, dass es nicht geht, und bleibt dann halt erst mal bei R5.11, wenn man die PHP-Version wirklich noch nicht hochsetzen kann/mag.
(Eventuell würde ich noch eine 5.11.1 rausbringen. Falls ich das mache, könnte man da dann natürlich schon doch noch die Warnung einbauen.)