### PR TITLE
remove unused code

### DIFF
--- a/.tools/psalm/baseline-taint.xml
+++ b/.tools/psalm/baseline-taint.xml
@@ -1,144 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.4.1@9fd7a7d885b3a216cff8dec9d8c21a132f275224">
   <file src="redaxo/src/addons/structure/plugins/history/fragments/history/layer.php">
-    <TaintedHtml occurrences="56">
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
+    <TaintedHtml occurrences="4">
       <code>$this-&gt;getVar('content1iframe')</code>
       <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
       <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
       <code>$this-&gt;getVar('content2select')</code>
     </TaintedHtml>
   </file>
   <file src="redaxo/src/core/fragments/core/fe_ooops.php">
-    <TaintedHtml occurrences="14">
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
+    <TaintedHtml occurrences="1">
       <code>$this-&gt;getVar('content', '')</code>
     </TaintedHtml>
   </file>
   <file src="redaxo/src/core/fragments/core/page/docs.php">
-    <TaintedHtml occurrences="42">
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
+    <TaintedHtml occurrences="3">
       <code>$this-&gt;getVar('content')</code>
       <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
       <code>$this-&gt;getVar('toc')</code>
     </TaintedHtml>
   </file>
   <file src="redaxo/src/core/fragments/core/page/readme.php">
-    <TaintedHtml occurrences="14">
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
+    <TaintedHtml occurrences="1">
       <code>$this-&gt;getVar('content')</code>
     </TaintedHtml>
   </file>

--- a/redaxo/src/core/lib/form/elements/control.php
+++ b/redaxo/src/core/lib/form/elements/control.php
@@ -51,7 +51,6 @@ class rex_form_control_element extends rex_form_element
             }
 
             $e = [];
-            $e['class'] = $this->saveElement->formatClass();
             $e['field'] = $this->saveElement->formatElement();
             $elements[] = $e;
         }
@@ -62,7 +61,6 @@ class rex_form_control_element extends rex_form_element
             }
 
             $e = [];
-            $e['class'] = $this->applyElement->formatClass();
             $e['field'] = $this->applyElement->formatElement();
             $elements[] = $e;
         }
@@ -73,7 +71,6 @@ class rex_form_control_element extends rex_form_element
             }
 
             $e = [];
-            $e['class'] = $this->abortElement->formatClass();
             $e['field'] = $this->abortElement->formatElement();
             $elements[] = $e;
         }
@@ -88,7 +85,6 @@ class rex_form_control_element extends rex_form_element
             }
 
             $e = [];
-            $e['class'] = $this->deleteElement->formatClass();
             $e['field'] = $this->deleteElement->formatElement();
             $elements[] = $e;
         }
@@ -103,7 +99,6 @@ class rex_form_control_element extends rex_form_element
             }
 
             $e = [];
-            $e['class'] = $this->resetElement->formatClass();
             $e['field'] = $this->resetElement->formatElement();
             $elements[] = $e;
         }


### PR DESCRIPTION
Der `class`-Key wird im Fragment gar nicht verwendet, sondern über `formatElement()` wird bereits auch das `class`-Attribut gesetzt.