### PR TITLE
REX_LINK[id=1 output=url]: URL nicht in Cache

### DIFF
--- a/redaxo/src/addons/structure/lib/linkmap/var_link.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_link.php
@@ -36,7 +36,7 @@ class rex_var_link extends rex_var
             $value = self::getWidget($id, 'REX_INPUT_LINK[' . $id . ']', $value, $args);
         } else {
             if ($value && $this->hasArg('output') && 'id' != $this->getArg('output')) {
-                $value = rex_getUrl($value);
+                return 'rex_getUrl('.self::quote($value).')';
             }
         }
 


### PR DESCRIPTION
fixes #4730 

Nicht die generierte URL darf in den Cache, sondern der PHP-Code zum Abruf der URL.
Sonst hat die URL die falsche Sprache, wenn der Cache unter anderer Sprache generiert wird (zum Beispiel beim Einbinden der Sprachversion in eine andere Sprache).