### PR TITLE
rex_sql: Params mit korrektem Typ binden

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -5822,7 +5822,7 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$fldName</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="12">
+    <MixedAssignment occurrences="13">
       <code>$buffered</code>
       <code>$buffered</code>
       <code>$errors['error']</code>
@@ -5832,6 +5832,7 @@
       <code>$lastRow</code>
       <code>$params[$paramName]</code>
       <code>$this-&gt;lastRow</code>
+      <code>$value</code>
       <code>$value</code>
       <code>$version</code>
       <code>$version</code>

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -373,7 +373,19 @@ class rex_sql implements Iterator
             $this->flush();
             $this->params = $params;
 
-            $this->stmt->execute($params);
+            static $types = [
+                'bool' => PDO::PARAM_BOOL,
+                'integer' => PDO::PARAM_INT,
+                'null' => PDO::PARAM_NULL,
+            ];
+            foreach ($params as $param => $value) {
+                $param = is_int($param) ? $param + 1 : $param;
+                $type = $types[gettype($value)] ?? PDO::PARAM_STR;
+
+                $this->stmt->bindValue($param, $value, $type);
+            }
+
+            $this->stmt->execute();
             $this->rows = $this->stmt->rowCount();
             $this->lastInsertId = self::$pdo[$this->DBID]->lastInsertId();
         } catch (PDOException $e) {

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -373,6 +373,7 @@ class rex_sql implements Iterator
             $this->flush();
             $this->params = $params;
 
+            /** @var array<string, PDO::PARAM_*> $types */
             static $types = [
                 'bool' => PDO::PARAM_BOOL,
                 'integer' => PDO::PARAM_INT,

--- a/redaxo/src/core/tests/sql/sql_select_test.php
+++ b/redaxo/src/core/tests/sql/sql_select_test.php
@@ -127,16 +127,20 @@ class rex_sql_select_test extends TestCase
 
     public function testPreparedSetQuery()
     {
+        $this->insertRow();
+
         $sql = rex_sql::factory();
-        $sql->setQuery('SELECT * FROM ' . self::TABLE . ' WHERE col_str = ? and col_int = ?', ['abc', 5]);
+        $sql->setQuery('SELECT * FROM ' . self::TABLE . ' WHERE col_str = ? and col_int = ? LIMIT ?', ['abc', 5, 1]);
 
         static::assertEquals(1, $sql->getRows());
     }
 
     public function testPreparedNamedSetQuery()
     {
+        $this->insertRow();
+
         $sql = rex_sql::factory();
-        $sql->setQuery('SELECT * FROM ' . self::TABLE . ' WHERE col_str = :mystr and col_int = :myint', ['mystr' => 'abc', ':myint' => 5]);
+        $sql->setQuery('SELECT * FROM ' . self::TABLE . ' WHERE col_str = :mystr and col_int = :myint LIMIT :limit', ['mystr' => 'abc', ':myint' => 5, 'limit' => 1]);
 
         static::assertEquals(1, $sql->getRows());
     }


### PR DESCRIPTION
Somit können Params auch an Stellen verwendet werden, wo SQL einen Integer erwartet, wie bei `LIMIT :limit`.

fixes #1419