### PR TITLE
nikic/php-parser auf 4.10.4 festsetzen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.18.5",
         "friendsofredaxo/linter": "1.3.0",
+        "nikic/php-parser": "4.10.4",
         "phpstan/extension-installer": "1.1.0",
         "phpstan/phpstan": "0.12.83",
         "phpstan/phpstan-deprecation-rules": "0.12.6",


### PR DESCRIPTION
Wir müssen im bugfix-Branch die Version festsetzen wegen https://github.com/rectorphp/rector/issues/6322.
Im main-Branch können wir das wieder rausnehmen, wenn wir rector und psalm und weitere updaten.