### PR TITLE
rex_formatter: handle 0000-00-00

### DIFF
--- a/redaxo/src/core/lib/util/formatter.php
+++ b/redaxo/src/core/lib/util/formatter.php
@@ -400,7 +400,7 @@ abstract class rex_formatter
         }
 
         if (str_starts_with($value, '0000-00-00')) {
-            trigger_error(sprintf('%s: "%s" is not a valid dateime string.', __METHOD__, $value));
+            trigger_error(sprintf('%s: "%s" is not a valid dateime string.', __METHOD__, $value), E_USER_WARNING);
 
             return null;
         }

--- a/redaxo/src/core/lib/util/formatter.php
+++ b/redaxo/src/core/lib/util/formatter.php
@@ -49,11 +49,17 @@ abstract class rex_formatter
             return '';
         }
 
+        $timestamp = self::getTimestamp($value);
+
+        if (null === $timestamp) {
+            return '';
+        }
+
         if ('' == $format) {
             $format = 'd.m.Y';
         }
 
-        return date($format, self::getTimestamp($value));
+        return date($format, $timestamp);
     }
 
     /**
@@ -72,6 +78,12 @@ abstract class rex_formatter
             return '';
         }
 
+        $timestamp = self::getTimestamp($value);
+
+        if (null === $timestamp) {
+            return '';
+        }
+
         if ('' == $format || 'date' == $format) {
             // Default REX-Dateformat
             $format = rex_i18n::msg('dateformat');
@@ -82,7 +94,7 @@ abstract class rex_formatter
             // Default REX-Timeformat
             $format = rex_i18n::msg('timeformat');
         }
-        return strftime($format, self::getTimestamp($value));
+        return strftime($format, $timestamp);
     }
 
     /**
@@ -369,7 +381,7 @@ abstract class rex_formatter
      *
      * @param string|int $value
      *
-     * @return int
+     * @return int|null
      */
     private static function getTimestamp($value)
     {
@@ -377,12 +389,22 @@ abstract class rex_formatter
             return (int) $value;
         }
 
-        $time = strtotime($value);
-
-        if (false === $time) {
-            throw new InvalidArgumentException(sprintf('"%s" is not a valid datetime string.', $value));
+        if (!is_string($value)) {
+            throw new InvalidArgumentException('$value must be a unix timestamp as int or a date(time) string, but "'.get_debug_type($value).'" given');
         }
 
-        return $time;
+        $time = strtotime($value);
+
+        if (false !== $time) {
+            return $time;
+        }
+
+        if (str_starts_with($value, '0000-00-00')) {
+            trigger_error(sprintf('%s: "%s" is not a valid dateime string.', __METHOD__, $value));
+
+            return null;
+        }
+
+        throw new InvalidArgumentException(sprintf('"%s" is not a valid datetime string.', $value));
     }
 }


### PR DESCRIPTION
closes #4493

Ich habe es nun so gemacht, dass bei den speziellen 0000er Dates nur eine Warnung kommt (und der Formatter liefert letztlich einen leeren String).
Bei anderen ungültigen Strings bleibt es bei der Exception.

Lässt sich schwer unittesten, da man dafür ein 32bit-System bräuchte. Auf 64bit lässt sich "0000-00-00" als int-timestamp darstellen und ist somit valide.