### PR TITLE
Neue Methode rex::requireUser()

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -574,14 +574,6 @@
       <code>$req-&gt;databaseUpdates</code>
       <code>rex_debug_clockwork::getInstance()-&gt;getRequest()-&gt;id</code>
     </MixedPropertyFetch>
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/debug/lib/api_debug.php">
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/debug/lib/debug_clockwork.php">
     <MixedArgument occurrences="3">
@@ -702,9 +694,6 @@
       <code>array&lt;int, array{version: string, description: string, path: string, checksum: string}&gt;</code>
       <code>rex_install_webservice::getJson('core')</code>
     </MixedReturnTypeCoercion>
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/install/lib/api/api_package_add.php">
     <MixedAssignment occurrences="1">
@@ -713,14 +702,6 @@
     <MixedOperand occurrences="1">
       <code>$message</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/install/lib/api/api_package_delete.php">
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/install/lib/api/api_package_update.php">
     <MixedAssignment occurrences="1">
@@ -729,9 +710,6 @@
     <MixedOperand occurrences="1">
       <code>$message</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/install/lib/api/api_package_upload.php">
     <MixedAssignment occurrences="4">
@@ -740,9 +718,6 @@
       <code>$file['version']</code>
       <code>$packageExclude</code>
     </MixedAssignment>
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/install/lib/archive.php">
     <MixedArgument occurrences="9">
@@ -1473,10 +1448,6 @@
       <code>rex_escape($list-&gt;getValue('description'))</code>
       <code>rex_escape($list-&gt;getValue('name'))</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="2">
-      <code>getLogin</code>
-      <code>getLogin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/media_manager/tests/media_manager_test.php">
     <MixedArgument occurrences="3">
@@ -1512,9 +1483,6 @@
       <code>rex_escape($ftitle)</code>
       <code>rex_extension::registerPoint(new rex_extension_point('MEDIA_FORM_ADD', ''))</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
-      <code>getComplexPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/lib/cache_media.php">
     <MixedAssignment occurrences="4">
@@ -1668,9 +1636,6 @@
     <MixedAssignment occurrences="1">
       <code>$this-&gt;checkPerms</code>
     </MixedAssignment>
-    <PossiblyNullReference occurrences="1">
-      <code>getComplexPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/lib/mediapool.php">
     <MixedArgument occurrences="3">
@@ -1779,9 +1744,6 @@
       <code>$name</code>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
-      <code>getComplexPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/lib/var_medialist.php">
     <MixedArgument occurrences="3">
@@ -1811,9 +1773,6 @@
       <code>$name</code>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
-      <code>getComplexPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/index.php">
     <MixedAssignment occurrences="2">
@@ -1823,8 +1782,7 @@
     <MixedOperand occurrences="1">
       <code>rex_escape($argValue)</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="2">
-      <code>getComplexPerm</code>
+    <PossiblyNullReference occurrences="1">
       <code>getSubpages</code>
     </PossiblyNullReference>
   </file>
@@ -1894,14 +1852,6 @@
     <PossiblyNullOperand occurrences="1">
       <code>$gf-&gt;getDateTimeValue('updatedate')</code>
     </PossiblyNullOperand>
-    <PossiblyNullReference occurrences="6">
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getValue</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/media.list.php">
     <MixedArgument occurrences="8">
@@ -1923,20 +1873,12 @@
       <code>$media-&gt;getValue('updatedate')</code>
       <code>$mediaManagerUrl('rex_mediapool_preview', urlencode($media-&gt;getFileName()), $media-&gt;getValue('updatedate'))</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="3">
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/media.php">
     <MixedArgument occurrences="1"/>
     <MixedAssignment occurrences="1">
       <code>$toolbar</code>
     </MixedAssignment>
-    <PossiblyNullReference occurrences="1">
-      <code>getComplexPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/structure.php">
     <MixedArgument occurrences="3">
@@ -1985,9 +1927,6 @@
       <code>$data['filename']</code>
       <code>$filename</code>
     </MixedAssignment>
-    <PossiblyNullReference occurrences="1">
-      <code>getValue</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/upload.php">
     <MixedArgument occurrences="2">
@@ -2009,10 +1948,6 @@
       <code>$data['filename']</code>
       <code>$data['filename']</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="2">
-      <code>getComplexPerm</code>
-      <code>getValue</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/tests/mediapool_test.php">
     <MixedArgument occurrences="3">
@@ -2134,9 +2069,6 @@
     <MixedAssignment occurrences="1">
       <code>$return</code>
     </MixedAssignment>
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/metainfo/lib/handler/article_handler.php">
     <MixedArgument occurrences="6">
