### PR TITLE
ini_get kann auch leeren String liefern

### DIFF
--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -183,7 +183,7 @@ class rex_setup
             $security[] = rex_i18n::msg('setup_security_warn_mod_security');
         }
 
-        if ('0' !== ini_get('session.auto_start')) {
+        if (ini_get('session.auto_start')) {
             $security[] = rex_i18n::msg('setup_session_autostart_warning');
         }
 


### PR DESCRIPTION
Für boolsche Variablen kann auch ein leerer String für false zurück kommen.

Kam heute in Slack auf: https://friendsofredaxo.slack.com/archives/C1BAXLN2F/p1604919943469600