### PR TITLE
WIP: Extract package manager requirements check

### DIFF
--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -401,50 +401,10 @@ abstract class rex_package_manager
     {
         $requirements = $this->package->getProperty('requires', []);
 
-        if (!is_array($requirements)) {
-            $this->message = $this->i18n('requirement_wrong_format');
-
-            return false;
-        }
-
-        if (!$this->checkRedaxoRequirement(rex::getVersion())) {
-            return false;
-        }
-
-        $state = [];
-
-        if (isset($requirements['php'])) {
-            if (!is_array($requirements['php'])) {
-                $requirements['php'] = ['version' => $requirements['php']];
-            }
-            if (isset($requirements['php']['version']) && !rex_version::matchVersionConstraints(PHP_VERSION,$requirements['php']['version'])) {
-                $state[] = $this->i18n('requirement_error_php_version', PHP_VERSION, $requirements['php']['version']);
-            }
-            if (isset($requirements['php']['extensions']) && $requirements['php']['extensions']) {
-                $extensions = (array) $requirements['php']['extensions'];
-                foreach ($extensions as $reqExt) {
-                    if (is_string($reqExt) && !extension_loaded($reqExt)) {
-                        $state[] = $this->i18n('requirement_error_php_extension', $reqExt);
-                    }
-                }
-            }
-        }
-
-        if (empty($state)) {
-            if (isset($requirements['packages']) && is_array($requirements['packages'])) {
-                foreach ($requirements['packages'] as $package => $_) {
-                    if (!$this->checkPackageRequirement($package)) {
-                        $state[] = $this->message;
-                    }
-                }
-            }
-        }
-
-        if (empty($state)) {
-            return true;
-        }
-        $this->message = implode('<br />', $state);
-        return false;
+        $checker = new rex_package_requirement($requirements, $this->i18nPrefix);
+        $result = $checker->checkRequirements();
+        $this->message = $checker->getMessage();
+        return $result;
     }
 
     /**

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -417,7 +417,7 @@ abstract class rex_package_manager
             if (!is_array($requirements['php'])) {
                 $requirements['php'] = ['version' => $requirements['php']];
             }
-            if (isset($requirements['php']['version']) && !self::matchVersionConstraints(PHP_VERSION, $requirements['php']['version'])) {
+            if (isset($requirements['php']['version']) && !rex_version::matchVersionConstraints(PHP_VERSION,$requirements['php']['version'])) {
                 $state[] = $this->i18n('requirement_error_php_version', PHP_VERSION, $requirements['php']['version']);
             }
             if (isset($requirements['php']['extensions']) && $requirements['php']['extensions']) {
@@ -457,7 +457,7 @@ abstract class rex_package_manager
     public function checkRedaxoRequirement($redaxoVersion)
     {
         $requirements = $this->package->getProperty('requires', []);
-        if (isset($requirements['redaxo']) && !self::matchVersionConstraints($redaxoVersion, $requirements['redaxo'])) {
+        if (isset($requirements['redaxo']) && !rex_version::matchVersionConstraints($redaxoVersion,$requirements['redaxo'])) {
             $this->message = $this->i18n('requirement_error_redaxo_version', $redaxoVersion, $requirements['redaxo']);
             return false;
         }
@@ -515,7 +515,7 @@ abstract class rex_package_manager
             return false;
         }
 
-        if (!self::matchVersionConstraints($package->getVersion(), $requirements['packages'][$packageId])) {
+        if (!rex_version::matchVersionConstraints($package->getVersion(), $requirements['packages'][$packageId])) {
             $this->message = $this->i18n(
                 'requirement_error_' . $package->getType() . '_version',
                 $package->getPackageId(),
@@ -555,7 +555,7 @@ abstract class rex_package_manager
             $constraints = $conflicts['packages'][$this->package->getPackageId()];
             if (!is_string($constraints) || !$constraints || '*' === $constraints) {
                 $state[] = $this->i18n('reverse_conflict_error_' . $package->getType(), $package->getPackageId());
-            } elseif (self::matchVersionConstraints($this->package->getVersion(), $constraints)) {
+            } elseif (rex_version::matchVersionConstraints($this->package->getVersion(), $constraints)) {
                 $state[] = $this->i18n('reverse_conflict_error_' . $package->getType() . '_version', $package->getPackageId(), $constraints);
             }
         }
@@ -586,7 +586,7 @@ abstract class rex_package_manager
             $this->message = $this->i18n('conflict_error_' . $package->getType(), $package->getPackageId());
             return false;
         }
-        if (self::matchVersionConstraints($package->getVersion(), $constraints)) {
+        if (rex_version::matchVersionConstraints($package->getVersion(), $constraints)) {
             $this->message = $this->i18n('conflict_error_' . $package->getType() . '_version', $package->getPackageId(), $constraints);
             return false;
         }
@@ -758,71 +758,6 @@ abstract class rex_package_manager
 
         rex::setConfig('package-config', $config);
         rex_addon::initialize();
-    }
-
-    /**
-     * Checks the version of the requirement.
-     *
-     * @param string $version     Version
-     * @param string $constraints Constraint list, separated by comma
-     *
-     * @throws rex_exception
-     *
-     * @return bool
-     */
-    private static function matchVersionConstraints($version, $constraints)
-    {
-        $rawConstraints = array_filter(array_map('trim', explode(',', $constraints)));
-        $constraints = [];
-        foreach ($rawConstraints as $constraint) {
-            if ('*' === $constraint) {
-                continue;
-            }
-
-            if (!preg_match('/^(?<op>==?|<=?|>=?|!=|~|\^|) ?(?<version>\d+(?:\.\d+)*)(?<wildcard>\.\*)?(?<prerelease>[ -.]?[a-z]+(?:[ -.]?\d+)?)?$/i', $constraint, $match)
-                || isset($match['wildcard']) && $match['wildcard'] && ('' != $match['op'] || isset($match['prerelease']) && $match['prerelease'])
-            ) {
-                throw new rex_exception('Unknown version constraint "' . $constraint . '"!');
-            }
-
-            if (isset($match['wildcard']) && $match['wildcard']) {
-                $constraints[] = ['>=', $match['version']];
-                $pos = strrpos($match['version'], '.');
-                if (false === $pos) {
-                    $constraints[] = ['<', (int) $match['version'] + 1];
-                } else {
-                    ++$pos;
-                    $sub = (int) substr($match['version'], $pos);
-                    $constraints[] = ['<', substr_replace($match['version'], (string) ($sub + 1), $pos)];
-                }
-            } elseif (in_array($match['op'], ['~', '^'])) {
-                $constraints[] = ['>=', $match['version'] . ($match['prerelease'] ?? '')];
-                if ('^' === $match['op'] || false === $pos = strrpos($match['version'], '.')) {
-                    // add "-foo" to get a version lower than a "-dev" version
-                    $constraints[] = ['<', ((int) $match['version'] + 1) . '-foo'];
-                } else {
-                    $main = '';
-                    $sub = substr($match['version'], 0, $pos);
-                    if (false !== ($pos = strrpos($sub, '.'))) {
-                        $main = substr($sub, 0, $pos + 1);
-                        $sub = substr($sub, $pos + 1);
-                    }
-                    // add "-foo" to get a version lower than a "-dev" version
-                    $constraints[] = ['<', $main . ((int) $sub + 1) . '-foo'];
-                }
-            } else {
-                $constraints[] = [$match['op'] ?: '=', $match['version'] . ($match['prerelease'] ?? '')];
-            }
-        }
-
-        /** @psalm-var array{0: '='|'=='|'!='|'<>'|'<'|'<='|'>'|'>=', 1: string} $constraint */
-        foreach ($constraints as $constraint) {
-            if (!rex_version::compare($version, $constraint[1], $constraint[0])) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /**

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -458,7 +458,7 @@ abstract class rex_package_manager
     {
         $requirements = $this->package->getProperty('requires', []);
 
-        $checker = new rex_package_requirement($requirements);
+        $checker = new rex_package_requirement($requirements, $this->i18nPrefix);
         $result =  $checker->checkRedaxoRequirement($redaxoVersion);
         $this->message = $checker->getMessage();
         return $result;

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -457,11 +457,11 @@ abstract class rex_package_manager
     public function checkRedaxoRequirement($redaxoVersion)
     {
         $requirements = $this->package->getProperty('requires', []);
-        if (isset($requirements['redaxo']) && !rex_version::matchVersionConstraints($redaxoVersion,$requirements['redaxo'])) {
-            $this->message = $this->i18n('requirement_error_redaxo_version', $redaxoVersion, $requirements['redaxo']);
-            return false;
-        }
-        return true;
+
+        $checker = new rex_package_requirement($requirements);
+        $result =  $checker->checkRedaxoRequirement($redaxoVersion);
+        $this->message = $checker->getMessage();
+        return $result;
     }
 
     /**

--- a/redaxo/src/core/lib/packages/manager.php
+++ b/redaxo/src/core/lib/packages/manager.php
@@ -474,57 +474,11 @@ abstract class rex_package_manager
     public function checkPackageRequirement($packageId)
     {
         $requirements = $this->package->getProperty('requires', []);
-        if (!isset($requirements['packages'][$packageId])) {
-            return true;
-        }
-        $package = rex_package::get($packageId);
-        $requiredVersion = '';
-        if (!$package->isAvailable()) {
-            if ('' != $requirements['packages'][$packageId]) {
-                $requiredVersion = ' '.$requirements['packages'][$packageId];
-            }
 
-            if (!rex_package::exists($packageId)) {
-                [$addonId] = rex_package::splitId($packageId);
-                $jumpToInstaller = '';
-                if (rex_addon::get('install')->isAvailable() && !rex_addon::exists($addonId)) {
-                    // package need to be downloaded via installer
-                    $installUrl = rex_url::backendPage('install/packages/add', ['addonkey' => $addonId]);
-
-                    $jumpToInstaller = ' <a href="'. $installUrl .'"><i class="rex-icon fa-arrow-circle-right" title="'. $this->i18n('search_in_installer', $addonId) .'"></i></a>';
-                }
-
-                $this->message = $this->i18n('requirement_error_' . $package->getType(), $packageId.$requiredVersion).$jumpToInstaller;
-                return false;
-            }
-
-            // this package requires a plugin from another addon.
-            // first make sure the addon itself is available.
-            $jumpPackageId = $packageId;
-            if ($package instanceof rex_plugin_interface && !$package->getAddon()->isAvailable()) {
-                $jumpPackageId = (string) $package->getAddon()->getPackageId();
-            }
-
-            $jumpPackageUrl = '#package-'.  rex_string::normalize($jumpPackageId, '-', '_');
-            if ('packages' !== rex_be_controller::getCurrentPage()) {
-                // error while update/install within install-addon. x-link to packages core page
-                $jumpPackageUrl = rex_url::backendPage('packages').$jumpPackageUrl;
-            }
-
-            $this->message = $this->i18n('requirement_error_' . $package->getType(), $packageId.$requiredVersion) . ' <a href="'. $jumpPackageUrl .'"><i class="rex-icon fa-arrow-circle-right" title="'. $this->i18n('jump_to', $jumpPackageId) .'"></i></a>';
-            return false;
-        }
-
-        if (!rex_version::matchVersionConstraints($package->getVersion(), $requirements['packages'][$packageId])) {
-            $this->message = $this->i18n(
-                'requirement_error_' . $package->getType() . '_version',
-                $package->getPackageId(),
-                $package->getVersion(),
-                $requirements['packages'][$packageId]
-            );
-            return false;
-        }
-        return true;
+        $checker = new rex_package_requirement($requirements, $this->i18nPrefix);
+        $result = $checker->checkPackageRequirement($packageId);
+        $this->message = $checker->getMessage();
+        return $result;
     }
 
     /**

--- a/redaxo/src/core/lib/packages/requirement.php
+++ b/redaxo/src/core/lib/packages/requirement.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @package redaxo\core\packages
+ */
+class rex_package_requirement
+{
+    /**
+     * @var array
+     */
+    private $requirements;
+
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @var string
+     */
+    private $i18nPrefix;
+
+    public function __construct(array $requirements, string $i18nPrefix)
+    {
+        $this->requirements = $requirements;
+        $this->i18nPrefix = $i18nPrefix;
+    }
+
+    /**
+     * Translates the given key.
+     *
+     * @param string $key Key
+     *
+     * @return string Tranlates text
+     */
+    protected function i18n($key)
+    {
+        $args = func_get_args();
+        $key = $this->i18nPrefix . $args[0];
+        if (!rex_i18n::hasMsg($key)) {
+            $key = 'package_' . $args[0];
+        }
+        $args[0] = $key;
+
+        return call_user_func_array([rex_i18n::class, 'msg'], $args);
+    }
+
+    /**
+     * Returns the message.
+     *
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * Checks whether the redaxo requirement is met.
+     *
+     * @param string $redaxoVersion REDAXO version
+     *
+     * @return bool
+     */
+    public function checkRedaxoRequirement($redaxoVersion)
+    {
+        if (isset($this->requirements['redaxo']) && !rex_version::matchVersionConstraints($redaxoVersion,$this->requirements['redaxo'])) {
+            $this->message = $this->i18n('requirement_error_redaxo_version', $redaxoVersion, $this->requirements['redaxo']);
+            return false;
+        }
+        return true;
+    }
+}

--- a/redaxo/src/core/lib/packages/requirement.php
+++ b/redaxo/src/core/lib/packages/requirement.php
@@ -70,4 +70,68 @@ class rex_package_requirement
         }
         return true;
     }
