### PR TITLE
intl-Extension nicht frühzeitig im Setup nutzen

### DIFF
--- a/redaxo/src/core/layout/top.php
+++ b/redaxo/src/core/layout/top.php
@@ -23,7 +23,9 @@ if (!$curPage->hasLayout()) {
 }
 
 $bodyAttr = [];
-$bodyId = rex_string::normalize(rex_be_controller::getCurrentPage(), '-', ' ');
+
+// rex_string::normalize requires intl extension, which may not exist before extensions check in setup
+$bodyId = rex::isSetup() ? 'setup' : rex_string::normalize(rex_be_controller::getCurrentPage(), '-', ' ');
 
 $bodyAttr['id'] = ['rex-page-' . $bodyId];
 $bodyAttr['onunload'] = ['closeAll();'];

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -48,7 +48,7 @@ class rex_i18n
         if ($phpSetLocale) {
             [$lang, $country] = explode('_', self::getLocale(), 2);
 
-            if (!rex::isSetup() || class_exists(Locale::class)) {
+            if (class_exists(Locale::class)) {
                 Locale::setDefault($lang.'-'.strtoupper($country));
             }
 

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -47,7 +47,10 @@ class rex_i18n
 
         if ($phpSetLocale) {
             [$lang, $country] = explode('_', self::getLocale(), 2);
-            Locale::setDefault($lang.'-'.strtoupper($country));
+
+            if (!rex::isSetup() || class_exists(Locale::class)) {
+                Locale::setDefault($lang.'-'.strtoupper($country));
+            }
 
             $locales = [];
             foreach (explode(',', trim(self::msg('setlocale'))) as $locale) {

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -48,6 +48,7 @@ class rex_i18n
         if ($phpSetLocale) {
             [$lang, $country] = explode('_', self::getLocale(), 2);
 
+            // In setup we want to reach the php extensions check even if intl extension is missing
             if (class_exists(Locale::class)) {
                 Locale::setDefault($lang.'-'.strtoupper($country));
             }


### PR DESCRIPTION
fixes #4898

Seitdem wir mit der intl-Extension für Datumsformatierung arbeiten, setzt `rex_i18n::setLocale` auch die Default-Locale in der `Locale`-Klasse der intl-Extension.

Nach diesem PR wird die Zeile nicht ausgeführt bei aktivem Setup, wenn die Klasse nicht existiert, damit man im Setup bis zum eigentlichen Extensions-Check kommt.

Konnte es leider gerade nicht wirklich testen, da ich nicht so leicht bei mir die intl-Extension deaktivieren kann.

/cc @eaCe 