### PR TITLE
Native type-hints nutzen

### DIFF
--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -324,14 +324,11 @@ class rex
     }
 
     /**
-     * @param int $db
-     * @psalm-param positive-int $db
+     * @param positive-int $db
      *
      * @throws rex_exception
-     *
-     * @return rex_config_db
      */
-    public static function getDbConfig($db = 1)
+    public static function getDbConfig(int $db = 1): rex_config_db
     {
         $config = self::getProperty('db', null);
 


### PR DESCRIPTION
Da die Methode neu ist, können wir native Type-hints nutzen