### PR TITLE
MM-Effekte-Namen einheitlicher

### DIFF
--- a/redaxo/src/addons/media_manager/lang/en_gb.lang
+++ b/redaxo/src/addons/media_manager/lang/en_gb.lang
@@ -78,7 +78,7 @@ media_manager_effect_blur_repeats = Repeats
 media_manager_effect_blur_type = Blur type
 media_manager_effect_blur_smoothit = smoothing (negative values for sharpening)
 
-media_manager_effect_colorize = Img: colorize
+media_manager_effect_colorize = Image: colorize
 media_manager_effect_colorize_r = Red value
 media_manager_effect_colorize_g = Green value
 media_manager_effect_colorize_b = Blue value
@@ -107,10 +107,10 @@ media_manager_effect_rounded_corners_topright = Top right
 media_manager_effect_rounded_corners_bottomleft = Bottom left
 media_manager_effect_rounded_corners_bottomright = Bottom right
 
-media_manager_effect_flip = Direction
+media_manager_effect_flip = Image: mirror horizontal/vertical
 media_manager_effect_flip_direction = Direction
 
-media_manager_effect_rotate = Rotate (degree)
+media_manager_effect_rotate = Image: rotate
 media_manager_effect_rotate_degree = Rotate (degrees)
 
 media_manager_effect_mirror = Image: add water reflection
@@ -127,7 +127,7 @@ media_manager_effect_workspace_pos = Position
 
 media_manager_effect_folder = Alternative path default: "media"
 
-media_manager_effect_mediapath = Media path
+media_manager_effect_mediapath = File: adjust path
 media_manager_effect_mediapath_path = Media folder
 media_manager_effect_mediapath_path_notice = Path to image source relative to the REDAXO installation instead of <code>media</code>, i.e. <code>images</code>. Leading/trailing slashes are not needed.
 
@@ -155,11 +155,11 @@ media_manager_effect_image_properties_png_compression_notice = [0-9]. Leave empt
 media_manager_effect_image_properties_webp_quality_notice = [0-100]. Leave empty for default value.
 media_manager_effect_image_properties_interlace_notice = Leave empty for default value.
 
-media_manager_effect_brightness = Brightness
+media_manager_effect_brightness = Image: brightness
 media_manager_effect_brightness_value = Brightness
 media_manager_effect_brightness_notice = [-255 to 255]. Leave empty for default value. (0).
 
-media_manager_effect_contrast = Contrast
+media_manager_effect_contrast = Image: contrast
 media_manager_effect_contrast_value = Contrast
 media_manager_effect_contrast_notice = [-100 to 100]. Leave empty for default value (0).
 

--- a/redaxo/src/addons/media_manager/lang/es_es.lang
+++ b/redaxo/src/addons/media_manager/lang/es_es.lang
@@ -107,10 +107,10 @@ media_manager_effect_rounded_corners_topright = Arriba a la derecha
 media_manager_effect_rounded_corners_bottomleft = Abajo a la izquierda
 media_manager_effect_rounded_corners_bottomright = Abajo a la derecha
 
-media_manager_effect_flip = Dirección
+media_manager_effect_flip =
 media_manager_effect_flip_direction = Dirección
 
-media_manager_effect_rotate = Rotar (grado)
+media_manager_effect_rotate = Imagen: Rotar
 media_manager_effect_rotate_degree = Volver (grado)
 
 media_manager_effect_mirror = Imagen: Añade reflejo de agua
@@ -127,7 +127,7 @@ media_manager_effect_workspace_pos = Posición
 
 media_manager_effect_folder = Ruta alternativa predeterminada: "media"
 
-media_manager_effect_mediapath = Vía de medios
+media_manager_effect_mediapath =
 media_manager_effect_mediapath_path = Carpeta de medios
 media_manager_effect_mediapath_path_notice = Ruta al origen de la imagen en relación con la instalación de REDAXO en lugar de <code>media</code>, por ejemplo, el directorio <code>images</code>. No se requiere una barra diagonal inicial/final (<code>/</code>).
 
