### PR TITLE
addSqlOptions / addDBSqlOptions: DB-Auswahl ergänzt

### DIFF
--- a/redaxo/src/core/lib/select.php
+++ b/redaxo/src/core/lib/select.php
@@ -226,7 +226,7 @@ class rex_select
     /**
      * Fügt Optionen anhand der Übergeben SQL-Select-Abfrage hinzu.
      */
-    public function addSqlOptions($query, $db=1)
+    public function addSqlOptions($query, int $db = 1)
     {
         $sql = rex_sql::factory($db);
         $this->addOptions($sql->getArray($query, [], PDO::FETCH_NUM));

--- a/redaxo/src/core/lib/select.php
+++ b/redaxo/src/core/lib/select.php
@@ -235,9 +235,9 @@ class rex_select
     /**
      * Fügt Optionen anhand der Übergeben DBSQL-Select-Abfrage hinzu.
      */
-    public function addDBSqlOptions($query, $db=1)
+    public function addDBSqlOptions($query)
     {
-        $sql = rex_sql::factory($db);
+        $sql = rex_sql::factory();
         $this->addOptions($sql->getDBArray($query, [], PDO::FETCH_NUM));
     }
 

--- a/redaxo/src/core/lib/select.php
+++ b/redaxo/src/core/lib/select.php
@@ -225,6 +225,7 @@ class rex_select
 
     /**
      * Fügt Optionen anhand der Übergeben SQL-Select-Abfrage hinzu.
+     * @psalm-param positive-int $db
      */
     public function addSqlOptions($query, int $db = 1)
     {

--- a/redaxo/src/core/lib/select.php
+++ b/redaxo/src/core/lib/select.php
@@ -226,18 +226,18 @@ class rex_select
     /**
      * Fügt Optionen anhand der Übergeben SQL-Select-Abfrage hinzu.
      */
-    public function addSqlOptions($query)
+    public function addSqlOptions($query, $db=1)
     {
-        $sql = rex_sql::factory();
+        $sql = rex_sql::factory($db);
         $this->addOptions($sql->getArray($query, [], PDO::FETCH_NUM));
     }
 
     /**
      * Fügt Optionen anhand der Übergeben DBSQL-Select-Abfrage hinzu.
      */
-    public function addDBSqlOptions($query)
+    public function addDBSqlOptions($query, $db=1)
     {
-        $sql = rex_sql::factory();
+        $sql = rex_sql::factory($db);
         $this->addOptions($sql->getDBArray($query, [], PDO::FETCH_NUM));
     }
 


### PR DESCRIPTION
Ich wollte in einem *rex_form* mit dem Select-Feld Daten aus der zweiten Datenbank zur Auswahl stellen (_addSqlOptions_). Das klappte nicht, da keine DB-Id angegeben werden kann und daher DB=1 genutzt wird. Um das zu lösen habe ich bei den beiden Methoden zu SQL-Optionen den neuen zusätzlichen Parameter $db eingebaut.

```php
/**
 * Fügt Optionen anhand der Übergeben SQL-Select-Abfrage hinzu.
 */
public function addSqlOptions($query,$db=1)
{
    $sql = rex_sql::factory($db);
    $this->addOptions($sql->getArray($query, [], PDO::FETCH_NUM));
}

/**
 * Fügt Optionen anhand der Übergeben DBSQL-Select-Abfrage hinzu.
 */
public function addDBSqlOptions($query, $db=1)
{
    $sql = rex_sql::factory($db);
    $this->addOptions($sql->getDBArray($query, [], PDO::FETCH_NUM));
}
```