### PR TITLE
new rex_string::normalizeId($string)

### DIFF
--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -56,6 +56,23 @@ class rex_string
     }
 
     /**
+     * Normalizes a string.
+     *
+     * Only whitespace characters need to be removed in HTML5 id attributes
+     *
+     * @param string $string       Input string
+     * @param string $replaceChar  Character that is used to replace not allowed chars
+     *
+     * @return string
+     */
+    
+    public static function normalizeId($string, $replaceChar = '_')
+    {
+        $string = self::normalizeEncoding($string);
+        return = str_replace([' '], [$replaceChar], $string);
+    }
+
+    /**
      * Splits a string by spaces
      * (Strings with quotes will be regarded).
      *


### PR DESCRIPTION
https://github.com/yakamara/redaxo_yform/issues/1224

In der Welt von HTML5 und vollständigem Unicode-Support gibt es keine Notwendigkeit mehr, über das Leerzeichen hinaus Strings zu normalisieren. Wer ein Emoji oder sonst etwas nutzen möchte, darf es.

Alternative Namensvorschläge für die Methode: `normalizeHtmlAttr`, `normalizeAttr`, `normalizeHtmlId`