### PR TITLE
filter-extension als erforderlich gesetzt

### DIFF
--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -23,7 +23,7 @@ class rex_setup
     public const DB_MODE_SETUP_IMPORT_BACKUP = 3;
     public const DB_MODE_SETUP_UPDATE_FROM_PREVIOUS = 4;
 
-    private static $MIN_PHP_EXTENSIONS = ['fileinfo', 'iconv', 'pcre', 'pdo', 'pdo_mysql', 'session', 'tokenizer'];
+    private static $MIN_PHP_EXTENSIONS = ['fileinfo', 'filter', 'iconv', 'pcre', 'pdo', 'pdo_mysql', 'session', 'tokenizer'];
 
     /**
      * very basic setup steps, so everything is in place for our browser-based setup wizard.


### PR DESCRIPTION
Seit https://github.com/redaxo/redaxo/commit/620900ad7ff6a86bc0ff312829ff93c116749a9a verwenden wir zum ersten Mal direkt die `filter_var`-Funktion. 
Wobei sie indirekt scheinbar auch vorher schon erforderlich war, da unter anderem AntiXSS sie verwendet.
Und auch sf/http-foundation verwendet sie.

Die filter-Extension ist sehr Standard, aber doch auch nicht immer vorhanden. Daher besser der explizite Check.
(Ich meine, ich hätte im Slack schon jemanden gesehen, wo die Extension fehlte.)
Siehe auch https://externals.io/message/112976.