### PR TITLE
metainfo: Ablaufoptimierungen

### DIFF
--- a/redaxo/src/addons/metainfo/lib/handler/category_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/category_handler.php
@@ -117,7 +117,7 @@ $catHandler = new rex_metainfo_category_handler();
 rex_extension::register('CAT_FORM_ADD', [$catHandler, 'extendForm']);
 rex_extension::register('CAT_FORM_EDIT', [$catHandler, 'extendForm']);
 
-rex_extension::register('CAT_ADDED', [$catHandler, 'extendForm']);
-rex_extension::register('CAT_UPDATED', [$catHandler, 'extendForm']);
+rex_extension::register('CAT_ADDED', [$catHandler, 'extendForm'], rex_extension::EARLY);
+rex_extension::register('CAT_UPDATED', [$catHandler, 'extendForm'], rex_extension::EARLY);
 
 rex_extension::register('CAT_FORM_BUTTONS', [$catHandler, 'renderToggleButton']);

--- a/redaxo/src/addons/metainfo/lib/handler/clang_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/clang_handler.php
@@ -91,7 +91,7 @@ $clangHandler = new rex_metainfo_clang_handler();
 rex_extension::register('CLANG_FORM_ADD', [$clangHandler, 'extendForm']);
 rex_extension::register('CLANG_FORM_EDIT', [$clangHandler, 'extendForm']);
 
-rex_extension::register('CLANG_ADDED', [$clangHandler, 'extendForm']);
-rex_extension::register('CLANG_UPDATED', [$clangHandler, 'extendForm']);
+rex_extension::register('CLANG_ADDED', [$clangHandler, 'extendForm'], rex_extension::EARLY);
+rex_extension::register('CLANG_UPDATED', [$clangHandler, 'extendForm'], rex_extension::EARLY);
 
 rex_extension::register('CLANG_FORM_BUTTONS', [$clangHandler, 'renderToggleButton']);

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -653,14 +653,14 @@ abstract class rex_metainfo_handler
      *
      * @return string
      */
-    public function renderFormAndSave($prefix, array $params)
+    public function renderFormAndSave($prefix, array $params, bool $fireCallbacks = true)
     {
         $filterCondition = $this->buildFilterCondition($params);
         $sqlFields = static::getSqlFields($prefix, $filterCondition);
         $params = $this->handleSave($params, $sqlFields);
 
         // trigger callback of sql fields
-        if ('post' == rex_request_method()) {
+        if ($fireCallbacks && 'post' == rex_request_method()) {
             $this->fireCallbacks($sqlFields);
         }
 

--- a/redaxo/src/addons/metainfo/lib/handler/media_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/media_handler.php
@@ -179,7 +179,7 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
     public function extendForm(rex_extension_point $ep)
     {
         $params = $ep->getParams();
-        $params['save'] = in_array($ep->getName(), ['MEDIA_ADDED', 'MEDIA_UPDATED'], true);
+        $params['save'] = $save = in_array($ep->getName(), ['MEDIA_ADDED', 'MEDIA_UPDATED'], true);
 
         // Nur beim EDIT gibts auch ein Medium zum bearbeiten
         if ('MEDIA_FORM_EDIT' == $ep->getName()) {
@@ -196,7 +196,7 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
             }
         }
 
-        return $ep->getSubject() . parent::renderFormAndSave(self::PREFIX, $params, $params['save']);
+        return $ep->getSubject() . parent::renderFormAndSave(self::PREFIX, $params, $save);
     }
 }
 

--- a/redaxo/src/addons/metainfo/lib/handler/media_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/media_handler.php
@@ -163,8 +163,8 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
 
         parent::fetchRequestValues($params, $media, $sqlFields);
 
-        // do the save only when metafields are defined
-        if ($media->hasValues()) {
+        // do the save only when EP = MEDIA_ADDED/UPDATED and metafields are defined
+        if ($params['save'] && $media->hasValues()) {
             $media->update();
         }
 
@@ -179,6 +179,8 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
     public function extendForm(rex_extension_point $ep)
     {
         $params = $ep->getParams();
+        $params['save'] = in_array($ep->getName(), ['MEDIA_ADDED', 'MEDIA_UPDATED'], true);
+
         // Nur beim EDIT gibts auch ein Medium zum bearbeiten
         if ('MEDIA_FORM_EDIT' == $ep->getName()) {
             $params['activeItem'] = $params['media'];
@@ -194,7 +196,7 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
             }
         }
 
-        return $ep->getSubject() . parent::renderFormAndSave(self::PREFIX, $params);
+        return $ep->getSubject() . parent::renderFormAndSave(self::PREFIX, $params, $params['save']);
     }
 }
 
@@ -203,7 +205,7 @@ $mediaHandler = new rex_metainfo_media_handler();
 rex_extension::register('MEDIA_FORM_EDIT', [$mediaHandler, 'extendForm']);
 rex_extension::register('MEDIA_FORM_ADD', [$mediaHandler, 'extendForm']);
 
-rex_extension::register('MEDIA_ADDED', [$mediaHandler, 'extendForm']);
-rex_extension::register('MEDIA_UPDATED', [$mediaHandler, 'extendForm']);
+rex_extension::register('MEDIA_ADDED', [$mediaHandler, 'extendForm'], rex_extension::EARLY);
+rex_extension::register('MEDIA_UPDATED', [$mediaHandler, 'extendForm'], rex_extension::EARLY);
 
 rex_extension::register('MEDIA_IS_IN_USE', [rex_metainfo_media_handler::class, 'isMediaInUse']);


### PR DESCRIPTION
fixes #1661: Ich habe in den letzten Jahren mehrfach angesetzt, um das sauber zu fixen, aber bin immer zu keiner schönen Lösung gekommen, bzw. es wäre mir zu viel Umbau im metainfo-Addon. Deshalb nun eine bisschen Quick&Dirty-Lösung. Gibt immer noch Dinge, die ich nicht optimal finde, aber so wird das eigentliche Ticket zumindest gelöst (kein doppeltes Speichern mehr, und keine doppelt ausgeführten Callbacks).

fixes #1660: Einerseits hängt sich das metainfo nun EARLY and die EPs (`MEDIA_UPDATED` etc.). So wird dafür gesorgt, dass wenn andere Extensions sich an die EPs hängen, die Metainfos auch bereits gespeichert wurden. Des Weiteren spielte hier auch das doppelte Speichern von oben noch mit rein. Also selbst wenn man sich selbst an `MEDIA_UPDATED` mit LATE registriert hat, dann waren da zwar die Metainfos schon gespeichert, sie wurden aber später im Ablauf nochmal erneut gespeichert. Somit gingen eigene Änderungen verloren.