### PR TITLE
Begriffe "blacklist"/"whitelist" vermeiden

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -45,8 +45,8 @@
   <file src="redaxo/src/addons/backup/lib/cronjob.php">
     <MixedArgument occurrences="4">
       <code>$filename</code>
-      <code>$this-&gt;getParam('blacklist_tables')</code>
       <code>$this-&gt;getParam('delete_interval')</code>
+      <code>$this-&gt;getParam('exclude_tables')</code>
       <code>$this-&gt;getParam('mailaddress')</code>
     </MixedArgument>
     <MixedAssignment occurrences="1">
@@ -2021,7 +2021,7 @@
       <code>$path</code>
     </MixedArgument>
     <MixedAssignment occurrences="1">
-      <code>$whitelist</code>
+      <code>$allowedMimeTypes</code>
     </MixedAssignment>
   </file>
   <file src="redaxo/src/addons/mediapool/update.php">

--- a/redaxo/src/addons/backup/lang/de_de.lang
+++ b/redaxo/src/addons/backup/lang/de_de.lang
@@ -65,8 +65,8 @@ backup_delete_interval_weekly = Ein Backup pro Woche behalten
 backup_delete_interval_monthly = Ein Backup pro Monat behalten
 backup_delete_interval_notice = Es werden nur Backups gelöscht, die älter als ein Monat sind und deren Dateinamen auf <code>.cronjob.sql</code> enden.
 
-backup_blacklist_tables = Von Backup ausschließen
-backup_blacklist_tables_notice = Wenn ausgewählt, werden diese Tabellen nicht gesichert. Tabellen mit dem Präfix <code>rex_tmp_*</code> werden automatisch ausgeschlossen.
+backup_exclude_tables = Von Backup ausschließen
+backup_exclude_tables_notice = Wenn ausgewählt, werden diese Tabellen nicht gesichert. Tabellen mit dem Präfix <code>rex_tmp_*</code> werden automatisch ausgeschlossen.
 
 perm_general_backup[export] = Webseite exportieren
 

--- a/redaxo/src/addons/backup/lang/en_gb.lang
+++ b/redaxo/src/addons/backup/lang/en_gb.lang
@@ -65,8 +65,8 @@ backup_delete_interval_weekly = Keep one backup per week
 backup_delete_interval_monthly = Keep one backup per month
 backup_delete_interval_notice = Only backups older than one month will be deleted, and file name must end with <code>.cronjob.sql</code>.
 
-backup_blacklist_tables = Exclude from backup
-backup_blacklist_tables_notice = The selected tables will not be backed up. Tables with a prefix of <code>rex_tmp_*</code> will be excluded automatically.
+backup_exclude_tables = Exclude from backup
+backup_exclude_tables_notice = The selected tables will not be backed up. Tables with a prefix of <code>rex_tmp_*</code> will be excluded automatically.
 
 perm_general_backup[export] = Webseite exportieren
 

--- a/redaxo/src/addons/backup/lang/es_es.lang
+++ b/redaxo/src/addons/backup/lang/es_es.lang
@@ -62,8 +62,8 @@ backup_delete_interval_weekly = Mantenga una copia de seguridad por semana
 backup_delete_interval_monthly = Mantenga una copia de seguridad por mes
 backup_delete_interval_notice = Solo se eliminarán las copias de seguridad anteriores a un mes y el nombre del archivo debe finalizar con <code>.cronjob.sql</ code>.
 
-backup_blacklist_tables = Excluir de copia de seguridad
-backup_blacklist_tables_notice = Las tablas seleccionadas no serán respaldadas.  Las tablas con un prefijo <code>rex_tmp_ *</code> se excluirán automáticamente.
+backup_exclude_tables = Excluir de copia de seguridad
+backup_exclude_tables_notice = Las tablas seleccionadas no serán respaldadas.  Las tablas con un prefijo <code>rex_tmp_ *</code> se excluirán automáticamente.
 
 perm_general_backup[export] = Sitio web de exportación
 

--- a/redaxo/src/addons/backup/lang/sv_se.lang
+++ b/redaxo/src/addons/backup/lang/sv_se.lang
@@ -65,8 +65,8 @@ backup_delete_interval_weekly = Spara en säkerhetskopia per vecka
 backup_delete_interval_monthly = Spara en säkerhetskopia per månad
 backup_delete_interval_notice = Endast säkerhetskopior som är äldre än en månad och deras filnamn slutar på <code> .cronjob.sql </ code>raderas.
 
-backup_blacklist_tables = Uteslut från säkerhetskopiering
-backup_blacklist_tables_notice = Om utvald kommer de här tabellerna inte att sparas.  Tabeller med prefixet <code> rex_tmp_ * </code> utesluts automatiskt.
+backup_exclude_tables = Uteslut från säkerhetskopiering
+backup_exclude_tables_notice = Om utvald kommer de här tabellerna inte att sparas.  Tabeller med prefixet <code> rex_tmp_ * </code> utesluts automatiskt.
 
 perm_general_backup[export] = Exportera webbsajten
 

