### PR TITLE
cronjob: job-typ hinzugefügt um Dateien zu komprimieren

### DIFF
--- a/redaxo/src/addons/cronjob/lang/de_de.lang
+++ b/redaxo/src/addons/cronjob/lang/de_de.lang
@@ -29,6 +29,11 @@ cronjob_type_urlrequest_post = POST-Parameter
 cronjob_type_urlrequest_httpauth = HTTP-Authentifizierung
 cronjob_type_urlrequest_user = Benutzer
 cronjob_type_urlrequest_password = Passwort
+cronjob_type_compress = Dateien komprimieren
+cronjob_type_compress_glob = glob-pattern zum finden der Dateien
+cronjob_type_compress_glob_notice = Absoluter Pfad oder relativer Pfad zum <code>rex_path::base()</code> Verzeichnis, zum Beispiel redaxo/data/addons/backup/*.sql
+cronjob_type_compress_cleanup = Original-Datei nach komprimierung löschen
+
 cronjob_type_parameters = Typspezifische Parameter
 cronjob_type_no_parameters = Für diesen Typ sind keine weiteren Parameter notwendig!
 

--- a/redaxo/src/addons/cronjob/lib/manager.php
+++ b/redaxo/src/addons/cronjob/lib/manager.php
@@ -15,9 +15,10 @@ class rex_cronjob_manager
      * @return class-string<T>[]
      */
     private static $types = [
-        'rex_cronjob_phpcode',
-        'rex_cronjob_phpcallback',
-        'rex_cronjob_urlrequest',
+        rex_cronjob_phpcode::class,
+        rex_cronjob_phpcallback::class,
+        rex_cronjob_urlrequest::class,
+        rex_cronjob_compress::class,
     ];
 
     /** @var string */

--- a/redaxo/src/addons/cronjob/lib/types/compress.php
+++ b/redaxo/src/addons/cronjob/lib/types/compress.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Cronjob Addon.
+ *
+ * @author  Markus Staab
+ *
+ * @package redaxo\cronjob
+ */
+class rex_cronjob_compress extends rex_cronjob
+{
+    public function execute()
+    {
+        $glob = $this->getParam('glob');
+
+        // try to resolve absolute path
+        $files = glob($glob);
+        if (!$files) {
+            // try to resolve the path relative to the rex-base path
+            $files = glob(rex_path::base($glob));
+        }
+
+        if ($files) {
+            foreach($files as $file) {
+                if (is_file($file) && !str_ends_with($file, '.zip')) {
+                    if (!is_readable($file)) {
+                        $this->setMessage('file is not readable "'. $file .'"');
+                        return false;
+                    }
+                    $zipArchive = new ZipArchive();
+                    if ($zipArchive->open($file.'.zip', ZipArchive::CREATE) && $zipArchive->addFile($file) && $zipArchive->close()) {
+                        if ('|1|' == $this->getParam('cleanup')) {
+                            rex_file::delete($file);
+                        }
+                    }
+                }
+            }
+        } else {
+            $this->setMessage('Unable glob() with path '. $glob);
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getTypeName()
+    {
+        return rex_i18n::msg('cronjob_type_compress');
+    }
+
+    public function getParamFields()
+    {
+        return [
+            [
+                'label' => rex_i18n::msg('cronjob_type_compress_glob'),
+                'name' => 'glob',
+                'type' => 'text',
+                'notice' => rex_i18n::msg('cronjob_type_compress_glob_notice'),
+            ],
+            [
+                'name' => 'cleanup',
+                'type' => 'checkbox',
+                'options' => [1 => rex_i18n::msg('cronjob_type_compress_cleanup')],
+            ],
+        ];
+    }
+}

--- a/redaxo/src/addons/cronjob/lib/types/compress.php
+++ b/redaxo/src/addons/cronjob/lib/types/compress.php
@@ -21,7 +21,7 @@ class rex_cronjob_compress extends rex_cronjob
         }
 
         if ($files) {
-            foreach($files as $file) {
+            foreach ($files as $file) {
                 if (is_file($file) && !str_ends_with($file, '.zip')) {
                     if (!is_readable($file)) {
                         $this->setMessage('file is not readable "'. $file .'"');

--- a/redaxo/src/addons/cronjob/lib/types/compress.php
+++ b/redaxo/src/addons/cronjob/lib/types/compress.php
@@ -36,7 +36,7 @@ class rex_cronjob_compress extends rex_cronjob
                 }
             }
         } else {
-            $this->setMessage('Unable glob() with path '. $glob);
+            $this->setMessage('Unable to glob() with path '. $glob);
             return false;
         }
 

--- a/redaxo/src/addons/cronjob/package.yml
+++ b/redaxo/src/addons/cronjob/package.yml
@@ -18,7 +18,9 @@ pages:
         perm: admin[]
 
 requires:
-    php: '>=7.3'
+    php:
+        version: '>=7.3'
+        extensions: [zip]
     redaxo: ^5.9.0
 
 console_commands:


### PR DESCRIPTION
anhand eines `glob` patterns, kann man definieren dass Dateien in einem Pfad via cron komprimiert werden sollen:

![grafik](https://user-images.githubusercontent.com/120441/103465875-f1351b80-4d3f-11eb-87e2-79d012c9cb9a.png)

zusätzlich hat man die möglichkeit zu definieren ob das original gelöscht werden soll.
prinzipiell macht es nicht viel sinn, wenn man das original nicht löscht - allerdings wollte ich es dem user unter die nase reiben und aktiv von ihm die entscheidung erzwingen

closes https://github.com/redaxo/redaxo/issues/3809