### PR TITLE
refresh script: alle core packages reinstallieren, aber nur wenn schon installiert

### DIFF
--- a/.tools/bin/refresh
+++ b/.tools/bin/refresh
@@ -13,18 +13,30 @@ if [ "true" = $(redaxo/bin/console config:get setup) ]; then
     exit
 fi
 
-redaxo/bin/console package:install --ansi --re-install backup
-redaxo/bin/console package:install --ansi --re-install be_style
-redaxo/bin/console package:install --ansi --re-install be_style/redaxo
-redaxo/bin/console package:install --ansi --re-install cronjob
-redaxo/bin/console package:install --ansi --re-install install
-redaxo/bin/console package:install --ansi --re-install media_manager
-redaxo/bin/console package:install --ansi --re-install mediapool
-redaxo/bin/console package:install --ansi --re-install metainfo
-redaxo/bin/console package:install --ansi --re-install phpmailer
-redaxo/bin/console package:install --ansi --re-install structure
-redaxo/bin/console package:install --ansi --re-install structure/content
-redaxo/bin/console package:install --ansi --re-install users
+packages="
+backup
+be_style
+be_style/customizer
+be_style/redaxo
+cronjob
+debug
+install
+media_manager
+mediapool
+metainfo
+phpmailer
+structure
+structure/content
+structure/history
+structure/version
+users
+"
+
+for package in $packages; do
+    if redaxo/bin/console package:list --package $package --installed-only --error-when-empty --quiet; then
+        redaxo/bin/console package:install --ansi --re-install $package
+    fi
+done
 
 redaxo/bin/console cache:clear --ansi
 


### PR DESCRIPTION
Das refresh-Skript (um die lokale Entwicklungsumgebung nach pull oder branch wechsel zu aktualisieren) reinstalliert nun alle vorhandenen Core-Packages (vorher fehlten manche).
Und es reinstalliert aber nur noch die, die vorher schon installiert waren.