### PR TITLE
PHP-Cache-Dateien: Bei Neugenerierung Opcache invalidieren

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/cache_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/cache_template.php
@@ -28,8 +28,13 @@ class rex_template_cache
         $content = $sql->getValue('content');
         $content = rex_var::parse($content, rex_var::ENV_FRONTEND, 'template');
 
-        if (!rex_file::put(self::getPath($id), $content)) {
+        $path = self::getPath($id);
+        if (!rex_file::put($path, $content)) {
             throw new rex_exception('Unable to generate template "' . $id . '".');
+        }
+
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($path);
         }
     }
 

--- a/redaxo/src/addons/structure/plugins/content/lib/content_service.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/content_service.php
@@ -351,6 +351,10 @@ class rex_content_service
             if (!rex_file::put($articleContentFile, $articleContent)) {
                 throw new rex_exception(sprintf('Article %d could not be generated, check the directory permissions for "%s".', $articleId, rex_path::addonCache('structure')));
             }
+
+            if (function_exists('opcache_invalidate')) {
+                opcache_invalidate($articleContentFile);
+            }
         }
 
         return true;


### PR DESCRIPTION
@schuer war es auf redaxo.org aufgefallen, dass Slice-Änderungen sich teils nicht direkt ausgewirkt haben.

Neu wird nun bei unseren Cache-Dateien im PHP-Format nach jeder Neugenerierung der Opcache für die jeweilige Datei invalidiert.