### PR TITLE
disable owasp/Atomicorp.com rules which block html content in textareas

### DIFF
--- a/redaxo/src/.htaccess
+++ b/redaxo/src/.htaccess
@@ -5,3 +5,9 @@
     Order deny,allow
     Deny from all
 </IfModule>
+
+<IfModule security2_module>
+# disable owasp/Atomicorp.com rules which block html content in textareas
+    SecRuleRemoveById 33350147
+    SecRuleRemoveById 949110
+</IfModule>

--- a/redaxo/src/.htaccess
+++ b/redaxo/src/.htaccess
@@ -10,4 +10,5 @@
 # disable owasp/Atomicorp.com rules which block html content in textareas
     SecRuleRemoveById 33350147
     SecRuleRemoveById 949110
+    SecRuleRemoveById 980130
 </IfModule>


### PR DESCRIPTION
https://serverfault.com/a/842711 

Refs https://github.com/redaxo/redaxo/issues/4271#issuecomment-752992387

ungetestet