### PR TITLE
update tools

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -116,6 +116,7 @@
       <path value="$PROJECT_DIR$/vendor/symplify/symfony-php-config" />
       <path value="$PROJECT_DIR$/vendor/symplify/symplify-kernel" />
       <path value="$PROJECT_DIR$/vendor/symplify/composer-json-manipulator" />
+      <path value="$PROJECT_DIR$/vendor/symplify/rule-doc-generator-contracts" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.3">

--- a/.idea/redaxo.iml
+++ b/.idea/redaxo.iml
@@ -126,6 +126,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/symplify/symfony-php-config" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symplify/symplify-kernel" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symplify/composer-json-manipulator" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symplify/rule-doc-generator-contracts" />
       <excludePattern pattern=".php_cs.cache" />
       <excludePattern pattern="composer.lock" />
     </content>

--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -11,21 +11,6 @@ parameters:
 			path: ../../redaxo/src/addons/install/lib/archive.php
 
 		-
-			message: "#^Method rex_media\\:\\:getRootMedia\\(\\) should return array\\<static\\(rex_media\\)\\> but returns array\\<rex_media\\>\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/lib/media.php
-
-		-
-			message: "#^Method rex_media\\:\\:getInstanceList\\(\\) should return array\\<T of object\\> but returns array\\<int, mixed\\>\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/lib/media.php
-
-		-
-			message: "#^Result of \\|\\| is always true\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/lib/media.php
-
-		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/mediapool/lib/media_category_select.php
@@ -46,12 +31,7 @@ parameters:
 			path: ../../redaxo/src/addons/structure/lib/select_category.php
 
 		-
-			message: "#^Parameter \\#2 \\$createCallback of static method rex_structure_element\\:\\:getInstance\\(\\) expects \\(callable\\(\\.\\.\\.mixed\\)\\: rex_structure_element\\|null\\)\\|null, Closure\\(mixed, mixed\\)\\: static\\(rex_structure_element\\)\\|null given\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/lib/structure_element.php
-
-		-
-			message: "#^Method rex_structure_element\\:\\:getChildElements\\(\\) should return array\\<static\\(rex_structure_element\\)\\> but returns array\\<rex_structure_element\\>\\.$#"
+			message: "#^Parameter \\#2 \\$createCallback of static method rex_structure_element\\:\\:getInstance\\(\\) expects \\(callable\\(\\.\\.\\.mixed\\)\\: static\\(rex_structure_element\\)\\|null\\)\\|null, Closure\\(mixed, mixed\\)\\: static\\(rex_structure_element\\)\\|null given\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/structure/lib/structure_element.php
 
@@ -126,6 +106,16 @@ parameters:
 			path: ../../redaxo/src/core/lib/autoload.php
 
 		-
+			message: "#^Method rex_media\\:\\:getInstanceList\\(\\) should return array\\<T of object\\> but returns array\\<int, mixed\\>\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/mediapool/lib/media.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/mediapool/lib/media.php
+
+		-
 			message: "#^Method rex_media_category\\:\\:getInstanceList\\(\\) should return array\\<T of object\\> but returns array\\<int, mixed\\>\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/mediapool/lib/media_category.php
@@ -156,7 +146,7 @@ parameters:
 			path: ../../redaxo/src/core/lib/sql/table.php
 
 		-
-			message: "#^Parameter \\#2 \\$createCallback of static method rex_sql_table\\:\\:getInstance\\(\\) expects \\(callable\\(\\.\\.\\.mixed\\)\\: rex_sql_table\\|null\\)\\|null, Closure\\(mixed, mixed\\)\\: static\\(rex_sql_table\\) given\\.$#"
+			message: "#^Parameter \\#2 \\$createCallback of static method rex_sql_table\\:\\:getInstance\\(\\) expects \\(callable\\(\\.\\.\\.mixed\\)\\: static\\(rex_sql_table\\)\\|null\\)\\|null, Closure\\(mixed, mixed\\)\\: static\\(rex_sql_table\\) given\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/sql/table.php
 
@@ -287,11 +277,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, Closure\\(mixed, mixed\\)\\: void given\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/util/socket/socket.php
-
-		-
-			message: "#^If condition is always false\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/util/socket/socket.php
 

--- a/.tools/psalm/baseline-taint.xml
+++ b/.tools/psalm/baseline-taint.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.6.3@f1a840727dd756899eee2f1f9ea443e265a4763f">
+<files psalm-version="4.6.4@97fe86c4e158b5a57c5150aa5055c38b5a809aab">
   <file src="redaxo/src/addons/backup/lib/backup.php">
     <TaintedInclude occurrences="5">
       <code>$filename</code>

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.6.3@f1a840727dd756899eee2f1f9ea443e265a4763f">
+<files psalm-version="4.6.4@97fe86c4e158b5a57c5150aa5055c38b5a809aab">
   <file src="redaxo/src/addons/backup/pages/export.php">
     <NullOperand occurrences="1">
       <code>rex_escape($exportfilename)</code>

--- a/composer.json
+++ b/composer.json
@@ -7,18 +7,18 @@
         "php": ">=7.3"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.18.2",
+        "friendsofphp/php-cs-fixer": "2.18.3",
         "friendsofredaxo/linter": "1.3.0",
         "phpstan/extension-installer": "1.1.0",
-        "phpstan/phpstan": "0.12.80",
+        "phpstan/phpstan": "0.12.82",
         "phpstan/phpstan-deprecation-rules": "0.12.6",
-        "phpstan/phpstan-phpunit": "0.12.17",
-        "phpstan/phpstan-symfony": "0.12.20",
+        "phpstan/phpstan-phpunit": "0.12.18",
+        "phpstan/phpstan-symfony": "0.12.21",
         "phpunit/phpunit": "^9.3",
         "psalm/plugin-phpunit": "0.15.1",
         "psalm/plugin-symfony": "2.2.1",
-        "rector/rector": "0.9.31",
-        "vimeo/psalm": "4.6.3"
+        "rector/rector": "0.9.32",
+        "vimeo/psalm": "4.6.4"
     },
     "replace": {
         "erusev/parsedown": "1.7.4",


### PR DESCRIPTION
rector schlägt aktuell fehl, aufgrund eines Updates einer Abhängigkeit von rector.
Deswegen aktualisiere ich hier die Tools für den bugfix-Branch.