### PR TITLE
use modern crypto for socket connections

### DIFF
--- a/redaxo/src/core/lib/util/socket/socket_proxy.php
+++ b/redaxo/src/core/lib/util/socket/socket_proxy.php
@@ -72,7 +72,7 @@ class rex_socket_proxy extends rex_socket
             if (!$response->isOk()) {
                 throw new rex_socket_exception(sprintf('Couldn\'t connect to proxy server, server responds with "%s %s"', $response->getStatusCode(), $response->getStatusMessage()));
             }
-            stream_socket_enable_crypto($this->stream, true, STREAM_CRYPTO_METHOD_SSLv3_CLIENT);
+            stream_socket_enable_crypto($this->stream, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
         } else {
             unset($this->headers['Connection']);
             $this->addHeader('Proxy-Connection', 'Close');


### PR DESCRIPTION
use tls1.2 instead of sslv3 to support proxies with higher
security defaults and also improve security