### PR TITLE
phpstan: don't use excludes_analyse deprecated config

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,12 +21,13 @@ parameters:
         - redaxo/src/addons/project
         - redaxo/src/addons/structure
         - redaxo/src/addons/users
-    excludes_analyse:
-        - redaxo/src/addons/backup/vendor/
-        - redaxo/src/addons/be_style/vendor/
-        - redaxo/src/addons/debug/vendor/
-        - redaxo/src/addons/phpmailer/vendor/
-        - redaxo/src/core/vendor/
+    excludePaths:
+        analyse:
+            - redaxo/src/addons/backup/vendor/
+            - redaxo/src/addons/be_style/vendor/
+            - redaxo/src/addons/debug/vendor/
+            - redaxo/src/addons/phpmailer/vendor/
+            - redaxo/src/core/vendor/
     # https://phpstan.org/config-reference#universal-object-crates
     universalObjectCratesClasses:
         - rex_fragment


### PR DESCRIPTION
to ease migration to phpstan 1.0