@@ -2336,10 +2268,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$id</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="2">
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/metainfo/lib/handler/media_handler.php">
     <MixedArgument occurrences="3">
@@ -2382,9 +2310,8 @@
       <code>$warning</code>
       <code>$warning</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference occurrences="1">
       <code>getPathAsArray</code>
-      <code>isAdmin</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/metainfo/lib/input.php">
@@ -2832,11 +2759,6 @@
       <code>getId</code>
     </MixedMethodCall>
   </file>
-  <file src="redaxo/src/addons/structure/functions/function_rex_category.php">
-    <PossiblyNullReference occurrences="1">
-      <code>getComplexPerm</code>
-    </PossiblyNullReference>
-  </file>
   <file src="redaxo/src/addons/structure/functions/function_rex_url.php">
     <MixedAssignment occurrences="1">
       <code>$url</code>
@@ -2849,83 +2771,28 @@
     </MixedReturnStatement>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_article2category.php">
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference occurrences="1">
       <code>getCategoryId</code>
-      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_article2startarticle.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getCategoryId</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_add.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getComplexPerm</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_copy.php">
     <PossiblyNullReference occurrences="1">
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_delete.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getComplexPerm</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_edit.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getComplexPerm</code>
-      <code>hasPerm</code>
+      <code>getCategoryId</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_article_move.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getCategoryId</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_status.php">
     <PossiblyNullReference occurrences="1">
-      <code>getComplexPerm</code>
+      <code>getCategoryId</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_category2article.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getCategoryId</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_category_add.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getComplexPerm</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_category_delete.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getComplexPerm</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_category_edit.php">
     <PossiblyNullReference occurrences="1">
-      <code>hasPerm</code>
+      <code>getCategoryId</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_category_move.php">
-    <PossiblyNullReference occurrences="2">
-      <code>getCategoryId</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_category_status.php">
     <PossiblyNullReference occurrences="1">
-      <code>getComplexPerm</code>
+      <code>getCategoryId</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/article.php">
@@ -3003,10 +2870,8 @@
       <code>$this-&gt;listItem($article, $categoryId)</code>
       <code>$this-&gt;treeItem($cat, $liclasses, $linkclasses, $subLi, $liIcon)</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="3">
+    <PossiblyNullReference occurrences="1">
       <code>getArticles</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/linkmap/sitemap.php">
@@ -3040,8 +2905,7 @@
       <code>$name</code>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="2">
-      <code>getComplexPerm</code>
+    <PossiblyNullReference occurrences="1">
       <code>getId</code>
     </PossiblyNullReference>
   </file>
@@ -3069,8 +2933,7 @@
       <code>$name</code>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="2">
-      <code>getComplexPerm</code>
+    <PossiblyNullReference occurrences="1">
       <code>getId</code>
     </PossiblyNullReference>
   </file>
@@ -3181,14 +3044,6 @@
       <code>$level</code>
       <code>$level</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="6">
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/service_article.php">
     <MixedArgument occurrences="20">
@@ -3270,9 +3125,8 @@
       <code>$message</code>
       <code>$newstatus</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference occurrences="1">
       <code>getCategoryId</code>
-      <code>getLogin</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/service_category.php">
@@ -3334,9 +3188,6 @@
       <code>$message</code>
       <code>$newstatus</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="1">
-      <code>getLogin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/structure_context.php">
     <MixedArgument occurrences="3">
@@ -3369,12 +3220,6 @@
       <code>$this-&gt;getValue('function', '')</code>
       <code>$this-&gt;getValue('rows_per_page', 30)</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="4">
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/structure_element.php">
     <EmptyArrayAccess occurrences="1">
@@ -3568,20 +3413,6 @@
       <code>rex_escape($sql-&gt;getValue('priority'))</code>
       <code>rex_escape($sql-&gt;getValue('priority'))</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="12">
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/pages/linkmap.php">
     <MixedAssignment occurrences="1">
@@ -3617,16 +3448,6 @@
     </MixedOperand>
     <PossiblyNullReference occurrences="1">
       <code>setIsActive</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_copy.php">
-    <PossiblyNullReference occurrences="1">
-      <code>hasPerm</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_slice_status.php">
-    <PossiblyNullReference occurrences="1">
-      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/api_module.php">
@@ -3724,10 +3545,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$template-&gt;getKey()</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="2">
-      <code>getId</code>
-      <code>getLogin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php">
     <MixedArgument occurrences="1">
@@ -3741,14 +3558,6 @@
     <MixedOperand occurrences="1">
       <code>$select</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="6">
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/article_slice.php">
     <MixedArgument occurrences="10">
