### PR TITLE
taint analyse: has_quotes berücksichtigen

### DIFF
--- a/.tools/psalm/baseline-taint.xml
+++ b/.tools/psalm/baseline-taint.xml
@@ -1,83 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa">
-  <file src="redaxo/src/addons/backup/pages/export.php">
-    <TaintedTextWithQuotes occurrences="1">
-      <code>rex_view::success($success)</code>
-    </TaintedTextWithQuotes>
-  </file>
   <file src="redaxo/src/addons/cronjob/pages/cronjobs.php">
     <TaintedHtml occurrences="1">
       <code>$visibleJs . "\n"</code>
     </TaintedHtml>
-    <TaintedTextWithQuotes occurrences="11">
-      <code>$envFieldId</code>
-      <code>$envFieldId</code>
-      <code>$envJs</code>
-      <code>$envJs</code>
-      <code>$typeFieldId</code>
-      <code>$typeFieldId</code>
-      <code>$typeFieldId</code>
-      <code>$typeFieldId</code>
+    <TaintedTextWithQuotes occurrences="1">
       <code>$visibleJs . "\n"</code>
-      <code>$visibleJs . "\n"</code>
-      <code>$visibleJs . "\n"</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/install/pages/packages.add.php">
-    <TaintedTextWithQuotes occurrences="1">
-      <code>rex_api_function::getMessage()</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/install/pages/packages.upload.php">
-    <TaintedTextWithQuotes occurrences="3">
-      <code>rex_api_function::getMessage()</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/mediapool/pages/index.php">
-    <TaintedTextWithQuotes occurrences="2">
-      <code>$openerInputField ? 'rex.mediapoolOpenerInputField = "'.rex_escape($openerInputField, 'js').'";' : ''</code>
-      <code>$openerInputField ? 'rex.mediapoolOpenerInputField = "'.rex_escape($openerInputField, 'js').'";' : ''</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/mediapool/pages/sync.php">
-    <TaintedTextWithQuotes occurrences="1">
-      <code>$content</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/mediapool/pages/upload.php">
-    <TaintedTextWithQuotes occurrences="2">
-      <code>rex_mediapool_Uploadform($rexFileCategory)</code>
-      <code>rex_mediapool_Uploadform($rexFileCategory)</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/metainfo/pages/field.php">
-    <TaintedTextWithQuotes occurrences="1">
-      <code>rex_api_function::getMessage()</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/navigation.php">
-    <TaintedTextWithQuotes occurrences="4">
-      <code>$this-&gt;get($categoryId, $depth, $open, $ignoreOfflines)</code>
-      <code>$this-&gt;get($categoryId, $depth, $open, $ignoreOfflines)</code>
-      <code>$this-&gt;getBreadcrumb($startPageLabel, $includeCurrent, $categoryId)</code>
-      <code>$this-&gt;getBreadcrumb($startPageLabel, $includeCurrent, $categoryId)</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/structure/pages/index.php">
-    <TaintedTextWithQuotes occurrences="1">
-      <code>rex_api_function::getMessage()</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/structure/pages/linkmap.php">
-    <TaintedTextWithQuotes occurrences="2">
-      <code>$funcBody . "\n"</code>
-      <code>$funcBody . "\n"</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/addons/structure/plugins/content/pages/templates.php">
-    <TaintedTextWithQuotes occurrences="2">
-      <code>$content</code>
-      <code>$content</code>
     </TaintedTextWithQuotes>
   </file>
   <file src="redaxo/src/addons/structure/plugins/history/fragments/history/layer.php">
@@ -87,53 +15,24 @@
       <code>$this-&gt;getVar('content2iframe')</code>
       <code>$this-&gt;getVar('content2select')</code>
     </TaintedHtml>
-    <TaintedTextWithQuotes occurrences="12">
-      <code>$this-&gt;getVar('content1iframe')</code>
-      <code>$this-&gt;getVar('content1iframe')</code>
+    <TaintedTextWithQuotes occurrences="4">
       <code>$this-&gt;getVar('content1iframe')</code>
       <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content1select')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
-      <code>$this-&gt;getVar('content2iframe')</code>
       <code>$this-&gt;getVar('content2iframe')</code>
       <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-      <code>$this-&gt;getVar('content2select')</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/core/fragments/core/buttons/button.php">
