### PR TITLE
rex_formatter::intl*: Fix default value for $format

### DIFF
--- a/redaxo/src/core/lib/util/formatter.php
+++ b/redaxo/src/core/lib/util/formatter.php
@@ -103,13 +103,14 @@ abstract class rex_formatter
      * @see https://www.php.net/manual/en/class.intldateformatter.php
      *
      * @param string|int|DateTimeInterface|null $value  Unix timestamp, datetime string for `strtotime` or DateTimeInterface object
-     * @param IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|array{0: IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|IntlDateFormatter::NONE, 1: IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|IntlDateFormatter::NONE}|string $format
+     * @param IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|array{0: IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|IntlDateFormatter::NONE, 1: IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|IntlDateFormatter::NONE}|string|null $format
      *              Possible format values:
      *                  - `IntlDateFormatter` constant, like `IntlDateFormatter::MEDIUM`
      *                  - array with two `IntlDateFormatter` constants for date format and time format, like `[IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT]`
      *                  - string pattern, like `dd.MM.y`
+     *              Defaults to `[IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT]`
      */
-    public static function intlDateTime($value, $format = [IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT]): string
+    public static function intlDateTime($value, $format = null): string
     {
         if (empty($value)) {
             return '';
@@ -125,6 +126,10 @@ abstract class rex_formatter
             }
 
             $timeZone = date_default_timezone_get();
+        }
+
+        if (null === $format || '' === $format) {
+            $format = [IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT];
         }
 
         if (is_string($format)) {
@@ -174,13 +179,18 @@ abstract class rex_formatter
      * @see https://www.php.net/manual/en/class.intldateformatter.php
      *
      * @param string|int|DateTimeInterface|null $value  Unix timestamp, date string for `strtotime` or DateTimeInterface object
-     * @param IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|string $format
+     * @param IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|string|null $format
      *              Possible format values:
      *                  - `IntlDateFormatter` constant, like `IntlDateFormatter::MEDIUM`
      *                  - string pattern, like `dd.MM.y`
+     *              Defaults to `IntlDateFormatter::MEDIUM`
      */
-    public static function intlDate($value, $format = IntlDateFormatter::MEDIUM): string
+    public static function intlDate($value, $format = null): string
     {
+        if (null === $format || '' === $format) {
+            $format = IntlDateFormatter::MEDIUM;
+        }
+
         return self::intlDateTime($value, is_string($format) ? $format : [$format, IntlDateFormatter::NONE]);
     }
 
@@ -190,13 +200,18 @@ abstract class rex_formatter
      * @see https://www.php.net/manual/en/class.intldateformatter.php
      *
      * @param string|int|DateTimeInterface|null $value  Unix timestamp, time string for `strtotime` or DateTimeInterface object
-     * @param IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|string $format
+     * @param IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|string|null $format
      *              Possible format values:
      *                  - `IntlDateFormatter` constant, like `IntlDateFormatter::MEDIUM`
      *                  - string pattern, like `HH:mm`
+     *              Defaults to `IntlDateFormatter::SHORT`
      */
     public static function intlTime($value, $format = IntlDateFormatter::SHORT): string
     {
+        if (null === $format || '' === $format) {
+            $format = IntlDateFormatter::SHORT;
+        }
+
         return self::intlDateTime($value, is_string($format) ? $format : [IntlDateFormatter::NONE, $format]);
     }
 


### PR DESCRIPTION
Wenn man `rex_list::setColumnFormat($col, 'intlDate')` nutzt, dann wird für den $format-Parameter ein leerer String durchgereicht (über allgemeine Methode `rex_formatter::format`).

Will an dem Prinzip aus BC-Gründen jetzt nichts ändern. Deswegen akzeptieren die intl-Methoden nun `null` und `''` als Wert für `$format`, und nutzen dann das Default-Format.