### PR TITLE
phpstan: disable treatPhpDocTypesAsCertain

### DIFF
--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: ../../redaxo/src/addons/install/pages/index.php
 
 		-
-			message: "#^Call to function is_bool\\(\\) with string\\|null will always evaluate to false\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
-
-		-
 			message: "#^Method rex_media\\:\\:getRootMedia\\(\\) should return array\\<static\\(rex_media\\)\\> but returns array\\<rex_media\\>\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/mediapool/lib/media.php
@@ -326,12 +321,12 @@ parameters:
 			path: ../../redaxo/src/core/lib/util/socket/socket.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, Closure\\(mixed, mixed\\)\\: void given\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/util/socket/socket.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, Closure\\(mixed, mixed\\)\\: void given\\.$#"
+			message: "#^If condition is always false\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/util/socket/socket.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,7 @@ includes:
 
 parameters:
     level: 5
+    treatPhpDocTypesAsCertain: false
     paths:
         # restrict to core and core addons, ignore other locally installed addons
         - redaxo/src/core

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1414,7 +1414,6 @@ class rex_sql implements Iterator
                 continue;
             }
 
-            /** @phpstan-ignore-next-line */
             throw new InvalidArgumentException('Argument $values must be an array of ints and/or strings, but it contains "'.get_debug_type($value).'"');
         }
 


### PR DESCRIPTION
https://phpstan.org/config-reference#treatphpdoctypesascertain

Wenn wir einen Typ nur per phpdoc deklarieren, dann wollen wir ihn durchaus php-seitig nochmal explizit checken und verlassen uns nicht immer nur auf den phpdoc.
Daher würde ich diese Option in phpstan so setzen.