### PR TITLE
Addon-Installation: Eigene Zusatzmeldungen auch bei Erfolg

### DIFF
--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -138,8 +138,10 @@ abstract class rex_package_manager
             rex_i18n::addDirectory($this->package->getPath('lang'));
 
             // include install.php
+            $statusMessage = '';
             if (is_readable($this->package->getPath(rex_package::FILE_INSTALL))) {
                 $this->package->includeFile(rex_package::FILE_INSTALL);
+                $statusMessage = $this->package->getProperty('statusmsg', '');
 
                 if ('' != ($instmsg = $this->package->getProperty('installmsg', ''))) {
                     throw new rex_functional_exception($instmsg);
@@ -178,6 +180,9 @@ abstract class rex_package_manager
             }
 
             $this->message = $this->i18n($reinstall ? 'reinstalled' : 'installed', $this->package->getName());
+            if ($statusMessage) {
+                $this->message .= ' '. $statusMessage;
+            }
 
             return true;
         } catch (rex_functional_exception $e) {

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -138,10 +138,10 @@ abstract class rex_package_manager
             rex_i18n::addDirectory($this->package->getPath('lang'));
 
             // include install.php
-            $statusMessage = '';
+            $successMessage = '';
             if (is_readable($this->package->getPath(rex_package::FILE_INSTALL))) {
                 $this->package->includeFile(rex_package::FILE_INSTALL);
-                $statusMessage = $this->package->getProperty('statusmsg', '');
+                $successMessage = $this->package->getProperty('successmsg', '');
 
                 if ('' != ($instmsg = $this->package->getProperty('installmsg', ''))) {
                     throw new rex_functional_exception($instmsg);
@@ -180,8 +180,8 @@ abstract class rex_package_manager
             }
 
             $this->message = $this->i18n($reinstall ? 'reinstalled' : 'installed', $this->package->getName());
-            if ($statusMessage) {
-                $this->message .= ' '. $statusMessage;
+            if ($successMessage) {
+                $this->message .= ' '. $successMessage;
             }
 
             return true;


### PR DESCRIPTION
finalizes https://github.com/redaxo/redaxo/pull/3991

closes #3961

Co-authored-by: Vitalij Mik <BlackScorp@users.noreply.github.com>

getestet mit 
```
$addon->setProperty('statusmsg', 'bitte verwende den neuen <a href="lala">menupunkt</a>');
```
im debug addon in der `install.php`:

![grafik](https://user-images.githubusercontent.com/120441/101278135-add7a380-37b9-11eb-94b7-ba204bb1cbea.png)
