### PR TITLE
Socket Aufruf von fsockopen auf stream_context_create geändert

### DIFF
--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -46,7 +46,7 @@ class rex_socket
     /** @vat resource */
     protected $stream;
     /** @var array<array-key, mixed> */
-    protected $options;
+    protected $options = [];
 
     /**
      * Constructor.
@@ -125,7 +125,7 @@ class rex_socket
      *
      * @return $this Current socket
      */
-    public function setOptions($options = [])
+    public function setOptions(array $options)
     {
         $this->options = $options;
 

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -359,8 +359,7 @@ class rex_socket
 
         try {
             $context = stream_context_create($this->options);
-            $this->stream = stream_socket_client($host.':'.$this->port, $errno, $errstr, ini_get("default_socket_timeout"), STREAM_CLIENT_CONNECT, $context);
-
+            $this->stream = stream_socket_client($host.':'.$this->port, $errno, $errstr, ini_get('default_socket_timeout'), STREAM_CLIENT_CONNECT, $context);
         } finally {
             restore_error_handler();
         }

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -121,6 +121,8 @@ class rex_socket
     /**
      * Sets the socket options.
      *
+     * Available options can be found on https://www.php.net/manual/en/context.php
+     *
      * @return $this Current socket
      */
     public function setOptions(array $options)

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -121,8 +121,6 @@ class rex_socket
     /**
      * Sets the socket options.
      *
-     * @param array $options
-     *
      * @return $this Current socket
      */
     public function setOptions(array $options)

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -45,7 +45,7 @@ class rex_socket
     protected $headers = [];
     /** @vat resource */
     protected $stream;
-    /** @var array<string, string> */
+    /** @var array<array-key, mixed> */
     protected $options;
 
     /**
@@ -359,7 +359,7 @@ class rex_socket
 
         try {
             $context = stream_context_create($this->options);
-            $this->stream = stream_socket_client($host.':'.$this->port, $errno, $errstr, ini_get('default_socket_timeout'), STREAM_CLIENT_CONNECT, $context);
+            $this->stream = stream_socket_client($host.':'.$this->port, $errno, $errstr, floatval(ini_get('default_socket_timeout')), STREAM_CLIENT_CONNECT, $context);
         } finally {
             restore_error_handler();
         }

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -119,7 +119,7 @@ class rex_socket
     }
 
     /**
-     * Sets the socket options.
+     * Sets the socket context options.
      *
      * Available options can be found on https://www.php.net/manual/en/context.php
      *

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -359,7 +359,7 @@ class rex_socket
 
         try {
             $context = stream_context_create($this->options);
-            $this->stream = stream_socket_client($host.':'.$this->port, $errno, $errstr, floatval(ini_get('default_socket_timeout')), STREAM_CLIENT_CONNECT, $context);
+            $this->stream = stream_socket_client($host.':'.$this->port, $errno, $errstr, (float) (ini_get('default_socket_timeout')), STREAM_CLIENT_CONNECT, $context);
         } finally {
             restore_error_handler();
         }

--- a/redaxo/src/core/tests/util/socket_test.php
+++ b/redaxo/src/core/tests/util/socket_test.php
@@ -23,8 +23,8 @@ class rex_socket_test extends TestCase
     public function testFactory()
     {
         $socket = rex_socket::factory('www.example.com');
+        $socket->setOptions([]);
         static::assertEquals(rex_socket::class, get_class($socket));
-
         return $socket;
     }
 
@@ -32,12 +32,14 @@ class rex_socket_test extends TestCase
     {
         rex::setProperty('socket_proxy', 'proxy.example.com:8888');
         $socket = rex_socket::factory('www.example.com');
+        $socket->setOptions([]);
         static::assertEquals(rex_socket_proxy::class, get_class($socket));
     }
 
     public function testFactoryUrl()
     {
         $socket = rex_socket::factoryUrl('www.example.com');
+        $socket->setOptions([]);
         static::assertEquals(rex_socket::class, get_class($socket));
     }
 
@@ -45,6 +47,7 @@ class rex_socket_test extends TestCase
     {
         rex::setProperty('socket_proxy', 'proxy.example.com:8888');
         $socket = rex_socket::factoryUrl('www.example.com');
+        $socket->setOptions([]);
         static::assertEquals(rex_socket_proxy::class, get_class($socket));
     }
 


### PR DESCRIPTION
um Optionen wie

`$socket->setOptions(['ssl' => ['verify_peer' => false, 'verify_peer_name' => false ] ]);`

zu erlauben