@@ -3856,10 +3665,9 @@
       <code>$article</code>
       <code>$article</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="3">
+    <PossiblyNullReference occurrences="2">
       <code>getCategoryId</code>
       <code>getId</code>
-      <code>getLogin</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/event_select.php">
@@ -3940,21 +3748,9 @@
     <MixedOperand occurrences="1">
       <code>rex_escape($hiddenFields)</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="14">
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
+    <PossiblyNullReference occurrences="2">
       <code>getName</code>
       <code>getName</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/pages/content.php">
@@ -4001,18 +3797,10 @@
       <code>$key</code>
       <code>rex_be_controller::includeCurrentPageSubPath(compact('info', 'warning', 'templateAttributes', 'article', 'articleId', 'categoryId', 'clang', 'sliceId', 'sliceRevision', 'function', 'ctype', 'context'))</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="11">
+    <PossiblyNullReference occurrences="3">
       <code>addSubpage</code>
       <code>getCategoryId</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
       <code>getSubpages</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/pages/modules.actions.php">
@@ -4221,10 +4009,6 @@
       <code>$version['history_date']</code>
       <code>$version['history_user']</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="2">
-      <code>getLogin</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/history/fragments/history/layer.php">
     <MixedArgument occurrences="4">
@@ -4242,9 +4026,6 @@
     <MixedOperand occurrences="1">
       <code>$historyDate</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
-      <code>getValue</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/history/lib/cronjob.php">
     <MixedAssignment occurrences="1">
@@ -4313,13 +4094,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$article</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="5">
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-      <code>hasPerm</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/version/lib/revision.php">
     <MixedArgument occurrences="4">
@@ -4497,27 +4271,9 @@
       <code>rex_escape($useremail)</code>
       <code>rex_escape($username)</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="20">
-      <code>getId</code>
-      <code>getId</code>
-      <code>getId</code>
-      <code>getId</code>
-      <code>getId</code>
+    <PossiblyNullReference occurrences="2">
       <code>getLogin</code>
       <code>getValue</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
-      <code>isAdmin</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/backend.php">
@@ -4649,9 +4405,6 @@
     <MixedArgument occurrences="1">
       <code>$this-&gt;time</code>
     </MixedArgument>
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/fragments/core/form/checkbox.php">
     <MixedArgument occurrences="1">
@@ -4886,8 +4639,7 @@
     <MixedArgument occurrences="1">
       <code>$this-&gt;meta_navigation</code>
     </MixedArgument>
-    <PossiblyNullReference occurrences="3">
-      <code>isAdmin</code>
+    <PossiblyNullReference occurrences="2">
       <code>isPopup</code>
       <code>isPopup</code>
     </PossiblyNullReference>
@@ -5194,9 +4946,7 @@
     <MixedOperand occurrences="1">
       <code>$k</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="3">
-      <code>getLogin</code>
-      <code>getName</code>
+    <PossiblyNullReference occurrences="1">
       <code>hasLayout</code>
     </PossiblyNullReference>
   </file>
@@ -5356,9 +5106,6 @@
       <code>isActive</code>
       <code>isActive</code>
     </MixedMethodCall>
-    <PossiblyNullArgument occurrences="1">
-      <code>rex::getUser()</code>
-    </PossiblyNullArgument>
   </file>
   <file src="redaxo/src/core/lib/be/page.php">
     <MixedArgument occurrences="1">
@@ -5997,10 +5744,6 @@
       <code>rex_extension::registerPoint(new rex_extension_point('REX_FORM_DELETED', $deleted, ['form' =&gt; $this, 'sql' =&gt; $deleteSql]))</code>
       <code>rex_extension::registerPoint(new rex_extension_point('REX_FORM_SAVED', $saved, ['form' =&gt; $this, 'sql' =&gt; $sql]))</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="2">
-      <code>getValue</code>
-      <code>getValue</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/lib/form/form_base.php">
     <MixedArrayOffset occurrences="3">
@@ -6169,10 +5912,6 @@
     <MixedAssignment occurrences="1">
       <code>$impersonate</code>
     </MixedAssignment>
-    <PossiblyNullReference occurrences="2">
-      <code>getLogin</code>
-      <code>isAdmin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/lib/login/backend_login.php">
     <MixedArgument occurrences="1">
@@ -6526,9 +6265,6 @@
       <code>$packages</code>
       <code>self[]</code>
     </MixedReturnTypeCoercion>
-    <PossiblyNullReference occurrences="1">
-      <code>isAdmin</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/lib/packages/plugins/plugin.php">
     <MixedInferredReturnType occurrences="1">
