### PR TITLE
psalm action: type-coverage ausgeben

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,7 +40,7 @@ jobs:
             -   name: Check psalm baseline and show type coverage
                 if: ${{ success() }}
                 run: |
-                    psalm --set-baseline=.tools/psalm/baseline.xml --stats
+                    vendor/bin/psalm --set-baseline=.tools/psalm/baseline.xml --stats
                     git diff --exit-code .tools/psalm/baseline.xml || (echo "::error file=.tools/psalm/baseline.xml,line=1,col=1::Psalm baseline file is outdated and must be regenerated via \`composer psalm-baseline\`." && exit 1)
 
     psalm-taint-analysis:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -37,10 +37,10 @@ jobs:
             -   name: Run psalm analysis
                 run: vendor/bin/psalm --show-info=false --shepherd --diff --output-format=github
 
-            -   name: Check psalm baseline
+            -   name: Check psalm baseline and show type coverage
                 if: ${{ success() }}
                 run: |
-                    composer psalm-baseline
+                    psalm --set-baseline=.tools/psalm/baseline.xml --stats
                     git diff --exit-code .tools/psalm/baseline.xml || (echo "::error file=.tools/psalm/baseline.xml,line=1,col=1::Psalm baseline file is outdated and must be regenerated via \`composer psalm-baseline\`." && exit 1)
 
     psalm-taint-analysis:


### PR DESCRIPTION
So können wir in der Action immer mal nachschauen/vergleichen, wie die type-coverage aktuell aussieht.
Refs #4052 
