### PR TITLE
rex_media_category_select: fix root & perm handling

### DIFF
--- a/redaxo/src/addons/mediapool/lib/media_category_select.php
+++ b/redaxo/src/addons/mediapool/lib/media_category_select.php
@@ -60,7 +60,7 @@ class rex_media_category_select extends rex_select
         }
     }
 
-    protected function addCatOption(rex_media_category $mediacat)
+    protected function addCatOption(rex_media_category $mediacat, int $parentId = 0)
     {
         if (!$this->check_perms ||
                 $this->check_perms && rex::getUser()->getComplexPerm('media')->hasCategoryPerm($mediacat->getId())
@@ -68,13 +68,13 @@ class rex_media_category_select extends rex_select
             $mid = $mediacat->getId();
             $mname = $mediacat->getName();
 
-            $this->addOption($mname, $mid, $mid, $mediacat->getParentId());
-            $childs = $mediacat->getChildren();
-            if (is_array($childs)) {
-                foreach ($childs as $child) {
-                    $this->addCatOption($child);
-                }
-            }
+            $this->addOption($mname, $mid, $mid, $parentId);
+
+            $parentId = $mediacat->getId();
+        }
+
+        foreach ($mediacat->getChildren() as $child) {
+            $this->addCatOption($child, $parentId);
         }
     }
 


### PR DESCRIPTION
Der PR löst gleich zwei Probleme:

* Bei Nutzung von `setRootId` war das Select leer, wenn die Root-Kategorie nicht auf oberster Ebene liegt (dieses Repo nutzt nirgends `setRootId`)
* Bei eingeschränkten Mediacat-Rechten fehlten Kategorien, wenn man Rechte für Unterkategorien hatte, aber nicht für deren Root

Beide Bugs muss es bereits seit 5.0 gegeben haben, der Code hat sich seitdem nicht geändert.

fixes #4135 /cc @skerbis 