### PR TITLE
Core-Update: Logger-Klasse vor Update laden

### DIFF
--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -36,6 +36,10 @@ class rex_api_install_core_update extends rex_api_function
         } catch (rex_functional_exception $e) {
             throw new rex_api_exception($e->getMessage());
         }
+
+        // load logger class before core update to avoid getting logger class from new core while logging success message
+        $logger = rex_logger::factory();
+
         $message = '';
         $temppath = rex_path::coreCache('.new.core/');
         $coreAddons = [];
@@ -182,7 +186,7 @@ class rex_api_install_core_update extends rex_api_function
             $message = $installAddon->i18n('warning_core_not_updated') . '<br />' . $message;
             $success = false;
         } else {
-            rex_logger::factory()->info('REDAXO Core updated from '. rex::getVersion() .' to version '. $version['version']);
+            $logger->info('REDAXO Core updated from '. rex::getVersion() .' to version '. $version['version']);
 
             $message = $installAddon->i18n('info_core_updated');
             $success = true;


### PR DESCRIPTION
Dieses Issue löst das Problem, was einige in Slack gemeldet haben.

Nach dem Core-Update, aber noch vor dem Reload, loggen wir über `rex_logger` eine Erfolgsmeldung.
Wenn die `rex_logger`-Klasse bis dahin aber noch nicht geladen wurde, wird sie dort bereits aus dem neuen Core geladen, obwohl der Request noch im alten Core läuft. So kommt es zu einer inkompatiblen Klassenkombination.

Daher lade ich nun vor dem Update bereits die Klasse.

Das Problem trat zum Beispiel nicht auf, wenn das debug-Addon aktiv ist, da dann die rex_logger-Klasse immer geladen wird, da das Addon dafür eine factory-class registriert.

Ich konnte das Problem nachstellen und mit diesem PR nicht mehr feststellen. Somit getestet.