### PR TITLE
php-cs-fixer: utilize multiple processors

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -50,7 +50,7 @@ jobs:
                     commit_user_email: rex-bot@users.noreply.github.com
 
             -   name: Check code style
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 30 -P 3 vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle --config=.php-cs-fixer.dist.php | cs2pr # check whether there are still errors left
+                run: vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle | cs2pr # check whether there are still errors left
 
     rector:
         runs-on: ubuntu-latest

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer fix --diff
+                run: vendor/bin/php-cs-fixer list-files | xargs -P 3 vendor/bin/php-cs-fixer fix --diff
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4
@@ -50,7 +50,7 @@ jobs:
                     commit_user_email: rex-bot@users.noreply.github.com
 
             -   name: Check code style
-                run: vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle | cs2pr # check whether there are still errors left
+                run: vendor/bin/php-cs-fixer list-files | xargs -P 3 vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle | cs2pr # check whether there are still errors left
 
     rector:
         runs-on: ubuntu-latest

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer list-files | xargs -P 3 vendor/bin/php-cs-fixer fix --diff
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -P 3 vendor/bin/php-cs-fixer fix --diff
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4
@@ -50,7 +50,7 @@ jobs:
                     commit_user_email: rex-bot@users.noreply.github.com
 
             -   name: Check code style
-                run: vendor/bin/php-cs-fixer list-files | xargs -P 3 vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle | cs2pr # check whether there are still errors left
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -P 3 vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle | cs2pr # check whether there are still errors left
 
     rector:
         runs-on: ubuntu-latest

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -50,6 +50,7 @@ jobs:
                     commit_user_email: rex-bot@users.noreply.github.com
 
             -   name: Check code style
+                if: env.writable == 0
                 run: vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle | cs2pr # check whether there are still errors left
 
     rector:

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -P 3 vendor/bin/php-cs-fixer fix --diff
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4
@@ -50,7 +50,7 @@ jobs:
                     commit_user_email: rex-bot@users.noreply.github.com
 
             -   name: Check code style
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -P 3 vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle | cs2pr # check whether there are still errors left
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -P 3 vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle --config=.php-cs-fixer.dist.php | cs2pr # check whether there are still errors left
 
     rector:
         runs-on: ubuntu-latest

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 50 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 30 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 50 -P 4 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 50 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 150 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 250 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 30 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 50 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 30 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 50 -P 4 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 50 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 150 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -39,7 +39,7 @@ jobs:
 
             -   name: Fix code style
                 if: env.writable == 1
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 30 -P 3 vendor/bin/php-cs-fixer fix --diff --config=.php-cs-fixer.dist.php
 
             -   name: Commit changed files
                 uses: stefanzweifel/git-auto-commit-action@v4
@@ -50,7 +50,7 @@ jobs:
                     commit_user_email: rex-bot@users.noreply.github.com
 
             -   name: Check code style
-                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -P 3 vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle --config=.php-cs-fixer.dist.php | cs2pr # check whether there are still errors left
+                run: vendor/bin/php-cs-fixer list-files --config=.php-cs-fixer.dist.php | xargs -n 30 -P 3 vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle --config=.php-cs-fixer.dist.php | cs2pr # check whether there are still errors left
 
     rector:
         runs-on: ubuntu-latest

--- a/redaxo/src/core/lib/csrf_token.php
+++ b/redaxo/src/core/lib/csrf_token.php
@@ -7,8 +7,7 @@
  *
  * @package redaxo\core
  */
-class rex_csrf_token
-{
+class rex_csrf_token{
     use rex_factory_trait;
 
     public const PARAM = '_csrf_token';

--- a/redaxo/src/core/lib/csrf_token.php
+++ b/redaxo/src/core/lib/csrf_token.php
@@ -7,7 +7,8 @@
  *
  * @package redaxo\core
  */
-class rex_csrf_token{
+class rex_csrf_token
+{
     use rex_factory_trait;
 
     public const PARAM = '_csrf_token';


### PR DESCRIPTION
utilize multi core capabilities. Using 3 processes at a time, because github action VMs have 2 cpus, but cs-fixer is also doing some IO and therefore its likely processes are blocked for IO.

In CI php-cs-fixer cannot benefit from the cs-fixer-cache, therefore running things in parallel results in a great perf boost.

Refs https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5390