### PR TITLE
fix php test warning: "session_destroy(): Trying to destroy uninitial…

### DIFF
--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -41,7 +41,9 @@ class rex_backend_login_test extends TestCase
         $deleteuser->setQuery('DELETE FROM ' . rex::getTablePrefix() . "user WHERE login = '". $this->login ."' LIMIT 1");
 
         // make sure we don't mess up the global scope
-        session_destroy();
+        if (PHP_SESSION_ACTIVE == session_status()) {
+            session_destroy();
+        }
     }
 
     public function testSuccessfullLogin()

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -7,19 +7,12 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_backend_login_test extends TestCase
 {
-    private $skipped = false;
-
     private $login = 'testusr';
     private $password = 'test1234';
     private $cookiekey = 'mycookie';
 
     protected function setUp(): void
     {
-        if (rex::getUser()) {
-            $this->skipped = true;
-            static::markTestSkipped('The rex_backend_login class can not be tested when test suite is running in redaxo backend.');
-        }
-
         $adduser = rex_sql::factory();
         $adduser->setTable(rex::getTablePrefix() . 'user');
         $adduser->setValue('name', 'test user');
@@ -33,17 +26,8 @@ class rex_backend_login_test extends TestCase
 
     protected function tearDown(): void
     {
-        if ($this->skipped) {
-            return;
-        }
-
         $deleteuser = rex_sql::factory();
         $deleteuser->setQuery('DELETE FROM ' . rex::getTablePrefix() . "user WHERE login = '". $this->login ."' LIMIT 1");
-
-        // make sure we don't mess up the global scope
-        if (PHP_SESSION_ACTIVE == session_status()) {
-            session_destroy();
-        }
     }
 
     public function testSuccessfullLogin()


### PR DESCRIPTION
…ized session"

warning erscheint wenn man die tests via CLI startet.

relates to https://github.com/redaxo/redaxo/issues/558