### PR TITLE
rex_article_slice: Array-Methoden

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
@@ -461,7 +461,7 @@ class rex_article_slice
 
     /**
      * @param int $index
-     * @return string|null
+     * @return string|null liefert kommaseparierten String
      */
     public function getLinkList($index)
     {
@@ -504,7 +504,7 @@ class rex_article_slice
 
     /**
      * @param int $index
-     * @return string|null
+     * @return string|null liefert kommaseparierten String
      */
     public function getMediaList($index)
     {


### PR DESCRIPTION
Der PR stellt drei neue Methoden in `rex_article_slice` bereit:
* `getValueArray`: Ist das Gegenstück zu `rex_var::toArray('REX_VALUE[1]')`, sodass auch im Slice-Objekt eine einfache Möglichkeit besteht, an das Array zu kommen
* `getMediaListArray`: Medialist als Array (`getMedialist` liefert kommaseparierten String)
* `getLinkListArray`: Wie bei Medialist