### PR TITLE
setup a minimal exception handler to print early errors in console

### DIFF
--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -4,7 +4,7 @@ set_time_limit(0);
 
 // setup a minimal exception handler to print early errors,
 // happening before redaxo itself was able to register its rex_error_handler
-set_exception_handler(static function (Throwable $exception):void {
+set_exception_handler(static function (Throwable $exception): void {
     fwrite(STDERR, $exception->getMessage()."\n");
     exit(254);
 });

--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -4,7 +4,7 @@ set_time_limit(0);
 
 // setup a minimal exception handler to print early errors,
 // happening before redaxo itself was able to register its rex_error_handler
-set_exception_handler(static function ($exception) {
+set_exception_handler(static function(Throwable $exception) {
     fwrite(STDERR, $exception->getMessage()."\n");
     exit(254);
 });

--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -2,6 +2,13 @@
 
 set_time_limit(0);
 
+// setup a minimal exception handler to print early errors,
+// happening before redaxo itself was able to register its rex_error_handler
+set_exception_handler(function($exception) {
+    fwrite(STDERR, $exception->getMessage()."\n");
+    exit(254);
+});
+
 require __DIR__.'/boot.php';
 
 // force debug mode to enable output of notices/warnings and dump() function

--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -6,6 +6,7 @@ set_time_limit(0);
 // happening before redaxo itself was able to register its rex_error_handler
 set_exception_handler(static function (Throwable $exception): void {
     fwrite(STDERR, $exception->getMessage()."\n");
+    fwrite(STDERR, $exception->getTraceAsString()."\n");
     exit(254);
 });
 

--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -4,7 +4,7 @@ set_time_limit(0);
 
 // setup a minimal exception handler to print early errors,
 // happening before redaxo itself was able to register its rex_error_handler
-set_exception_handler(static function(Throwable $exception) {
+set_exception_handler(static function (Throwable $exception) {
     fwrite(STDERR, $exception->getMessage()."\n");
     exit(254);
 });

--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -4,7 +4,7 @@ set_time_limit(0);
 
 // setup a minimal exception handler to print early errors,
 // happening before redaxo itself was able to register its rex_error_handler
-set_exception_handler(static function (Throwable $exception) {
+set_exception_handler(static function (Throwable $exception):void {
     fwrite(STDERR, $exception->getMessage()."\n");
     exit(254);
 });

--- a/redaxo/src/core/console.php
+++ b/redaxo/src/core/console.php
@@ -4,7 +4,7 @@ set_time_limit(0);
 
 // setup a minimal exception handler to print early errors,
 // happening before redaxo itself was able to register its rex_error_handler
-set_exception_handler(function($exception) {
+set_exception_handler(static function ($exception) {
     fwrite(STDERR, $exception->getMessage()."\n");
     exit(254);
 });


### PR DESCRIPTION
otherwise we would never see the `PHP version >=7.3 needed!` message, when the rex-console is invoked with a unsupported php version.

before this PR invoking `redaxo/bin/console config:get setup` on PHP 7.2 would just return empty with a 255 exit code.
```
$ php redaxo/bin/console config:get setup
$ echo $?
255
```

after this PR we are getting the underlying error on STDERR and a 254 error code.
```
$ php redaxo/bin/console config:get setup
PHP version >=7.3 needed!
#0 /cluster/www/www/www/redaxo/redaxo/src/core/console.php(13): require()
#1 /cluster/www/www/www/redaxo/redaxo/bin/console(11): require('/cluster/www/ww...')
#2 {main}
$ echo $?
254
```