### PR TITLE
psalm: RexTypeReturnProvider erweitert

### DIFF
--- a/.tools/psalm/RexTypeReturnProvider.php
+++ b/.tools/psalm/RexTypeReturnProvider.php
@@ -1,21 +1,37 @@
 <?php
 
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Scalar\String_;
 use Psalm\CodeLocation;
 use Psalm\Context;
+use Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface;
+use Psalm\Plugin\Hook\MethodReturnTypeProviderInterface;
 use Psalm\StatementsSource;
 use Psalm\Type;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TArrayKey;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TMixed;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Union;
 
-class RexTypeReturnProvider implements \Psalm\Plugin\Hook\MethodReturnTypeProviderInterface
+class RexTypeReturnProvider implements MethodReturnTypeProviderInterface, FunctionReturnTypeProviderInterface
 {
     public static function getClassLikeNames(): array
     {
-        return ['rex_type'];
+        return [rex_type::class, rex_request::class];
+    }
+
+    public static function getFunctionIds(): array
+    {
+        return ['rex_get', 'rex_post', 'rex_request', 'rex_server', 'rex_session', 'rex_cookie', 'rex_files', 'rex_env'];
     }
 
     /**
      * @param array<PhpParser\Node\Arg> $call_args
-     *
-     * @return ?Type\Union
      */
     public static function getMethodReturnType(
         StatementsSource $source,
@@ -27,32 +43,145 @@ class RexTypeReturnProvider implements \Psalm\Plugin\Hook\MethodReturnTypeProvid
         array $template_type_parameters = null,
         string $called_fq_classlike_name = null,
         string $called_method_name_lowercase = null
-    ): ?Type\Union {
-        if (
-            'cast' !== $method_name_lowercase
-            || !isset($call_args[1]->value->inferredType)
-            || !$call_args[1]->value->inferredType->isSingleStringLiteral()
-        ) {
+    ): ?Union {
+        if (rex_type::class === $fq_classlike_name) {
+            if ('cast' === $method_name_lowercase) {
+                return self::resolveType($call_args[1]->value);
+            }
+
             return null;
         }
 
-        $vartype = (string) $call_args[1]->value->inferredType->getSingleStringLiteral()->value;
-
-        switch ($vartype) {
-            case 'bool':
-            case 'boolean':
-            case 'int':
-            case 'integer':
-            case 'double':
-            case 'float':
-            case 'real':
-            case 'string':
-            case 'object':
-            case 'array':
-                return Type::parseString($vartype);
+        switch ($method_name_lowercase) {
+            case 'get':
+            case 'post':
+            case 'request':
+            case 'server':
+            case 'session':
+            case 'cookie':
+            case 'files':
+            case 'env':
+                if (!isset($call_args[1])) {
+                    return null;
+                }
+                $argType = $call_args[1];
+                $argDefault = $call_args[2] ?? null;
+                break;
+            case 'arraykeycast':
+                $argType = $call_args[2];
+                $argDefault = $call_args[3] ?? null;
+                break;
+            default:
+                return null;
         }
 
-        // dont know..
+        return self::resolveType($argType->value, $argDefault->value ?? null);
+    }
+
+    /**
+     * @param array<PhpParser\Node\Arg> $call_args
+     */
+    public static function getFunctionReturnType(
+        StatementsSource $statements_source,
+        string $function_id,
+        array $call_args,
+        Context $context,
+        CodeLocation $code_location
+    ): ?Union {
+        if (!isset($call_args[1])) {
+            return null;
+        }
+
+        return self::resolveType($call_args[1]->value, $call_args[2]->value ?? null);
+    }
+
+    private static function resolveType(Expr $typeExpr, ?Expr $defaultExpr = null): Union
+    {
+        if ($typeExpr instanceof String_) {
+            $type = self::resolveTypeFromString($typeExpr);
+        } elseif ($typeExpr instanceof Array_) {
+            $type = self::resolveTypeFromArray($typeExpr);
+        } else {
+            return Type::getMixed();
+        }
+
+        if ($defaultExpr instanceof ConstFetch && 'null' === $defaultExpr->name->parts[0]) {
+            $type->addType(new TNull());
+        }
+
+        return $type;
+    }
+
+    private static function resolveTypeFromString(String_ $string): Union
+    {
+        $vartype = $string->value;
+
+        if (in_array($vartype, [
+            'bool',
+            'boolean',
+            'int',
+            'integer',
+            'double',
+            'float',
+            'real',
+            'string',
+            'object',
+            'array',
+        ], true)) {
+            return Type::parseString($vartype);
+        }
+
+        if (preg_match('/^array\[(.+)\]$/', $vartype, $match)) {
+            return new Union([new TArray([
+                new Union([new TArrayKey()]),
+                Type::parseString($match[1]),
+            ])]);
+        }
+
         return Type::getMixed();
+    }
+
+    private static function resolveTypeFromArray(Array_ $array): Union
+    {
+        $fallback = new Union([new TArray([
+            new Union([new TString()]),
+            new Union([new TMixed()]),
+        ])]);
+
+        $types = [];
+
+        foreach ($array->items as $item) {
+            if (!$item->value instanceof Array_) {
+                return $fallback;
+            }
+
+            $subItems = $item->value->items;
+
+            if (!isset($subItems[0])) {
+                return $fallback;
+            }
+
+            $itemKey = $subItems[0]->value;
+
+            if (!$itemKey instanceof String_) {
+                return $fallback;
+            }
+
+            $key = $itemKey->value;
+
+            if (!isset($subItems[1])) {
+                $type = Type::getMixed();
+            } else {
+                $type = self::resolveType($subItems[1]->value, $subItems[2]->value ?? null);
+            }
+
+            $types[$key] = $type;
+        }
+
+        if (!$types) {
+            return $fallback;
+        }
+
+        return new Union([new TKeyedArray($types)]);
     }
 }

--- a/redaxo/src/addons/structure/plugins/content/pages/content.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.php
@@ -9,7 +9,6 @@
 $article_id = rex_request('article_id', 'int');
 $clang = rex_request('clang', 'int');
 $slice_id = rex_request('slice_id', 'int', '');
-$function = rex_request('function', 'string');
 
 $article_id = rex_article::get($article_id) ? $article_id : 0;
 $clang = rex_clang::exists($clang) ? $clang : rex_clang::getStartId();
@@ -180,7 +179,7 @@ if (!rex::getUser()->getComplexPerm('structure')->hasCategoryPerm($category_id))
 
                         if ('edit' == $function) {
                             $newsql->setWhere(['id' => $slice_id]);
-                        } elseif ('add' == $function) {
+                        } else {
                             // determine priority value to get the new slice into the right order
                             $prevSlice = rex_sql::factory();
                             // $prevSlice->setDebug();
@@ -232,7 +231,7 @@ if (!rex::getUser()->getComplexPerm('structure')->hasCategoryPerm($category_id))
                             } catch (rex_sql_exception $e) {
                                 $warning = $action_message . $e->getMessage();
                             }
-                        } elseif ('add' == $function) {
+                        } else {
                             $newsql->addGlobalUpdateFields();
                             $newsql->addGlobalCreateFields();
 

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
@@ -11,7 +11,7 @@ $OUT = true;
 
 $action_id = rex_request('action_id', 'int');
 $function = rex_request('function', 'string');
-$save = rex_request('save', 'int');
+$save = rex_request('save', 'bool');
 $goon = rex_request('goon', 'string');
 
 $success = '';
@@ -69,10 +69,10 @@ if ('add' == $function || 'edit' == $function) {
     $presavestatus = 255;
     $postsavestatus = 255;
 
-    if ('1' == $save && !$csrfToken->isValid()) {
+    if ($save && !$csrfToken->isValid()) {
         $error = rex_i18n::msg('csrf_token_invalid');
-        $save = '0';
-    } elseif ('1' == $save) {
+        $save = false;
+    } elseif ($save) {
         $faction = rex_sql::factory();
 
         $previewstatus = rex_post('previewstatus', 'array');
@@ -121,13 +121,13 @@ if ('add' == $function || 'edit' == $function) {
         }
 
         if (isset($goon) && '' != $goon) {
-            $save = '0';
+            $save = false;
         } else {
             $function = '';
         }
     }
 
-    if ('1' != $save) {
+    if (!$save) {
         if ('edit' == $function) {
             $legend = rex_i18n::msg('action_edit') . ' <small class="rex-primary-id">' . rex_i18n::msg('id') . '=' . $action_id . '</small>';
 

--- a/redaxo/src/core/pages/setup.php
+++ b/redaxo/src/core/pages/setup.php
@@ -5,9 +5,6 @@
  */
 
 $step = rex_request('step', 'int', 1);
-$send = rex_request('send', 'string');
-$createdb = rex_request('createdb', 'string');
-$noadmin = rex_request('noadmin', 'string');
 $lang = rex_request('lang', 'string');
 
 $context = new rex_context([
@@ -218,7 +215,7 @@ if ($step > 5 && $createdb > -1) {
         $errors[] = rex_view::error(rex_i18n::msg('error_undefined'));
     }
 
-    if (0 == count($errors) && '' !== $createdb) {
+    if (0 == count($errors)) {
         $error = rex_setup_importer::verifyDbSchema();
         if ('' != $error) {
             $errors[] = $error;

--- a/redaxo/src/core/pages/system.clangs.php
+++ b/redaxo/src/core/pages/system.clangs.php
@@ -12,7 +12,7 @@ $clang_id = rex_request('clang_id', 'int');
 $clang_code = rex_request('clang_code', 'string');
 $clang_name = rex_request('clang_name', 'string');
 $clang_prio = rex_request('clang_prio', 'int');
-$clang_status = rex_request('clang_status', 'int');
+$clang_status = rex_request('clang_status', 'bool');
 $func = rex_request('func', 'string');
 
 // -------------- Form Submits


### PR DESCRIPTION
fixes #4003

Es werden nun auch die komplexeren Array-Typen unterstützt, wie z. B. hier: https://github.com/redaxo/redaxo/blob/master/redaxo/src/addons/media_manager/pages/settings.php#L20-L25

Bringt zumindest 1% mehr Typsicherheit ;)

```
// Vorher
Psalm was able to infer types for 87.8527% of the codebase

// Nachher
Psalm was able to infer types for 88.8930% of the codebase
```