### PR TITLE
Passwortänderung: Sessions beenden

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -6849,18 +6849,14 @@
     <MixedArrayAccess occurrences="1">
       <code>$_SESSION[rex::getProperty('instname')]['backend_login']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="2">
-      <code>$_SESSION[rex::getProperty('instname').'_backend']['backend_login']</code>
+    <MixedArrayAssignment occurrences="1">
       <code>$config['setup_addons'][]</code>
     </MixedArrayAssignment>
     <MixedArrayOffset occurrences="1">
       <code>$_SESSION[rex::getProperty('instname')]</code>
     </MixedArrayOffset>
     <MixedAssignment occurrences="1">
-      <code>$_SESSION[rex::getProperty('instname').'_backend']['backend_login']</code>
+      <code>$_SESSION[$sessionKey]['backend_login']</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>rex::getProperty('instname')</code>
-    </MixedOperand>
   </file>
 </files>

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -154,6 +154,7 @@ if ($warnings) {
         $updateuser->setValue('password', $passwordHash);
         $updateuser->setDateTimeValue('password_changed', time());
         $updateuser->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords($user, $passwordHash));
+        // On password change the "stay logged in" cookies must be invalidated
         $updateuser->setValue('cookiekey', null);
     }
 

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -148,11 +148,13 @@ if ($warnings) {
         $updateuser->setValue('status', 0);
     }
 
+    $passwordHash = null;
     if ('' != $userpsw) {
         $passwordHash = rex_login::passwordHash($userpsw);
         $updateuser->setValue('password', $passwordHash);
         $updateuser->setDateTimeValue('password_changed', time());
         $updateuser->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords($user, $passwordHash));
+        $updateuser->setValue('cookiekey', null);
     }
 
     $updateuser->setValue('password_change_required', (int) $passwordChangeRequired);
@@ -163,6 +165,10 @@ if ($warnings) {
 
     rex_user::clearInstance($userId);
     $user = rex_user::require($userId);
+
+    if (null !== $passwordHash && $userId == rex::requireUser()->getId()) {
+        rex::getProperty('login')->changedPassword($passwordHash);
+    }
 
     rex_extension::registerPoint(new rex_extension_point('USER_UPDATED', '', [
         'id' => $userId,

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -154,9 +154,13 @@ class rex_backend_login extends rex_login
         return (bool) $this->getSessionVar(self::SESSION_PASSWORD_CHANGE_REQUIRED, false);
     }
 
-    public function changedPassword(): void
+    public function changedPassword(?string $passwordHash = null): void
     {
         $this->setSessionVar(self::SESSION_PASSWORD_CHANGE_REQUIRED, false);
+
+        if (null !== $passwordHash) {
+            parent::changedPassword($passwordHash);
+        }
     }
 
     public static function deleteSession()

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -157,6 +157,9 @@ class rex_backend_login extends rex_login
         return (bool) $this->getSessionVar(self::SESSION_PASSWORD_CHANGE_REQUIRED, false);
     }
 
+    /**
+     * @param null|string $passwordHash Passing `null` or ommitting this param is DEPRECTED
+     */
     public function changedPassword(?string $passwordHash = null): void
     {
         $this->setSessionVar(self::SESSION_PASSWORD_CHANGE_REQUIRED, false);

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -158,7 +158,7 @@ class rex_backend_login extends rex_login
     }
 
     /**
-     * @param null|string $passwordHash Passing `null` or ommitting this param is DEPRECTED
+     * @param null|string $passwordHash Passing `null` or ommitting this param is DEPRECATED
      */
     public function changedPassword(?string $passwordHash = null): void
     {

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -225,6 +225,7 @@ class rex_login
                     $ok = true;
                     self::regenerateSessionId();
                     $this->setSessionVar('UID', $this->user->getValue($this->idColumn));
+                    $this->setSessionVar('password', $this->user->getValue($this->passwordColumn));
                 } else {
                     $this->message = rex_i18n::msg('login_error');
                 }
@@ -249,6 +250,10 @@ class rex_login
                         $ok = false;
                         $this->message = rex_i18n::msg('login_user_not_found');
                     }
+                    if ($this->impersonator->getValue($this->passwordColumn) !== $this->getSessionVar('password')) {
+                        $ok = false;
+                        $this->message = rex_i18n::msg('login_session_expired');
+                    }
                 }
 
                 if ($ok) {
@@ -259,6 +264,10 @@ class rex_login
                     if (!$this->user->getRows()) {
                         $ok = false;
                         $this->message = rex_i18n::msg('login_user_not_found');
+                    }
+                    if (!$this->impersonator && $this->user->getValue($this->passwordColumn) !== $this->getSessionVar('password')) {
+                        $ok = false;
+                        $this->message = rex_i18n::msg('login_session_expired');
                     }
                 }
             }
