### PR TITLE
require composer v2.. our setup doesn't work with v1 anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=7.3"
     },
     "require-dev": {
+        "composer-plugin-api": "^2",
         "friendsofphp/php-cs-fixer": "2.16.7",
         "friendsofredaxo/linter": "1.2.7",
         "j13k/yaml-lint": "^1.1@dev",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.3"
     },
     "require-dev": {
-        "composer-plugin-api": "^2",
+        "composer-runtime-api": "^2",
         "friendsofphp/php-cs-fixer": "2.16.7",
         "friendsofredaxo/linter": "1.2.7",
         "j13k/yaml-lint": "^1.1@dev",


### PR DESCRIPTION
man bekommt jetzt einen error wenn man noch compoer v1 benutzt:

```
$ composer update

Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package composer-plugin-api ^2 exists as composer-plugin-api[1.1.0] but these are rejected by your constraint.
```

technisch funktionierts, schön ist es nicht.. daher upstream issues: https://github.com/composer/composer/issues/9501