### PR TITLE
fix sidebar panel toggle js (structure/content)

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/assets/content.js
+++ b/redaxo/src/addons/structure/plugins/content/assets/content.js
@@ -1,6 +1,6 @@
 // save & restore sidebar panel toggle status via localstorage
 $(document).on('rex:ready', function (event, viewRoot) {
-    var $sidebar = viewRoot.find('#rex-page-content-edit #rex-js-main-sidebar'),
+    var $sidebar = viewRoot.is('#rex-page-content-edit') && viewRoot.find('#rex-js-main-sidebar'),
         sidebar_status,
         $sections;
     function store_sidebar_status () {


### PR DESCRIPTION
Betrifft das Script zum Speichern der Toggle-Status der Sidebar-Panels im localStorage (#4178): Mit der Umstellung auf [viewRoot.find()](704cf581f5af05b13368f3049ba8ec7380b75c75) ist das Script kaputt gegangen. Weil `viewRoot` nur noch den Inhalt des `<body>` enthält, an dem `#rex-page-content-edit` hängt, liefert das nachfolgende `find()` kein Ergebnis mehr. Denn das durchsucht ja nur Kindelemente, und nicht das aktuelle Element.