### PR TITLE
rex_article_slice: Propertynamen korrigiert

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
@@ -430,9 +430,8 @@ class rex_article_slice
             return $this->values[$index - 1];
         }
 
-        $attrName = '_' . $index;
-        if (isset($this->$attrName)) {
-            return $this->$attrName;
+        if (isset($this->$index)) {
+            return $this->$index;
         }
 
         return null;


### PR DESCRIPTION
Ist hier passiert: https://github.com/redaxo/redaxo/pull/4465/files
Ich hatte in dem PR eigentlich mir extra die rex_article_slice-Klasse noch angeschaut, ob die Umbenennung irgendwo ein Problem sein könnte. Aber die Stelle hatte ich leider nicht entdeckt.