### PR TITLE
MP: Sync der ersten Datei aus der Liste funktioniert teils nicht

### DIFF
--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -1,5 +1,5 @@
 package: mediapool
-version: '2.11.0'
+version: '2.11.1-dev'
 author: 'Jan Kristinus'
 supportpage: https://github.com/redaxo/redaxo
 

--- a/redaxo/src/addons/mediapool/pages/sync.php
+++ b/redaxo/src/addons/mediapool/pages/sync.php
@@ -66,7 +66,7 @@ $csrf = rex_csrf_token::factory('mediapool');
                 $success = [];
                 $first = true;
                 foreach ($syncFiles as $filename) {
-                    if (!($key = array_search($filename, $diffFiles))) {
+                    if (false === $key = array_search($filename, $diffFiles)) {
                         continue;
                     }
 


### PR DESCRIPTION
Der Fehler kam mit https://github.com/redaxo/redaxo/commit/32220c9e97f56966c320304ba796385cd9294a5c.