### PR TITLE
"Eingeloggt bleiben" repariert

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -5142,14 +5142,18 @@
     </MixedAssignment>
   </file>
   <file src="redaxo/src/core/lib/login/backend_login.php">
+    <InvalidArgument occurrences="1"/>
     <MixedArgument occurrences="1">
       <code>rex::getProperty('instname')</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess occurrences="4">
       <code>$_SESSION[$sessionNs][self::SYSTEM_ID]['UID']</code>
       <code>$_SESSION[static::getSessionNamespace()][self::SYSTEM_ID]</code>
+      <code>$sessionConfig['samesite']</code>
+      <code>$sessionConfig['secure']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment occurrences="2">
+      <code>$sessionConfig</code>
       <code>$userId</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">


### PR DESCRIPTION
Es gab zwei Probleme:

* Es wurde `sameSite=Strict` verwendet. Das führt zumindest im Safari dazu, dass bei Browser-Neustart der Cookie gelöscht wird. Wundere mich warum, aber man findet dazu auch mehrere Berichte, wie [hier](https://stackoverflow.com/questions/68309242/samesite-strict-cookie-not-sent-in-safari-when-opening-a-new-tab). Laut einem Kommentar dort betrifft es auch Chrome. Neu nehme ich nun die gleiche samesite-Einstellung wie für den Session-Cookie (default Lax).
* Nach einem Login über den Cookie, wurde fälschlich eine vermeintliche Passwortänderung "bemerkt" und deswegen wurde man direkt wieder ausgeloggt