### PR TITLE
PHPMailer :: Absender der Errormail

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -290,12 +290,12 @@ class rex_mailer extends PHPMailer
         $mailBody .= '    </tbody>';
         $mailBody .= '</table>';
         //End - generate mailbody
-
+        $addon = rex_addon::get('phpmailer');
         $mail = new self();
         $mail->Subject = rex::getServerName() . ' - error report ';
         $mail->Body = $mailBody;
         $mail->AltBody = strip_tags($mailBody);
-        $mail->setFrom($this->From, 'REDAXO error report');
+        $mail->setFrom($addon->getConfig('from'), 'REDAXO error report');
         $mail->addAddress(rex::getErrorEmail());
 
         $addon->setConfig('last_log_file_send_time', time());

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -290,6 +290,7 @@ class rex_mailer extends PHPMailer
         $mailBody .= '    </tbody>';
         $mailBody .= '</table>';
         //End - generate mailbody
+
         $mail = new self();
         $mail->Subject = rex::getServerName() . ' - error report ';
         $mail->Body = $mailBody;

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -290,12 +290,11 @@ class rex_mailer extends PHPMailer
         $mailBody .= '    </tbody>';
         $mailBody .= '</table>';
         //End - generate mailbody
-        $addon = rex_addon::get('phpmailer');
         $mail = new self();
         $mail->Subject = rex::getServerName() . ' - error report ';
         $mail->Body = $mailBody;
         $mail->AltBody = strip_tags($mailBody);
-        $mail->setFrom($addon->getConfig('from'), 'REDAXO error report');
+        $mail->FromName('REDAXO error report');
         $mail->addAddress(rex::getErrorEmail());
 
         $addon->setConfig('last_log_file_send_time', time());

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -295,7 +295,7 @@ class rex_mailer extends PHPMailer
         $mail->Subject = rex::getServerName() . ' - error report ';
         $mail->Body = $mailBody;
         $mail->AltBody = strip_tags($mailBody);
-        $mail->setFrom(rex::getErrorEmail(), 'REDAXO error report');
+        $mail->setFrom($this->From, 'REDAXO error report');
         $mail->addAddress(rex::getErrorEmail());
 
         $addon->setConfig('last_log_file_send_time', time());

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -294,7 +294,7 @@ class rex_mailer extends PHPMailer
         $mail->Subject = rex::getServerName() . ' - error report ';
         $mail->Body = $mailBody;
         $mail->AltBody = strip_tags($mailBody);
-        $mail->FromName('REDAXO error report');
+        $mail->FromName = 'REDAXO error report';
         $mail->addAddress(rex::getErrorEmail());
 
         $addon->setConfig('last_log_file_send_time', time());


### PR DESCRIPTION
sollte aus PHPMailer-Config kommen. 

E-Mails können nicht versendet werden, wenn hier ein Absender steht, der nicht berechtigt ist E-Mails unter dem konfigurierten Postfach oder der Domain zu versenden. 

https://github.com/redaxo/redaxo/blob/c9e667d630870942dfa5568bf7be56c8a89661db/redaxo/src/addons/phpmailer/lib/mailer.php#L298-L299