### PR TITLE
console-setup: print file-errors in list-style

### DIFF
--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -568,7 +568,7 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
                 if (count($messages) > 0) {
                     $affectedFiles = [];
                     foreach ($messages as $message) {
-                        $affectedFiles[] = rex_path::relative($message);
+                        $affectedFiles[] = '- '. rex_path::relative($message);
                     }
                     $errors[] = rex_i18n::msg($key) . "\n". implode("\n", $affectedFiles);
                 }


### PR DESCRIPTION
vorher

![grafik](https://user-images.githubusercontent.com/120441/103292985-40511880-49ef-11eb-8639-3ca6dcd547b7.png)

nachher

![grafik](https://user-images.githubusercontent.com/120441/103292960-362f1a00-49ef-11eb-96ef-6ea190d96b21.png)


man beachte das `-` Auflistungskennzeichen