### PR TITLE
add global .gitattributes to make git checkouts work when git core.autocrlf is configured

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/.tools/bin/* text eol=lf
+/redaxo/bin/* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,4 @@
 # See core.whitespace @ https://git-scm.com/docs/git-config for whitespace flags.
 *.php   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4 diff=php
 *.json  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
-*.yml   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=2
+*.yml   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,5 +7,4 @@
 # See core.whitespace @ https://git-scm.com/docs/git-config for whitespace flags.
 *.php   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4 diff=php
 *.json  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
-*.test  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
 *.yml   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,11 @@
-/.tools/bin/* text eol=lf
-/redaxo/bin/* text eol=lf
+# inspired by https://github.com/composer/composer/blob/2406a094d3b2e5d73ce105764b36898ebd19b69d/.gitattributes
+
+# Auto-detect text files, ensure they use LF.
+*       text=auto eol=lf
+
+# These files are always considered text and should use LF.
+# See core.whitespace @ https://git-scm.com/docs/git-config for whitespace flags.
+*.php   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4 diff=php
+*.json  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
+*.test  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
+*.yml   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=2


### PR DESCRIPTION
otherwise the scripts, when running on windows, might not work (because of git core.autocrlf)

see https://docs.github.com/en/free-pro-team@latest/github/using-git/configuring-git-to-handle-line-endings