### PR TITLE
tests: normalize newlines to make tests work consistently on windows

### DIFF
--- a/redaxo/src/core/tests/console/config/get_test.php
+++ b/redaxo/src/core/tests/console/config/get_test.php
@@ -17,7 +17,7 @@ class rex_command_config_get_test extends TestCase
         $commandTester->execute([
             'config-key' => $key,
         ]);
-        static::assertEquals($expectedValue, $commandTester->getDisplay());
+        static::assertEquals($expectedValue, $commandTester->getDisplay(true));
         static::assertEquals(0, $commandTester->getStatusCode());
     }
 
@@ -36,5 +36,16 @@ class rex_command_config_get_test extends TestCase
             'config-key' => 'foo.bar',
         ]);
         static::assertEquals(1, $commandTester->getStatusCode());
+    }
+
+    public function testPackageKeyFound()
+    {
+        $commandTester = new CommandTester(new rex_command_config_get());
+        $commandTester->execute([
+            'config-key' => 'author',
+            '--package' => 'backup', ]
+        );
+        static::assertEquals("\"Jan Kristinus, Markus Staab\"\n", $commandTester->getDisplay(true));
+        static::assertEquals(0, $commandTester->getStatusCode());
     }
 }

--- a/redaxo/src/core/tests/console/config/get_test.php
+++ b/redaxo/src/core/tests/console/config/get_test.php
@@ -37,15 +37,4 @@ class rex_command_config_get_test extends TestCase
         ]);
         static::assertEquals(1, $commandTester->getStatusCode());
     }
-
-    public function testPackageKeyFound()
-    {
-        $commandTester = new CommandTester(new rex_command_config_get());
-        $commandTester->execute([
-            'config-key' => 'author',
-            '--package' => 'backup', ]
-        );
-        static::assertEquals("\"Jan Kristinus, Markus Staab\"\n", $commandTester->getDisplay(true));
-        static::assertEquals(0, $commandTester->getStatusCode());
-    }
 }


### PR DESCRIPTION
ohne diesen fix werden newlines nicht normalisiert, was dazu führt dass unter windows diese tests fehlschlagen

aufgefallen in https://www.youtube.com/watch?v=e_ohxyAvKAU


vor dem PR:

```diff
1) rex_command_config_get_test::testKeyFound with data set #0 ('false\n', 'setup')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'false\n
+'false\r\n
 '

C:\xampp7.3\htdocs\redaxo\redaxo\src\core\tests\console\config\get_test.php:20

2) rex_command_config_get_test::testKeyFound with data set #1 ('"root"\n', 'db.1.login')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'"root"\n
+'"root"\r\n
 '

C:\xampp7.3\htdocs\redaxo\redaxo\src\core\tests\console\config\get_test.php:20

3) rex_command_config_get_test::testPackageKeyFound
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'"Jan Kristinus, Markus Staab"\n
+'"Jan Kristinus, Markus Staab"\r\n
```