### PR TITLE
Neuer Command: package:run-update-script

### DIFF
--- a/redaxo/src/core/lib/console/command_loader.php
+++ b/redaxo/src/core/lib/console/command_loader.php
@@ -34,6 +34,7 @@ class rex_console_command_loader implements CommandLoaderInterface
                 'package:delete' => rex_command_package_delete::class,
                 'package:list' => rex_command_package_list::class,
                 'package:install' => rex_command_package_install::class,
+                'package:run-update-script' => rex_command_package_run_update_script::class,
                 'package:uninstall' => rex_command_package_uninstall::class,
                 'system:report' => rex_command_system_report::class,
                 'user:set-password' => rex_command_user_set_password::class,

--- a/redaxo/src/core/lib/console/package/run_update_script.php
+++ b/redaxo/src/core/lib/console/package/run_update_script.php
@@ -1,0 +1,56 @@
+<?php
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @package redaxo\core
+ *
+ * @internal
+ */
+class rex_command_package_run_update_script extends rex_console_command
+{
+    protected function configure()
+    {
+        $this
+            ->setDescription('Runs the update.php of the given package with given previous version')
+            ->addArgument('package-id', InputArgument::REQUIRED, 'The id of the package (addon or plugin); e.g. "cronjob" or "structure/content"')
+            ->addArgument('previous-version', InputArgument::REQUIRED, 'The previous package version that is used for version comparisons in update.php')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = $this->getStyle($input, $output);
+
+        $packageId = $input->getArgument('package-id');
+
+        $package = rex_package::get($packageId);
+        if (!$package->isInstalled()) {
+            $io->error('Package "'.$packageId.'" is not installed!');
+            return 1;
+        }
+
+        $version = $package->getVersion();
+        $package->setProperty('version', $input->getArgument('previous-version'));
+
+        try {
+            $package->includeFile(rex_package::FILE_UPDATE);
+        } finally {
+            $package->setProperty('version', $version);
+        }
+
+        if ('' !== ($message = (string) $package->getProperty('updatemsg', ''))) {
+            $io->error($message);
+            return 1;
+        }
+        if (!$package->getProperty('update', true)) {
+            $io->error('Failed without a given reason.');
+            return 1;
+        }
+
+        $io->success('Successfully executed the update.php.');
+        return 0;
+    }
+}


### PR DESCRIPTION
Das Skript ist nützlich, um die `update.php` testen zu können.
Es kann auch verwendet werden, wenn man ein Package manuell geupdatet hat.

Man muss beim Aufruf allerdings die vorherige Version angeben. Diese wird für die Versionsvergleiche benötigt.

`redaxo/bin/console package:run-update-script my_package 1.3.0`

So wird also die `update.php` von `my_package` ausgeführt, so als käme man von der Version `1.3.0`.