### PR TITLE
Remove ci-skip handling

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -8,7 +8,7 @@ jobs:
     build:
 
         runs-on: ubuntu-latest
-        if: "github.event.pull_request.draft == false && !contains(github.event.head_commit.message, '[ci skip]')"
+        if: "github.event.pull_request.draft == false"
 
         services:
             mysql:


### PR DESCRIPTION
It might be the cause why the action sometimes isnt triggered (and we dont use it nevertheless)