@@ -6881,13 +6617,11 @@
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;rawFieldnames</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="6">
+    <PossiblyNullReference occurrences="4">
       <code>fetch</code>
       <code>fetchAll</code>
       <code>fetchAll</code>
       <code>getColumnMeta</code>
-      <code>getValue</code>
-      <code>getValue</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/lib/sql/table.php">
@@ -6950,9 +6684,6 @@
       <code>$query</code>
       <code>$ret[]</code>
     </MixedAssignment>
-    <PossiblyNullReference occurrences="1">
-      <code>getValue</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/lib/system_report.php">
     <MixedArgument occurrences="13">
@@ -7519,12 +7250,8 @@
     <PossiblyNullArgument occurrences="1">
       <code>rex_be_controller::getCurrentPagePart(1)</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="5">
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
-      <code>getComplexPerm</code>
+    <PossiblyNullReference occurrences="1">
       <code>getSubpages</code>
-      <code>isAdmin</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/packages.php">
@@ -7584,11 +7311,6 @@
       <code>$icon</code>
       <code>$key ?: $function</code>
     </MixedOperand>
-  </file>
-  <file src="redaxo/src/core/pages/profile.php">
-    <PossiblyNullReference occurrences="1">
-      <code>getId</code>
-    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/pages/setup.php">
     <MixedArgument occurrences="6">

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -574,6 +574,14 @@
       <code>$req-&gt;databaseUpdates</code>
       <code>rex_debug_clockwork::getInstance()-&gt;getRequest()-&gt;id</code>
     </MixedPropertyFetch>
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/debug/lib/api_debug.php">
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/debug/lib/debug_clockwork.php">
     <MixedArgument occurrences="3">
@@ -694,6 +702,9 @@
       <code>array&lt;int, array{version: string, description: string, path: string, checksum: string}&gt;</code>
       <code>rex_install_webservice::getJson('core')</code>
     </MixedReturnTypeCoercion>
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/install/lib/api/api_package_add.php">
     <MixedAssignment occurrences="1">
@@ -702,6 +713,14 @@
     <MixedOperand occurrences="1">
       <code>$message</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/install/lib/api/api_package_delete.php">
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/install/lib/api/api_package_update.php">
     <MixedAssignment occurrences="1">
@@ -710,6 +729,9 @@
     <MixedOperand occurrences="1">
       <code>$message</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/install/lib/api/api_package_upload.php">
     <MixedAssignment occurrences="4">
@@ -718,6 +740,9 @@
       <code>$file['version']</code>
       <code>$packageExclude</code>
     </MixedAssignment>
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/install/lib/archive.php">
     <MixedArgument occurrences="9">
@@ -1448,6 +1473,10 @@
       <code>rex_escape($list-&gt;getValue('description'))</code>
       <code>rex_escape($list-&gt;getValue('name'))</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="2">
+      <code>getLogin</code>
+      <code>getLogin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/media_manager/tests/media_manager_test.php">
     <MixedArgument occurrences="3">
@@ -1483,6 +1512,9 @@
       <code>rex_escape($ftitle)</code>
       <code>rex_extension::registerPoint(new rex_extension_point('MEDIA_FORM_ADD', ''))</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="1">
+      <code>getComplexPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/lib/cache_media.php">
     <MixedAssignment occurrences="4">
@@ -1636,6 +1668,9 @@
     <MixedAssignment occurrences="1">
       <code>$this-&gt;checkPerms</code>
     </MixedAssignment>
+    <PossiblyNullReference occurrences="1">
+      <code>getComplexPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/lib/mediapool.php">
     <MixedArgument occurrences="3">
@@ -1744,6 +1779,9 @@
       <code>$name</code>
       <code>$value</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="1">
+      <code>getComplexPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/lib/var_medialist.php">
     <MixedArgument occurrences="3">
@@ -1773,6 +1811,9 @@
       <code>$name</code>
       <code>$value</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="1">
+      <code>getComplexPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/index.php">
     <MixedAssignment occurrences="2">
@@ -1782,7 +1823,8 @@
     <MixedOperand occurrences="1">
       <code>rex_escape($argValue)</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
+      <code>getComplexPerm</code>
       <code>getSubpages</code>
     </PossiblyNullReference>
   </file>
@@ -1852,6 +1894,14 @@
     <PossiblyNullOperand occurrences="1">
       <code>$gf-&gt;getDateTimeValue('updatedate')</code>
     </PossiblyNullOperand>
+    <PossiblyNullReference occurrences="6">
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getValue</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/media.list.php">
     <MixedArgument occurrences="8">
