### PR TITLE
rex_media::forId ergänzt

### DIFF
--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -91,7 +91,7 @@ class rex_media
      * @throws rex_sql_exception
      * @return null|static
      */
-    public static function fromId(int $mediaId): ?self
+    public static function forId(int $mediaId): ?self
     {
         $media = rex_sql::factory();
         $media->setQuery('select filename from ' . rex::getTable('media') . ' where id=?', [$mediaId]);

--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -91,15 +91,15 @@ class rex_media
      * @throws rex_sql_exception
      * @return null|static
      */
-    public static function getById(int $mediaId)
+    public static function fromId(int $mediaId):?self
     {
         $media = rex_sql::factory();
-        $media->setQuery('select * from ' . rex::getTable('media') . ' where id=?', [$mediaId]);
+        $media->setQuery('select filename from ' . rex::getTable('media') . ' where id=?', [$mediaId]);
 
         if (1 != $media->getRows()) {
             return null;
         }
-        return self::get($media->getValue('filename'));
+        return static::get((string) $media->getValue('filename'));
     }
 
     /**

--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -88,11 +88,9 @@ class rex_media
     }
 
     /**
-     * @param int $mediaId
      * @throws rex_sql_exception
      * @return null|static
      */
-
     public static function getById(int $mediaId)
     {
         $media = rex_sql::factory();

--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -91,7 +91,7 @@ class rex_media
      * @throws rex_sql_exception
      * @return null|static
      */
-    public static function fromId(int $mediaId):?self
+    public static function fromId(int $mediaId): ?self
     {
         $media = rex_sql::factory();
         $media->setQuery('select filename from ' . rex::getTable('media') . ' where id=?', [$mediaId]);

--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -88,6 +88,23 @@ class rex_media
     }
 
     /**
+     * @param int $mediaId
+     * @throws rex_sql_exception
+     * @return null|static
+     */
+
+    public static function getById(int $mediaId)
+    {
+        $media = rex_sql::factory();
+        $media->setQuery('select * from ' . rex::getTable('media') . ' where id=?', [$mediaId]);
+
+        if (1 != $media->getRows()) {
+            return null;
+        }
+        return self::get($media->getValue('filename'));
+    }
+
+    /**
      * @return static[]
      */
     public static function getRootMedia()


### PR DESCRIPTION
Weil wir eine ID eines Medium haben und der Fall wohl öfter gebraucht wird.

closes https://github.com/redaxo/redaxo/issues/1807