-    <TaintedTextWithQuotes occurrences="2">
-      <code>'&lt;' .$tag . $href . rex_string::buildAttributes($button['attributes']) . '&gt;' . $icon . $button['label'] . '&lt;/' . $tag . '&gt;'</code>
-      <code>'&lt;' .$tag . $href . rex_string::buildAttributes($button['attributes']) . '&gt;' . $icon . $button['label'] . '&lt;/' . $tag . '&gt;'</code>
     </TaintedTextWithQuotes>
   </file>
   <file src="redaxo/src/core/fragments/core/fe_ooops.php">
     <TaintedHtml occurrences="1">
       <code>$this-&gt;getVar('content', '')</code>
     </TaintedHtml>
-    <TaintedTextWithQuotes occurrences="3">
-      <code>$this-&gt;getVar('content', '')</code>
-      <code>$this-&gt;getVar('content', '')</code>
+    <TaintedTextWithQuotes occurrences="1">
       <code>$this-&gt;getVar('content', '')</code>
     </TaintedTextWithQuotes>
   </file>
   <file src="redaxo/src/core/fragments/core/form/search.php">
     <TaintedHtml occurrences="1"/>
-    <TaintedTextWithQuotes occurrences="3"/>
-  </file>
-  <file src="redaxo/src/core/fragments/core/navigations/content.php">
-    <TaintedTextWithQuotes occurrences="1">
-      <code>'&lt;div' . ((isset($this-&gt;id) &amp;&amp; '' != $this-&gt;id) ? ' id="' .  $this-&gt;id . '"' : '') . ' class="nav rex-page-nav"&gt;' . $out . '&lt;/div&gt;'</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/core/fragments/core/navigations/main.php">
-    <TaintedTextWithQuotes occurrences="4">
-      <code>$itemAttr</code>
-      <code>$itemAttr</code>
-      <code>$linkAttr</code>
-      <code>$linkAttr</code>
-    </TaintedTextWithQuotes>
+    <TaintedTextWithQuotes occurrences="1"/>
   </file>
   <file src="redaxo/src/core/fragments/core/page/docs.php">
     <TaintedHtml occurrences="3">
@@ -141,15 +40,9 @@
       <code>$this-&gt;getVar('sidebar')</code>
       <code>$this-&gt;getVar('toc')</code>
     </TaintedHtml>
-    <TaintedTextWithQuotes occurrences="9">
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
+    <TaintedTextWithQuotes occurrences="3">
       <code>$this-&gt;getVar('content')</code>
       <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('sidebar')</code>
-      <code>$this-&gt;getVar('toc')</code>
-      <code>$this-&gt;getVar('toc')</code>
       <code>$this-&gt;getVar('toc')</code>
     </TaintedTextWithQuotes>
   </file>
@@ -157,56 +50,14 @@
     <TaintedHtml occurrences="1">
       <code>$this-&gt;getVar('content')</code>
     </TaintedHtml>
-    <TaintedTextWithQuotes occurrences="3">
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-      <code>$this-&gt;getVar('content')</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/core/fragments/core/page/section.php">
-    <TaintedTextWithQuotes occurrences="4">
-      <code>'' != $header ? '&lt;header' . rex_string::buildAttributes($attributes) . '&gt;' . $header . '&lt;/header&gt;' : ''</code>
-      <code>'' != $header ? '&lt;header' . rex_string::buildAttributes($attributes) . '&gt;' . $header . '&lt;/header&gt;' : ''</code>
-      <code>rex_string::buildAttributes($sectionAttributes)</code>
-      <code>rex_string::buildAttributes($sectionAttributes)</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/core/layout/top.php">
-    <TaintedTextWithQuotes occurrences="2">
-      <code>'&lt;title&gt;' . rex_escape(rex_be_controller::getPageTitle()) . '&lt;/title&gt;'</code>
-      <code>'&lt;title&gt;' . rex_escape(rex_be_controller::getPageTitle()) . '&lt;/title&gt;'</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/core/lib/error_handler.php">
-    <TaintedTextWithQuotes occurrences="3">
-      <code>$exceptionString</code>
-      <code>'&lt;div&gt;&lt;b&gt;' . self::getErrorType($errno) . '&lt;/b&gt;: '.rex_escape($errstr)." in &lt;b&gt;$file&lt;/b&gt; on line &lt;b&gt;$errline&lt;/b&gt;&lt;/div&gt;"</code>
-      <code>'&lt;div&gt;&lt;b&gt;' . self::getErrorType($errno) . '&lt;/b&gt;: '.rex_escape($errstr)." in &lt;b&gt;$file&lt;/b&gt; on line &lt;b&gt;$errline&lt;/b&gt;&lt;/div&gt;"</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/core/lib/form/form_base.php">
-    <TaintedTextWithQuotes occurrences="4">
-      <code>$this-&gt;get()</code>
-      <code>$this-&gt;get()</code>
-      <code>'redirect to: ' . rex_escape($this-&gt;applyUrl . $paramString)</code>
-      <code>'redirect to: ' . rex_escape($this-&gt;applyUrl . $paramString)</code>
-    </TaintedTextWithQuotes>
-  </file>
-  <file src="redaxo/src/core/lib/list.php">
     <TaintedTextWithQuotes occurrences="1">
