### PR TITLE
increase phpstan level to 5 and generated a baseline

### DIFF
--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -1,0 +1,367 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/cronjob/pages/log.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/debug/lib/debug_clockwork.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/install/lib/archive.php
+
+		-
+			message: "#^Parameter \\#3 \\$alias of class PharData constructor expects string, null given\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/install/lib/archive.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/install/pages/index.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method rex_sql\\:\\:addRecord\\(\\) expects callable\\(rex_sql\\)\\: void, Closure\\(rex_sql\\)\\: mixed given\\.$#"
+			count: 2
+			path: ../../redaxo/src/addons/media_manager/install.php
+
+		-
+			message: "#^Call to function is_bool\\(\\) with string\\|null will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+
+		-
+			message: "#^Method rex_media\\:\\:getRootMedia\\(\\) should return array\\<static\\(rex_media\\)\\> but returns array\\<rex_media\\>\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/mediapool/lib/media.php
+
+		-
+			message: "#^Method rex_media\\:\\:getInstanceList\\(\\) should return array\\<T of object\\> but returns array\\<int, mixed\\>\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/mediapool/lib/media.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/mediapool/lib/media.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/mediapool/lib/media_category_select.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and string will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/metainfo/functions/function_metainfo.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method rex_sql\\:\\:addRecord\\(\\) expects callable\\(rex_sql\\)\\: void, Closure\\(rex_sql\\)\\: mixed given\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/metainfo/install.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/phpmailer/boot.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/phpmailer/pages/log.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 3
+			path: ../../redaxo/src/addons/structure/lib/select_category.php
+
+		-
+			message: "#^Parameter \\#2 \\$createCallback of static method rex_structure_element\\:\\:getInstance\\(\\) expects \\(callable\\(\\.\\.\\.mixed\\)\\: rex_structure_element\\|null\\)\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/structure/lib/structure_element.php
+
+		-
+			message: "#^Method rex_structure_element\\:\\:getChildElements\\(\\) should return array\\<static\\(rex_structure_element\\)\\> but returns array\\<object\\>\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/structure/lib/structure_element.php
+
+		-
+			message: "#^Parameter \\#3 \\$createListCallback of static method rex_structure_element\\:\\:getInstanceList\\(\\) expects \\(callable\\(\\.\\.\\.mixed\\)\\: array\\)\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/structure/lib/structure_element.php
+
+		-
+			message: "#^Method rex_structure_element\\:\\:getInstanceList\\(\\) should return array\\<T of object\\> but returns array\\<int, mixed\\>\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/structure/lib/structure_element.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/structure/lib/structure_element.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/structure/plugins/content/pages/content.edit.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+
+		-
+			message: "#^Comparison operation \"\\>\" between int\\<min, 0\\>\\|null and 0 is always false\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/structure/plugins/version/boot.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 2
+			path: ../../redaxo/src/core/lib/api_function.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/api_function.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/api_function.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/api_function.php
+
+		-
+			message: "#^Argument of an invalid type rex_api_result supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/api_function.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/autoload.php
+
+		-
+			message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, array\\('rex_autoload', 'autoload'\\) given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/autoload.php
+
+		-
+			message: "#^Method rex_media_category\\:\\:getInstanceList\\(\\) should return array\\<T of object\\> but returns array\\<int, mixed\\>\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/mediapool/lib/media_category.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/mediapool/lib/media_category.php
+
+		-
+			message: "#^Method rex_test_instance_list_pool\\:\\:getInstanceList\\(\\) should return array\\<T of object\\> but returns array\\<int, mixed\\>\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/base/instance_list_pool_trait_test.php
+
+		-
+			message: "#^Parameter \\#3 \\$createListCallback of static method rex_test_instance_list_pool\\:\\:getInstanceList\\(\\) expects \\(callable\\(\\.\\.\\.mixed\\)\\: array\\)\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/base/instance_list_pool_trait_test.php
+
+		-
+			message: "#^Parameter \\#2 \\$getInstanceCallback of static method rex_test_instance_list_pool\\:\\:getInstanceList\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: object\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/base/instance_list_pool_trait_test.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/sql/table.php
+
+		-
+			message: "#^Parameter \\#2 \\$createCallback of static method rex_sql_table\\:\\:getInstance\\(\\) expects \\(callable\\(\\.\\.\\.mixed\\)\\: rex_sql_table\\|null\\)\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/sql/table.php
+
+		-
+			message: "#^Call to function assert\\(\\) with false will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/sql/table.php
+
+		-
+			message: "#^Call to function is_int\\(\\) with false will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/sql/table.php
+
+		-
+			message: "#^Parameter \\#2 \\$offset of function array_slice expects int, string given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/sql/table.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function array_slice expects int\\|null, string given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/sql/table.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with arguments rex_test_instance_pool_1, null and 'getInstance uses…' will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
+
+		-
+			message: "#^Parameter \\#2 \\$createCallback of static method rex_test_instance_pool_base\\:\\:getInstance\\(\\) expects \\(callable\\(\\.\\.\\.mixed\\)\\: rex_test_instance_pool_1\\|null\\)\\|null, Closure\\(mixed, mixed\\)\\: mixed given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/login/user.php
+
+		-
+			message: "#^Method rex_user\\:\\:getComplexPerm\\(\\) should return rex_clang_perm\\|rex_media_perm\\|rex_module_perm\\|rex_structure_perm\\|null but returns rex_complex_perm\\|null\\.$#"
+			count: 2
+			path: ../../redaxo/src/core/lib/login/user.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method rex_sql\\:\\:addRecord\\(\\) expects callable\\(rex_sql\\)\\: void, Closure\\(rex_sql\\)\\: mixed given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/config.php
+
+		-
+			message: "#^Parameter \\#1 \\$exception_handler of function set_exception_handler expects \\(callable\\(Throwable\\)\\: void\\)\\|null, array\\('rex_error_handler', 'handleException'\\) given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/error_handler.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/form/elements/prio.php
+
+		-
+			message: "#^Method rex_form_base\\:\\:getControlElement\\(\\) should return rex_form_control_element\\|null but returns rex_form_element\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/form/form_base.php
+
+		-
+			message: "#^Call to function is_string\\(\\) with int\\|false will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/form/form_base.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/form/form_base.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and string will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/fragment.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/fragment.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 2
+			path: ../../redaxo/src/core/lib/login/api_user_impersonate.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/login/login.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/login/login.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/login/login.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between false and false will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/sql/sql.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 2
+			path: ../../redaxo/src/core/lib/util/log_file.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/util/log_file.php
+
+		-
+			message: "#^Method rex_socket\\:\\:factory\\(\\) should return static\\(rex_socket\\) but returns rex_socket_proxy\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/util/socket/socket.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/util/socket/socket.php
+
+		-
+			message: "#^Parameter \\#2 \\$form of static method Normalizer\\:\\:normalize\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/util/string.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and bool will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/util/version.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/lib/var_dumper.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with \\*NEVER\\* and array\\<int, \\(int\\|string\\)\\> will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
+
+		-
+			message: "#^Array \\(array\\<PDO\\>\\) does not accept class@anonymous/core/tests/sql/sql_test\\.php\\:135\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/sql/sql_test.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method rex_sql\\:\\:addRecord\\(\\) expects callable\\(rex_sql\\)\\: void, Closure\\(rex_sql\\)\\: mixed given\\.$#"
+			count: 10
+			path: ../../redaxo/src/core/tests/sql/sql_test.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of static method rex_formatter\\:\\:bytes\\(\\) expects int\\|string, float given\\.$#"
+			count: 3
+			path: ../../redaxo/src/core/tests/util/formatter_test.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'abc' and null will always evaluate to false\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/util/validator_test.php
+

