### PR TITLE
ReturnTypeWillChange-Attribut nutzen

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1594,6 +1594,7 @@ class rex_sql implements Iterator
      *
      * @throws rex_sql_exception
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->reset();
@@ -1604,6 +1605,7 @@ class rex_sql implements Iterator
      *
      * @return $this
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this;
@@ -1612,6 +1614,7 @@ class rex_sql implements Iterator
     /**
      * @see http://www.php.net/manual/en/iterator.key.php
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->counter;
@@ -1620,6 +1623,7 @@ class rex_sql implements Iterator
     /**
      * @see http://www.php.net/manual/en/iterator.next.php
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->counter;
@@ -1629,6 +1633,7 @@ class rex_sql implements Iterator
     /**
      * @see http://www.php.net/manual/en/iterator.valid.php
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->hasNext();

--- a/redaxo/src/core/lib/util/finder.php
+++ b/redaxo/src/core/lib/util/finder.php
@@ -265,6 +265,7 @@ class rex_finder implements IteratorAggregate, Countable
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return iterator_count($this->getIterator());

--- a/redaxo/src/core/lib/util/log_file.php
+++ b/redaxo/src/core/lib/util/log_file.php
@@ -67,6 +67,7 @@ class rex_log_file implements Iterator
     /**
      * @return rex_log_entry
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         if (null === $this->currentLine) {
@@ -79,6 +80,7 @@ class rex_log_file implements Iterator
     /**
      * Reads the log file backwards line by line (each call reads one line).
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         /** @var int $bufferSize */
@@ -151,6 +153,7 @@ class rex_log_file implements Iterator
     /**
      * @return int|null
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->key;
@@ -159,6 +162,7 @@ class rex_log_file implements Iterator
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return !empty($this->currentLine);
@@ -167,6 +171,7 @@ class rex_log_file implements Iterator
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->second = false;


### PR DESCRIPTION
Das ist seit PHP 8.1 notwendig.
Die zugehörigen Deprecated-Meldungen sehen wir nicht, weil wir die [aktuell unterdrücken im Autoloader](https://github.com/redaxo/redaxo/blob/722888500317dcc01e0fee99ab2453e8308e4117/redaxo/src/core/lib/autoload.php#L109).
Das werde ich eventuell auch ändern, hat aber auch Auswirkungen auf Addons. Muss ich nochmal schauen.
Hier zunächst daher nur die Attribute.