### PR TITLE
Adding: rex_extension_point: PHPMAILER_CONFIG

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -56,8 +56,9 @@ class rex_mailer extends PHPMailer
             $this->addBCC($bcc);
         }
         $this->archive = $addon->getConfig('archive');
-        rex_extension::registerPoint(new rex_extension_point('PHPMAILER_CONFIG', $this));
         parent::__construct($exceptions);
+
+        rex_extension::registerPoint(new rex_extension_point('PHPMAILER_CONFIG', $this));
     }
 
     protected function addOrEnqueueAnAddress($kind, $address, $name)


### PR DESCRIPTION
to overwrite PHPMailer-Setting from outside.

**Example usage in boot.php:**

```php 
function customMailer($ep) {
    $subject = $ep->getSubject();
    $subject->FromName = 'Willi Muster'; // changes sender name
    // set SMTPOptions
    $subject->SMTPOptions = array(
    'ssl' => array(
        'verify_peer' => false,
        'verify_peer_name' => false,
        'allow_self_signed' => true
    ),
    'tls' => array(
        'verify_peer' => false,
        'verify_peer_name' => false,
        'allow_self_signed' => true
    ),
);
    return $ep;
}
rex_extension::register('PHPMAILER_CONFIG', "customMailer");
```

closes: https://github.com/redaxo/redaxo/issues/4797

entspricht auch der Idee von: https://github.com/redaxo/redaxo/pull/4657

