### PR TITLE
Metainfo: Widget-IDs mit eigenem Präfix

### DIFF
--- a/redaxo/src/addons/mediapool/lib/var_media.php
+++ b/redaxo/src/addons/mediapool/lib/var_media.php
@@ -52,6 +52,7 @@ class rex_var_media extends rex_var
     }
 
     /**
+     * @param int|string $id
      * @return string
      */
     public static function getWidget($id, $name, $value, array $args = [])
@@ -80,10 +81,11 @@ class rex_var_media extends rex_var
         $viewFunc = '';
         if (rex::getUser()->getComplexPerm('media')->hasMediaPerm()) {
             $disabled = '';
-            $openFunc = 'openREXMedia(' . $id . ',\'' . $openParams . '\');';
-            $addFunc = 'addREXMedia(' . $id . ',\'' . $openParams . '\');';
-            $deleteFunc = 'deleteREXMedia(' . $id . ');';
-            $viewFunc = 'viewREXMedia(' . $id . ',\'' . $openParams . '\');';
+            $quotedId = "'".rex_escape($id, 'js')."'";
+            $openFunc = 'openREXMedia(' . $quotedId . ', \'' . $openParams . '\');';
+            $addFunc = 'addREXMedia(' . $quotedId . ', \'' . $openParams . '\');';
+            $deleteFunc = 'deleteREXMedia(' . $quotedId . ');';
+            $viewFunc = 'viewREXMedia(' . $quotedId . ', \'' . $openParams . '\');';
         }
 
         $e = [];

--- a/redaxo/src/addons/mediapool/lib/var_medialist.php
+++ b/redaxo/src/addons/mediapool/lib/var_medialist.php
@@ -42,6 +42,7 @@ class rex_var_medialist extends rex_var
     }
 
     /**
+     * @param int|string $id
      * @return string
      */
     public static function getWidget($id, $name, $value, array $args = [])
@@ -76,22 +77,23 @@ class rex_var_medialist extends rex_var
         $addFunc = '';
         $deleteFunc = '';
         $viewFunc = '';
+        $quotedId = "'".rex_escape($id, 'js')."'";
         if (rex::getUser()->getComplexPerm('media')->hasMediaPerm()) {
             $disabled = '';
-            $openFunc = 'openREXMedialist(' . $id . ',\'' . $openParams . '\');';
-            $addFunc = 'addREXMedialist(' . $id . ',\'' . $openParams . '\');';
-            $deleteFunc = 'deleteREXMedialist(' . $id . ');';
-            $viewFunc = 'viewREXMedialist(' . $id . ',\'' . $openParams . '\');';
+            $openFunc = 'openREXMedialist(' . $quotedId . ', \'' . $openParams . '\');';
+            $addFunc = 'addREXMedialist(' . $quotedId . ', \'' . $openParams . '\');';
+            $deleteFunc = 'deleteREXMedialist(' . $quotedId . ');';
+            $viewFunc = 'viewREXMedialist(' . $quotedId . ', \'' . $openParams . '\');';
         }
 
         $e = [];
         $e['before'] = '<div class="rex-js-widget' . $wdgtClass . '">';
         $e['field'] = '<select class="form-control" name="REX_MEDIALIST_SELECT[' . $id . ']" id="REX_MEDIALIST_SELECT_' . $id . '" size="10">' . $options . '</select><input type="hidden" name="' . $name . '" id="REX_MEDIALIST_' . $id . '" value="' . $value . '" />';
         $e['moveButtons'] = '
