### PR TITLE
HTTP_BAD_REQUEST ergänzt

### DIFF
--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -12,6 +12,7 @@ class rex_response
     public const HTTP_MOVED_PERMANENTLY = '301 Moved Permanently';
     public const HTTP_NOT_MODIFIED = '304 Not Modified';
     public const HTTP_MOVED_TEMPORARILY = '307 Temporary Redirect';
+    public const HTTP_BAD_REQUEST = '400 Bad Request';
     public const HTTP_NOT_FOUND = '404 Not Found';
     public const HTTP_FORBIDDEN = '403 Forbidden';
     public const HTTP_UNAUTHORIZED = '401 Unauthorized';


### PR DESCRIPTION
Was ja z.B. bei API-Calls vorkommen kann, sind falsch aufgebaute URLs. Das wird bei der Parameter-Überprüfung festgestellt und entsprechend reagiert. Da Server und Applikation wie konstruiert arbeiten, aber der Client ungültige Anfragedatens schickt, wäre 400 Bad Request eine passende Antwort. (siehe https://de.wikipedia.org/wiki/HTTP-Statuscode).

Hierfür ist keine Konstante in rex_response vorhanden, die hiermit vorgeschlagen wird.