### PR TITLE
visual-tests: fix error handling

### DIFF
--- a/.github/tests-visual/visual-record.js
+++ b/.github/tests-visual/visual-record.js
@@ -305,7 +305,8 @@ async function main() {
 // print uncaught exceptions and make github action fail
 main().catch(error => {
     console.error("::error ::" +
-        error.replace(/%/g, '%25')
+        error.toString()
+             .replace(/%/g, '%25')
              .replace(/\r/g, '%0D')
              .replace(/\n/g, '%0A')
     );


### PR DESCRIPTION

```
(node:2091) UnhandledPromiseRejectionWarning: TypeError: error.replace is not a function
    at /home/runner/work/redaxo/redaxo/.github/tests-visual/visual-record.js:310:15
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:2091) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:2091) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
https://github.com/redaxo/redaxo/runs/4056307011?check_suite_focus=true#step:14:112