### PR TITLE
remove nunomaduro/collision dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "friendsofphp/php-cs-fixer": "2.17.0",
         "friendsofredaxo/linter": "1.2.7",
         "j13k/yaml-lint": "^1.1@dev",
-        "nunomaduro/collision": "^5.1",
         "phpstan/extension-installer": "1.0.5",
         "phpstan/phpstan": "0.12.59",
         "phpstan/phpstan-deprecation-rules": "0.12.5",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
      beStrictAboutTodoAnnotatedTests="true"
      verbose="true"
      colors="true"
-     printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
 >
     <testsuites>
         <testsuite name="core">


### PR DESCRIPTION
after some initial testing this depenency does not solve a problem we have.

additionally it slows down our test-runs a lot