--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -356,11 +356,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/sql/sql_test.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of static method rex_formatter\\:\\:bytes\\(\\) expects int\\|string, float given\\.$#"
-			count: 3
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between 'abc' and null will always evaluate to false\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/validator_test.php

--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,7 @@
         "cs": "php-cs-fixer fix -v --ansi",
         "phpunit": "phpunit --colors=always",
         "phpstan": "phpstan analyse --ansi",
+        "phpstan-baseline": "phpstan analyse --generate-baseline .tools/phpstan/baseline.neon",
         "psalm": "psalm --diff",
         "sa": [
             "@phpstan",
@@ -125,6 +126,7 @@
         "cs": "Fix code style via php-cs-fixer",
         "phpunit": "Run phpunit",
         "phpstan": "Run static analysis via phpstan",
+        "phpstan-baseline": "Regenerate the phpstan baseline",
         "psalm": "Run static analysis via psalm",
         "sa": "Run all static analyses (psalm and phpstan)",
         "check": "Check all (code style, static analysis, unit tests)"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,8 @@
+includes:
+	- .tools/phpstan/baseline.neon
+
 parameters:
-    level: 2
+    level: 5
     paths:
         # restrict to core and core addons, ignore other locally installed addons
         - redaxo/src/core


### PR DESCRIPTION
Upstream issues
- https://github.com/phpstan/phpstan/issues/3069
- https://github.com/phpstan/phpstan/issues/3549

hinzufügen einer phpstan baseline die via composer scripts generiert werden kann.

`composer phpstan` prüft die code base und meldet fehler
`composer phpstan-baseline` ignoriert alle in der codebase gefunden fehler für zukünftige phpstan-scans

feedback aus https://github.com/redaxo/redaxo/pull/3535 übernommen