### PR TITLE
Autoloader: fix cache handling

### DIFF
--- a/redaxo/src/core/functions/function_rex_other.php
+++ b/redaxo/src/core/functions/function_rex_other.php
@@ -23,6 +23,7 @@ function rex_delete_cache()
         ->ignoreSystemStuff(false);
     rex_dir::deleteIterator($finder);
 
+    rex_autoload::removeCache();
     rex_clang::reset();
 
     if (function_exists('opcache_reset')) {

--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -30,7 +30,7 @@ class rex_autoload
      */
     protected static $cacheChanged = false;
     /**
-     * @var bool Remember the cache was deleted, to make sure we don't generate a stale cache file.
+     * @var bool remember the cache was deleted, to make sure we don't generate a stale cache file
      */
     protected static $cacheDeleted = false;
     /**

--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -30,7 +30,7 @@ class rex_autoload
      */
     protected static $cacheChanged = false;
     /**
-     * @var bool
+     * @var bool Remember the cache was deleted, to make sure we don't generate a stale cache file.
      */
     protected static $cacheDeleted = false;
     /**

--- a/redaxo/src/core/lib/autoload.php
+++ b/redaxo/src/core/lib/autoload.php
@@ -32,6 +32,10 @@ class rex_autoload
     /**
      * @var bool
      */
+    protected static $cacheDeleted = false;
+    /**
+     * @var bool
+     */
     protected static $reloaded = false;
     /**
      * @var string[][]
@@ -162,7 +166,7 @@ class rex_autoload
      */
     public static function saveCache()
     {
-        if (!self::$cacheChanged) {
+        if (!self::$cacheChanged || self::$cacheDeleted) {
             return;
         }
 
@@ -209,6 +213,7 @@ class rex_autoload
     public static function removeCache()
     {
         rex_file::delete(self::$cacheFile);
+        self::$cacheDeleted = true;
     }
 
     /**
@@ -226,7 +231,6 @@ class rex_autoload
         self::$addedDirs[] = $dir;
         if (!isset(self::$dirs[$dir])) {
             self::_addDirectory($dir);
-            self::$cacheChanged = true;
         }
     }
 
@@ -253,6 +257,7 @@ class rex_autoload
 
         if (!isset(self::$dirs[$dir])) {
             self::$dirs[$dir] = [];
+            self::$cacheChanged = true;
         }
         $files = self::$dirs[$dir];
         $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dirPath, RecursiveDirectoryIterator::SKIP_DOTS));


### PR DESCRIPTION
@polarpixel hatte beim Update auf die 5.12 Probleme, nach dem Update wurde gemeldet, es würde die Klasse `rex_config_db` fehlen. 
Ich konnte es auf seiner Seite debuggen und habe dabei zwei Probleme festgestellt:

### Problem 1

Wenn man `rex_autoload::addDirectory()` mit einem nicht-existierenden Ordner aufruft, dann wird der Cache neugeschrieben, der Inhalt bleibt aber wie zuvor.

Peter nutzt das theme-Addon. Dieses [fügt einen eigenen Pfad zum Autoloader hinzu](https://github.com/FriendsOfREDAXO/theme/blob/6c20cb8ce3b88bba8b4289c32c6f95efa69db652/boot.php#L12).
Dieser Pfad existiert aber nicht immer, je nachdem, was man letztlich so im theme-Ordner drin hat. Bei Peter ist der Pfad nicht vorhanden.
Das hat zur Folge, dass bei Peter bei jedem Seitenaufruf der Autoload-Cache neugeschrieben wird.

Das ist natürlich nicht schön, und wird hier im PR behoben.
In Kombination mit Problem 2 wurde es dann noch unschöner.

### Problem 2

Der Autoloader registriert ganz am Anfang eine Shutdown-Function. Diese prüft beim Aufruf, ob das `$cacheChanged`-Flag gesetzt wurde, und wenn ja, wird der Cache in die Datei geschrieben.

Wenn man `rex_delete_cache()` aufruft (über System, oder im konkreten Fall durch den Installer nach Core-Update), dann wird dabei die Cache-Datei gelöscht. Am Ende des Requests kommt aber noch die Shutdown-Function, und wenn im selben Request auch noch sich etwas am Cache geändert hat, wird am Ende direkt der Cache wieder geschrieben.
Durch Problem 1 war das bei Peter der Fall.

Dieser direkt wieder geschriebene Cache ist aber eventuell veraltet, denn es gab ja einen Grund, weshalb `rex_delete_cache()` aufgerufen wurde.
Wenn also der Cache gelöscht wird, sollte der Cache erst wieder im nächsten, ganz frischen Request erzeugt werden.

Daher wird mit diesem PR noch ein neues Flag `$cacheDeleted` gesetzt, und dann bricht die Shutdown-Function auch ab, und speichert nicht den Cache.