### PR TITLE
rector: disable process timeout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,10 @@
         "phpstan-baseline": "phpstan analyse --generate-baseline .tools/phpstan/baseline.neon",
         "psalm": "psalm --use-baseline=.tools/psalm/baseline.xml",
         "psalm-baseline": "psalm --set-baseline=.tools/psalm/baseline.xml",
-        "rector": "rector process --ansi",
+        "rector": [
+            "Composer\\Config::disableProcessTimeout",
+            "rector process --ansi"
+        ],
         "taint": "psalm --use-baseline=.tools/psalm/baseline-taint.xml --taint-analysis --no-cache --threads=1",
         "taint-baseline": "psalm --set-baseline=.tools/psalm/baseline-taint.xml --taint-analysis --no-cache --threads=1 || git checkout -- psalm.xml",
         "sa": [


### PR DESCRIPTION
running into process timeouts..

```
$ composer rector
> rector process --ansi
  415/2112 [=====>----------------------]  19%PHP Warning:  Use of undefined constant REX_MIN_PHP_VERSION - assumed 'REX_MIN_PHP_VERSION' (this will throw an Error in a future version of PHP) in phar://C:/xampp7.3/htdocs/redaxo/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/ClassConstantReflection.php on line 48
Warning: Use of undefined constant REX_MIN_PHP_VERSION - assumed 'REX_MIN_PHP_VERSION' (this will throw an Error in a future version of PHP) in phar://C:/xampp7.3/htdocs/redaxo/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/ClassConstantReflection.php on line 48
  463/2112 [======>---------------------]  21%

  [Symfony\Component\Process\Exception\ProcessTimedOutException]
  The process "rector process --ansi" exceeded the timeout of 300 seconds.
```

refs https://getcomposer.org/doc/06-config.md#process-timeout