### PR TITLE
.idea: prevent "suggest default language level change"

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -95,7 +95,9 @@
       <path value="$PROJECT_DIR$/vendor/symfony/framework-bundle" />
     </include_path>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="7.3" />
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.3">
+    <option name="suggestChangeDefaultLanguageLevel" value="false" />
+  </component>
   <component name="PhpStan">
     <PhpStan_settings>
       <PhpStanConfiguration tool_path="$PROJECT_DIR$/vendor/bin/phpstan" />


### PR DESCRIPTION
phpstorm versucht schlau zu sein und einen lang level selbst zu erkennen.
dies wird hiermit unterbunden