### PR TITLE
redaxo/php-cs-fixer-config nutzen

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -91,6 +91,7 @@
       <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
       <path value="$PROJECT_DIR$/vendor/webmozart/path-util" />
       <path value="$PROJECT_DIR$/vendor/rector/rector" />
+      <path value="$PROJECT_DIR$/vendor/redaxo/php-cs-fixer-config" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.3">

--- a/.idea/redaxo.iml
+++ b/.idea/redaxo.iml
@@ -102,6 +102,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/path-util" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/rector/rector" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/redaxo/php-cs-fixer-config" />
       <excludePattern pattern=".php_cs.cache" />
       <excludePattern pattern=".phpunit.result.cache" />
       <excludePattern pattern="composer.lock" />

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -33,57 +33,6 @@ $finder = PhpCsFixer\Finder::create()
     })
 ;
 
-return (new PhpCsFixer\Config())
-    ->setUsingCache(true)
-    ->setRiskyAllowed(true)
-    ->setRules([
-        '@Symfony' => true,
-        '@Symfony:risky' => true,
-        '@PHP73Migration' => true,
-        '@PHP71Migration:risky' => true,
-        '@PHPUnit84Migration:risky' => true,
-        'array_indentation' => true,
-        'blank_line_before_statement' => false,
-        'braces' => ['allow_single_line_closure' => false],
-        'comment_to_phpdoc' => true,
-        'concat_space' => false,
-        'declare_strict_types' => false,
-        'echo_tag_syntax' => false,
-        'empty_loop_condition' => false,
-        'heredoc_to_nowdoc' => true,
-        'list_syntax' => ['syntax' => 'short'],
-        'method_argument_space' => ['on_multiline' => 'ignore'],
-        'native_constant_invocation' => false,
-        'no_alternative_syntax' => false,
-        'no_blank_lines_after_phpdoc' => false,
-        'no_null_property_initialization' => true,
-        'no_superfluous_elseif' => true,
-        'no_unreachable_default_argument_value' => true,
-        'no_useless_else' => true,
-        'no_useless_return' => true,
-        'ordered_class_elements' => ['order' => [
-            'use_trait',
-            'constant_public',
-            'constant_protected',
-            'constant_private',
-            'property',
-            'construct',
-            'phpunit',
-            'method',
-        ]],
-        'php_unit_internal_class' => true,
-        'php_unit_test_case_static_method_calls' => true,
-        'phpdoc_align' => false,
-        'phpdoc_no_package' => false,
-        'phpdoc_order' => true,
-        'phpdoc_separation' => false,
-        'phpdoc_to_comment' => false,
-        'phpdoc_types_order' => false,
-        'phpdoc_var_annotation_correct_order' => true,
-        'psr_autoloading' => false,
-        'semicolon_after_instruction' => false,
-        'static_lambda' => true,
-        'void_return' => false,
-    ])
+return (new Redaxo\PhpCsFixerConfig\Config())
     ->setFinder($finder)
 ;

--- a/.tools/rector/Util/UnderscoreCamelCaseConflictingNameGuard.php
+++ b/.tools/rector/Util/UnderscoreCamelCaseConflictingNameGuard.php
@@ -10,6 +10,7 @@ use Rector\Naming\Contract\Guard\ConflictingNameGuardInterface;
 use Rector\Naming\PhpArray\ArrayFilter;
 use Rector\Naming\ValueObject\PropertyRename;
 use Rector\NodeNameResolver\NodeNameResolver;
+use function in_array;
 
 final class UnderscoreCamelCaseConflictingNameGuard implements ConflictingNameGuardInterface
 {
@@ -35,7 +36,7 @@ final class UnderscoreCamelCaseConflictingNameGuard implements ConflictingNameGu
     public function isConflicting($renameValueObject): bool
     {
         $conflictingPropertyNames = $this->resolve($renameValueObject->getClassLike());
-        return \in_array($renameValueObject->getExpectedName(), $conflictingPropertyNames, true);
+        return in_array($renameValueObject->getExpectedName(), $conflictingPropertyNames, true);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "psalm/plugin-phpunit": "0.16.1",
         "psalm/plugin-symfony": "3.0.4",
         "rector/rector": "0.11.60",
+        "redaxo/php-cs-fixer-config": "dev-dev",
         "vimeo/psalm": "4.11.2"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "psalm/plugin-phpunit": "0.16.1",
         "psalm/plugin-symfony": "3.0.4",
         "rector/rector": "0.11.60",
-        "redaxo/php-cs-fixer-config": "dev-dev",
+        "redaxo/php-cs-fixer-config": "1.0.0",
         "vimeo/psalm": "4.11.2"
     },
     "replace": {


### PR DESCRIPTION
Ähnlich wie in dem anderen PR für das psalm-plugin habe ich hier unsere CS-Config in ein eigenes Paket ausgelagert, welches auch von Rex-Addons und Projekten genutzt werden kann.

Auch hier werde ich vor dem Merge noch ein Release erstellen des Pakets.