+
+    /**
+     * Checks whether the package requirement is met.
+     *
+     * @param string $packageId Package ID
+     *
+     * @return bool
+     */
+    public function checkPackageRequirement($packageId)
+    {
+        $requirements = $this->requirements;
+
+        if (!isset($requirements['packages'][$packageId])) {
+            return true;
+        }
+        $package = rex_package::get($packageId);
+        $requiredVersion = '';
+        if (!$package->isAvailable()) {
+            if ('' != $requirements['packages'][$packageId]) {
+                $requiredVersion = ' '.$requirements['packages'][$packageId];
+            }
+
+            if (!rex_package::exists($packageId)) {
+                [$addonId] = rex_package::splitId($packageId);
+                $jumpToInstaller = '';
+                if (rex_addon::get('install')->isAvailable() && !rex_addon::exists($addonId)) {
+                    // package need to be downloaded via installer
+                    $installUrl = rex_url::backendPage('install/packages/add', ['addonkey' => $addonId]);
+
+                    $jumpToInstaller = ' <a href="'. $installUrl .'"><i class="rex-icon fa-arrow-circle-right" title="'. $this->i18n('search_in_installer', $addonId) .'"></i></a>';
+                }
+
+                $this->message = $this->i18n('requirement_error_' . $package->getType(), $packageId.$requiredVersion).$jumpToInstaller;
+                return false;
+            }
+
+            // this package requires a plugin from another addon.
+            // first make sure the addon itself is available.
+            $jumpPackageId = $packageId;
+            if ($package instanceof rex_plugin_interface && !$package->getAddon()->isAvailable()) {
+                $jumpPackageId = (string) $package->getAddon()->getPackageId();
+            }
+
+            $jumpPackageUrl = '#package-'.  rex_string::normalize($jumpPackageId, '-', '_');
+            if ('packages' !== rex_be_controller::getCurrentPage()) {
+                // error while update/install within install-addon. x-link to packages core page
+                $jumpPackageUrl = rex_url::backendPage('packages').$jumpPackageUrl;
+            }
+
+            $this->message = $this->i18n('requirement_error_' . $package->getType(), $packageId.$requiredVersion) . ' <a href="'. $jumpPackageUrl .'"><i class="rex-icon fa-arrow-circle-right" title="'. $this->i18n('jump_to', $jumpPackageId) .'"></i></a>';
+            return false;
+        }
+
+        if (!rex_version::matchVersionConstraints($package->getVersion(), $requirements['packages'][$packageId])) {
+            $this->message = $this->i18n(
+                'requirement_error_' . $package->getType() . '_version',
+                $package->getPackageId(),
+                $package->getVersion(),
+                $requirements['packages'][$packageId]
+            );
+            return false;
+        }
+        return true;
+    }
 }

