### PR TITLE
run php 7.3 actions on ubuntu-18.04

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     php-cs-fixer:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         if: github.event.pull_request.draft == false
 
         steps:

--- a/.github/workflows/rexlint.yml
+++ b/.github/workflows/rexlint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     rexlint:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         if: "github.event.pull_request.draft == false && !contains(github.event.head_commit.message, '[ci skip]')"
 
         steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,13 +8,15 @@ on:
 
 jobs:
     phpunit:
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
         if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
         strategy:
             matrix:
+                os: [ubuntu-latest]
                 include:
-                    -   php-version: '7.3'
+                    -   os: ubuntu-18.04
+                        php-version: '7.3'
                         db-image: 'mysql:5.6'
                     -   php-version: '7.4'
                         db-image: 'mysql:5.7'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,18 +13,21 @@ jobs:
 
         strategy:
             matrix:
-                os: [ubuntu-latest]
                 include:
                     -   os: ubuntu-18.04
                         php-version: '7.3'
                         db-image: 'mysql:5.6'
-                    -   php-version: '7.4'
+                    -   os: ubuntu-latest
+                        php-version: '7.4'
                         db-image: 'mysql:5.7'
-                    -   php-version: '8.0'
+                    -   os: ubuntu-latest
+                        php-version: '8.0'
                         db-image: 'mysql:8.0'
-                    -   php-version: '7.3'
+                    -   os: ubuntu-18.04
+                        php-version: '7.3'
                         db-image: 'mariadb:10.1'
-                    -   php-version: '7.4'
+                    -   os: ubuntu-latest
+                        php-version: '7.4'
                         db-image: 'mariadb:latest'
 
         # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers


### PR DESCRIPTION
Mir ist aufgefallen, dass unsere 7.3-Builds immer recht langsam sind.
Vermutlich da sie nicht vorinstalliert sind auf ubuntu-latest: https://github.com/shivammathur/setup-php#github-hosted-runners

Mal schauen, wie es mit diesem PR ausschaut.