### PR TITLE
fix parse error

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -411,7 +411,7 @@ abstract class rex_error_handler
         $markdown .= <<<OUTPUT
             <details>
             <summary>Stacktrace</summary>
-
+            
             $table
             </details>
 


### PR DESCRIPTION
Parse error: Invalid body indentation level (expecting an indentation level of at least 12) in C:\xampp74\htdocs\xxx\master\src\core\lib\error_handler.php on line 414