### PR TITLE
Release install 2.9.2

### DIFF
--- a/redaxo/src/addons/install/CHANGELOG.md
+++ b/redaxo/src/addons/install/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Version 2.9.2 – 16.11.2021
+--------------------------
+
+### Bugfixes
+
+* Core-Update:
+    - Beim Update auf 5.13 kam es teils zu einem Fehler beim Erstellen der Erfolgsmeldung im Log (@gharlan)
+    - Besserer Umgang mit fehlenden Schreibrechten (@gharlan)
+
+
 Version 2.9.0 – 03.03.2021
 --------------------------
 

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -1,5 +1,5 @@
 package: install
-version: '2.9.1'
+version: '2.9.2'
 author: Gregor Harlan
 supportpage: https://github.com/redaxo/redaxo
 


### PR DESCRIPTION
Wenn #4921 und #4922 gemerged sind, werde ich ein Einzel-Update für den Installer rausbringen.

Und beim Core-Update auf 5.13 werde ich dann den Installer 2.9.2 erfordern.