-                <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $id . ',\'top\');return false;" title="' . rex_i18n::msg('var_medialist_move_top') . '"><i class="rex-icon rex-icon-top"></i></a>
-                <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $id . ',\'up\');return false;" title="' . rex_i18n::msg('var_medialist_move_up') . '"><i class="rex-icon rex-icon-up"></i></a>
-                <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $id . ',\'down\');return false;" title="' . rex_i18n::msg('var_medialist_move_down') . '"><i class="rex-icon rex-icon-down"></i></a>
-                <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $id . ',\'bottom\');return false;" title="' . rex_i18n::msg('var_medialist_move_bottom') . '"><i class="rex-icon rex-icon-bottom"></i></a>';
+                <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $quotedId . ',\'top\');return false;" title="' . rex_i18n::msg('var_medialist_move_top') . '"><i class="rex-icon rex-icon-top"></i></a>
+                <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $quotedId . ',\'up\');return false;" title="' . rex_i18n::msg('var_medialist_move_up') . '"><i class="rex-icon rex-icon-up"></i></a>
+                <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $quotedId . ',\'down\');return false;" title="' . rex_i18n::msg('var_medialist_move_down') . '"><i class="rex-icon rex-icon-down"></i></a>
+                <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $quotedId . ',\'bottom\');return false;" title="' . rex_i18n::msg('var_medialist_move_bottom') . '"><i class="rex-icon rex-icon-bottom"></i></a>';
         $e['functionButtons'] = '
                 <a href="#" class="btn btn-popup" onclick="' . $openFunc . 'return false;" title="' . rex_i18n::msg('var_media_open') . '"' . $disabled . '><i class="rex-icon rex-icon-open-mediapool"></i></a>
                 <a href="#" class="btn btn-popup" onclick="' . $addFunc . 'return false;" title="' . rex_i18n::msg('var_media_new') . '"' . $disabled . '><i class="rex-icon rex-icon-add-media"></i></a>

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -1,5 +1,5 @@
 package: mediapool
-version: '2.10.0'
+version: '2.10.1-dev'
 author: 'Jan Kristinus'
 supportpage: https://github.com/redaxo/redaxo
 

--- a/redaxo/src/addons/metainfo/lib/input/linkbutton.php
+++ b/redaxo/src/addons/metainfo/lib/input/linkbutton.php
@@ -19,8 +19,8 @@ class rex_input_linkbutton extends rex_input
 
     public function setButtonId($buttonId)
     {
-        $this->buttonId = $buttonId;
-        $this->setAttribute('id', 'LINK_' . $buttonId);
+        $this->buttonId = 'METAINFO_'.$buttonId;
+        $this->setAttribute('id', 'REX_LINK_' . $this->buttonId);
     }
 
     public function setCategoryId($categoryId)

--- a/redaxo/src/addons/metainfo/lib/input/linklistbutton.php
+++ b/redaxo/src/addons/metainfo/lib/input/linklistbutton.php
@@ -19,8 +19,8 @@ class rex_input_linklistbutton extends rex_input
 
     public function setButtonId($buttonId)
     {
-        $this->buttonId = $buttonId;
-        $this->setAttribute('id', 'REX_LINKLIST_' . $buttonId);
+        $this->buttonId = 'METAINFO_'.$buttonId;
+        $this->setAttribute('id', 'REX_LINKLIST_' . $this->buttonId);
     }
 
     public function setCategoryId($categoryId)

--- a/redaxo/src/addons/metainfo/lib/input/mediabutton.php
+++ b/redaxo/src/addons/metainfo/lib/input/mediabutton.php
@@ -18,8 +18,8 @@ class rex_input_mediabutton extends rex_input
 
     public function setButtonId($buttonId)
     {
-        $this->buttonId = $buttonId;
-        $this->setAttribute('id', 'REX_MEDIA_' . $buttonId);
+        $this->buttonId = 'METAINFO_'.$buttonId;
+        $this->setAttribute('id', 'REX_MEDIA_' . $this->buttonId);
     }
 
     public function setCategoryId($categoryId)

--- a/redaxo/src/addons/metainfo/lib/input/medialistbutton.php
+++ b/redaxo/src/addons/metainfo/lib/input/medialistbutton.php
@@ -18,8 +18,8 @@ class rex_input_medialistbutton extends rex_input
 
     public function setButtonId($buttonId)
     {
-        $this->buttonId = $buttonId;
-        $this->setAttribute('id', 'REX_MEDIALIST_' . $buttonId);
+        $this->buttonId = 'METAINFO_'.$buttonId;
+        $this->setAttribute('id', 'REX_MEDIALIST_' . $this->buttonId);
     }
 
     public function setCategoryId($categoryId)

