### PR TITLE
psalm: Debug-Trace-Ausgaben als error werten

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -42,6 +42,7 @@
         <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin" />
     </plugins>
     <issueHandlers>
+        <Trace errorLevel="error"/> <!-- https://psalm.dev/docs/running_psalm/issues/Trace/ -->
         <InvalidGlobal>
             <errorLevel type="info">
                 <file name="redaxo/src/addons/mediapool/pages/index.php"/>


### PR DESCRIPTION
Siehe https://psalm.dev/docs/running_psalm/issues/Trace/.

Man kann per `@psalm-trace $var` sich einen Typ einer Variable ausgeben lassen.
Ich wunderte mich schon eine Zeit, warum das bei mir nicht funktionierte. Jetzt habe ich kapiert, dass die Trace-Meldungen info-Meldungen sind, die wir normalerweise nicht ausgeben.

Ich würde die als Error werten. So sieht man sie definitiv, praktisch für das Debuggen. Und wir wollen die ja auch nicht dauerhaft im Code haben, und so wird auch verhindert, dass wir sie versehentlich mit mergen.