### PR TITLE
PHP 8.2: Attribut AllowDynamicProperties verwenden

### DIFF
--- a/redaxo/src/addons/mediapool/lib/media.php
+++ b/redaxo/src/addons/mediapool/lib/media.php
@@ -5,6 +5,7 @@
  *
  * @package redaxo\mediapool
  */
+#[AllowDynamicProperties]
 class rex_media
 {
     use rex_instance_list_pool_trait;

--- a/redaxo/src/addons/structure/lib/structure_element.php
+++ b/redaxo/src/addons/structure/lib/structure_element.php
@@ -5,6 +5,7 @@
  *
  * @package redaxo\structure
  */
+#[AllowDynamicProperties]
 abstract class rex_structure_element
 {
     use rex_instance_list_pool_trait;

--- a/redaxo/src/core/lib/clang/clang.php
+++ b/redaxo/src/core/lib/clang/clang.php
@@ -7,6 +7,7 @@
  *
  * @package redaxo\core
  */
+#[AllowDynamicProperties]
 class rex_clang
 {
     /**


### PR DESCRIPTION
Als Vorbereitung für PHP 8.2: https://wiki.php.net/rfc/deprecate_dynamic_properties