### PR TITLE
DX: whoops Fehlerseite verwenden für requests via localhost

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -65,7 +65,7 @@ abstract class rex_error_handler
             }
             rex_response::setStatus($status);
 
-            if (rex::isSetup() || rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin()) {
+            if (rex::isSetup() || rex::isDebugMode() || rex_request::isLocalhost() || ($user = rex_backend_login::createUser()) && $user->isAdmin()) {
                 [$errPage, $contentType] = self::renderWhoops($exception);
                 rex_response::sendContent($errPage, $contentType);
                 exit(1);

--- a/redaxo/src/core/lib/request.php
+++ b/redaxo/src/core/lib/request.php
@@ -281,7 +281,7 @@ class rex_request
             '::1'
         );
 
-        return in_array($_SERVER['REMOTE_ADDR'], $whitelist);
+        return isset($_SERVER['REMOTE_ADDR']) && in_array($_SERVER['REMOTE_ADDR'], $whitelist);
     }
 
     /**

--- a/redaxo/src/core/lib/request.php
+++ b/redaxo/src/core/lib/request.php
@@ -271,6 +271,20 @@ class rex_request
     }
 
     /**
+     * Returns whether the current request is served for localhost
+     *
+     * @return bool
+     */
+    public static function isLocalhost():bool {
+        $whitelist = array(
+            '127.0.0.1',
+            '::1'
+        );
+
+        return in_array($_SERVER['REMOTE_ADDR'], $whitelist);
+    }
+
+    /**
      * Returns the session namespace for the current http request.
      *
      * @return string


### PR DESCRIPTION
wenn via localhost gearbeitet wird, können wir davon ausgehen dass wir einen vertrauenswürden user vor uns haben.
daher in diesem fall immer die Whoops Fehlerseite verwenden um die Developer Experience zu verbessern.

Die "Oooops" Fehlerseite ist ja bewusst mit wenig informationen versehen aber das kann neulinge verschrecken, wenn sie nicht wissen wo sie nach dem Fehler suchen sollen.

Die Idee dazu kam mir beim schauen des [Hacktoberfest Recordings](https://www.youtube.com/watch?v=e_ohxyAvKAU) da dort der unbedarfte user mit einer Ooops seite konfrontiert wurde, und dann erstmal nicht weiter wusste.