### PR TITLE
Setup: Backend-Session nicht beenden

### DIFF
--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -36,9 +36,6 @@ class rex_setup
         // initial purge all generated files
         rex_delete_cache();
 
-        // delete backend session
-        rex_backend_login::deleteSession();
-
         // copy alle media files of the current rex-version into redaxo_media
         rex_dir::copy(rex_path::core('assets'), rex_path::coreAssets());
         // in a regular release the folder will never be empty, because we ship it prefilled.


### PR DESCRIPTION
closes #4492

Ich habe nochmal geschaut, wann wir das Beenden der Session dort eingefügt haben:
https://github.com/redaxo/redaxo/commit/c3e93dbe8903f2790fd66e3644ca1f65e3fd1cd9, als Reaktion auf https://github.com/redaxo/redaxo/issues/150.

Es ging also nicht um technische Gründe, sondern nur um die Unstimmigkeit des "Zum Login"-Buttons ganz am Ende.

Ich würde das wieder rückgängig machen. Ich finde die Unstimmigkeit nicht so schlimm, dass man bei erneutem Setup dann trotz "Zum Login"-Buttons direkt im Backend landet.

Man könnte den Button auch umbenennen, wobei auch weiter oben im Text steht, man solle sich einloggen. Siehe https://github.com/redaxo/redaxo/pull/4371.
Ich würde es wohl erstmal einfach so lassen.

---

Es stellt sich jetzt höchstens die Frage, ob es vielleicht doch auch technische Gründe für das Beenden der Session gibt, auch wenn es nicht die ursprüngliche Intention war.
Mir fällt da aber eigentlich nix ein, und gerade bei erneutem Setup wäre es schon bequem, im Backend zu bleiben.