### PR TITLE
PhpStorm-Settings: baselines nicht mehr excluden

### DIFF
--- a/.idea/redaxo.iml
+++ b/.idea/redaxo.iml
@@ -141,7 +141,6 @@
       <excludePattern pattern="jquery*.js" />
       <excludePattern pattern="jquery*.min.map" />
       <excludePattern pattern="sha1.js" />
-      <excludePattern pattern="baseline*" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
Hat sich doch als nachteilig rausgestellt.