@@ -1873,12 +1923,20 @@
       <code>$media-&gt;getValue('updatedate')</code>
       <code>$mediaManagerUrl('rex_mediapool_preview', urlencode($media-&gt;getFileName()), $media-&gt;getValue('updatedate'))</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="3">
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/media.php">
     <MixedArgument occurrences="1"/>
     <MixedAssignment occurrences="1">
       <code>$toolbar</code>
     </MixedAssignment>
+    <PossiblyNullReference occurrences="1">
+      <code>getComplexPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/structure.php">
     <MixedArgument occurrences="3">
@@ -1927,6 +1985,9 @@
       <code>$data['filename']</code>
       <code>$filename</code>
     </MixedAssignment>
+    <PossiblyNullReference occurrences="1">
+      <code>getValue</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/upload.php">
     <MixedArgument occurrences="2">
@@ -1948,6 +2009,10 @@
       <code>$data['filename']</code>
       <code>$data['filename']</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="2">
+      <code>getComplexPerm</code>
+      <code>getValue</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/mediapool/tests/mediapool_test.php">
     <MixedArgument occurrences="3">
@@ -2069,6 +2134,9 @@
     <MixedAssignment occurrences="1">
       <code>$return</code>
     </MixedAssignment>
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/metainfo/lib/handler/article_handler.php">
     <MixedArgument occurrences="6">
@@ -2268,6 +2336,10 @@
     <PossiblyNullArgument occurrences="1">
       <code>$id</code>
     </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/metainfo/lib/handler/media_handler.php">
     <MixedArgument occurrences="3">
@@ -2310,8 +2382,9 @@
       <code>$warning</code>
       <code>$warning</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
       <code>getPathAsArray</code>
+      <code>isAdmin</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/metainfo/lib/input.php">
@@ -2759,6 +2832,11 @@
       <code>getId</code>
     </MixedMethodCall>
   </file>
+  <file src="redaxo/src/addons/structure/functions/function_rex_category.php">
+    <PossiblyNullReference occurrences="1">
+      <code>getComplexPerm</code>
+    </PossiblyNullReference>
+  </file>
   <file src="redaxo/src/addons/structure/functions/function_rex_url.php">
     <MixedAssignment occurrences="1">
       <code>$url</code>
@@ -2771,28 +2849,83 @@
     </MixedReturnStatement>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_article2category.php">
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
       <code>getCategoryId</code>
+      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_article2startarticle.php">
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
       <code>getCategoryId</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_add.php">
+    <PossiblyNullReference occurrences="2">
+      <code>getComplexPerm</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_copy.php">
+    <PossiblyNullReference occurrences="1">
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_delete.php">
+    <PossiblyNullReference occurrences="2">
+      <code>getComplexPerm</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_edit.php">
+    <PossiblyNullReference occurrences="2">
+      <code>getComplexPerm</code>
+      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_article_move.php">
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
       <code>getCategoryId</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_status.php">
+    <PossiblyNullReference occurrences="1">
+      <code>getComplexPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_category2article.php">
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
       <code>getCategoryId</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/lib/api_functions/api_category_add.php">
+    <PossiblyNullReference occurrences="2">
+      <code>getComplexPerm</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/lib/api_functions/api_category_delete.php">
+    <PossiblyNullReference occurrences="2">
+      <code>getComplexPerm</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/lib/api_functions/api_category_edit.php">
+    <PossiblyNullReference occurrences="1">
+      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/api_functions/api_category_move.php">
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
       <code>getCategoryId</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/lib/api_functions/api_category_status.php">
+    <PossiblyNullReference occurrences="1">
+      <code>getComplexPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/article.php">
@@ -2870,8 +3003,10 @@
       <code>$this-&gt;listItem($article, $categoryId)</code>
       <code>$this-&gt;treeItem($cat, $liclasses, $linkclasses, $subLi, $liIcon)</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="3">
       <code>getArticles</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/linkmap/sitemap.php">
@@ -2905,7 +3040,8 @@
       <code>$name</code>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
+      <code>getComplexPerm</code>
       <code>getId</code>
     </PossiblyNullReference>
   </file>
@@ -2933,7 +3069,8 @@
       <code>$name</code>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
+      <code>getComplexPerm</code>
       <code>getId</code>
     </PossiblyNullReference>
   </file>
@@ -3044,6 +3181,14 @@
       <code>$level</code>
       <code>$level</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="6">
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/service_article.php">
     <MixedArgument occurrences="20">
@@ -3125,8 +3270,9 @@
       <code>$message</code>
       <code>$newstatus</code>
     </MixedReturnStatement>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference occurrences="2">
       <code>getCategoryId</code>
