### PR TITLE
UI: Weitere Hinzufügen-Links vergrößert

### DIFF
--- a/redaxo/src/addons/media_manager/pages/types.php
+++ b/redaxo/src/addons/media_manager/pages/types.php
@@ -93,7 +93,7 @@ if ('' == $func) {
     });
 
     // icon column
-    $thIcon = '<a href="' . $list->getUrl(['func' => 'add']) . '" title="' . rex_i18n::msg('media_manager_type_create') . '"><i class="rex-icon rex-icon-add-mediatype"></i></a>';
+    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['func' => 'add']) . '" title="' . rex_i18n::msg('media_manager_type_create') . '"><i class="rex-icon rex-icon-add-mediatype"></i></a>';
     $list->addColumn($thIcon, '', 0, ['<th class="rex-table-icon">###VALUE###</th>', '<td class="rex-table-icon">###VALUE###</td>']);
     $list->setColumnParams($thIcon, ['func' => 'edit', 'type_id' => '###id###']);
     $list->setColumnFormat($thIcon, 'custom', static function () use ($list, $thIcon) {

--- a/redaxo/src/addons/metainfo/pages/field.php
+++ b/redaxo/src/addons/metainfo/pages/field.php
@@ -49,7 +49,7 @@ if ('' == $func) {
     $list->addTableAttribute('class', 'table-striped table-hover');
 
     $tdIcon = '<i class="rex-icon rex-icon-metainfo"></i>';
-    $thIcon = '<a href="' . $list->getUrl(['func' => 'add']) . '"><i class="rex-icon rex-icon-add-metainfo"></i></a>';
+    $thIcon = '<a class="rex-link-expanded" href="' . $list->getUrl(['func' => 'add']) . '"><i class="rex-icon rex-icon-add-metainfo"></i></a>';
     $list->addColumn($thIcon, $tdIcon, 0, ['<th class="rex-table-icon">###VALUE###</th>', '<td class="rex-table-icon">###VALUE###</td>']);
     $list->setColumnParams($thIcon, ['func' => 'edit', 'field_id' => '###id###']);
 


### PR DESCRIPTION
Es gab unter den Core-AddOns noch zwei Links ohne Klasse `.rex-link-expanded`, die die Klickfläche vergrößert. Diese habe ich ergänzt.