### PR TITLE
rector: prevent 'Use of undefined constant REX_MIN_PHP_VERSION' warnings

### DIFF
--- a/.tools/rector/rector.php
+++ b/.tools/rector/rector.php
@@ -16,6 +16,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         // SetList::DEAD_CODE,
     ]);
 
+    $parameters->set(OPTION::OPTION_AUTOLOAD_FILE, [
+        __DIR__.'/../constants.php',
+    ]);
+
     // this list will grow over time.
     // to make sure we can review every transformation and not introduce unseen bugs
     $parameters->set(Option::PATHS, [


### PR DESCRIPTION
use the same autoload file, we already use for psalm/phpstan