### PR TITLE
`composer refresh`: fix core-assets copying

### DIFF
--- a/.tools/bin/refresh
+++ b/.tools/bin/refresh
@@ -3,7 +3,7 @@
 # refreshes the redaxo installation.
 # most of the time this is required when working on the REDAXO sources after checking out a Pull Request via GitHub.com
 
-cp -R redaxo/src/core/assets/ assets/core/
+cp -R redaxo/src/core/assets/* assets/core/
 
 if [ "true" = $(redaxo/bin/console config:get setup) ]; then
     redaxo/bin/console cache:clear --ansi


### PR DESCRIPTION
vor diesem fix wurde der core-assets ordner in den /assets/core/ ordner kopiert.

![grafik](https://user-images.githubusercontent.com/120441/102697434-08e7ac80-4236-11eb-929e-9133312c6dc5.png)


nach dem fix werden nur noch die Inhalte des assets ordner kopiert:

![grafik](https://user-images.githubusercontent.com/120441/102697415-e5246680-4235-11eb-8e75-2f788dc8ae2f.png)

da die dateien nicht richtig kopiert wurden war bei mir auch das REDAXO Logo so rießig dargestellt worden