### PR TITLE
Taint-Analyse: Werte aus DB als unsicher betrachten

### DIFF
--- a/.tools/psalm/baseline-taint.xml
+++ b/.tools/psalm/baseline-taint.xml
@@ -1,19 +1,85 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.11.2@6fba5eb554f9507b72932f9c75533d8af593688d">
+  <file src="redaxo/src/addons/cronjob/lib/types/phpcode.php">
+    <TaintedEval occurrences="1">
+      <code>$code</code>
+    </TaintedEval>
+  </file>
+  <file src="redaxo/src/addons/cronjob/pages/cronjobs.php">
+    <TaintedHtml occurrences="1">
+      <code>$envJs</code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes occurrences="1">
+      <code>$envJs</code>
+    </TaintedTextWithQuotes>
+  </file>
+  <file src="redaxo/src/addons/structure/plugins/content/pages/modules.actions.php">
+    <TaintedHtml occurrences="1">
+      <code>$message</code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes occurrences="1">
+      <code>$message</code>
+    </TaintedTextWithQuotes>
+  </file>
+  <file src="redaxo/src/addons/structure/plugins/history/fragments/history/layer.php">
+    <TaintedHtml occurrences="4">
+      <code>$this-&gt;getVar('content1iframe')</code>
+      <code>$this-&gt;getVar('content1select')</code>
+      <code>$this-&gt;getVar('content2iframe')</code>
+      <code>$this-&gt;getVar('content2select')</code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes occurrences="4">
+      <code>$this-&gt;getVar('content1iframe')</code>
+      <code>$this-&gt;getVar('content1select')</code>
+      <code>$this-&gt;getVar('content2iframe')</code>
+      <code>$this-&gt;getVar('content2select')</code>
+    </TaintedTextWithQuotes>
+  </file>
+  <file src="redaxo/src/core/fragments/core/fe_ooops.php">
+    <TaintedHtml occurrences="1">
+      <code>$this-&gt;getVar('content', '')</code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes occurrences="1">
+      <code>$this-&gt;getVar('content', '')</code>
+    </TaintedTextWithQuotes>
+  </file>
+  <file src="redaxo/src/core/fragments/core/form/search.php">
+    <TaintedHtml occurrences="1"/>
+    <TaintedTextWithQuotes occurrences="1"/>
+  </file>
+  <file src="redaxo/src/core/fragments/core/page/docs.php">
+    <TaintedHtml occurrences="3">
+      <code>$this-&gt;getVar('content')</code>
+      <code>$this-&gt;getVar('sidebar')</code>
+      <code>$this-&gt;getVar('toc')</code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes occurrences="3">
+      <code>$this-&gt;getVar('content')</code>
+      <code>$this-&gt;getVar('sidebar')</code>
+      <code>$this-&gt;getVar('toc')</code>
+    </TaintedTextWithQuotes>
+  </file>
+  <file src="redaxo/src/core/fragments/core/page/readme.php">
+    <TaintedHtml occurrences="1">
+      <code>$this-&gt;getVar('content')</code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes occurrences="1">
+      <code>$this-&gt;getVar('content')</code>
+    </TaintedTextWithQuotes>
+  </file>
   <file src="redaxo/src/core/lib/response.php">
-    <TaintedHeader occurrences="1">
+    <TaintedHeader occurrences="2">
       <code>$str</code>
+      <code>'Location: ' . $url</code>
     </TaintedHeader>
   </file>
   <file src="redaxo/src/core/lib/sql/schema_dumper.php">
-    <TaintedHtml occurrences="1">
+    <TaintedHtml occurrences="2">
+      <code>$scalar</code>
       <code>$scalar</code>
     </TaintedHtml>
   </file>
   <file src="redaxo/src/core/lib/sql/sql.php">
-    <TaintedHtml occurrences="1">
-      <code>$values</code>
-    </TaintedHtml>
     <TaintedSql occurrences="2">
       <code>$query</code>
       <code>$query</code>

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -6045,14 +6045,12 @@
       <code>$matches[0]</code>
       <code>$matches[0]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="22">
+    <MixedAssignment occurrences="20">
       <code>$buffered</code>
       <code>$buffered</code>
       <code>$errors['error']</code>
       <code>$field</code>
       <code>$i</code>
-      <code>$id</code>
-      <code>$id</code>
       <code>$key</code>
       <code>$lastRow</code>
       <code>$params[$paramName]</code>
@@ -6069,16 +6067,14 @@
       <code>$version</code>
       <code>$version</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="5">
+    <MixedInferredReturnType occurrences="4">
       <code>array</code>
-      <code>int</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="4">
+    <MixedOperand occurrences="3">
       <code>$i</code>
-      <code>$id</code>
       <code>$metadata['table']</code>
       <code>$value</code>
     </MixedOperand>
@@ -6086,8 +6082,7 @@
       <code>$this-&gt;rawFieldnames</code>
       <code>$this-&gt;tablenames</code>
     </MixedPropertyTypeCoercion>
-    <MixedReturnStatement occurrences="5">
-      <code>$id</code>
+    <MixedReturnStatement occurrences="4">
       <code>$sql-&gt;getValue('Create Table')</code>
       <code>$version</code>
       <code>json_decode($this-&gt;getValue($column), true)</code>

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -35,6 +35,7 @@ abstract class rex_metainfo_handler
 
             $name = (string) $sqlFields->getValue('name');
             $title = $sqlFields->getValue('title');
+            /** @psalm-taint-escape sql */ // it is intended that admins can paste sql queries inside this field
             $params = $sqlFields->getValue('params');
             $typeLabel = $sqlFields->getValue('label');
             $attr = $sqlFields->getValue('attributes');

--- a/redaxo/src/core/lib/sql/util.php
+++ b/redaxo/src/core/lib/sql/util.php
@@ -112,6 +112,7 @@ class rex_sql_util
     private static function prepareQuery($query)
     {
         // rex::getUser() gibts im Setup nicht
+        /** @psalm-taint-escape sql */ // we trust the user db table
         $user = rex::getUser() ? rex::getUser()->getValue('login') : '';
 
         $query = str_replace('%USER%', $user, $query);

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -132,6 +132,8 @@ class rex_i18n
      * @param string|int ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return string Translation for the key
+     *
+     * @psalm-taint-specialize
      */
     public static function rawMsg($key, ...$replacements)
     {
@@ -355,6 +357,7 @@ class rex_i18n
      * @throws InvalidArgumentException
      *
      * @psalm-taint-escape ($escape is true ? "html" : null)
+     * @psalm-taint-specialize
      *
      * @return string Translated text
      */


### PR DESCRIPTION
Ich schlage vor, alle Werte aus der DB als unsicher zu markieren (`@psalm-taint-source input`).
Denn wir können ja nicht die Verknüpfung ziehen zu den Stellen, wo in die entsprechenden Felder geschrieben wird.

Als Beispiel: Durch prepared Statements verhindert man SQL Injections. Aber es wird ja nicht verhindert, dass am Ende SQL-Syntax in der DB landet. Daher beim Auslesen wieder als unsicheren Wert betrachten, der wieder escaped werden muss.

Ich habe bereits Folge-PRs in Vorbereitung mit vielen Fixes, aber wollte diesen PR nicht zu groß werden lassen.