### PR TITLE
rex_api um die Kompatibilität von HTTP-Request Methoden wie PUT, DELETE, UPDATE, ... erweitern + Fix REST-API Requests an das Backend ohne den Parameter 'page'

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -16,14 +16,14 @@ if (rex_get('asset') && rex_get('buster')) {
 
     // relative to the assets-root
     if (str_starts_with($assetFile, '/assets/')) {
-        $assetFile = '..'. $assetFile;
+        $assetFile = '..' . $assetFile;
     }
 
     $fullPath = realpath($assetFile);
     $assetDir = rex_path::assets();
 
     if (!str_starts_with($fullPath, $assetDir)) {
-        throw new Exception('Assets can only be streamed from within the assets folder. "'. $fullPath .'" is not within "'. $assetDir .'"');
+        throw new Exception('Assets can only be streamed from within the assets folder. "' . $fullPath . '" is not within "' . $assetDir . '"');
     }
 
     $ext = rex_file::extension($assetFile);
@@ -200,6 +200,8 @@ include_once rex_path::core('packages.php');
 // ----- Prepare AddOn Pages
 if (rex::getUser()) {
     rex_be_controller::appendPackagePages();
+
+    rex_api_function::handleCall();
 }
 
 $pages = rex_extension::registerPoint(new rex_extension_point('PAGES_PREPARED', rex_be_controller::getPages()));
@@ -221,13 +223,6 @@ rex_view::setJsProperty('page', $page);
 // ----- EXTENSION POINT
 // page variable validated
 rex_extension::registerPoint(new rex_extension_point('PAGE_CHECKED', $page, ['pages' => $pages], true));
-
-// trigger api functions
-// If the backend session is timed out, rex_api_function would throw an exception
-// so only trigger api functions if page != login
-if ('login' != $page) {
-    rex_api_function::handleCall();
-}
 
 // include the requested backend page
 rex_be_controller::includeCurrentPage();

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -16,14 +16,14 @@ if (rex_get('asset') && rex_get('buster')) {
 
     // relative to the assets-root
     if (str_starts_with($assetFile, '/assets/')) {
-        $assetFile = '..' . $assetFile;
+        $assetFile = '..'. $assetFile;
     }
 
     $fullPath = realpath($assetFile);
     $assetDir = rex_path::assets();
 
     if (!str_starts_with($fullPath, $assetDir)) {
-        throw new Exception('Assets can only be streamed from within the assets folder. "' . $fullPath . '" is not within "' . $assetDir . '"');
+        throw new Exception('Assets can only be streamed from within the assets folder. "'. $fullPath .'" is not within "'. $assetDir .'"');
     }
 
     $ext = rex_file::extension($assetFile);

--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -80,7 +80,7 @@ abstract class rex_api_function
         }
 
         $api = rex_request(self::REQ_CALL_PARAM, 'string');
-        
+
         if (empty($api)) {
             $messageBody = file_get_contents("php://input");
             if (!empty($messageBody)) {
@@ -99,7 +99,7 @@ abstract class rex_api_function
                     self::$instance = $apiImpl;
                     return $apiImpl;
                 }
-                throw new rex_exception('$apiClass is expected to define a subclass of rex_api_function, "' . $apiClass . '" given!');
+                throw new rex_exception('$apiClass is expected to define a subclass of rex_api_function, "'. $apiClass .'" given!');
             }
             throw new rex_exception('$apiClass "' . $apiClass . '" not found!');
         }
@@ -119,7 +119,7 @@ abstract class rex_api_function
         $class = static::class;
 
         if (self::class === $class) {
-            throw new BadMethodCallException(__FUNCTION__ . ' must be called on subclasses of "' . self::class . '".');
+            throw new BadMethodCallException(__FUNCTION__.' must be called on subclasses of "'.self::class.'".');
         }
 
         // remove the `rex_api_` prefix
@@ -140,7 +140,7 @@ abstract class rex_api_function
         $class = static::class;
 
         if (self::class === $class) {
-            throw new BadMethodCallException(__FUNCTION__ . ' must be called on subclasses of "' . self::class . '".');
+            throw new BadMethodCallException(__FUNCTION__.' must be called on subclasses of "'.self::class.'".');
         }
 
         // remove the `rex_api_` prefix
@@ -148,7 +148,7 @@ abstract class rex_api_function
         assert(false !== $name);
 
         return sprintf('<input type="hidden" name="%s" value="%s"/>', self::REQ_CALL_PARAM, rex_escape($name))
