### PR TITLE
use php8 attributes for deprecated methods which allows automatic rep…

### DIFF
--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -63,6 +63,10 @@ class rex_password_policy
      *
      * @deprecated since 5.12, use `getDescription` instead
      */
+    #[\JetBrains\PhpStorm\Deprecated(
+        reason: 'since 5.12, use `getDescription` instead',
+        replacement: '%class%->getDescription()'
+    )]
     protected function getRule()
     {
         return $this->getDescription() ?? '';

--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -63,10 +63,7 @@ class rex_password_policy
      *
      * @deprecated since 5.12, use `getDescription` instead
      */
-    #[\JetBrains\PhpStorm\Deprecated(
-        reason: 'since 5.12, use `getDescription` instead',
-        replacement: '%class%->getDescription()'
-    )]
+    #[\JetBrains\PhpStorm\Deprecated( reason: 'since 5.12, use `getDescription` instead', replacement: '%class%->getDescription()')]
     protected function getRule()
     {
         return $this->getDescription() ?? '';

--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -63,7 +63,7 @@ class rex_password_policy
      *
      * @deprecated since 5.12, use `getDescription` instead
      */
-    #[\JetBrains\PhpStorm\Deprecated( reason: 'since 5.12, use `getDescription` instead', replacement: '%class%->getDescription()')]
+    #[\JetBrains\PhpStorm\Deprecated(reason: 'since 5.12, use `getDescription` instead', replacement: '%class%->getDescription()')]
     protected function getRule()
     {
         return $this->getDescription() ?? '';

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -397,10 +397,7 @@ class rex
     /**
      * @deprecated since 5.10, use `rex_version::gitHash` instead
      */
-    #[\JetBrains\PhpStorm\Deprecated(
-        reason: 'since 5.10, use `rex_version::gitHash` instead',
-        replacement: 'rex_version::gitHash(!%parametersList%)'
-    )]
+    #[\JetBrains\PhpStorm\Deprecated(reason: 'since 5.10, use `rex_version::gitHash` instead', replacement: 'rex_version::gitHash(!%parametersList%)')]
     public static function getVersionHash($path, ?string $repo = null)
     {
         return rex_version::gitHash($path, $repo) ?? false;

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -397,6 +397,10 @@ class rex
     /**
      * @deprecated since 5.10, use `rex_version::gitHash` instead
      */
+    #[\JetBrains\PhpStorm\Deprecated(
+        reason: 'since 5.10, use `rex_version::gitHash` instead',
+        replacement: 'rex_version::gitHash(!%parametersList%)'
+    )]
     public static function getVersionHash($path, ?string $repo = null)
     {
         return rex_version::gitHash($path, $repo) ?? false;

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -103,10 +103,7 @@ class rex_string
     /**
      * @deprecated since 5.10, use `rex_version::split` instead
      */
-    #[\JetBrains\PhpStorm\Deprecated(
-        reason: 'since 5.10, use `rex_version::split` instead',
-        replacement: 'rex_version::split(!%parameter0%)'
-    )]
+    #[\JetBrains\PhpStorm\Deprecated(reason: 'since 5.10, use `rex_version::split` instead', replacement: 'rex_version::split(!%parameter0%)')]
     public static function versionSplit($version)
     {
         return rex_version::split($version);
@@ -115,10 +112,7 @@ class rex_string
     /**
      * @deprecated since 5.10, use `rex_version::compare` instead
      */
-    #[\JetBrains\PhpStorm\Deprecated(
-        reason: 'since 5.10, use `rex_version::compare` instead',
-        replacement: 'rex_version::compare(!%parametersList%)'
-    )]
+    #[\JetBrains\PhpStorm\Deprecated(reason: 'since 5.10, use `rex_version::compare` instead', replacement: 'rex_version::compare(!%parametersList%)')]
     public static function versionCompare($version1, $version2, $comparator = null)
     {
         return rex_version::compare($version1, $version2, $comparator);

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -103,6 +103,10 @@ class rex_string
     /**
      * @deprecated since 5.10, use `rex_version::split` instead
      */
+    #[\JetBrains\PhpStorm\Deprecated(
+        reason: 'since 5.10, use `rex_version::split` instead',
+        replacement: 'rex_version::split(!%parameter0%)'
+    )]
     public static function versionSplit($version)
     {
         return rex_version::split($version);
@@ -111,6 +115,10 @@ class rex_string
     /**
      * @deprecated since 5.10, use `rex_version::compare` instead
      */
+    #[\JetBrains\PhpStorm\Deprecated(
+        reason: 'since 5.10, use `rex_version::compare` instead',
+        replacement: 'rex_version::compare(!%parametersList%)'
+    )]
     public static function versionCompare($version1, $version2, $comparator = null)
     {
         return rex_version::compare($version1, $version2, $comparator);


### PR DESCRIPTION
…lacements within phpstorm

__construct() zu methode scheint noch nicht zu funktionieren.
auch ein static to non-static scheint aktuell nicht möglich.

closes https://github.com/redaxo/redaxo/issues/4187

hab das mal exemplarisch für alle deprecated methoden im core umgesetzt.
für alle anderen deprecations im core hat das nicht funktioniert. mal sehen obs was taugt/einen nutzen hat.

Beispiel:

![grafik](https://user-images.githubusercontent.com/120441/102698565-a810a200-423e-11eb-85b1-5b13d64d7088.png)
