### PR TITLE
Core-Update: Besserer Umgang mit fehlenden Schreibrechten

### DIFF
--- a/redaxo/src/addons/install/lang/de_de.lang
+++ b/redaxo/src/addons/install/lang/de_de.lang
@@ -54,6 +54,7 @@ install_warning_addon_zip_not_extracted = Beim Entpacken der Zip-Datei in das Ad
 install_warning_message_from_addon = AddOn <b>{0}</b> meldet:
 install_warning_message_from_plugin = PlugIn <b>{0}</b> meldet:
 
+install_warning_directory_not_writable = Der Ordner <b>{0}</b> ist nicht beschreibbar!
 install_warning_zip_wrong_checksum = Die Prüfsumme der heruntergeladenen Zip-Datei stimmt nicht mit der erwarteten überein. Bitte in wenigen Minuten noch einmal probieren!
 install_warning_zip_wrong_format = Die Zip-Datei ist nicht im erforderlichen Format.
 

--- a/redaxo/src/addons/install/lang/en_gb.lang
+++ b/redaxo/src/addons/install/lang/en_gb.lang
@@ -54,6 +54,7 @@ install_warning_addon_zip_not_extracted = Zip file could not bee extracted in th
 install_warning_message_from_addon = AddOn <b>{0}</b> reports:
 install_warning_message_from_plugin = PlugIn <b>{0}</b> reports:
 
+install_warning_directory_not_writable = The directory <b>{0}</b> is not writable!
 install_warning_zip_wrong_checksum = The checksum of the downloaded zip file does not match. Please try again in a few minutes!
 install_warning_zip_wrong_format = The zip file is not in the required format.
 

--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -31,6 +31,9 @@ class rex_api_install_core_update extends rex_api_function
         if (!rex_version::compare($version['version'], rex::getVersion(), '>')) {
             throw new rex_api_exception(sprintf('Existing version of Core (%s) is newer than %s', rex::getVersion(), $version['version']));
         }
+        if (!is_writable(rex_path::core())) {
+            throw new rex_functional_exception($installAddon->i18n('warning_directory_not_writable', rex_path::core()));
+        }
         try {
             $archivefile = rex_install_webservice::getArchive($version['path']);
         } catch (rex_functional_exception $e) {
@@ -70,7 +73,13 @@ class rex_api_install_core_update extends rex_api_function
 
                     $coreAddons[$addonkey] = $addonkey;
                     if (rex_addon::exists($addonkey)) {
-                        $updateAddons[$addonkey] = rex_addon::get($addonkey);
+                        $addon = rex_addon::get($addonkey);
+
+                        if (!is_writable($addon->getPath())) {
+                            throw new rex_functional_exception($installAddon->i18n('warning_directory_not_writable', $addon->getPath()));
+                        }
+
+                        $updateAddons[$addonkey] = $addon;
                         $updateAddonsConfig[$addonkey] = $config;
                     }
                 }
@@ -162,7 +171,11 @@ class rex_api_install_core_update extends rex_api_function
             }
             foreach ($coreAddons as $addonkey) {
                 if (isset($updateAddons[$addonkey])) {
-                    rex_dir::delete(rex_path::addon($addonkey));
+                    $pathOld = rex_path::addon($addonkey.'.old');
+                    // move whole old addon to a temp dir (high priority to get the free space for new addon version)
+                    // and try to delete it afterwards (lower priority)
+                    rename(rex_path::addon($addonkey), $pathOld);
+                    rex_dir::delete($pathOld);
                 }
                 rename($temppath . 'addons/' . $addonkey, rex_path::addon($addonkey));
                 if (is_dir(rex_path::addon($addonkey, 'assets'))) {


### PR DESCRIPTION
fixes #4652

Hiermit versuche ich obiges Issue zu lösen.
Einerseits versuche ich vorab die Schreibrechte etwas mehr zu prüfen. 
Andererseits beim Update der Core-Addons nenne ich den alten Ordner erst um (in der Hoffnung, dass das zumindest klappt), und versuche dann den Tempordner zu löschen. Falls letzteres mal nicht klappt, weil irgendwelche Unterordner/dateien nicht gelöscht werden konnten, wäre das nicht so dramatisch. Man hätte dann halt den temp-Ordner da noch liegen.
Abbrechen können wir da nicht mehr, da Core (und ggf. manche Addons) bereits ausgetauscht wurden.

(Das ist noch nicht die Lösung für das heute in Slack besprochene Problem. Aber mir war es dort bei @skerbis als Nebenproblem aufgefallen, dass das debug-Addon bei ihm nicht richtig aktualisiert werden konnte.)