### PR TITLE
mediapool: use word-break for title and file name

### DIFF
--- a/redaxo/src/addons/mediapool/pages/media.detail.php
+++ b/redaxo/src/addons/mediapool/pages/media.detail.php
@@ -227,7 +227,7 @@ if ($TPERM) {
 
     $e = [];
     $e['label'] = '<label>' . rex_i18n::msg('pool_filename') . '</label>';
-    $e['field'] = '<p class="form-control-static"><a href="' . rex_url::media($encoded_fname) . '">' . rex_escape($fname) . '</a> <span class="rex-filesize">' . $ffile_size . '</span></p>';
+    $e['field'] = '<p class="form-control-static rex-word-break"><a href="' . rex_url::media($encoded_fname) . '">' . rex_escape($fname) . '</a> <span class="rex-filesize">' . $ffile_size . '</span></p>';
     $formElements[] = $e;
 
     $e = [];

--- a/redaxo/src/addons/mediapool/pages/media.list.php
+++ b/redaxo/src/addons/mediapool/pages/media.list.php
@@ -339,8 +339,8 @@ $panel = '
 
                     $panel .= '<tr>
                     ' . $add_td . '
-                    <td data-title="' . rex_i18n::msg('pool_file_thumbnail') . '"><a href="' . $ilink . '"><div class="lazyload" data-noscript=""><noscript>' . $thumbnail . '</noscript></div></a></td>
-                    <td data-title="' . rex_i18n::msg('pool_file_info') . '">
+                    <td class="rex-word-break" data-title="' . rex_i18n::msg('pool_file_thumbnail') . '"><a href="' . $ilink . '"><div class="lazyload" data-noscript=""><noscript>' . $thumbnail . '</noscript></div></a></td>
+                    <td class="rex-word-break" data-title="' . rex_i18n::msg('pool_file_info') . '">
                         <h3><a class="rex-link-expanded" href="' . $ilink . '">' . rex_escape($file_title) . '</a></h3>
                         ' . $desc . '
                         <p>' . rex_escape($file_name) . ' <span class="rex-filesize">' . $file_size . '</span></p>


### PR DESCRIPTION
ref #4456

Lange Titel und Dateinamen werden umgebrochen. An den Spaltenbreiten wurde nichts geändert.

<img width="1200" alt="Screenshot 2021-02-17 at 21 32 46" src="https://user-images.githubusercontent.com/1297466/108264488-e4417f80-7167-11eb-9a23-b5a724124bc3.png">

<img width="1200" alt="Screenshot 2021-02-17 at 21 32 56" src="https://user-images.githubusercontent.com/1297466/108264495-e6a3d980-7167-11eb-976b-a5af312e8f79.png">

Update. Auf der Detailseite ebenso für den Filenamen ergänzt:

<img width="1198" alt="Screenshot 2021-02-18 at 08 03 45" src="https://user-images.githubusercontent.com/1297466/108318390-0c5ccd00-71c0-11eb-959e-234784c39cec.png">