-      <code>$this-&gt;get()</code>
+      <code>$this-&gt;getVar('content')</code>
     </TaintedTextWithQuotes>
   </file>
   <file src="redaxo/src/core/lib/response.php">
     <TaintedHeader occurrences="1">
       <code>$str</code>
     </TaintedHeader>
-  </file>
-  <file src="redaxo/src/core/lib/select.php">
-    <TaintedTextWithQuotes occurrences="2">
-      <code>$this-&gt;get()</code>
-      <code>$this-&gt;get()</code>
-    </TaintedTextWithQuotes>
   </file>
   <file src="redaxo/src/core/lib/sql/schema_dumper.php">
     <TaintedHtml occurrences="1">
@@ -232,11 +83,5 @@
     <TaintedCallable occurrences="1">
       <code>$data</code>
     </TaintedCallable>
-  </file>
-  <file src="redaxo/src/core/pages/system.report.markdown.php">
-    <TaintedTextWithQuotes occurrences="2">
-      <code>'&lt;pre&gt;'.rex_escape($report).'&lt;/pre&gt;'</code>
-      <code>'&lt;pre&gt;'.rex_escape($report).'&lt;/pre&gt;'</code>
-    </TaintedTextWithQuotes>
   </file>
 </files>

--- a/redaxo/src/addons/backup/pages/export.php
+++ b/redaxo/src/addons/backup/pages/export.php
@@ -44,6 +44,7 @@ if ($export && !$csrfToken->isValid()) {
     $exportfilename = strtolower($exportfilename);
     /**
      * @psalm-taint-escape file
+     * @psalm-taint-escape has_quotes
      * @psalm-taint-escape html
      * @psalm-taint-escape shell
      */

--- a/redaxo/src/core/functions/function_rex_escape.php
+++ b/redaxo/src/core/functions/function_rex_escape.php
@@ -27,6 +27,7 @@
  *
  * @return mixed
  *
+ * @psalm-taint-escape has_quotes
  * @psalm-taint-escape html
  */
 function rex_escape($value, $strategy = 'html')

--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -51,7 +51,11 @@ abstract class rex_error_handler
 
             // in case exceptions happen early - before symfony-console doRun()
             if ('cli' === PHP_SAPI) {
-                /** @psalm-taint-escape html */ // actually it is not escaped, it is not necessary in cli output
+                /**
+                 * actually it is not escaped, it is not necessary in cli output.
+                 * @psalm-taint-escape has_quotes
+                 * @psalm-taint-escape html
+                 */
                 $exceptionString = $exception->__toString();
                 echo $exceptionString;
                 exit(1);

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -114,6 +114,7 @@ class rex_i18n
      *
      * @return string Translation for the key
      *
+     * @psalm-taint-escape has_quotes
      * @psalm-taint-escape html
      */
     public static function msg($key, ...$replacements)
@@ -143,6 +144,7 @@ class rex_i18n
      *
      * @return string Translation for the key
      *
+     * @psalm-taint-escape has_quotes
      * @psalm-taint-escape html
      */
     public static function msgInLocale($key, $locale, ...$replacements)


### PR DESCRIPTION
Seit https://github.com/vimeo/psalm/commit/47bf5ed56797e5605eeb656bd7ec98bb87650d8f gibt es neu `has_quotes`, was wir bisher nicht berücksichtigt haben. Deswegen hatten wir sehr viele false-positive in der baseline.