-            . rex_csrf_token::factory($class)->getHiddenField();
+            .rex_csrf_token::factory($class)->getHiddenField();
     }
 
     /**
@@ -190,7 +190,7 @@ abstract class rex_api_function
                     $result = $apiFunc->execute();
 
                     if (!($result instanceof rex_api_result)) {
-                        throw new rex_exception('Illegal result returned from api-function ' . rex_get(self::REQ_CALL_PARAM) . '. Expected a instance of rex_api_result but got "' . (is_object($result) ? get_class($result) : gettype($result)) . '".');
+                        throw new rex_exception('Illegal result returned from api-function ' . rex_get(self::REQ_CALL_PARAM) .'. Expected a instance of rex_api_result but got "'. (is_object($result) ? get_class($result) : gettype($result)) .'".');
                     }
 
                     $apiFunc->result = $result;

--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -80,6 +80,16 @@ abstract class rex_api_function
         }
 
         $api = rex_request(self::REQ_CALL_PARAM, 'string');
+        
+        if (empty($api)) {
+            $messageBody = file_get_contents("php://input");
+            if (!empty($messageBody)) {
+                parse_str($messageBody, $data);
+                if (isset($data[self::REQ_CALL_PARAM])) {
+                    $api = $data[self::REQ_CALL_PARAM];
+                }
+            }
+        }
 
         if ($api) {
             $apiClass = 'rex_api_' . $api;
@@ -89,7 +99,7 @@ abstract class rex_api_function
                     self::$instance = $apiImpl;
                     return $apiImpl;
                 }
-                throw new rex_exception('$apiClass is expected to define a subclass of rex_api_function, "'. $apiClass .'" given!');
+                throw new rex_exception('$apiClass is expected to define a subclass of rex_api_function, "' . $apiClass . '" given!');
             }
             throw new rex_exception('$apiClass "' . $apiClass . '" not found!');
         }
@@ -109,7 +119,7 @@ abstract class rex_api_function
         $class = static::class;
 
         if (self::class === $class) {
-            throw new BadMethodCallException(__FUNCTION__.' must be called on subclasses of "'.self::class.'".');
+            throw new BadMethodCallException(__FUNCTION__ . ' must be called on subclasses of "' . self::class . '".');
         }
 
         // remove the `rex_api_` prefix
@@ -130,7 +140,7 @@ abstract class rex_api_function
         $class = static::class;
 
         if (self::class === $class) {
-            throw new BadMethodCallException(__FUNCTION__.' must be called on subclasses of "'.self::class.'".');
+            throw new BadMethodCallException(__FUNCTION__ . ' must be called on subclasses of "' . self::class . '".');
         }
 
         // remove the `rex_api_` prefix
@@ -138,7 +148,7 @@ abstract class rex_api_function
         assert(false !== $name);
 
         return sprintf('<input type="hidden" name="%s" value="%s"/>', self::REQ_CALL_PARAM, rex_escape($name))
-            .rex_csrf_token::factory($class)->getHiddenField();
+            . rex_csrf_token::factory($class)->getHiddenField();
     }
 
     /**
@@ -180,7 +190,7 @@ abstract class rex_api_function
                     $result = $apiFunc->execute();
 
                     if (!($result instanceof rex_api_result)) {
-                        throw new rex_exception('Illegal result returned from api-function ' . rex_get(self::REQ_CALL_PARAM) .'. Expected a instance of rex_api_result but got "'. (is_object($result) ? get_class($result) : gettype($result)) .'".');
+                        throw new rex_exception('Illegal result returned from api-function ' . rex_get(self::REQ_CALL_PARAM) . '. Expected a instance of rex_api_result but got "' . (is_object($result) ? get_class($result) : gettype($result)) . '".');
                     }
 
                     $apiFunc->result = $result;


### PR DESCRIPTION
Hallo zusammen,
dass ist mein erster Pull-Request.

Hier gibt es zwei Änderungen:
1. Unterstützung der HTTP-Request Methoden PUT, UPDATE, DELETE, etc... 
2. API Request ohne den Parameter 'page' führen zu einer Umleitung auf die Login-Page.

Ich arbeite nur gelegentlich mit PHP und Redaxo, daher könnte die Änderung u.U. noch überarbeitet werden, wenn es ein besseres Vorgehen gibt.

Vielen Dank für das Verstandnis.
