### PR TITLE
rex_var::toArray Dekodierung an rex_escape anpassen

### DIFF
--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -395,12 +395,13 @@ abstract class rex_var
      * Converts a REX_VAR content to a PHP array.
      *
      * @param string $value
+     * @param int $decode_strategy How to handle quotes during decoding. Possible values are `ENT_QUOTES` (default), `ENT_NOQUOTES` and `ENT_COMPAT`.
      *
      * @return array|null
      */
-    public static function toArray($value)
+    public static function toArray($value, $decode_strategy = ENT_QUOTES)
     {
-        $value = json_decode(htmlspecialchars_decode($value), true);
+        $value = json_decode(htmlspecialchars_decode($value, $decode_strategy), true);
         return is_array($value) ? $value : null;
     }
 

--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -395,13 +395,12 @@ abstract class rex_var
      * Converts a REX_VAR content to a PHP array.
      *
      * @param string $value
-     * @param int $decode_strategy How to handle quotes during decoding. Possible values are `ENT_QUOTES` (default), `ENT_NOQUOTES` and `ENT_COMPAT`.
      *
      * @return array|null
      */
-    public static function toArray($value, $decode_strategy = ENT_QUOTES)
+    public static function toArray($value)
     {
-        $value = json_decode(htmlspecialchars_decode($value, $decode_strategy), true);
+        $value = json_decode(htmlspecialchars_decode($value, ENT_QUOTES), true);
         return is_array($value) ? $value : null;
     }
 

--- a/redaxo/src/core/tests/var/var_test.php
+++ b/redaxo/src/core/tests/var/var_test.php
@@ -159,6 +159,16 @@ EOT
 
         $content = '<?php print_r(rex_var::toArray("REX_TEST_VAR[content=\'' . addcslashes(htmlspecialchars(json_encode($array)), '[]"')  . '\']"));';
         $this->assertParseOutputEquals(print_r($array, true), $content, 'toArray() works with htmlspecialchar\'ed data');
+
+        $array = ['&#039;', '&quot;']; // [code for ', code for "]
+        $unescaped_array = ["'", '"'];
+        $content = '<?php print_r(rex_var::toArray("REX_TEST_VAR[content=\'' . addcslashes(json_encode($array), '[]"') . '\']"));';
+        $this->assertParseOutputEquals(print_r($unescaped_array, true), $content, 'toArray() rebuilds quotes');
+
+        $array = ['&lt;strong&gt;inject me&lt;/strong&gt;', 'foo&amp;bar'];
+        $unescaped_array = ['<strong>inject me</strong>', 'foo&bar'];
+        $content = '<?php print_r(rex_var::toArray("REX_TEST_VAR[content=\'' . addcslashes(json_encode($array), '[]"') . '\']"));';
+        $this->assertParseOutputEquals(print_r($unescaped_array, true), $content, 'toArray() rebuilds HTML');
     }
 
     public function testQuote()

--- a/redaxo/src/core/tests/var/var_test.php
+++ b/redaxo/src/core/tests/var/var_test.php
@@ -160,7 +160,7 @@ EOT
         $content = '<?php print_r(rex_var::toArray("REX_TEST_VAR[content=\'' . addcslashes(htmlspecialchars(json_encode($array)), '[]"')  . '\']"));';
         $this->assertParseOutputEquals(print_r($array, true), $content, 'toArray() works with htmlspecialchar\'ed data');
 
-        $array = ['&#039;', '&quot;']; // [code for ', code for "]
+        $array = ['&#039;', '\&quot;']; // [code for ', code for "]
         $unescaped_array = ["'", '"'];
         $content = '<?php print_r(rex_var::toArray("REX_TEST_VAR[content=\'' . addcslashes(json_encode($array), '[]"') . '\']"));';
         $this->assertParseOutputEquals(print_r($unescaped_array, true), $content, 'toArray() rebuilds quotes');


### PR DESCRIPTION
Dieser Commit gleicht die verwendeten Parameter beim Aufruf von
htmlspecialchars_decode an die Parameter an, die rex_escape fuer
das Escaping mittels htmlspecialchars nutzt. Dadurch wird eine
Inkonsistenz bzgl. der Interpretation von Quotes behoben und damit
eine freie Kombination von rex_var::toArray und rex_escape ermoeglicht.

Siehe Issue #3886 für eine ausführlichere Diskussion des Problems.