### PR TITLE
PHP 8: Warnings vermeiden

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1655,7 +1655,7 @@ class rex_sql implements Iterator
         }
 
         $tables = $this->getArray($qry);
-        $tables = array_map(function (array $table) {
+        $tables = array_map(static function (array $table) {
             return reset($table);
         }, $tables);
 

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1655,7 +1655,9 @@ class rex_sql implements Iterator
         }
 
         $tables = $this->getArray($qry);
-        $tables = array_map('reset', $tables);
+        $tables = array_map(function (array $table) {
+            return reset($table);
+        }, $tables);
 
         return $tables;
     }


### PR DESCRIPTION
> reset(): Argument 1 ($array) must be passed by reference, value given