### PR TITLE
rex_logger: rex_exceptions ohne Großbuchstabe vorne

### DIFF
--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -104,7 +104,11 @@ class rex_logger extends AbstractLogger
         // interpolate replacement values into the message and return
         $message = strtr($message, $replace);
 
-        $logData = [ucfirst($level), $message];
+        if (!str_starts_with($level, 'rex_')) {
+            $level = ucfirst($level);
+        }
+
+        $logData = [$level, $message];
         if ($file && $line) {
             $logData[] = rex_path::relative($file);
             $logData[] = $line;


### PR DESCRIPTION
Seit https://github.com/redaxo/redaxo/pull/3904 schreiben wir das Loglevel immer mit einem Großbuchstaben in die Logdatei.
Das ist aber bei unseren `rex_exceptions` nicht so schön, da die nun mal eigentlich klein geschrieben werden.

<img width="389" alt="Bildschirmfoto 2021-01-21 um 22 30 56" src="https://user-images.githubusercontent.com/330436/105414882-622d6c00-5c38-11eb-9d1d-83c7fd417511.png">
