### PR TITLE
Debug-Addon: Notice vermeiden in custom cli-Skripten

### DIFF
--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -123,7 +123,7 @@ $shutdownFn = static function () {
     $ep->table('Registered Extensions', rex_extension_debug::getExtensions());
 };
 
-if (rex::getConsole()) {
+if ('cli' === PHP_SAPI) {
     rex_extension::register(rex_extension_point_console_shutdown::NAME, static function (rex_extension_point_console_shutdown $extensionPoint) use ($shutdownFn) {
         $shutdownFn();
 


### PR DESCRIPTION
Wenn man REDAXO in einem custom cli-Skript lädt, also nicht über unsere rex-console, dann wirft Debug eine Notice:

> Notice: Undefined index: REQUEST_URI in redaxo/src/addons/debug/boot.php on line 154

Daher mein Vorschlag, allgemein bei cli in den if-zweig zu gehen. Und die Extension greift dann halt, wenn rex-console, ansonsten nicht.

Aufgefallen war es mir im Release-Skript (.tools/bin/release).