### PR TITLE
Dependabot: weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
         directory: /
         versioning-strategy: increase
         schedule:
-            interval: daily
+            interval: weekly
 
     -   package-ecosystem: github-actions
         directory: /
         schedule:
-            interval: daily
+            interval: weekly


### PR DESCRIPTION
Ich schlage vor, das Intervall auf `weekly` umzustellen. 
Wir brauchen ja nicht dringend taggleiche Updates, und manche Libs updaten sehr oft. Daher würde ich das bei uns reduzieren wollen.

Falls man mal schneller ein Update haben möchte, kann man ja auch immer noch hier manuell den Prozess starten:
https://github.com/redaxo/redaxo/network/updates