--- a/redaxo/src/addons/metainfo/package.yml
+++ b/redaxo/src/addons/metainfo/package.yml
@@ -18,5 +18,5 @@ requires:
     php: '>=7.3'
     redaxo: '^5.10'
     packages:
-        structure: '^2.0.0'
-        mediapool: '^2.0.0'
+        structure: '^2.12.1-dev'
+        mediapool: '^2.10.1-dev'

--- a/redaxo/src/addons/structure/lib/linkmap/var_link.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_link.php
@@ -44,6 +44,7 @@ class rex_var_link extends rex_var
     }
 
     /**
+     * @param int|string $id
      * @return string
      */
     public static function getWidget($id, $name, $value, array $args = [])
@@ -70,8 +71,9 @@ class rex_var_link extends rex_var
         $deleteFunc = '';
         if (rex::getUser()->getComplexPerm('structure')->hasStructurePerm()) {
             $class = '';
-            $openFunc = 'openLinkMap(\'REX_LINK_' . $id . '\', \'' . $openParams . '\');';
-            $deleteFunc = 'deleteREXLink(' . $id . ');';
+            $escapedId = rex_escape($id, 'js');
+            $openFunc = 'openLinkMap(\'REX_LINK_' . $escapedId . '\', \'' . $openParams . '\');';
+            $deleteFunc = 'deleteREXLink(\'' . $escapedId . '\');';
         }
 
         $e = [];

--- a/redaxo/src/addons/structure/lib/linkmap/var_linklist.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_linklist.php
@@ -40,6 +40,7 @@ class rex_var_linklist extends rex_var
     }
 
     /**
+     * @param int|string $id
      * @return string
      */
     public static function getWidget($id, $name, $value, array $args = [])
@@ -66,10 +67,11 @@ class rex_var_linklist extends rex_var
         $disabled = ' disabled';
         $openFunc = '';
         $deleteFunc = '';
+        $quotedId = "'".rex_escape($id, 'js')."'";
         if (rex::getUser()->getComplexPerm('structure')->hasStructurePerm()) {
             $disabled = '';
-            $openFunc = 'openREXLinklist(' . $id . ', \'' . $openParams . '\');';
-            $deleteFunc = 'deleteREXLinklist(' . $id . ');';
+            $openFunc = 'openREXLinklist(' . $quotedId . ', \'' . $openParams . '\');';
+            $deleteFunc = 'deleteREXLinklist(' . $quotedId . ');';
         }
 
         $e = [];
@@ -79,10 +81,10 @@ class rex_var_linklist extends rex_var
                 </select>
                 <input type="hidden" name="' . $name . '" id="REX_LINKLIST_' . $id . '" value="' . $value . '" />';
         $e['moveButtons'] = '