--- a/redaxo/src/core/lib/util/version.php
+++ b/redaxo/src/core/lib/util/version.php
@@ -98,4 +98,73 @@ class rex_version
 
         return 0 === $exitCode ? $version : null;
     }
+
+    /**
+     * Checks the version of the requirement.
+     *
+     * @param string $version     Version
+     * @param string $constraints Constraint list, separated by comma
+     *
+     * @throws rex_exception
+     *
+     * @return bool
+     */
+    public static function matchVersionConstraints($version, $constraints)
+    {
+        $rawConstraints = array_filter(array_map('trim', explode(',', $constraints)));
+        $constraints = [];
+        foreach ($rawConstraints as $constraint) {
+            if ('*' === $constraint) {
+                continue;
+            }
+
+            if (!preg_match(
+                    '/^(?<op>==?|<=?|>=?|!=|~|\^|) ?(?<version>\d+(?:\.\d+)*)(?<wildcard>\.\*)?(?<prerelease>[ -.]?[a-z]+(?:[ -.]?\d+)?)?$/i',
+                    $constraint,
+                    $match
+                )
+                || isset($match['wildcard']) && $match['wildcard'] && ('' != $match['op'] || isset($match['prerelease']) && $match['prerelease'])
+            ) {
+                throw new rex_exception('Unknown version constraint "'.$constraint.'"!');
+            }
+
+            if (isset($match['wildcard']) && $match['wildcard']) {
+                $constraints[] = ['>=', $match['version']];
+                $pos = strrpos($match['version'], '.');
+                if (false === $pos) {
+                    $constraints[] = ['<', (int) $match['version'] + 1];
+                } else {
+                    ++$pos;
+                    $sub = (int) substr($match['version'], $pos);
+                    $constraints[] = ['<', substr_replace($match['version'], (string) ($sub + 1), $pos)];
+                }
+            } elseif (in_array($match['op'], ['~', '^'])) {
+                $constraints[] = ['>=', $match['version'].($match['prerelease'] ?? '')];
+                if ('^' === $match['op'] || false === $pos = strrpos($match['version'], '.')) {
+                    // add "-foo" to get a version lower than a "-dev" version
+                    $constraints[] = ['<', ((int) $match['version'] + 1).'-foo'];
+                } else {
+                    $main = '';
+                    $sub = substr($match['version'], 0, $pos);
+                    if (false !== ($pos = strrpos($sub, '.'))) {
+                        $main = substr($sub, 0, $pos + 1);
+                        $sub = substr($sub, $pos + 1);
+                    }
+                    // add "-foo" to get a version lower than a "-dev" version
+                    $constraints[] = ['<', $main.((int) $sub + 1).'-foo'];
+                }
+            } else {
+                $constraints[] = [$match['op'] ?: '=', $match['version'].($match['prerelease'] ?? '')];
+            }
+        }
+
+        /** @psalm-var array{0: '='|'=='|'!='|'<>'|'<'|'<='|'>'|'>=', 1: string} $constraint */
+        foreach ($constraints as $constraint) {
+            if (!self::compare($version, $constraint[1], $constraint[0])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
soll als vorbereitung für https://github.com/redaxo/redaxo/issues/2974 dienen.

( Dieser PR soll die grobe Idee skizzieren und berücksichtigt noch keine BC etc. )

---

Ziel: Requirement-Checks ohne physikalisch existierendes rex_package zu durchlaufen. Wir bekommen über den Webservice schon die package.yml ausgeliefert.

Alternative Idee wäre, eine art dummy rex_package zu erzeugen und dieses in die normalen Funktionalitäten von rex_package_manager zu geben.

Bitte Feedback :wink: 