### PR TITLE
Bereiche regeln auch zugelassene Module - entsprechend labeln

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lang/de_de.lang
+++ b/redaxo/src/addons/structure/plugins/content/lang/de_de.lang
@@ -59,8 +59,8 @@ content_toarticle_failed = Diese Kategorie konnte nicht in einen Artikel umgewan
 content_toarticle_ok = Diese Kategorie wurde erfolgreich in einen Artikel umgewandelt
 move_category = nach
 category_moved = Kategorie wurde verschoben
-content_types = Bereiche (ctypes)
-content_type = Bereich (ctype)
+content_types = Bereiche (ctypes) und Module
+content_type = Bereich (ctype) und Module
 
 perm_options_moveSlice[] = Blöcke verschieben
 perm_options_publishSlice[] = Blöcke veröffentlichen


### PR DESCRIPTION
Wenn man sich nach Urzeiten mal wieder fragt, wo man bei den Templates die zugelassenen Module regelt - daher eine Korrektur als Vorschlag.

![image](https://user-images.githubusercontent.com/3855487/120156243-172cf200-c1f2-11eb-9df9-ff3da05ac321.png)
