### PR TITLE
be_style: Während Update korrekte Assets kopieren

### DIFF
--- a/redaxo/src/addons/be_style/install.php
+++ b/redaxo/src/addons/be_style/install.php
@@ -13,9 +13,10 @@
 
 $addon = rex_addon::get('be_style');
 
+// use path relative to __DIR__ to get correct path in update temp dir
 $files = require __DIR__.'/vendor_files.php';
 
 foreach ($files as $source => $destination) {
     // ignore errors, because this file is included very early in setup, before the regular file permissions check
-    rex_file::copy($addon->getPath($source), $addon->getAssetsPath($destination));
+    rex_file::copy(__DIR__.'/'.$source, $addon->getAssetsPath($destination));
 }


### PR DESCRIPTION
Während des Updates, wurden die Vendorfiles von bootstrap-select und fontawesome aus dem alten Release kopiert, statt aus dem Temp-Ordner, aus dem das Update ausgeführt wird.