### PR TITLE
Fehlende Package-Page: Fehlermeldung optimiert

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -5457,7 +5457,8 @@
     </MixedReturnStatement>
   </file>
   <file src="redaxo/src/core/lib/packages/package.php">
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="9">
+      <code>$__file</code>
       <code>$__file</code>
       <code>$__file</code>
       <code>$dir</code>

--- a/redaxo/src/core/lib/packages/package.php
+++ b/redaxo/src/core/lib/packages/package.php
@@ -280,13 +280,19 @@ abstract class rex_package implements rex_package_interface
         extract($__context, EXTR_SKIP);
 
         /** @noRector \Rector\Naming\Rector\Variable\UnderscoreToCamelCaseVariableNameRector */
-        if (is_file($this->getPath($__file))) {
+        if (is_file($__path = $this->getPath($__file))) {
             /** @noRector \Rector\Naming\Rector\Variable\UnderscoreToCamelCaseVariableNameRector */
-            return include $this->getPath($__file);
+            return require $__path;
         }
 
         /** @noRector \Rector\Naming\Rector\Variable\UnderscoreToCamelCaseVariableNameRector */
-        return include $__file;
+        if (is_file($__file)) {
+            /** @noRector \Rector\Naming\Rector\Variable\UnderscoreToCamelCaseVariableNameRector */
+            return require $__file;
+        }
+
+        /** @noRector \Rector\Naming\Rector\Variable\UnderscoreToCamelCaseVariableNameRector */
+        throw new rex_exception(sprintf('Package "%s": the page path "%s" neither exists as standalone path nor as package subpath "%s"', $this->getPackageId(), $__file, $__path));
     }
 
     /**


### PR DESCRIPTION
closes #2876

Problem war vor allem, dass die Page-Pfade zunächst als Sub-Pfade zum Addon probiert wurden, und wenn dort nicht vorhanden, als globale, bzw. relative Pfade. Somit bekam man letztlich eine Fehlermeldung nur mit dem relativen Pfad (siehe Issue), obwohl meist der zuerst geprüfte Subpath eher der "richtigere" gewesen wäre.

Daher nun mit eigener Fehlermeldung. Schaut nun so aus:

<img width="926" alt="Bildschirmfoto 2022-01-10 um 00 29 27" src="https://user-images.githubusercontent.com/330436/148705712-fbe71456-c0e9-4199-854e-ee361e50d56a.png">