### PR TITLE
Markdown TOC: Handling von HTML/Markdown/SpecialChars innerhalb der Überschriften

### DIFF
--- a/redaxo/src/core/lib/util/markdown.php
+++ b/redaxo/src/core/lib/util/markdown.php
@@ -137,6 +137,7 @@ final class rex_parsedown_with_toc extends ParsedownExtra
         [$level] = sscanf($block['element']['name'], 'h%d');
 
         $plainText = strip_tags($this->{$block['element']['handler']}($block['element']['text']));
+        $plainText = htmlspecialchars_decode($plainText);
 
         if (!isset($block['element']['attributes']['id'])) {
             $baseId = $id = 'header-'.rex_string::normalize($plainText, '-');

--- a/redaxo/src/core/lib/util/markdown.php
+++ b/redaxo/src/core/lib/util/markdown.php
@@ -136,12 +136,10 @@ final class rex_parsedown_with_toc extends ParsedownExtra
 
         [$level] = sscanf($block['element']['name'], 'h%d');
 
-        if ($level < $this->topLevel || $level > $this->bottomLevel) {
-            return $block;
-        }
+        $plainText = strip_tags($this->{$block['element']['handler']}($block['element']['text']));
 
         if (!isset($block['element']['attributes']['id'])) {
-            $baseId = $id = 'header-'.rex_string::normalize($block['element']['text'], '-');
+            $baseId = $id = 'header-'.rex_string::normalize($plainText, '-');
 
             for ($i = 2; isset($this->ids[$id]); ++$i) {
                 $id = $baseId.'-'.$i;
@@ -153,11 +151,13 @@ final class rex_parsedown_with_toc extends ParsedownExtra
         $id = $block['element']['attributes']['id'];
         $this->ids[$id] = true;
 
-        $this->headers[] = [
-            'level' => $level,
-            'id' => $id,
-            'text' => $block['element']['text'],
-        ];
+        if ($level >= $this->topLevel && $level <= $this->bottomLevel) {
+            $this->headers[] = [
+                'level' => $level,
+                'id' => $id,
+                'text' => $plainText,
+            ];
+        }
 
         return $block;
     }

--- a/redaxo/src/core/tests/util/markdown_test.php
+++ b/redaxo/src/core/tests/util/markdown_test.php
@@ -74,6 +74,8 @@ Foo bar
 ## [Title with Markdown](#sub-1)
 
 ## <i>Title with HTML</i>
+
+## Title with "quotes" & 'other' special &lt;chars&gt;
 MARKDOWN;
 
         [$toc, $content] = rex_markdown::factory()->parseWithToc($input, 2, 4);
@@ -120,6 +122,9 @@ MARKDOWN;
 </li>
 <li>
 <a href="#header-title-with-html">Title with HTML</a>
+</li>
+<li>
+<a href="#header-title-with-quotes-other-special-chars">Title with &quot;quotes&quot; &amp; &#039;other&#039; special &lt;chars&gt;</a>
 </li>
 </ul>
 

--- a/redaxo/src/core/tests/util/markdown_test.php
+++ b/redaxo/src/core/tests/util/markdown_test.php
@@ -66,6 +66,14 @@ Foo bar
 ## Sub 3
 
 ### Sub 3.1
+
+## Duplicate Test
+
+## Duplicate Test
+
+## [Title with Markdown](#sub-1)
+
+## <i>Title with HTML</i>
 MARKDOWN;
 
         [$toc, $content] = rex_markdown::factory()->parseWithToc($input, 2, 4);
@@ -101,6 +109,17 @@ MARKDOWN;
 <a href="#header-sub-3-1">Sub 3.1</a>
 </li>
 </ul>
+<li>
+<a href="#header-duplicate-test">Duplicate Test</a>
+</li>
+<li>
+<a href="#header-duplicate-test-2">Duplicate Test</a>
+</li>
+<li>
+<a href="#header-title-with-markdown">Title with Markdown</a>
+</li>
+<li>
+<a href="#header-title-with-html">Title with HTML</a>
 </li>
 </ul>
 


### PR DESCRIPTION
Dies ist teilweise ein Backport von https://github.com/redaxo/redaxo/pull/3833 (nicht enthalten ist die Header-ID-Präfixänderung).

Zusätzlich: fixes #3931
Wenn Überschriften Quotes enthalten, bleiben die in der Sprungnavi erhalten, und werden nun korrekt behandelt.