### PR TITLE
REGEXP in Medienpool-Suche erlauben

### DIFF
--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -278,8 +278,14 @@ final class rex_media_service
                     }
                     break;
                 case 'term':
-                    if (is_string($searchItem['value']) && '' != $searchItem['value']) {
-                        $where[] = '(m.filename LIKE :search_'.$counter.' || m.title LIKE :search_'.$counter.')';
+                    if (is_string($searchItem['value']) && '' != $searchItem['value']) {                      
+                        if(is_int(@preg_match("/^.*".$searchItem['value'].".*$/", '')) {
+                            $where[] = '(m.filename REGEXP :search_regexp_'.$counter.' || m.title LIKE :search_regexp_'.$counter.' || m.filename :search_'.$counter.' || m.title LIKE :search_'.$counter.')';
+                            $queryParams['search_regexp_'.$counter] = "^.*".$searchItem['value'].".*$";
+                        } else {
+                            $where[] = '(m.filename :search_'.$counter.' || m.title LIKE :search_'.$counter.')';
+                        }
+
                         $queryParams['search_'.$counter] = $searchItem['value'];
                     }
                     break;


### PR DESCRIPTION
Vorschlag zu #4691 

erlaubt Statements wie `meinbild.*\.jpg`

Stellt weiterhin Rückwartskompatibilität sicher, indem die Begriffe auch klassisch gesucht werden und somit keine Steuerzeichen von regexp dazwischenfunken.

Es wird erst validiert, ob das Suchmuster überhaupt gültig ist - falls der String kein gültiges REGEX ist, wird er ignoriert.