### PR TITLE
Use ramsey/composer-install@v1 to simplify GithubAction workflow

### DIFF
--- a/.github/workflows/cs-check.yml
+++ b/.github/workflows/cs-check.yml
@@ -27,15 +27,7 @@ jobs:
                 extensions: intl
                 coverage: none # disable xdebug, pcov
                 tools: cs2pr
-          - name: Get Composer Cache Directory
-            id: composer-cache
-            run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-          - name: Cache dependencies
-            uses: actions/cache@v2
+          - uses: "ramsey/composer-install@v1"
             with:
-                path: ${{ steps.composer-cache.outputs.dir }}
-                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-                restore-keys: ${{ runner.os }}-composer-
-          - name: Install Dependencies
-            run: composer install --ansi --prefer-dist
+                composer-options: "--ansi --prefer-dist"
           - run: vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle | cs2pr

--- a/.github/workflows/cs-fix.yml
+++ b/.github/workflows/cs-fix.yml
@@ -25,17 +25,9 @@ jobs:
         coverage: none # disable xdebug, pcov
         tools: cs2pr
 
-    - name: Get Composer Cache Directory
-      id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-    - name: Cache dependencies
-      uses: actions/cache@v2
+    - uses: "ramsey/composer-install@v1"
       with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-        restore-keys: ${{ runner.os }}-composer-
-    - name: Install Dependencies
-      run: composer install --ansi --prefer-dist
+        composer-options: "--ansi --prefer-dist"
 
     - run: vendor/bin/php-cs-fixer fix --diff
 

--- a/.github/workflows/rexlint.yml
+++ b/.github/workflows/rexlint.yml
@@ -31,17 +31,9 @@ jobs:
                   php-version: 7.3
                   extensions: intl
                   coverage: none # disable xdebug, pcov
-            - name: Get Composer Cache Directory
-              id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-            - name: Cache dependencies
-              uses: actions/cache@v2
+            - uses: "ramsey/composer-install@v1"
               with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-                  restore-keys: ${{ runner.os }}-composer-
-            - name: Install Dependencies
-              run: composer install --ansi --prefer-dist
+                  composer-options: "--ansi --prefer-dist"
             - run: |
                   sudo /etc/init.d/mysql start
                   mysql -uroot -h127.0.0.1 -proot -e 'create database redaxo5;'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -31,22 +31,14 @@ jobs:
                   php-version: 7.4
                   extensions: intl, imagick
                   coverage: none # disable xdebug, pcov
-            - name: Get Composer Cache Directory
-              id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-            - name: Cache dependencies
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-                  restore-keys: ${{ runner.os }}-composer-
             - name: "Psalm Resultcache"
               uses: actions/cache@v2
               with:
                   path: /tmp/psalm
                   key: "psalm-result-cache"
-            - name: Install Dependencies
-              run: composer install --ansi --prefer-dist
+            - uses: "ramsey/composer-install@v1"
+              with:
+                  composer-options: "--ansi --prefer-dist"
             - run: |
                   sudo /etc/init.d/mysql start
                   mysql -uroot -h127.0.0.1 -proot -e 'create database redaxo5;'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,17 +31,9 @@ jobs:
                   php-version: 7.4
                   extensions: intl
                   coverage: none # disable xdebug, pcov
-            - name: Get Composer Cache Directory
-              id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-            - name: Cache dependencies
-              uses: actions/cache@v2
+            - uses: "ramsey/composer-install@v1"
               with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-                  restore-keys: ${{ runner.os }}-composer-
-            - name: Install Dependencies
-              run: composer install --ansi --prefer-dist
+                  composer-options: "--ansi --prefer-dist"
 
             - name: Setup Problem Matchers for PHPUnit
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"


### PR DESCRIPTION
`https://github.com/ramsey/composer-install` impliziert dependency caching, daher wirds damit einfacher.

> ramsey/composer-install is a GitHub Action to streamline installation of Composer dependencies in workflows. It installs your Composer dependencies and caches them for improved build times.