### PR TITLE
GithubAction: added a psalm taint analysis job

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,7 +17,7 @@ jobs:
         name: psalm static code analysis
         runs-on: ubuntu-latest
         if: "!contains(github.event.head_commit.message, '[ci skip]')"
-        
+
         services:
             mysql:
                 image: mysql:5.7
@@ -55,11 +55,54 @@ jobs:
             - run: |
                   vendor/bin/psalm --show-info=false --shepherd --diff --output-format=github
 
+    psalm-taint-analysis:
+        name: psalm taint analysis
+        runs-on: ubuntu-latest
+        if: "github.event.pull_request.draft == false && !contains(github.event.head_commit.message, '[ci skip]')"
+
+        services:
+            mysql:
+                image: mysql:5.7
+                ports:
+                    - 3306
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 7.4
+                  extensions: intl, imagick
+                  coverage: none # disable xdebug, pcov
+            - name: "Psalm Resultcache"
+              uses: actions/cache@v2
+              with:
+                  path: /tmp/psalm
+                  key: "psalm-result-cache"
+            - uses: "ramsey/composer-install@v1"
+              with:
+                  composer-options: "--ansi --prefer-dist"
+            - run: |
+                  sudo /etc/init.d/mysql start
+                  mysql -uroot -h127.0.0.1 -proot -e 'create database redaxo5;'
+                  git apply .github/workflows/default.config.yml.github-action.diff
+            - run: |
+                  php .tools/bin/setup
+                  php redaxo/bin/console package:install phpmailer --ansi
+                  php redaxo/bin/console package:install cronjob --ansi
+                  php redaxo/bin/console package:install cronjob/article_status --ansi
+                  php redaxo/bin/console package:install cronjob/optimize_tables --ansi
+                  php redaxo/bin/console package:install debug --ansi
+                  php redaxo/bin/console package:install structure/history --ansi
+                  php redaxo/bin/console package:install structure/version --ansi
+            - run: |
+                  vendor/bin/psalm --taint-analysis
+              # todo: upload SARIF report after psalm release contains https://github.com/vimeo/psalm/pull/4582
+
     phpstan-analysis:
         name: phpstan static code analysis
         runs-on: ubuntu-latest
         if: "!contains(github.event.head_commit.message, '[ci skip]')"
-        
+
         services:
             mysql:
                 image: mysql:5.7


### PR DESCRIPTION
taint analysis job um sicherheitslücken im code zu finden.

https://psalm.dev/articles/detect-security-vulnerabilities-with-psalm

sobald das nächste psalm release erstellt wurde können wir dann auch SARIF reports erstellen und diese direkt ins github.com reinladen, sodass github die security reports im repo zur triage bereitstellt