### PR TITLE
rex_extension: Umgang mit $level-Param

### DIFF
--- a/redaxo/src/core/lib/extension.php
+++ b/redaxo/src/core/lib/extension.php
@@ -81,6 +81,18 @@ abstract class rex_extension
             static::callFactoryClass(__FUNCTION__, func_get_args());
             return;
         }
+
+        // bc
+        if (is_string($level)) {
+            trigger_error(__METHOD__.': Argument $level should be one of the constants rex_extension::EARLY/NORMAL/LATE, but string "'.$level.'" given', E_USER_WARNING);
+
+            $level = (int) $level;
+        }
+
+        if (!in_array($level, [self::EARLY, self::NORMAL, self::LATE], true)) {
+            throw new InvalidArgumentException('Argument $level should be one of the constants rex_extension::EARLY/NORMAL/LATE, but "'.(is_int($level) ? $level : get_debug_type($level)).'" given');
+        }
+
         foreach ((array) $extensionPoint as $ep) {
             self::$extensions[$ep][$level][] = [$extension, $params];
         }


### PR DESCRIPTION
Siehe dazu Diskussion in Slack: https://friendsofredaxo.slack.com/archives/C1BAXLN2F/p1614011906115000?thread_ts=1613996172.089200&cid=C1BAXLN2F
(insbesondere auch dann weiter unten im Thread)

Wie dort diskutiert, wegen BC, für den String-Fall nur eine Warnung, und ansonsten aber dem bisherigen Verhalten.
Es hat sich rausgestellt, dass es mehrere Stellen gibt, wo der String "LATE" übergeben wurde, und es damit trotzdem funktionierte in 5.11, da dort nach int gecastet wurde.