### PR TITLE
rex_media_service::getList: rex_pager nutzen

### DIFF
--- a/redaxo/src/addons/mediapool/pages/media.list.php
+++ b/redaxo/src/addons/mediapool/pages/media.list.php
@@ -268,13 +268,11 @@ $panel = '
 
             $pager = new rex_pager(5000);
 
-            $result = rex_media_service::getList($searchItems, [], $pager->getCursor(), $pager->getRowsPerPage());
-            $pager->setRowCount($result['count']);
+            $items = rex_media_service::getList($searchItems, [], $pager);
 
             $panel .= '<tbody>';
 
-            /** @var rex_media $media */
-            foreach ($result['items'] as $i => $media) {
+            foreach ($items as $i => $media) {
                 $alt = rex_escape($media->getTitle());
                 $desc = '<p>' . rex_escape(strip_tags((string) $media->getValue('med_description'))) . '</p>';
 


### PR DESCRIPTION
Die Methode hat @dergel letztens eingeführt. Dabei hat er nicht `rex_pager` genutzt, weil der bisher zwingend über `$_REQUEST` gesteuert wird.

Mit #4578 würde sich das aber ändern.
Und ich fände die Api hier dann mit `rex_pager` besser. Ein Parameter weniger, und simplerer Return-Type (da Gesamtzahl am pager-objekt zurückgeliefert wird).