@@ -155,11 +155,11 @@ media_manager_effect_image_properties_png_compression_notice = [0-9]. Dejar en b
 media_manager_effect_image_properties_webp_quality_notice = [0-100]. Dejar en blanco para el valor por defecto.
 media_manager_effect_image_properties_interlace_notice = Dejar en blanco para el valor por defecto.
 
-media_manager_effect_brightness = Brillo
+media_manager_effect_brightness = Imagen: Brillo
 media_manager_effect_brightness_value = Claridad
 media_manager_effect_brightness_notice = [-255 a 255]. Dejar en blanco para el valor por defecto. (0).
 
-media_manager_effect_contrast = Contraste
+media_manager_effect_contrast = Imagen: Contraste
 media_manager_effect_contrast_value = Contrastar
 media_manager_effect_contrast_notice = [-100 a 100]. Dejar en blanco para el valor por defecto (0).
 

--- a/redaxo/src/addons/media_manager/lang/sv_se.lang
+++ b/redaxo/src/addons/media_manager/lang/sv_se.lang
@@ -107,10 +107,10 @@ media_manager_effect_rounded_corners_topright = Uppe höger
 media_manager_effect_rounded_corners_bottomleft = Nedre vänster
 media_manager_effect_rounded_corners_bottomright = Nedre höger
 
-media_manager_effect_flip = Riktning
+media_manager_effect_flip = Bild: Riktning
 media_manager_effect_flip_direction = Riktning
 
-media_manager_effect_rotate = Vrida (grad)
+media_manager_effect_rotate = Bild: Vrida
 media_manager_effect_rotate_degree = Vrida med (vinkel)
 
 media_manager_effect_mirror = Bild: tillfoga vattenspegling
@@ -127,7 +127,7 @@ media_manager_effect_workspace_pos = Position
 
 media_manager_effect_folder = Alternativ mapp default: "media"
 
-media_manager_effect_mediapath = Medieamapp
+media_manager_effect_mediapath =
 media_manager_effect_mediapath_path = Mediamapp
 media_manager_effect_mediapath_path_notice = Vägen till bildkällan i förhållande till REDAXO-installationen istället för <code> media </ code>, t.ex. katalogen <code> images </ code>. Ledande / avslutande snedstreck (<code> / </ code>) krävs inte.
 
@@ -155,11 +155,11 @@ media_manager_effect_image_properties_png_compression_notice = [0-9]. Lämna tom
 media_manager_effect_image_properties_webp_quality_notice = [0-100]. Lämna tom för standardvärdet.
 media_manager_effect_image_properties_interlace_notice = Lämna tom för standardvärdet.
 
-media_manager_effect_brightness = Ljusstyrka
+media_manager_effect_brightness = Bild: Ljusstyrka
 media_manager_effect_brightness_value = Ljusstyrka
 media_manager_effect_brightness_notice = [-255 to 255]. Lämna tom för standardvärdet. (0)
 
-media_manager_effect_contrast = Kontrast
+media_manager_effect_contrast = Bild: Kontrast
 media_manager_effect_contrast_value = Kontrast
 media_manager_effect_contrast_notice = [-100 to 100].  Lämna tom för standardvärdet. (0)
 


### PR DESCRIPTION
Im Deutschen heißen die Effekte so:

<img width="865" alt="Bildschirmfoto 2021-02-05 um 20 20 41" src="https://user-images.githubusercontent.com/330436/107079228-d4cd4880-67ef-11eb-8d45-367ff4348535.png">

Im Englischen und auch den anderen Sprachen war der Präfix hingegen nicht so einheitlich:

<img width="865" alt="Bildschirmfoto 2021-02-05 um 20 19 40" src="https://user-images.githubusercontent.com/330436/107079279-e4e52800-67ef-11eb-9373-ffd5ebaa368b.png">

Nach diesem PR sieht es dann so aus:

<img width="864" alt="Bildschirmfoto 2021-02-05 um 20 19 05" src="https://user-images.githubusercontent.com/330436/107079295-ec0c3600-67ef-11eb-90ff-a45b01029c74.png">
