### PR TITLE
Nach Backup erstellen: Korrekte Felder einblenden

### DIFF
--- a/redaxo/src/addons/backup/pages/export.php
+++ b/redaxo/src/addons/backup/pages/export.php
@@ -160,7 +160,7 @@ foreach ($tables as $table) {
 
 $formElements = [];
 $n = [];
-$n['header'] = '<div id="rex-js-exporttype-sql-div">';
+$n['header'] = '<div id="rex-js-exporttype-sql-div"'.($checkedsql ? '' : ' style="display: none;"').'>';
 $n['label'] = '<label for="rex-form-exporttables">' . rex_i18n::msg('backup_export_select_tables') . '</label>';
 $n['field'] = $tableSelect->get();
 $n['footer'] = '</div>';
@@ -191,7 +191,7 @@ foreach ($folders as $path => $_) {
 }
 
 $n = [];
-$n['header'] = '<div id="rex-js-exporttype-files-div" style="display: none;">';
+$n['header'] = '<div id="rex-js-exporttype-files-div"'.($checkedfiles ? '' : ' style="display: none;"').'>';
 $n['label'] = '<label for="rex-form-exportdir">' . rex_i18n::msg('backup_export_select_dir') . '</label>';
 $n['field'] = $sel_dirs->get();
 $n['footer'] = '</div>';


### PR DESCRIPTION
Wenn man ein Dateibackup erstellt, erscheinen anschließend im Formular fälschlich sowohl die Tabellen-Auswahl als auch die Ordner-Auswahl. 

<img width="600" alt="Bildschirmfoto 2021-01-21 um 21 37 30" src="https://user-images.githubusercontent.com/330436/105409663-175c2600-5c31-11eb-824b-4b382857d0bb.png">

Nach diesem PR erscheint in dem Zustand korrekt nur noch die Ordner-Auswahl.