### PR TITLE
visual-tests: show origin for failed ajax requests

### DIFF
--- a/.github/tests-visual/visual-record.js
+++ b/.github/tests-visual/visual-record.js
@@ -222,7 +222,7 @@ async function main() {
         // ajax requests
         const origin = msg.location().url;
         if (origin) {
-            console.log(`BROWSER-CONSOLE: "${origin}" `, text);    
+            console.log(`BROWSER-CONSOLE: "${origin}" (Ajax)`, text);    
             return;
         }
         

--- a/.github/tests-visual/visual-record.js
+++ b/.github/tests-visual/visual-record.js
@@ -214,10 +214,19 @@ async function main() {
     let page = await browser.newPage();
     // log browser errors into the console
     page.on('console', function(msg) {
-        var text = msg.text();
-        if (text.indexOf("Unrecognized feature: 'interest-cohort'.") == -1) {
-            console.log('BROWSER-CONSOLE:', text);
+        const text = msg.text();
+        if (text.indexOf("Unrecognized feature: 'interest-cohort'.") !== -1) {
+            return;
         }
+        
+        // ajax requests
+        const origin = msg.location().url;
+        if (origin) {
+            console.log(`BROWSER-CONSOLE: "${origin}" `, text);    
+            return;
+        }
+        
+        console.log('BROWSER-CONSOLE:', text);
     });
 
     await page.setViewport({ width: viewportWidth, height: viewportHeight });


### PR DESCRIPTION
vorher
`BROWSER-CONSOLE: Failed to load resource: the server responded with a status of 500 (Internal Server Error)`

nachher
`BROWSER-CONSOLE: "http://localhost:8000/__clockwork/latest" Failed to load resource: the server responded with a status of 500 (Internal Server Error)`


ursprung https://github.com/redaxo/redaxo/runs/4056412059?check_suite_focus=true#step:14:112