### PR TITLE
rex_version::compare: fix result for $comparator=null

### DIFF
--- a/redaxo/src/core/tests/util/version_test.php
+++ b/redaxo/src/core/tests/util/version_test.php
@@ -43,37 +43,41 @@ class rex_version_test extends TestCase
     public function compareProvider()
     {
         return [
-            ['1',      '1',      '='],
-            ['1.0',    '1.0',    '='],
-            ['1',      '1.0',    '='],
-            ['1.0 a1', '1.0.a1', '='],
-            ['1.0a1',  '1.0.a1', '='],
-            ['1.0 alpha 1', '1.0.a1', '='],
+            [true, '1',      '1',      '='],
+            [true, '1.0',    '1.0',    '='],
+            [true, '1',      '1.0',    '='],
+            [true, '1.0 a1', '1.0.a1', '='],
+            [true, '1.0a1',  '1.0.a1', '='],
+            [true, '1.0 alpha 1', '1.0.a1', '='],
 
-            ['1',      '2',        '<'],
-            ['1',      '1.1',      '<'],
-            ['1.0',    '1.1',      '<'],
-            ['1.1',    '1.2',      '<'],
-            ['1.2',    '1.10',     '<'],
-            ['1.a1',   '1',        '<'],
-            ['1.a1',   '1.0',      '<'],
-            ['1.a1',   '1.a2',     '<'],
-            ['1.a1',   '1.b1',     '<'],
-            ['1.0.a1', '1',        '<'],
-            ['1.0.a1', '1.0.0.0.', '<'],
-            ['1.0a1',  '1.0',      '<'],
-            ['1.0a1',  '1.0.1',    '<'],
-            ['1.0a1',  '1.0a2',    '<'],
-            ['1.0',    '1.1a1',    '<'],
-            ['1.0.1',  '1.1a1',    '<'],
+            [true, '1',      '2',        '<'],
+            [true, '1',      '1.1',      '<'],
+            [true, '1.0',    '1.1',      '<'],
+            [true, '1.1',    '1.2',      '<'],
+            [true, '1.2',    '1.10',     '<'],
+            [true, '1.a1',   '1',        '<'],
+            [true, '1.a1',   '1.0',      '<'],
+            [true, '1.a1',   '1.a2',     '<'],
+            [true, '1.a1',   '1.b1',     '<'],
+            [true, '1.0.a1', '1',        '<'],
+            [true, '1.0.a1', '1.0.0.0.', '<'],
+            [true, '1.0a1',  '1.0',      '<'],
+            [true, '1.0a1',  '1.0.1',    '<'],
+            [true, '1.0a1',  '1.0a2',    '<'],
+            [true, '1.0',    '1.1a1',    '<'],
+            [true, '1.0.1',  '1.1a1',    '<'],
+
+            [0, '1.0', '1.0', null],
+            [-1, '1.0', '1.1', null],
+            [1, '1.1', '1.0', null],
         ];
     }
 
     /**
      * @dataProvider compareProvider
      */
-    public function testCompare($version1, $version2, $comparator)
+    public function testCompare($expected, string $version1, string $version2, ?string $comparator)
     {
-        static::assertTrue(rex_version::compare($version1, $version2, $comparator));
+        static::assertSame($expected, rex_version::compare($version1, $version2, $comparator));
     }
 }


### PR DESCRIPTION
In PHP 7 kommt dort ein bool raus, obwohl ein int (-1, 0, 1) kommen sollte. In PHP 7 muss scheinbar explizit der dritte Parameter bei `version_compare` weggelassen werden.
(Ab PHP 8 kann auch `null` übergeben werden.)