-                    <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $id . ',\'top\');return false;" title="' . rex_i18n::msg('var_linklist_move_top') . '"><i class="rex-icon rex-icon-top"></i></a>
-                    <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $id . ',\'up\');return false;" title="' . rex_i18n::msg('var_linklist_move_up') . '"><i class="rex-icon rex-icon-up"></i></a>
-                    <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $id . ',\'down\');return false;" title="' . rex_i18n::msg('var_linklist_move_down') . '"><i class="rex-icon rex-icon-down"></i></a>
-                    <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $id . ',\'bottom\');return false;" title="' . rex_i18n::msg('var_linklist_move_bottom') . '"><i class="rex-icon rex-icon-bottom"></i></a>';
+                    <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $quotedId . ',\'top\');return false;" title="' . rex_i18n::msg('var_linklist_move_top') . '"><i class="rex-icon rex-icon-top"></i></a>
+                    <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $quotedId . ',\'up\');return false;" title="' . rex_i18n::msg('var_linklist_move_up') . '"><i class="rex-icon rex-icon-up"></i></a>
+                    <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $quotedId . ',\'down\');return false;" title="' . rex_i18n::msg('var_linklist_move_down') . '"><i class="rex-icon rex-icon-down"></i></a>
+                    <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $quotedId . ',\'bottom\');return false;" title="' . rex_i18n::msg('var_linklist_move_bottom') . '"><i class="rex-icon rex-icon-bottom"></i></a>';
         $e['functionButtons'] = '
                     <a href="#" class="btn btn-popup" onclick="' . $openFunc . 'return false;" title="' . rex_i18n::msg('var_link_open') . '"' . $disabled . '><i class="rex-icon rex-icon-open-linkmap"></i></a>
                     <a href="#" class="btn btn-popup" onclick="' . $deleteFunc . 'return false;" title="' . rex_i18n::msg('var_link_delete') . '"' . $disabled . '><i class="rex-icon rex-icon-delete-link"></i></a>';

--- a/redaxo/src/addons/structure/package.yml
+++ b/redaxo/src/addons/structure/package.yml
@@ -1,5 +1,5 @@
 package: structure
-version: '2.12.0'
+version: '2.12.1-dev'
 author: Markus Staab
 supportpage: https://github.com/redaxo/redaxo
 

--- a/redaxo/src/addons/structure/pages/linkmap.php
+++ b/redaxo/src/addons/structure/pages/linkmap.php
@@ -33,7 +33,7 @@ if ('' != $openerInputField && '' == $openerInputFieldName) {
     $openerInputFieldName = $openerInputField . '_NAME';
 }
 if ('REX_LINKLIST_' == substr($openerInputField, 0, 13)) {
-    $id = (int) substr($openerInputField, 13, strlen($openerInputField));
+    $id = rex_escape(substr($openerInputField, 13, strlen($openerInputField)), 'js');
     $funcBody .= 'var linklist = "REX_LINKLIST_SELECT_' . $id . '";
                              var linkid = link.replace("redaxo://","");
                  var source = opener.document.getElementById(linklist);
@@ -44,7 +44,7 @@ if ('REX_LINKLIST_' == substr($openerInputField, 0, 13)) {
                              option.value = linkid;
 
                  source.options.add(option, sourcelength);
-                 opener.writeREXLinklist(' . $id . ');';
+                 opener.writeREXLinklist(\'' . $id . '\');';
 } else {
     $escapedOpenerInputField = rex_escape($openerInputField, 'js');
     $escapedOpenerInputFieldName = rex_escape($openerInputFieldName, 'js');

--- a/redaxo/src/addons/structure/pages/linkmap.php
+++ b/redaxo/src/addons/structure/pages/linkmap.php
@@ -33,7 +33,7 @@ if ('' != $openerInputField && '' == $openerInputFieldName) {
     $openerInputFieldName = $openerInputField . '_NAME';
 }
 if ('REX_LINKLIST_' == substr($openerInputField, 0, 13)) {
-    $id = rex_escape(substr($openerInputField, 13, strlen($openerInputField)), 'js');
+    $id = rex_escape((string) substr($openerInputField, 13, strlen($openerInputField)), 'js');
     $funcBody .= 'var linklist = "REX_LINKLIST_SELECT_' . $id . '";
                              var linkid = link.replace("redaxo://","");
                  var source = opener.document.getElementById(linklist);


### PR DESCRIPTION
fixes #4610

Aktuell nutzen die Slices und die Metainfos das gleiche ID-Schema und zählen beide eigenständig hoch.
YForm hat bereits angepasst, dass dort die ID einen zusätzlichen Präfix enthält.

Metainfo macht es nun genauso und fügt `METAINFO_` der ID hinzu.
Allerdings musste ich die Widgets selbst auch noch ein bisschen dafür anpassen, damit es überall korrekt funktioniert.