@@ -282,6 +291,7 @@ class rex_login
             $this->setSessionVar('STAMP', '');
             $this->setSessionVar('UID', '');
             $this->setSessionVar('impersonator', null);
+            $this->setSessionVar('password', null);
         }
 
         $this->loginStatus = $ok ? 1 : -1;
@@ -323,6 +333,11 @@ class rex_login
 
         $this->setSessionVar('UID', $this->user->getValue($this->idColumn));
         $this->setSessionVar('impersonator', null);
+    }
+
+    public function changedPassword(string $passwordHash): void
+    {
+        $this->setSessionVar('password', $passwordHash);
     }
 
     /**

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -125,6 +125,7 @@ if (rex_post('upd_psw_button', 'bool')) {
         $updateuser->setValue('password_change_required', 0);
         $updateuser->setDateTimeValue('password_changed', time());
         $updateuser->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords($user, $userpswNew1));
+        $updateuser->setValue('cookiekey', null);
 
         try {
             $updateuser->update();
@@ -134,8 +135,8 @@ if (rex_post('upd_psw_button', 'bool')) {
 
             if ($passwordChangeRequired) {
                 $passwordChangeRequired = false;
-                rex::getProperty('login')->changedPassword();
             }
+            rex::getProperty('login')->changedPassword($userpswNew1);
 
             rex_extension::registerPoint(new rex_extension_point('PASSWORD_UPDATED', '', [
                 'user_id' => $userId,

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -125,6 +125,7 @@ if (rex_post('upd_psw_button', 'bool')) {
         $updateuser->setValue('password_change_required', 0);
         $updateuser->setDateTimeValue('password_changed', time());
         $updateuser->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords($user, $userpswNew1));
+        // On password change the "stay logged in" cookies must be invalidated
         $updateuser->setValue('cookiekey', null);
 
         try {

--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -47,8 +47,11 @@ if (rex_string::versionCompare($installerVersion, '2.9.2', '<') && rex_string::v
     throw new rex_functional_exception('This update requires at least version <b>2.9.2</b> of the <b>install</b> addon!');
 }
 
+$sessionKey = (string) rex::getProperty('instname').'_backend';
+
 if (rex_string::versionCompare(rex::getVersion(), '5.7.0-beta3', '<')) {
-    $_SESSION[rex::getProperty('instname').'_backend']['backend_login'] = $_SESSION[rex::getProperty('instname')]['backend_login'];
+    /** @psalm-suppress MixedArrayAssignment */
+    $_SESSION[$sessionKey]['backend_login'] = $_SESSION[rex::getProperty('instname')]['backend_login'];
 }
 
 if (rex_string::versionCompare(rex::getVersion(), '5.9.0-beta1', '<')) {
@@ -56,6 +59,11 @@ if (rex_string::versionCompare(rex::getVersion(), '5.9.0-beta1', '<')) {
     rex_dir::create(rex_path::data('log'));
     @rename(rex_path::coreData('system.log'), rex_path::data('log/system.log'));
     @rename(rex_path::coreData('system.log.2'), rex_path::data('log/system.log.2'));
+}
+
+if (rex_string::versionCompare(rex::getVersion(), '5.13.1', '<') && ($user = rex::getUser())) {
+    /** @psalm-suppress MixedArrayAssignment */
+    $_SESSION[$sessionKey]['backend_login']['password'] = $user->getValue('password');
 }
 
 $path = rex_path::coreData('config.yml');


### PR DESCRIPTION
closes #4936

Wenn man das Passwort eines Users ändert, dann werden alle Sessions des Users invalidiert.
Dies passiert, indem der Passwort-Hash mit in die Session gelegt wird. So kann eine Änderung erkannt werden.

Wenn man sein eigenes Passwort ändert, egal ob über Profil oder über Benutzerverwaltung, dann wird die eigene gerade verwendete Session gerettet, indem der neue Passwort-Hash direkt in die Session gesetzt wird.

Auch die Eingeloggt-bleiben-Cookies werden invalidiert, indem das Feld in der DB geleert wird.