### PR TITLE
Github Action: use `pull_request_target` events to fix access issues

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -57,7 +57,12 @@ jobs:
 
     rector:
         runs-on: ubuntu-latest
-        if: github.event.pull_request.draft == false
+        if: |
+          (
+            github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' ||
+            github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'
+          )
+          && github.event.pull_request.draft == false
 
         steps:
             -   name: Checkout

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -5,11 +5,17 @@ on:
         branches: [master, bugfix, temp]
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
+    pull_request_target:
 
 jobs:
     php-cs-fixer:
         runs-on: ubuntu-18.04
-        if: github.event.pull_request.draft == false
+        if: |
+          (
+            github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' ||
+            github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'
+          )
+          && github.event.pull_request.draft == false
 
         steps:
             -   name: Checkout

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,11 +5,17 @@ on:
         branches: [master, bugfix, temp]
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
+    pull_request_target:
 
 jobs:
     psalm-analysis:
         name: psalm static code analysis
         runs-on: ubuntu-latest
+        if: |
+          (
+            github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' ||
+            github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'
+          )
 
         steps:
             -   name: Checkout
@@ -55,7 +61,12 @@ jobs:
     psalm-taint-analysis:
         name: psalm taint analysis
         runs-on: ubuntu-latest
-        if: "github.event.pull_request.draft == false"
+        if: |
+          (
+            github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' ||
+            github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'
+          )
+          && github.event.pull_request.draft == false
 
         steps:
             -   name: Checkout
@@ -101,6 +112,11 @@ jobs:
     phpstan-analysis:
         name: phpstan static code analysis
         runs-on: ubuntu-latest
+        if: |
+          (
+            github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' ||
+            github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'
+          )
 
         steps:
             -   name: Checkout

--- a/.github/workflows/styles-compile.yml
+++ b/.github/workflows/styles-compile.yml
@@ -5,6 +5,7 @@ on:
         branches: [master, bugfix, temp]
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
+    pull_request_target:
 
 jobs:
     compile:

--- a/.github/workflows/styles-compile.yml
+++ b/.github/workflows/styles-compile.yml
@@ -10,6 +10,11 @@ jobs:
     compile:
         name: be_style:compile
         runs-on: ubuntu-latest
+        if: |
+          (
+            github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' ||
+            github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'
+          )
 
         steps:
             -   name: Checkout

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -5,6 +5,7 @@ on:
         types: [opened, synchronize, reopened, ready_for_review]
     repository_dispatch:
         types: [visual-test-command] # triggered by /visual-test PR comment
+    pull_request_target:
 
 jobs:
     visual-tests:

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -9,7 +9,12 @@ on:
 jobs:
     visual-tests:
         runs-on: ubuntu-latest
-        if: "github.event.pull_request.draft == false"
+        if: |
+          (
+            github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' ||
+            github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'
+          )
+          && github.event.pull_request.draft == false
 
         steps:
             -   name: Add action run link to trigger comment


### PR DESCRIPTION
dependabot works like a private fork and has no longer permission to access Github-Action secrets within a `pull_request` event.

we need to use `pull_request_target` for that purpose

see 
- https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
- https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425

atm these checks are failing for dependabot PRs:

![grafik](https://user-images.githubusercontent.com/120441/111145805-f78a1400-8588-11eb-8d95-1c687ed5b99a.png)

with the following error

![grafik](https://user-images.githubusercontent.com/120441/111146112-5c456e80-8589-11eb-923d-efd42153b19d.png)
