### PR TITLE
Doppelte Variable $clang

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/content_service.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/content_service.php
@@ -325,26 +325,26 @@ class rex_content_service
      */
     public static function generateArticleContent($articleId, $clang = null)
     {
-        foreach (rex_clang::getAllIds() as $clang) {
-            if (null !== $clang && $clang != $clang) {
+        foreach (rex_clang::getAllIds() as $clangId) {
+            if (null !== $clang && $clangId != $clang) {
                 continue;
             }
 
             $CONT = new rex_article_content_base();
-            $CONT->setCLang($clang);
+            $CONT->setCLang($clangId);
             $CONT->setEval(false); // Content nicht ausführen, damit in Cachedatei gespeichert werden kann
             if (!$CONT->setArticleId($articleId)) {
                 throw new rex_exception(sprintf('Article %d does not exist.', $articleId));
             }
 
             // --------------------------------------------------- Artikelcontent speichern
-            $articleContentFile = rex_path::addonCache('structure', "$articleId.$clang.content");
+            $articleContentFile = rex_path::addonCache('structure', "$articleId.$clangId.content");
             $articleContent = $CONT->getArticle();
 
             // ----- EXTENSION POINT
             $articleContent = rex_extension::registerPoint(new rex_extension_point('GENERATE_FILTER', $articleContent, [
                 'id' => $articleId,
-                'clang' => $clang,
+                'clang' => $clangId,
                 'article' => $CONT,
             ]));
 


### PR DESCRIPTION
Bei irgendeinem Refactoring muss das passiert sein, dass der Parameter `$clang` nun gleich hieß wie die Schleifenvariable.
Dadurch hatte der Parameter keinen Effekt mehr, es wurden immer die Inhalte für alle Sprachen generiert.