+      <code>getLogin</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/service_category.php">
@@ -3188,6 +3334,9 @@
       <code>$message</code>
       <code>$newstatus</code>
     </MixedReturnStatement>
+    <PossiblyNullReference occurrences="1">
+      <code>getLogin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/structure_context.php">
     <MixedArgument occurrences="3">
@@ -3220,6 +3369,12 @@
       <code>$this-&gt;getValue('function', '')</code>
       <code>$this-&gt;getValue('rows_per_page', 30)</code>
     </MixedReturnStatement>
+    <PossiblyNullReference occurrences="4">
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/lib/structure_element.php">
     <EmptyArrayAccess occurrences="1">
@@ -3413,6 +3568,20 @@
       <code>rex_escape($sql-&gt;getValue('priority'))</code>
       <code>rex_escape($sql-&gt;getValue('priority'))</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="12">
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/pages/linkmap.php">
     <MixedAssignment occurrences="1">
@@ -3448,6 +3617,16 @@
     </MixedOperand>
     <PossiblyNullReference occurrences="1">
       <code>setIsActive</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_copy.php">
+    <PossiblyNullReference occurrences="1">
+      <code>hasPerm</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_slice_status.php">
+    <PossiblyNullReference occurrences="1">
+      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/api_module.php">
@@ -3545,6 +3724,10 @@
     <PossiblyNullArgument occurrences="1">
       <code>$template-&gt;getKey()</code>
     </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>getId</code>
+      <code>getLogin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php">
     <MixedArgument occurrences="1">
@@ -3558,6 +3741,14 @@
     <MixedOperand occurrences="1">
       <code>$select</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="6">
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/article_slice.php">
     <MixedArgument occurrences="10">
@@ -3665,9 +3856,10 @@
       <code>$article</code>
       <code>$article</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference occurrences="3">
       <code>getCategoryId</code>
       <code>getId</code>
+      <code>getLogin</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/event_select.php">
@@ -3748,9 +3940,21 @@
     <MixedOperand occurrences="1">
       <code>rex_escape($hiddenFields)</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference occurrences="14">
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
       <code>getName</code>
       <code>getName</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/pages/content.php">
@@ -3797,10 +4001,18 @@
       <code>$key</code>
       <code>rex_be_controller::includeCurrentPageSubPath(compact('info', 'warning', 'templateAttributes', 'article', 'articleId', 'categoryId', 'clang', 'sliceId', 'sliceRevision', 'function', 'ctype', 'context'))</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="3">
+    <PossiblyNullReference occurrences="11">
       <code>addSubpage</code>
       <code>getCategoryId</code>
+      <code>getComplexPerm</code>
+      <code>getComplexPerm</code>
       <code>getSubpages</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/pages/modules.actions.php">
@@ -4009,6 +4221,10 @@
       <code>$version['history_date']</code>
       <code>$version['history_user']</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="2">
+      <code>getLogin</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/history/fragments/history/layer.php">
     <MixedArgument occurrences="4">
@@ -4026,6 +4242,9 @@
     <MixedOperand occurrences="1">
       <code>$historyDate</code>
     </MixedOperand>
+    <PossiblyNullReference occurrences="1">
+      <code>getValue</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/history/lib/cronjob.php">
     <MixedAssignment occurrences="1">
@@ -4094,6 +4313,13 @@
     <PossiblyNullArgument occurrences="1">
       <code>$article</code>
     </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="5">
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+      <code>hasPerm</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/version/lib/revision.php">
     <MixedArgument occurrences="4">
@@ -4271,9 +4497,27 @@
       <code>rex_escape($useremail)</code>
       <code>rex_escape($username)</code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference occurrences="20">
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
       <code>getLogin</code>
       <code>getValue</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
+      <code>isAdmin</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/backend.php">
@@ -4405,6 +4649,9 @@
     <MixedArgument occurrences="1">
       <code>$this-&gt;time</code>
     </MixedArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/fragments/core/form/checkbox.php">
     <MixedArgument occurrences="1">
@@ -4639,7 +4886,8 @@
     <MixedArgument occurrences="1">
       <code>$this-&gt;meta_navigation</code>
     </MixedArgument>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference occurrences="3">
+      <code>isAdmin</code>
       <code>isPopup</code>
       <code>isPopup</code>
     </PossiblyNullReference>
@@ -6265,6 +6513,9 @@
       <code>$packages</code>
       <code>self[]</code>
     </MixedReturnTypeCoercion>
+    <PossiblyNullReference occurrences="1">
+      <code>isAdmin</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/lib/packages/plugins/plugin.php">
     <MixedInferredReturnType occurrences="1">
