### PR TITLE
Scoped fragments

### DIFF
--- a/redaxo/src/addons/structure/fragments/structure/scoped/category_row_header.php
+++ b/redaxo/src/addons/structure/fragments/structure/scoped/category_row_header.php
@@ -1,0 +1,14 @@
+<?php
+
+echo '
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th class="rex-table-icon">' . $this->add_category . '</th>
+                        <th class="rex-table-id">' . rex_i18n::msg('header_id') . '</th>
+                        <th class="rex-table-category">' . rex_i18n::msg('header_category') . '</th>
+                        <th class="rex-table-priority">' . rex_i18n::msg('header_priority') . '</th>
+                        <th class="rex-table-action" colspan="'.$this->colspan.'">' . rex_i18n::msg('header_status') . '</th>
+                    </tr>
+                </thead>
+                <tbody>';

--- a/redaxo/src/addons/structure/pages/index.php
+++ b/redaxo/src/addons/structure/pages/index.php
@@ -114,18 +114,11 @@ $canDelete = rex::getUser()->hasPerm('deleteCategory[]');
 $colspan = (int) $canEdit + (int) $canDelete + 1;
 
 // --------------------- PRINT CATS/SUBCATS
-$echo .= '
-            <table class="table table-striped table-hover">
-                <thead>
-                    <tr>
-                        <th class="rex-table-icon">' . $add_category . '</th>
-                        <th class="rex-table-id">' . rex_i18n::msg('header_id') . '</th>
-                        <th class="rex-table-category">' . rex_i18n::msg('header_category') . '</th>
-                        <th class="rex-table-priority">' . rex_i18n::msg('header_priority') . '</th>
-                        <th class="rex-table-action" colspan="'.$colspan.'">' . rex_i18n::msg('header_status') . '</th>
-                    </tr>
-                </thead>
-                <tbody>';
+
+$fragment = rex_fragment::scoped(rex_addon::get('structure'));
+$fragment->setVar('add_category', $add_category, false);
+$fragment->setVar('colspan', $colspan);
+$echo .= $fragment->parse('structure/scoped/category_row_header.php');
 
 // --------------------- KATEGORIE ADD FORM
 

--- a/redaxo/src/core/lib/fragment.php
+++ b/redaxo/src/core/lib/fragment.php
@@ -130,8 +130,8 @@ class rex_fragment
     }
 
     /**
+     * @param string $fragmentName
      * @param string $filename
-     * @param string $fragment
      * @throws rex_exception
      * @return string
      */

--- a/redaxo/src/core/lib/fragment.php
+++ b/redaxo/src/core/lib/fragment.php
@@ -169,7 +169,7 @@ class rex_fragment
         return $this;
     }
 
-    public static function scoped(rex_package $package):self {
+    public static function scoped(rex_package_interface $package):self {
         $fragment = new self();
         $fragment->scope = $package;
         return $fragment;

--- a/redaxo/src/core/lib/fragment.php
+++ b/redaxo/src/core/lib/fragment.php
@@ -18,7 +18,7 @@ class rex_fragment
      * a scope the fragment is bound to.
      * scoped fragments will not do a global lookup thru all registered fragment folders.
      *
-     * @var rex_package|null
+     * @var rex_package_interface|null
      */
     private $scope;
 

--- a/redaxo/src/core/lib/fragment.php
+++ b/redaxo/src/core/lib/fragment.php
@@ -126,7 +126,7 @@ class rex_fragment
             }
         }
 
-        throw new rex_exception(sprintf('Fragmentfile "%s" not found!', $filename));
+        throw new rex_exception(sprintf('Fragmentfile "%s" not found!', $fragmentName));
     }
 
     /**


### PR DESCRIPTION
erstmal eine Diskussionsgrundlage

Idee ist: man kann `rex_fragment` auch so benutzen, dass sie nicht durch andere addons überschrieben werden können.

das bedeutet man 'scoped' ein fragment für ein rex_package (also addOn oder plugIn) und bietet somit bewusst keine api oberfläche für andere addons die sich einklinken.

vorteil davon ist, dass man fragmente 'privat' benutzen kann und nicht für externe die rückwärtskompatibilität gewährleisten muss.
- man kann dann also auch html fragmente, die semantisch keinen vollständigen html-DOM ergeben zusammenpacken ohne schlechtes gewissen (z.b. weil sie ein element öffnen dass sie selbst nicht schließen - oder ein `<tr><td>` ohne umschließendes table o.ä.).
- man kann html fragmente nutzen ohne garantieren zu müssen dass die elemente über versionen hinweg in dieser art konsistent bleiben (weil sie eben nicht zur wiederverwendung ausserhalb des packages gedacht sind)
- man muss beim review von scoped-fragmenten kein bikeshedding betreiben um "die perfekte html form" zu erreichen, da man scoped fragmente jederzeit ändern kann, ohne rücksicht auf BC

ich bin mit dem begriff 'scoped fragments' nicht verheiratet.. namesvorschläge willkommen.

motiviert aus der diskussion gestartet hier: https://github.com/redaxo/redaxo/pull/3967#issuecomment-710120191 

Auch in der Diskussion um die neuen login screens haben wir uns wg api surface (überschreiben von fragmenten via addon) zum teil gegen fragmente enschieden