### PR TITLE
tooltips überall nutzbar machen

### DIFF
--- a/redaxo/src/addons/be_style/assets/javascripts/main.js
+++ b/redaxo/src/addons/be_style/assets/javascripts/main.js
@@ -8,5 +8,5 @@ $(document).on('rex:ready', function (event, container) {
     selects.selectpicker('refresh');
     
     // tooltip toggle on title
-    container.find('[data-toggle="tooltip"]').tooltip();   
+    container.find('[data-toggle="tooltip"]').tooltip();
 });

--- a/redaxo/src/addons/be_style/assets/javascripts/main.js
+++ b/redaxo/src/addons/be_style/assets/javascripts/main.js
@@ -7,6 +7,6 @@ $(document).on('rex:ready', function (event, container) {
     // refresh selects to force repaints fixing rendering issues in safari
     selects.selectpicker('refresh');
     
-     // tooltip toggle on title
-     container.find('[data-toggle="tooltip"]').tooltip();   
+    // tooltip toggle on title
+    container.find('[data-toggle="tooltip"]').tooltip();   
 });

--- a/redaxo/src/addons/be_style/assets/javascripts/main.js
+++ b/redaxo/src/addons/be_style/assets/javascripts/main.js
@@ -6,4 +6,7 @@ $(document).on('rex:ready', function (event, container) {
     });
     // refresh selects to force repaints fixing rendering issues in safari
     selects.selectpicker('refresh');
+    
+     // tooltip toggle on title
+     container.find('[data-toggle="tooltip"]').tooltip();   
 });

--- a/redaxo/src/addons/phpmailer/pages/config.php
+++ b/redaxo/src/addons/phpmailer/pages/config.php
@@ -371,7 +371,6 @@ echo '
     </form>';
 ?>
 <script>
-    $('[data-toggle="tooltip"]').tooltip();
     $('#smtpsettings').toggle(
         $('#phpmailer-mailer').find("option[value='smtp']").is(":checked")
     );

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -788,5 +788,5 @@ function rex_searchfield_init(selector_id) {
 
 // tooltip toggle on title
 $(document).on('rex:ready', function (event, container) {
-     $('[data-toggle="tooltip"]').tooltip();
+     container.find('[data-toggle="tooltip"]').tooltip();
 });

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -785,3 +785,8 @@ function rex_searchfield_init(selector_id) {
             .trigger('propertychange').focus();
     });
 }
+
+// tooltip toggle on title
+$(document).on('rex:ready', function (event, container) {
+     $('[data-toggle="tooltip"]').tooltip();
+});

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -786,7 +786,3 @@ function rex_searchfield_init(selector_id) {
     });
 }
 
-// tooltip toggle on title
-$(document).on('rex:ready', function (event, container) {
-     container.find('[data-toggle="tooltip"]').tooltip();
-});


### PR DESCRIPTION
- Entfernen der Initialisierung im PHPMailer