### PR TITLE
Phpdocs

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -3337,11 +3337,17 @@
     </MixedOperand>
   </file>
   <file src="redaxo/src/addons/structure/plugins/version/boot.php">
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="14">
       <code>$params['article_id']</code>
       <code>$params['article_id']</code>
       <code>$params['article_id']</code>
       <code>$params['article_id']</code>
+      <code>$params['article_id']</code>
+      <code>$params['article_id']</code>
+      <code>$params['article_id']</code>
+      <code>$params['clang']</code>
+      <code>$params['clang']</code>
+      <code>$params['clang']</code>
       <code>$params['clang']</code>
       <code>$params['clang']</code>
       <code>$params['clang']</code>
@@ -3395,11 +3401,6 @@
       <code>$colname</code>
       <code>$colname</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="3">
-      <code>$articleId</code>
-      <code>$fromRevisionId</code>
-      <code>$toRevisionId</code>
-    </MixedArgument>
   </file>
   <file src="redaxo/src/addons/structure/tests/article_test.php">
     <MixedArgument occurrences="1">

--- a/redaxo/src/addons/structure/plugins/version/lib/revision.php
+++ b/redaxo/src/addons/structure/plugins/version/lib/revision.php
@@ -9,6 +9,11 @@ class rex_article_revision
     public const WORK = 1; // working copy
 
     /**
+     * @param int $articleId
+     * @param int $clang
+     * @param int $fromRevisionId
+     * @param int $toRevisionId
+     *
      * @return bool
      */
     public static function copyContent($articleId, $clang, $fromRevisionId, $toRevisionId)
@@ -49,6 +54,10 @@ class rex_article_revision
     }
 
     /**
+     * @param int $articleId
+     * @param int $clang
+     * @param int $fromRevisionId
+     *
      * @return true
      */
     public static function clearContent($articleId, $clang, $fromRevisionId)


### PR DESCRIPTION
Should fix

```
 ------ ------------------------------------------------------------------------------------------
  Line   addons\structure\plugins\version\lib\revision.php
 ------ ------------------------------------------------------------------------------------------
  23     Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
  26     Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
  62     Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
 ------ ------------------------------------------------------------------------------------------
 ```

refs https://github.com/redaxo/redaxo/pull/4984#issuecomment-1017767525