### PR TITLE
DX: Hinweis ergänzt wenn keine datenbank connection aufgebaut werden kann

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -138,9 +138,8 @@ class rex_sql implements Iterator
         } catch (PDOException $e) {
             if ('cli' === PHP_SAPI) {
                 throw new rex_sql_exception("Could not connect to database.\n\nConsider starting either the web-based or console-based REDAXO setup to configure the database connection settings.", $e, $this);
-            } else {
-                throw new rex_sql_exception('Could not connect to database', $e, $this);
             }
+            throw new rex_sql_exception('Could not connect to database', $e, $this);
         }
     }
 

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -136,7 +136,11 @@ class rex_sql implements Iterator
                 $this->setQuery('SET SESSION SQL_MODE="", NAMES utf8mb4');
             }
         } catch (PDOException $e) {
-            throw new rex_sql_exception('Could not connect to database', $e, $this);
+            if ('cli' === PHP_SAPI) {
+                throw new rex_sql_exception("Could not connect to database.\n\nConsider starting either the web-based or console-based REDAXO setup to configure the database connection settings.", $e, $this);
+            } else {
+                throw new rex_sql_exception('Could not connect to database', $e, $this);
+            }
         }
     }
 


### PR DESCRIPTION
wenn ein neuer user direkt nach clonen des repositories phpunit startet, ohne das setup durchlaufen zu haben, fehlen die datenbank zugangsdaten und phpunit endet weniger hilfreich mit

```
$ vendor/bin/phpunit -v
PHPUnit 9.4.0 by Sebastian Bergmann and contributors.

Could not connect to database
```

um in diesem fall dem developer hinweise zu geben, werden in diesem fall eine aussagekräftigere fehlermeldung ausgegeben.

Vorschlag mit diesem PR:
```
$ vendor/bin/phpunit -v
PHPUnit 9.4.0 by Sebastian Bergmann and contributors.

Could not connect to database.

Consider starting either the web-based or console-based REDAXO setup to configure the database connection settings.
```