@@ -6417,6 +6668,9 @@
       <code>array&lt;string, array{install: bool, status: bool, plugins?: array&lt;string, array{install: bool, status: bool}&gt;}&gt;</code>
       <code>list&lt;string&gt;</code>
     </MixedReturnTypeCoercion>
+    <TypeDoesNotContainType occurrences="1">
+      <code>$user instanceof rex_user</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="redaxo/src/core/lib/select.php">
     <MixedArgument occurrences="7">
@@ -6617,11 +6871,13 @@
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;rawFieldnames</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="4">
+    <PossiblyNullReference occurrences="6">
       <code>fetch</code>
       <code>fetchAll</code>
       <code>fetchAll</code>
       <code>getColumnMeta</code>
+      <code>getValue</code>
+      <code>getValue</code>
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/lib/sql/table.php">
@@ -6684,6 +6940,9 @@
       <code>$query</code>
       <code>$ret[]</code>
     </MixedAssignment>
+    <PossiblyNullReference occurrences="1">
+      <code>getValue</code>
+    </PossiblyNullReference>
   </file>
   <file src="redaxo/src/core/lib/system_report.php">
     <MixedArgument occurrences="13">

--- a/redaxo/src/core/layout/top.php
+++ b/redaxo/src/core/layout/top.php
@@ -58,8 +58,10 @@ foreach ($bodyAttr as $k => $v) {
 
 $hasNavigation = $curPage->hasNavigation();
 
+$user = rex::getUser();
+
 $metaItems = [];
-if (rex::getUser() && $hasNavigation) {
+if ($user && $hasNavigation) {
     if (rex::isSafeMode()) {
         $item = [];
         $item['title'] = rex_i18n::msg('safemode_deactivate');
@@ -69,7 +71,7 @@ if (rex::getUser() && $hasNavigation) {
         unset($item);
     }
 
-    $userName = rex::getUser()->getName() ?: rex::getUser()->getLogin();
+    $userName = $user->getName() ?: $user->getLogin();
     $impersonator = rex::getImpersonator();
     if ($impersonator) {
         $impersonator = $impersonator->getName() ?: $impersonator->getLogin();
@@ -104,7 +106,7 @@ if (rex::getUser() && $hasNavigation) {
 
 // wird in bottom.php an Fragment uebergeben
 $navigation = '';
-if (rex::getUser() && $hasNavigation) {
+if ($user && $hasNavigation) {
     $n = rex_be_navigation::factory();
     foreach (rex_be_controller::getPages() as $p => $pageObj) {
         $p = strtolower($p);

--- a/redaxo/src/core/lib/be/navigation.php
+++ b/redaxo/src/core/lib/be/navigation.php
@@ -109,7 +109,7 @@ class rex_be_navigation
         $navigation = [];
 
         foreach ($blockPages as $page) {
-            if ($page->isHidden() || !$page->checkPermission(rex::getUser())) {
+            if ($page->isHidden() || !$page->checkPermission(rex::requireUser())) {
                 continue;
             }
             $n = [];

--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -287,7 +287,7 @@ class rex_form extends rex_form_base
         $fieldnames = $this->sql->getFieldnames();
 
         if (in_array('updateuser', $fieldnames)) {
-            $saveSql->setValue('updateuser', rex::getUser()->getValue('login'));
+            $saveSql->setValue('updateuser', rex::requireUser()->getValue('login'));
         }
 
         if (in_array('updatedate', $fieldnames)) {
@@ -296,7 +296,7 @@ class rex_form extends rex_form_base
 
         if (!$this->isEditMode()) {
             if (in_array('createuser', $fieldnames)) {
-                $saveSql->setValue('createuser', rex::getUser()->getValue('login'));
+                $saveSql->setValue('createuser', rex::requireUser()->getValue('login'));
             }
 
             if (in_array('createdate', $fieldnames)) {

--- a/redaxo/src/core/lib/login/api_user_impersonate.php
+++ b/redaxo/src/core/lib/login/api_user_impersonate.php
@@ -22,8 +22,9 @@ class rex_api_user_impersonate extends rex_api_function
             exit;
         }
 
-        if (!rex::getUser()->isAdmin()) {
-            throw new rex_api_exception(sprintf('Current user ("%s") must be admin to impersonate another user.', rex::getUser()->getLogin()));
+        $user = rex::requireUser();
+        if (!$user->isAdmin()) {
+            throw new rex_api_exception(sprintf('Current user ("%s") must be admin to impersonate another user.', $user->getLogin()));
         }
 
         rex::getProperty('login')->impersonate((int) $impersonate);

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -295,6 +295,8 @@ class rex
      * Returns the current user.
      *
      * @return null|rex_user
+     *
+     * @psalm-ignore-nullable-return
      */
     public static function getUser()
     {

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -295,12 +295,24 @@ class rex
      * Returns the current user.
      *
      * @return null|rex_user
-     *
-     * @psalm-ignore-nullable-return
      */
     public static function getUser()
     {
         return self::getProperty('user');
+    }
+
+    /**
+     * Returns the current user.
+     */
+    public static function requireUser(): rex_user
+    {
+        $user = self::getProperty('user');
+
+        if (!$user instanceof rex_user) {
+            throw new rex_exception('User object does not exist');
+        }
+
+        return $user;
     }
 
     /**

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -303,6 +303,8 @@ class rex
 
     /**
      * Returns the current user.
+     *
+     * In contrast to `getUser`, this method throw a `rex_exception` if the user does not exist.
      */
     public static function requireUser(): rex_user
     {

--- a/redaxo/src/core/lib/view.php
+++ b/redaxo/src/core/lib/view.php
@@ -347,7 +347,7 @@ class rex_view
 
         $items = [];
         foreach (rex_clang::getAll() as $id => $clang) {
-            if (rex::getUser()->getComplexPerm('clang')->hasPerm($id)) {
+            if (rex::requireUser()->getComplexPerm('clang')->hasPerm($id)) {
                 $icon = ($id == $context->getParam('clang')) ? '<i class="rex-icon rex-icon-language-active"></i> ' : '<i class="rex-icon rex-icon-language"></i> ';
                 $item = [];
                 $item['href'] = $context->getUrl(['clang' => $id]);
@@ -383,7 +383,7 @@ class rex_view
 
         $items = [];
         foreach (rex_clang::getAll() as $id => $clang) {
-            if (rex::getUser()->getComplexPerm('clang')->hasPerm($id)) {
+            if (rex::requireUser()->getComplexPerm('clang')->hasPerm($id)) {
                 $icon = $clang->isOnline() ? '<i class="rex-icon rex-icon-online"></i> ' : '<i class="rex-icon rex-icon-offline"></i> ';
                 $item = [];
                 $item['label'] = $icon . rex_i18n::translate($clang->getName());
@@ -413,10 +413,12 @@ class rex_view
             return '';
         }
 
+        $user = rex::requireUser();
+
         $buttonLabel = '';
         $items = [];
         foreach (rex_clang::getAll() as $id => $clang) {
-            if (rex::getUser()->getComplexPerm('clang')->hasPerm($id)) {
+            if ($user->getComplexPerm('clang')->hasPerm($id)) {
                 $item = [];
                 $item['title'] = rex_i18n::translate($clang->getName());
                 $item['href'] = $context->getUrl(['clang' => $id]);
@@ -435,7 +437,7 @@ class rex_view
         $fragment->setVar('header', rex_i18n::msg('clang_select'));
         $fragment->setVar('items', $items, false);
 
-        if (rex::getUser()->isAdmin()) {
+        if ($user->isAdmin()) {
             $fragment->setVar('footer', '<a href="' . rex_url::backendPage('system/lang') . '"><i class="fa fa-flag"></i> ' . rex_i18n::msg('languages_edit') . '</a>', false);
         }
 

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -6,7 +6,7 @@
 
 $error = '';
 $success = '';
-$user = rex::getUser();
+$user = rex::requireUser();
 $userId = $user->getId();
 
 $passwordChangeRequired = rex::getProperty('login')->requiresPasswordChange();


### PR DESCRIPTION
Fügt eine neue Methode `rex::requireUser()` hinzu, die im Gegensatz zu `getUser` nicht nullable ist.
Sie wirft also eine Exception, wenn der User nicht existiert.

<details>
<summary>Ursprünglicher Beitrag</summary>

Ich bin am überlegen, ob wir hier mal `@psalm-ignore-nullable-return` verwenden sollen.

Aus der Doku (https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-ignore-nullable-return):

> This can be used to tell Psalm not to worry if a function/method returns null. It’s a bit of a hack, but occasionally useful for scenarios where you either have a very high confidence of a non-null value, or some other function guarantees a non-null value for that particular code path.

Das trifft an vielen Stellen bei uns zu, zum Beispiel den ganzen Backend-Pages. Dort ist man sowieso eingeloggt, und somit der User vorhanden.
Wenn man aber `rex::getUser` an anderen Stellen verwendet, wird jetzt halt nicht mehr vor null gewarnt.

Alternative wäre mal wieder eine `rex::requireUser`-Methode, und dann alle entsprechenden Stellen anpassen.
</details>