### PR TITLE
added phpdocs

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1563,18 +1563,6 @@
     </PossiblyNullReference>
   </file>
   <file src="redaxo/src/addons/metainfo/functions/function_metainfo.php">
-    <MixedArgument occurrences="10">
-      <code>$attributes</code>
-      <code>$callback</code>
-      <code>$default</code>
-      <code>$name</code>
-      <code>$params</code>
-      <code>$priority</code>
-      <code>$restrictions</code>
-      <code>$title</code>
-      <code>$type</code>
-      <code>$validate</code>
-    </MixedArgument>
     <MixedArrayAccess occurrences="1">
       <code>$metaTables[$prefix]</code>
     </MixedArrayAccess>
@@ -1584,10 +1572,9 @@
       <code>$metaTables</code>
       <code>$page</code>
     </MixedAssignment>
-    <MixedOperand occurrences="3">
+    <MixedOperand occurrences="2">
       <code>$metaTable</code>
       <code>$metaTable</code>
-      <code>$type</code>
     </MixedOperand>
   </file>
   <file src="redaxo/src/addons/metainfo/lib/handler/api_default_fields.php">

--- a/redaxo/src/addons/metainfo/functions/function_metainfo.php
+++ b/redaxo/src/addons/metainfo/functions/function_metainfo.php
@@ -16,7 +16,7 @@
  * @param string $label
  * @param string $dbtype
  * @param int $dblength
- * @throws rex_sql_exception
+ *
  * @return string
  */
 function rex_metainfo_add_field_type($label, $dbtype, $dblength)

--- a/redaxo/src/addons/metainfo/functions/function_metainfo.php
+++ b/redaxo/src/addons/metainfo/functions/function_metainfo.php
@@ -12,6 +12,12 @@
  * Fügt einen neuen Feldtyp ein.
  *
  * Gibt beim Erfolg die Id des Feldes zurück, bei Fehler die Fehlermeldung
+ *
+ * @param string $label
+ * @param string $dbtype
+ * @param int $dblength
+ * @throws rex_sql_exception
+ * @return string
  */
 function rex_metainfo_add_field_type($label, $dbtype, $dblength)
 {
@@ -48,6 +54,8 @@ function rex_metainfo_add_field_type($label, $dbtype, $dblength)
  *
  * Gibt beim Erfolg true zurück, sonst eine Fehlermeldung
  *
+ * @param int $fieldTypeId
+ *
  * @return bool|string
  */
 function rex_metainfo_delete_field_type($fieldTypeId)
@@ -66,6 +74,19 @@ function rex_metainfo_delete_field_type($fieldTypeId)
 
 /**
  * Fügt ein MetaFeld hinzu und legt dafür eine Spalte in der MetaTable an.
+ *
+ * @param string $title
+ * @param string $name
+ * @param int $priority
+ * @param string $attributes
+ * @param int $type
+ * @param string $default
+ * @param string $params
+ * @param string $validate
+ * @param string $restrictions
+ * @param string $callback
+ *
+ * @return bool|string
  */
 function rex_metainfo_add_field($title, $name, $priority, $attributes, $type, $default, $params = null, $validate = null, $restrictions = '', $callback = null)
 {
@@ -128,6 +149,11 @@ function rex_metainfo_add_field($title, $name, $priority, $attributes, $type, $d
     return $tableManager->addColumn($name, $fieldDbType, $fieldDbLength, $default);
 }
 
+/**
+ * @param string|id $fieldIdOrName
+ *                                
+ * @return bool|string
+ */
 function rex_metainfo_delete_field($fieldIdOrName)
 {
     // Löschen anhand der FieldId

--- a/redaxo/src/addons/metainfo/functions/function_metainfo.php
+++ b/redaxo/src/addons/metainfo/functions/function_metainfo.php
@@ -151,7 +151,7 @@ function rex_metainfo_add_field($title, $name, $priority, $attributes, $type, $d
 
 /**
  * @param string|id $fieldIdOrName
- *                                
+ *
  * @return bool|string
  */
 function rex_metainfo_delete_field($fieldIdOrName)

--- a/redaxo/src/addons/metainfo/functions/function_metainfo.php
+++ b/redaxo/src/addons/metainfo/functions/function_metainfo.php
@@ -150,7 +150,7 @@ function rex_metainfo_add_field($title, $name, $priority, $attributes, $type, $d
 }
 
 /**
- * @param string|id $fieldIdOrName
+ * @param string|int $fieldIdOrName
  *
  * @return bool|string
  */


### PR DESCRIPTION
should fix
```
 ------ ------------------------------------------------------------------------------------------------------
  Line   addons\metainfo\functions\function_metainfo.php
 ------ ------------------------------------------------------------------------------------------------------
  83     Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
  93     Unresolvable Query: Cannot simulate parameter value for type: mixed~0|0.0|''|'0'|array{}|false|null.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
  101    Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
  160    Unresolvable Query: Cannot simulate parameter value for type: mixed.
         💡 Make sure all variables involved have a non-mixed type and array-types are specified.
 ------ ------------------------------------------------------------------------------------------------------

```

refs https://github.com/redaxo/redaxo/pull/4984#issuecomment-1017767525