### PR TITLE
cs: simplified if return

### DIFF
--- a/redaxo/src/addons/backup/lib/tar.php
+++ b/redaxo/src/addons/backup/lib/tar.php
@@ -329,10 +329,7 @@ class rex_backup_tar extends tar
                 }
             }
         }
-        if (count($this->messages) > 0) {
-            return false;
-        }
-        return true;
+        return !$this->messages;
     }
 
     /**

--- a/redaxo/src/addons/cronjob/lib/types/phpcode.php
+++ b/redaxo/src/addons/cronjob/lib/types/phpcode.php
@@ -30,10 +30,7 @@ class rex_cronjob_phpcode extends rex_cronjob
             $output = preg_replace('@in ' . preg_quote(__FILE__, '@') . "\([0-9]*\) : eval\(\)'d code @", '', $output);
             $this->setMessage($output);
         }
-        if (false !== $return) {
-            return true;
-        }
-        return false;
+        return false !== $return;
     }
 
     public function getTypeName()

--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -604,10 +604,7 @@ function rex_mediapool_isAllowedMediaType($filename, array $args = [])
     }
 
     $whitelist = rex_mediapool_getMediaTypeWhitelist($args);
-    if (count($whitelist) > 0 && !in_array($file_ext, $whitelist)) {
-        return false;
-    }
-    return true;
+    return !count($whitelist) || in_array($file_ext, $whitelist);
 }
 
 /**

--- a/redaxo/src/addons/mediapool/lib/cache_media.php
+++ b/redaxo/src/addons/mediapool/lib/cache_media.php
@@ -114,11 +114,7 @@ class rex_media_cache
         }
 
         $media_file = rex_path::addonCache('mediapool', $filename . '.media');
-        if (rex_file::putCache($media_file, $cacheArray)) {
-            return true;
-        }
-
-        return false;
+        return rex_file::putCache($media_file, $cacheArray);
     }
 
     /**
@@ -157,11 +153,7 @@ class rex_media_cache
         }
 
         $cat_file = rex_path::addonCache('mediapool', $category_id . '.mcat');
-        if (rex_file::putCache($cat_file, $cacheArray)) {
-            return true;
-        }
-
-        return false;
+        return rex_file::putCache($cat_file, $cacheArray);
     }
 
     /**
@@ -189,11 +181,7 @@ class rex_media_cache
         }
 
         $list_file = rex_path::addonCache('mediapool', $category_id . '.mlist');
-        if (rex_file::putCache($list_file, $cacheArray)) {
-            return true;
-        }
-
-        return false;
+        return rex_file::putCache($list_file, $cacheArray);
     }
 
     /**
@@ -222,10 +210,6 @@ class rex_media_cache
         }
 
         $list_file = rex_path::addonCache('mediapool', $category_id . '.mclist');
-        if (rex_file::putCache($list_file, $cacheArray)) {
-            return true;
-        }
-
-        return false;
+        return rex_file::putCache($list_file, $cacheArray);
     }
 }

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -201,11 +201,7 @@ class rex_template
             return true;
         }
 
-        if (is_array($template_modules[$ctype]) && in_array($module_id, $template_modules[$ctype])) {
-            return true;
-        }
-
-        return false;
+        return is_array($template_modules[$ctype]) && in_array($module_id, $template_modules[$ctype]);
     }
 
     /**


### PR DESCRIPTION
Eigentlich wollte ich die neue `simplified_if_return` rule aktivieren.
Aber einerseits ist die automatische Formatierung dort oftmals nicht so schön, andererseits gab es auch eine Stelle wo ich die vorherige Variante besser lesbar fand.

Deswegen habe ich den Fixer nur einmalig angewandt und habe die Stellen anschließend noch optimiert bzgl. Formatierung und bzgl. verneinte Klammern etc.