--- a/redaxo/src/addons/backup/lib/cronjob.php
+++ b/redaxo/src/addons/backup/lib/cronjob.php
@@ -17,9 +17,8 @@ class rex_cronjob_export extends rex_cronjob
         $dir = rex_backup::getDir() . '/';
         $ext = '.cronjob.sql';
 
-        $tables = rex_backup::getTables();
-        $blacklistTables = explode('|', $this->getParam('blacklist_tables'));
-        $whitelistTables = array_diff($tables, $blacklistTables);
+        $excludedTables = explode('|', $this->getParam('exclude_tables'));
+        $tables = array_diff(rex_backup::getTables(), $excludedTables);
 
         if (is_file($dir . $file . $ext)) {
             $i = 1;
@@ -30,7 +29,7 @@ class rex_cronjob_export extends rex_cronjob
         }
         $exportFilePath = $dir . $file . $ext;
 
-        if (rex_backup::exportDb($exportFilePath, $whitelistTables)) {
+        if (rex_backup::exportDb($exportFilePath, $tables)) {
             $message = rex_path::basename($exportFilePath) . ' created';
 
             if ($this->getParam('compress')) {
@@ -132,12 +131,12 @@ class rex_cronjob_export extends rex_cronjob
                 'notice' => rex_i18n::msg('backup_filename_notice'),
             ],
             [
-                'label' => rex_i18n::msg('backup_blacklist_tables'),
-                'name' => 'blacklist_tables',
+                'label' => rex_i18n::msg('backup_exclude_tables'),
+                'name' => 'exclude_tables',
                 'type' => 'select',
                 'attributes' => ['multiple' => 'multiple', 'data-live-search' => 'true'],
                 'options' => array_combine($tables, $tables),
-                'notice' => rex_i18n::msg('backup_blacklist_tables_notice'),
+                'notice' => rex_i18n::msg('backup_exclude_tables_notice'),
             ],
             [
                 'name' => 'sendmail',

--- a/redaxo/src/addons/backup/package.yml
+++ b/redaxo/src/addons/backup/package.yml
@@ -1,5 +1,5 @@
 package: backup
-version: '2.7.1-dev'
+version: '2.8.0-dev'
 author: 'Jan Kristinus, Markus Staab'
 supportpage: https://github.com/redaxo/redaxo
 

--- a/redaxo/src/addons/backup/update.php
+++ b/redaxo/src/addons/backup/update.php
@@ -1,0 +1,11 @@
+<?php
+
+$addon = rex_addon::get('backup');
+
+if (rex_addon::get('cronjob')->isInstalled() && rex_string::versionCompare($addon->getVersion(), '2.8.0-dev', '<')) {
+    rex_sql::factory()
+        ->setTable(rex::getTable('cronjob'))
+        ->setWhere(['type' => rex_cronjob_export::class])
+        ->setRawValue('parameters', 'REPLACE(parameters, \'"rex_cronjob_export_blacklist_tables":\', \'"rex_cronjob_export_exclude_tables":\')')
+        ->update();
+}

--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -333,7 +333,7 @@ function rex_mediapool_isAllowedMediaType($filename, array $args = [])
 }
 
 /**
- * Checks file against optional whitelist from property `allowed_mime_types`.
+ * Checks file against optional property `allowed_mime_types`.
  *
  * @param string      $path     Path to the physical file
  * @param null|string $filename Optional filename, will be used for extracting the file extension.
@@ -348,11 +348,11 @@ function rex_mediapool_isAllowedMimeType($path, $filename = null)
 }
 
 /**
- * get whitelist of mediatypes(extensions) given via media widget "types" param.
+ * Get allowed mediatype extensions given via media widget "types" param.
  *
  * @param array $args widget params
  *
- * @return array whitelisted extensions
+ * @return array allowed extensions
  * @deprecated since 2.11, use `rex_mediapool::getAllowedExtensions` instead
  */
 function rex_mediapool_getMediaTypeWhitelist($args = [])
@@ -361,9 +361,9 @@ function rex_mediapool_getMediaTypeWhitelist($args = [])
 }
 
 /**
- * return global mediatype blacklist from master.inc.
+ * Get global blocked mediatype extensions.
  *
- * @return array blacklisted mediatype extensions
+ * @return array blocked mediatype extensions
  * @deprecated since 2.11, use `rex_mediapool::getBlockedExtensions` instead
  */
 function rex_mediapool_getMediaTypeBlacklist()

--- a/redaxo/src/addons/mediapool/lib/mediapool.php
+++ b/redaxo/src/addons/mediapool/lib/mediapool.php
@@ -132,7 +132,7 @@ final class rex_mediapool
     }
 
     /**
-     * Checks file against optional AllowedMimetypes from property `allowed_mime_types`.
+     * Checks file against optional property `allowed_mime_types`.
      *
      * @param string      $path     Path to the physical file
      * @param null|string $filename Optional filename, will be used for extracting the file extension.
@@ -158,7 +158,7 @@ final class rex_mediapool
     }
 
     /**
-     * get allowedExtensions of mediatypes(extensions) given via media widget "types" param.
+     * Get allowed mediatype extensions given via media widget "types" param.
      *
      * @param array $args widget params
      *
@@ -182,7 +182,7 @@ final class rex_mediapool
     }
 
     /**
-     * return global mediatype blockedExtensions from master.inc.
+     * Get global blocked mediatype extensions.
      *
      * @return array blocked mediatype extensions
      */

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -19,7 +19,7 @@ page:
 
 blocked_extensions: [php, php3, php4, php5, php6, php7, phar, pht, phtml, hh, pl, asp, aspx, cfm, jsp, jsf, bat, sh, cgi, htaccess, htpasswd]
 
