### PR TITLE
Fehler optimiert, wenn kein Artikel vorhanden oder Artikel nicht gefunden

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -44,8 +44,12 @@ if (rex::isBackend()) {
         $article->setCLang(rex_clang::getCurrentId());
 
         if (!$article->setArticleId(rex_article::getCurrentId())) {
+            if (!rex::isDebugMode() && !rex_backend_login::hasSession()) {
+                throw new rex_exception('Article with id '.rex_article::getCurrentId().' does not exist');
+            }
+
             $fragment = new rex_fragment([
-                'content' => '<p><b>Kein Startartikel selektiert - No starting Article selected.</b><br />Please click here to enter <a href="' . rex_url::backendController() . '">redaxo</a>.</p>',
+                'content' => '<p><b>Article with ID '.rex_article::getCurrentId().' not found.</b><br />If this is a fresh setup, the first article must be created first.<br />Enter <a href="' . rex_url::backendController() . '">REDAXO</a>.</p>',
             ]);
             $content .= $fragment->parse('core/fe_ooops.php');
             rex_response::sendPage($content);

--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -49,7 +49,7 @@ if (rex::isBackend()) {
             }
 
             $fragment = new rex_fragment([
-                'content' => '<p><b>Article with ID '.rex_article::getCurrentId().' not found.</b><br />If this is a fresh setup, the first article must be created first.<br />Enter <a href="' . rex_url::backendController() . '">REDAXO</a>.</p>',
+                'content' => '<p><b>Article with ID '.rex_article::getCurrentId().' not found.</b><br />If this is a fresh setup, an article must be created first.<br />Enter <a href="' . rex_url::backendController() . '">REDAXO</a>.</p>',
             ]);
             $content .= $fragment->parse('core/fe_ooops.php');
             rex_response::sendPage($content);


### PR DESCRIPTION
closes #3916

Der PR macht zwei Dinge:
* Die Fehlermeldung im Frontend sehen nur eingeloggte Benutzer. Andere Seitenbesucher sollten keine Fehlermeldungen dieser Art und auch keinen Link zum Backend sehen. Daher für die eine normale Exception, die ins Log geht, und der Benutzer sieht dann die normale Fehlerseite
* Für eingeloggte Benutzer habe ich die Meldung optimiert. Fand ich nicht so leicht. Der Regelfall ist nach dem Setup, wenn noch gar kein Artikel existiert. Theoretisch kann der Fall aber auch in anderen Konstellationen auftreten. Ist unwahrscheinlich  (aber nicht ausgeschlossen), das System versucht die vorher schon zu verhindern.

<img width="673" alt="Bildschirmfoto 2022-01-01 um 23 20 12" src="https://user-images.githubusercontent.com/330436/147861374-19b65172-e1b8-411f-b228-7a363758a230.png">
