### PR TITLE
google FLoC optout per default aktivieren

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -8,7 +8,7 @@ header('X-Robots-Tag: noindex, nofollow, noarchive');
 header('X-Frame-Options: SAMEORIGIN');
 header("Content-Security-Policy: frame-ancestors 'self'");
 // Opt out of google FLoC
-header("Permissions-Policy: interest-cohort=()");
+header('Permissions-Policy: interest-cohort=()');
 
 // assets which are passed with a cachebuster will be cached very long,
 // as we assume their url will change when the underlying content changes

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -7,6 +7,8 @@
 header('X-Robots-Tag: noindex, nofollow, noarchive');
 header('X-Frame-Options: SAMEORIGIN');
 header("Content-Security-Policy: frame-ancestors 'self'");
+// Opt out of google FLoC
+header("Permissions-Policy: interest-cohort=()");
 
 // assets which are passed with a cachebuster will be cached very long,
 // as we assume their url will change when the underlying content changes


### PR DESCRIPTION
Floc im Backend per default deaktivieren. IMO sollte es im Frontend jeder Webseitenbetreiber selbst entscheiden

Closes https://github.com/redaxo/redaxo/issues/4640