-# optional mime type whitelist. the list is checked after the blocked_extensions check from above has passed.
+# optional mime type allowlist. the list is checked after the blocked_extensions check from above has passed.
 # exmaple:
 #   allowed_mime_types:
 #       gif: [image/gif]

--- a/redaxo/src/addons/mediapool/tests/mediapool_test.php
+++ b/redaxo/src/addons/mediapool/tests/mediapool_test.php
@@ -39,7 +39,7 @@ class rex_mediapool_test extends TestCase
     {
         $addon = rex_addon::get('mediapool');
 
-        $whitelist = $addon->getProperty('allowed_mime_types');
+        $allowedMimeTypes = $addon->getProperty('allowed_mime_types');
 
         $addon->setProperty('allowed_mime_types', [
             'md' => ['text/plain'],
@@ -47,7 +47,7 @@ class rex_mediapool_test extends TestCase
 
         static::assertSame($expected, rex_mediapool::isAllowedMimeType($path, $filename));
 
-        $addon->setProperty('allowed_mime_types', $whitelist);
+        $addon->setProperty('allowed_mime_types', $allowedMimeTypes);
     }
 
     public function provideIsAllowedMimeType()

--- a/redaxo/src/addons/project/boot.php
+++ b/redaxo/src/addons/project/boot.php
@@ -11,7 +11,7 @@ $addon = rex_addon::get('project');
 // register yorm class
 // rex_yform_manager_dataset::setModelClass('rex_my_table', my_classname::class);
 
-// Example of mediapool Whitelist
+// Example list of allowed mime types for mediapool
 /*
 rex_addon::get('mediapool')->setProperty('allowed_mime_types', [
     'gif'   => ['image/gif'],

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -450,18 +450,18 @@ jQuery(function($){
         time.setTime(time.getTime() + 1000 * 60 * 60 * 24);
         setCookie('rex_htaccess_check', '1', time.toGMTString(), '', '', false, 'lax');
 
-        var whiteUrl = 'index.php';
+        var allowedUrl = 'index.php';
 
         // test urls, which is not expected to be accessible
         // after each expected error, run a request which is expected to succeed.
         // that way we try to make sure tools like fail2ban dont block the client
         var urls = [
             'bin/console',
-            whiteUrl,
+            allowedUrl,
             'data/.redaxo',
-            whiteUrl,
+            allowedUrl,
             'src/core/boot.php',
-            whiteUrl,
+            allowedUrl,
             'cache/.redaxo'
         ];
 

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -42,7 +42,7 @@ class rex_string
      *
      * @param string $string       Input string
      * @param string $replaceChar  Character that is used to replace not allowed chars
-     * @param string $allowedChars Character whitelist
+     * @param string $allowedChars Allowed character list
      *
      * @return string
      */

--- a/redaxo/src/core/pages/setup.step3.php
+++ b/redaxo/src/core/pages/setup.step3.php
@@ -29,23 +29,23 @@ $security .= '<noscript>' . rex_view::error(rex_i18n::msg('setup_no_js_security_
 $security .= '<script>
 
     jQuery(function($){
-        var whiteUrl = "' . rex_url::backend('index.php') . '";
+        var allowedUrl = "' . rex_url::backend('index.php') . '";
 
         // test url, which is not expected to be accessible
         // after each expected error, run a request which is expected to succeed.
         // that way we try to make sure tools like fail2ban dont block the client
-        var blacklistedUrls = [
+        var urls = [
             "' . rex_url::backend('bin/console') . '",
-            whiteUrl,
+            allowedUrl,
             "' . rex_url::backend('data/.redaxo') . '",
-            whiteUrl,
+            allowedUrl,
             "' . rex_url::backend('src/core/boot.php') . '",
-            whiteUrl,
+            allowedUrl,
             "' . rex_url::backend('cache/.redaxo') . '"
         ];
 
         // NOTE: we have essentially a copy of this code in checkHtaccess() - see standard.js
-        $.each(blacklistedUrls, function (i, url) {
+        $.each(urls, function (i, url) {
             $.ajax({
                 url: url,
                 cache: false,


### PR DESCRIPTION
https://www.heise.de/news/Nichtrassistische-Sprache-Abschied-von-Blacklist-und-Whitelist-4784291.html