### PR TITLE
rex_pager: new methods setPage/setCursor

### DIFF
--- a/redaxo/src/core/lib/util/pager.php
+++ b/redaxo/src/core/lib/util/pager.php
@@ -22,6 +22,10 @@ class rex_pager
      * @var string
      */
     private $cursorName;
+    /**
+     * @var int|null
+     */
+    private $cursor;
 
     /**
      * Constructs a rex_pager.
@@ -76,6 +80,16 @@ class rex_pager
         return $this->rowsPerPage;
     }
 
+    public function setPage(int $page): void
+    {
+        $this->cursor = $page * $this->rowsPerPage;
+    }
+
+    public function setCursor(int $cursor): void
+    {
+        $this->cursor = $cursor;
+    }
+
     /**
      * Returns the current pagination position.
      *
@@ -89,7 +103,7 @@ class rex_pager
     public function getCursor($pageNo = null)
     {
         if (null === $pageNo) {
-            return rex_request($this->cursorName, 'int', 0);
+            return $this->cursor ?? rex_request($this->cursorName, 'int', 0);
         }
 
         return $pageNo * $this->rowsPerPage;
@@ -155,7 +169,7 @@ class rex_pager
      */
     public function getCurrentPage()
     {
-        $cursor = rex_request($this->cursorName, 'int', null);
+        $cursor = $this->cursor ?? rex_request($this->cursorName, 'int', null);
 
         if (null === $cursor) {
             return $this->getFirstPage();

--- a/redaxo/src/core/tests/util/pager_test.php
+++ b/redaxo/src/core/tests/util/pager_test.php
@@ -11,7 +11,7 @@ class rex_pager_test extends TestCase
     {
         $_REQUEST['start'] = 60;
 
-        $pager = new rex_pager();
+        $pager = new rex_pager(30);
         static::assertSame(60, $pager->getCursor());
         static::assertSame(2, $pager->getCurrentPage());
 
@@ -28,7 +28,7 @@ class rex_pager_test extends TestCase
     {
         $_REQUEST['start'] = 60;
 
-        $pager = new rex_pager();
+        $pager = new rex_pager(30);
         static::assertSame(60, $pager->getCursor());
         static::assertSame(2, $pager->getCurrentPage());
 

--- a/redaxo/src/core/tests/util/pager_test.php
+++ b/redaxo/src/core/tests/util/pager_test.php
@@ -1,0 +1,43 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class rex_pager_test extends TestCase
+{
+    public function testSetCursor(): void
+    {
+        $_REQUEST['start'] = 60;
+
+        $pager = new rex_pager();
+        static::assertSame(60, $pager->getCursor());
+        static::assertSame(2, $pager->getCurrentPage());
+
+        $pager->setCursor(0);
+        static::assertSame(0, $pager->getCursor());
+        static::assertSame(0, $pager->getCurrentPage());
+
+        $pager->setCursor(30);
+        static::assertSame(30, $pager->getCursor());
+        static::assertSame(1, $pager->getCurrentPage());
+    }
+
+    public function testSetPage(): void
+    {
+        $_REQUEST['start'] = 60;
+
+        $pager = new rex_pager();
+        static::assertSame(60, $pager->getCursor());
+        static::assertSame(2, $pager->getCurrentPage());
+
+        $pager->setPage(0);
+        static::assertSame(0, $pager->getCursor());
+        static::assertSame(0, $pager->getCurrentPage());
+
+        $pager->setPage(1);
+        static::assertSame(30, $pager->getCursor());
+        static::assertSame(1, $pager->getCurrentPage());
+    }
+}


### PR DESCRIPTION
So kann die aktuelle Page, bzw. der aktuelle Cursor auch programmatisch gesetzt werden, und muss nicht zwingend aus `$_REQUEST` kommen.