### PR TITLE
Whoops: fix buttons

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -215,10 +215,11 @@ abstract class rex_error_handler
             $errPage
         );
 
-        $errPage = preg_replace('@<button id="copy-button" .*?</button>@s', '$0<button class="clipboard" data-clipboard-text="'.rex_escape(self::getMarkdownReport($exception)).'" title="Copy exception details and system report as markdown to clipboard">
+        $errPage = preg_replace('@<button id="copy-button" .*?</button>@s', '$0<button class="rightButton clipboard" data-clipboard-text="'.rex_escape(self::getMarkdownReport($exception)).'" title="Copy exception details and system report as markdown to clipboard">
       COPY MARKDOWN
     </button>', $errPage);
         $errPage = str_replace('<button id="copy-button"', '<button ', $errPage);
+        $errPage = preg_replace('@<button id="hide-error" .*?</button>@s', '', $errPage);
 
         return [$errPage, $handler->contentType()];
     }

--- a/redaxo/src/core/vendor/filp/whoops/src/Whoops/Resources/js/whoops.base.js
+++ b/redaxo/src/core/vendor/filp/whoops/src/Whoops/Resources/js/whoops.base.js
@@ -100,7 +100,7 @@ Zepto(function($) {
 
   var clipboard = new Clipboard('.clipboard');
   var showTooltip = function(elem, msg) {
-    elem.setAttribute('class', 'clipboard tooltipped tooltipped-s');
+    elem.classList.add('tooltipped', 'tooltipped-s');
     elem.setAttribute('aria-label', msg);
   };
 
@@ -117,7 +117,7 @@ Zepto(function($) {
   var btn = document.querySelector('.clipboard');
 
   btn.addEventListener('mouseleave', function(e) {
-    e.currentTarget.setAttribute('class', 'clipboard');
+    e.currentTarget.classList.remove('tooltipped', 'tooltipped-s');
     e.currentTarget.removeAttribute('aria-label');
   });
 


### PR DESCRIPTION
- Button-Styles angeglichen
- Enthält auch den Fix aus https://github.com/filp/whoops/pull/685; würde den trotz Vendor-Code einfach schon bei uns so aufnehmen
- Whoops hat einen "Hide"-Button eingeführt. Der wird mit diesem PR entfernt, da er bei uns keinen Sinn macht. Denn nach Klick darauf sieht es so aus:

<img width="300" alt="Bildschirmfoto 2021-01-21 um 22 46 40" src="https://user-images.githubusercontent.com/330436/105416587-aae62480-5c3a-11eb-8d6d-79476e735c35.png">

---

Vorher:

<img width="371" alt="Bildschirmfoto 2021-01-21 um 22 44 05" src="https://user-images.githubusercontent.com/330436/105416674-cb15e380-5c3a-11eb-8937-419453e0f0c6.png">

Nachher:

<img width="372" alt="Bildschirmfoto 2021-01-21 um 22 44 26" src="https://user-images.githubusercontent.com/330436/105416693-d2d58800-5c3a-11eb-8d35-a0d0b429e5a9.png">