### PR TITLE
Phpdocs

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -3260,7 +3260,9 @@
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/structure/plugins/history/boot.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="3">
+      <code>$articleId</code>
+      <code>$clangId</code>
       <code>$version['history_date']</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="6">
@@ -3307,14 +3309,6 @@
     </MixedArgument>
   </file>
   <file src="redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php">
-    <MixedArgument occurrences="3">
-      <code>$articleId</code>
-      <code>$clangId</code>
-      <code>$historyType</code>
-    </MixedArgument>
-    <MixedOperand occurrences="1">
-      <code>$historyDate</code>
-    </MixedOperand>
     <PossiblyNullReference occurrences="1">
       <code>getValue</code>
     </PossiblyNullReference>
@@ -3343,10 +3337,12 @@
     </MixedOperand>
   </file>
   <file src="redaxo/src/addons/structure/plugins/version/boot.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="8">
       <code>$params['article_id']</code>
       <code>$params['article_id']</code>
       <code>$params['article_id']</code>
+      <code>$params['article_id']</code>
+      <code>$params['clang']</code>
       <code>$params['clang']</code>
       <code>$params['clang']</code>
       <code>$params['clang']</code>

--- a/redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php
+++ b/redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php
@@ -15,7 +15,7 @@ class rex_article_slice_history
         return rex::getTablePrefix() . 'article_slice_history';
     }
 
-    /*
+    /**
      * Only Snapshots from LiveVersion.
      *
      * @param int $articleId

--- a/redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php
+++ b/redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php
@@ -17,8 +17,11 @@ class rex_article_slice_history
 
     /*
      * Only Snapshots from LiveVersion.
+     *
+     * @param int $articleId
+     * @param int $clangId
+     * @param string $historyType
      */
-
     public static function makeSnapshot($articleId, $clangId, $historyType)
     {
         self::checkTables();
@@ -52,6 +55,9 @@ class rex_article_slice_history
     }
 
     /**
+     * @param int $articleId
+     * @param int $clangId
+     *
      * @return array
      */
     public static function getSnapshots($articleId, $clangId)
@@ -63,6 +69,10 @@ class rex_article_slice_history
     }
 
     /**
+     * @param string $historyDate
+     * @param int $articleId
+     * @param int $clangId
+     *
      * @return bool
      */
     public static function restoreSnapshot($historyDate, $articleId, $clangId)


### PR DESCRIPTION
Should fix

```
 ------ ------------------------------------------------------------------------------------------
  Line   addons\structure\plugins\history\lib\article_slice_history.php
 ------ ------------------------------------------------------------------------------------------
  26     Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
  59     Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
  73     Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
  84     Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
  87     Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
 ------ ------------------------------------------------------------------------------------------
 ```

refs https://github.com/redaxo/redaxo/pull/4984#issuecomment-1017767525