### PR TITLE
WIP: setup url validieren

### DIFF
--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -194,6 +194,7 @@ setup_309 = Ordnerrechte ok
 setup_310 = Weiter mit Schritt 4
 setup_311 = Die folgenden Dateien/Verzeichnisse sind für alle Anwender auf dem Server veränderbar ("Others"-Mode-Bit 7). Die Berechtigungen sollten restriktiver sein:
 setup_312 = Schritt 3 erneut durchführen
+setup_313 = Das Setup wird von einer invaliden Url ausgeführt
 setup_399 = 3 / Systemcheck
 
 setup_400 = Setup: Schritt 4 von 7 / Schreiben der '{0}'

--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -76,6 +76,11 @@ class rex_setup
             }
         }
 
+        $setupUri = ltrim(rex_server('REQUEST_URI', 'string'), '/');
+        if (strpos($setupUri, 'index.php') === 0) {
+            $errors[] = rex_i18n::msg('setup_313');
+        }
+
         return $errors;
     }
 


### PR DESCRIPTION
heute im hackathon hatte einer unserer entwickler erstmalig redaxo im setup.

er hat sich dabei vertan und den DOC_ROOT vom VHOST des lokalen webservers so konfiguriert dass https://redaxo.loc direkt auf die `index.php` des redaxo backends gezeigt hat.
dementsprechend hat er dann nirgends ein frontend finden können, da dies via url überhaupt nicht erreichbar war.

dieser PR implementiert einen naiven check, der dieses szenario erkennt. dabei ist noch nicht berücksichtigt dass man ggf. einen eigenen path provider verwendet und dann das ganze so nicht passt.

erstmal zur diskussion.. vllt hat jemand auch eine bessere idee das szenario zu erkennen