### PR TITLE
Anpassung rex_error_handler für PHP 8

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -239,8 +239,8 @@ abstract class rex_error_handler
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
         }
 
-        // silenced errors ("@" operator)
-        if (0 === error_reporting()) {
+        // silenced errors (via php.ini or "@" operator)
+        if (!(error_reporting() & $errno)) {
             return false;
         }
 
@@ -251,10 +251,6 @@ abstract class rex_error_handler
             (true === $debug['throw_always_exception'] || $errno === ($errno & $debug['throw_always_exception']))
         ) {
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
-        }
-
-        if ((error_reporting() & $errno) !== $errno) {
-            return;
         }
 
         if (ini_get('display_errors') && (rex::isSetup() || rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin())) {


### PR DESCRIPTION
https://www.php.net/manual/de/migration80.incompatible.php

> The @ operator will no longer silence fatal errors (E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR, E_PARSE). Error handlers that expect error_reporting to be 0 when @ is used, should be adjusted to use a mask check instead:

Das führt bei uns zu einem Problem, aber nur wenn `debug.throw_always_exception` in der config.yml aktiviert ist. Dann hat mit PHP 8 der `@`-Operator keinen Effekt mehr, und es kommt auch dort zu Exceptions, wo wir eigentlich bewusst unterdrücken wollen (`@file_get_content()` etc.).

Das neue Verhalten ist nun minimal anders:
Vorher: Fehlerunterdrückung wird immer beachtet. Aber `throw_always_exception` ignoriert die `error_reporting`-Einstellung aus der php.ini.
Neu: `throw_always_exception` greift nur noch bei Fehler-Typen, die insgesamt per `error_reporting` aktiviert sind.

(Wenn `throw_always_exception` deaktiviert ist, haben wir hingegen auch vorher schon `error_reporting` berücksichtigt für die Entscheidung, ob die Warnings/Notices (inline) ausgegeben werden.)

Ob ich das neue Verhalten besser finde, bin ich mir unsicher. Aber zumindest unter PHP 8 scheint es nicht anders zu gehen.
Wobei unser Verhalten vorher auch nicht so richtig optimal war, denke ich. Denn bei `error_reporting = 0` in der php.ini wurde es zum beispiel doch berücksichtigt, da nicht unterscheidbar vom `@`-Operator.

Insgesamt denke ich, passt das so schon. Wenn man Notices zu Exceptions wandeln möchte, muss also sowohl `throw_always_exception` aktiviert sein, als auch Notices generell per `error_reporting`.