### PR TITLE
phpstan: remove bleeding edge mode

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,5 @@
 includes:
 	- .tools/phpstan/baseline.neon
-	# activate dead code detection. this line should be removed after we updated to phpstan 1.0+
-	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
 
 parameters:
     level: 5


### PR DESCRIPTION
nicht mehr nötig seit phpstan 1.0

bleeding edge brauch man nur, wenn man unstabile features aktivieren will.. aktuell gibts aber keine relevanten