### PR TITLE
rex_sql: type support in getValue

### DIFF
--- a/.tools/psalm/RexTypeReturnProvider.php
+++ b/.tools/psalm/RexTypeReturnProvider.php
@@ -22,7 +22,7 @@ class RexTypeReturnProvider implements MethodReturnTypeProviderInterface, Functi
 {
     public static function getClassLikeNames(): array
     {
-        return [rex_type::class, rex_request::class];
+        return [rex_type::class, rex_request::class, rex_sql::class];
     }
 
     public static function getFunctionIds(): array
@@ -50,6 +50,17 @@ class RexTypeReturnProvider implements MethodReturnTypeProviderInterface, Functi
             }
 
             return null;
+        }
+
+        if (rex_sql::class === $fq_classlike_name) {
+            if (!in_array($method_name_lowercase, ['getvalue', 'castvalue'], true)) {
+                return null;
+            }
+            if (!isset($call_args[1])) {
+                return null;
+            }
+
+            return self::resolveType($call_args[1]->value);
         }
 
         switch ($method_name_lowercase) {

--- a/.tools/psalm/baseline-taint.xml
+++ b/.tools/psalm/baseline-taint.xml
@@ -53,11 +53,6 @@
       <code>rex_mediapool_Uploadform($rex_file_category)</code>
     </TaintedHtml>
   </file>
-  <file src="redaxo/src/addons/structure/plugins/content/lib/article_content_base.php">
-    <TaintedHtml occurrences="1">
-      <code>$articleContent</code>
-    </TaintedHtml>
-  </file>
   <file src="redaxo/src/addons/structure/plugins/content/pages/modules.actions.php">
     <TaintedHtml occurrences="1">
       <code>$content</code>

--- a/redaxo/src/core/lib/login/user.php
+++ b/redaxo/src/core/lib/login/user.php
@@ -116,7 +116,7 @@ class rex_user
      */
     public function getId()
     {
-        return $this->sql->getIntValue('id');
+        return $this->sql->getValue('id', 'int');
     }
 
     /**

--- a/redaxo/src/core/lib/login/user.php
+++ b/redaxo/src/core/lib/login/user.php
@@ -116,7 +116,7 @@ class rex_user
      */
     public function getId()
     {
-        return (int) $this->sql->getValue('id');
+        return $this->sql->getIntValue('id');
     }
 
     /**

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -708,7 +708,7 @@ class rex_sql implements Iterator
      * Returns the value of a column.
      *
      * @param string $column Name of the column
-     * @param string|array|callable|null $type Column type
+     * @param string|array|callable|null $type Column type, see `rex_type::cast()`
      *
      * @throws rex_sql_exception
      *
@@ -1915,7 +1915,7 @@ class rex_sql implements Iterator
 
     /**
      * @param mixed $value
-     * @param string|array|callable|null $type
+     * @param string|array|callable|null $type Column type, see `rex_type::cast()`
      */
     private function castValue($value, $type)
     {

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -739,6 +739,22 @@ class rex_sql implements Iterator
     }
 
     /**
+     * Return the integer value of a column.
+     *
+     * @throws rex_sql_exception
+     */
+    public function getIntValue(string $column): int
+    {
+        $value = $this->getValue($column);
+
+        if (!is_int($value) && !filter_var($value, FILTER_VALIDATE_INT)) {
+            throw new rex_exception('Column "'.$column.'" expected to contain an int, but "'.gettype($value).'" given');
+        }
+
+        return (int) $value;
+    }
+
+    /**
      * Returns the array value of a (json encoded) column.
      *
      * @param string $column Name of the column

--- a/redaxo/src/core/tests/sql/sql_test.php
+++ b/redaxo/src/core/tests/sql/sql_test.php
@@ -189,11 +189,14 @@ class rex_sql_test extends TestCase
         $sql->setTable(self::TABLE);
         $sql->setValue('col_str', 'abc');
         $sql->setValue('col_int', '5');
-        $sql->setArrayValue('col_array', ['foo' => 3, 'bar' => 2]);
+        $sql->setArrayValue('col_array_1', [3, '2', null]);
+        $sql->setArrayValue('col_array_2', ['foo' => 3, 'bar' => 2]);
 
         static::assertSame('abc', $sql->getValue('col_str', 'string'));
         static::assertSame(5, $sql->getValue('col_int', 'int'));
-        static::assertSame(['foo' => 3, 'baz' => 1], $sql->getValue('col_array', [
+        static::assertSame([3, '2', null], $sql->getValue('col_array_1', 'array'));
+        static::assertSame([3, 2, 0], $sql->getValue('col_array_1', 'array[int]'));
+        static::assertSame(['foo' => 3, 'baz' => 1], $sql->getValue('col_array_2', [
             ['foo', 'int', 0],
             ['baz', 'int', 1],
         ]));

--- a/redaxo/src/core/tests/sql/sql_test.php
+++ b/redaxo/src/core/tests/sql/sql_test.php
@@ -183,6 +183,22 @@ class rex_sql_test extends TestCase
         static::assertEquals([1, 2, 3], $sql->getArrayValue('col_array'), 'get a previous set array');
     }
 
+    public function testGetValueWithType()
+    {
+        $sql = rex_sql::factory();
+        $sql->setTable(self::TABLE);
+        $sql->setValue('col_str', 'abc');
+        $sql->setValue('col_int', '5');
+        $sql->setArrayValue('col_array', ['foo' => 3, 'bar' => 2]);
+
+        static::assertSame('abc', $sql->getValue('col_str', 'string'));
+        static::assertSame(5, $sql->getValue('col_int', 'int'));
+        static::assertSame(['foo' => 3, 'baz' => 1], $sql->getValue('col_array', [
+            ['foo', 'int', 0],
+            ['baz', 'int', 1],
+        ]));
+    }
+
     public function testInsertRow()
     {
         $sql = rex_sql::factory();


### PR DESCRIPTION
Hilft uns bei der Typsicherheit.

Ich bin mir aber noch unsicher. `getDateTimeValue` ist zum beispiel nullable, `getIntValue` nun aber nicht.
Man könnte daher auch überlegen, ob man ähnlich zu anderen klassen für die nicht nullable variante den require-präfix nimmt. Wäre hier dann also `requireIntValue`. Analog, falls wir Bedarf dafür finden, könnte man irgendwann auch noch `requireValue` als allgemeine non-nullable-methode einführen, oder eben `requireDateTimeValue`.
Und eventuell könnte man irgendwann auch eine nullable `getIntValue` gebrauchen für nullable int columns.