### PR TITLE
sanitizeHtml: allow "window.location" code snippet

### DIFF
--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -221,6 +221,7 @@ class rex_string
         if (!$antiXss) {
             $antiXss = new voku\helper\AntiXSS();
             $antiXss->removeEvilAttributes(['style']);
+            $antiXss->removeNeverAllowedRegex(['(\(?:?document\)?|\(?:?window\)?(?:\.document)?)\.(?:location|on\w*)' => '']);
             $antiXss->removeNeverAllowedStrAfterwards(['&lt;script&gt;', '&lt;/script&gt;']);
         }
 

--- a/redaxo/src/core/tests/util/string_test.php
+++ b/redaxo/src/core/tests/util/string_test.php
@@ -100,7 +100,10 @@ class rex_string_test extends TestCase
             <img src="foo.jpg" onmouseover="alert(1)"/>
 
             <pre><code>
-                &lt;script&gt; foo() &lt;/script&gt;
+                &lt;script&gt;
+                    foo();
+                    window.location.replace(my_link);
+                &lt;/script&gt;
             </code></pre>
             INPUT;
 
@@ -114,7 +117,10 @@ class rex_string_test extends TestCase
             <img src="foo.jpg" />
 
             <pre><code>
-                &lt;script&gt; foo() &lt;/script&gt;
+                &lt;script&gt;
+                    foo();
+                    window.location.replace(my_link);
+                &lt;/script&gt;
             </code></pre>
             EXPECTED;
 

--- a/redaxo/src/core/tests/util/string_test.php
+++ b/redaxo/src/core/tests/util/string_test.php
@@ -94,7 +94,10 @@ class rex_string_test extends TestCase
             <p align=center><img src="foo.jpg" style="width: 200px"></p>
             <a name="test"></a>
 
-            <script>alert(1)</script>
+            <script>
+                alert(1);
+                window.location.replace(my_link);
+            </script>
             <a href="javascript:alert(1)">Foo</a>
             <a href="index.php" onclick="alert(1)">Foo</a>
             <img src="foo.jpg" onmouseover="alert(1)"/>


### PR DESCRIPTION
fixes #4450

Ist nicht ganz unkritisch, hier mit Halbwissen in das AntiXSS-Skript einzugreifen.
Ich vermute aber, dass dieser Regex mehr ein "sicher ist sicher" darstellt, und kein direkt notwendiger ist.
Das leite ich daraus ab, dass das AntiXSS-Skript ja generell versucht, JS-Code zu verhindern, nicht nur diesen spezifischen.
Wenn dieser Regex so absolut notwendig wäre, wäre auch merkwürdig, dass man ihn ja sehr leicht umgehen könnte, indem man Leerzeichen um den `.`-Operator ergänzen würde.