### PR TITLE
Visual-Tests auch in Draft-PRs

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -9,7 +9,6 @@ on:
 jobs:
     visual-tests:
         runs-on: ubuntu-latest
-        if: "github.event.pull_request.draft == false"
 
         steps:
             -   name: Add action run link to trigger comment


### PR DESCRIPTION
@schuer setzt seinen PR manchmal auf "ready to review", wartet die Screenshots ab, und dann wieder auf Draft.
Ich denke, wir sollten den Check hier ganz rausnehmen. Auch in Draft-PRs ist es praktisch, bereits die Screenshots zu sehen.