### PR TITLE
Cronjob-Command: job-Option benötigt keinen Wert

### DIFF
--- a/redaxo/src/addons/cronjob/lib/command/run.php
+++ b/redaxo/src/addons/cronjob/lib/command/run.php
@@ -18,7 +18,7 @@ class rex_command_cronjob_run extends rex_console_command
     {
         $this
             ->setDescription('Executes cronjobs of the "script" environment')
-            ->addOption('job', null, InputOption::VALUE_REQUIRED, 'Execute single job (selected interactively or given by id)', false)
+            ->addOption('job', null, InputOption::VALUE_OPTIONAL, 'Execute single job (selected interactively or given by id)', false)
         ;
     }
 


### PR DESCRIPTION
Dies ist ein Teil-Revert von https://github.com/redaxo/redaxo/pull/3865.

An der Stelle war `VALUE_OPTIONAL` korrekt, man darf also `cronjob:run --job` ohne weiteren Wert aufrufen, und bekommt dann interaktiv eine Auswahl der Jobs.