### PR TITLE
Cli-Setup: Warnung, dass Checks nur die Cli-Umgebung prüfen

### DIFF
--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -109,6 +109,8 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         // ---------------------------------- Step 3 . Perms, Environment
         $io->title('Step 3 of 6 / System check');
 
+        $io->warning('The checks are executed only in the cli environment and do not guarantee correctness in the web server environment.');
+
         if (0 !== $code = $this->performSystemcheck()) {
             return $code;
         }


### PR DESCRIPTION
fixes #3690

<img width="848" alt="Bildschirmfoto 2022-01-01 um 14 29 07" src="https://user-images.githubusercontent.com/330436/147851717-e6d3d018-8ce6-49f5-be47-4d36abf248f1.png">

