### PR TITLE
rex_version: Abfangen, wenn exec() nicht zur Verfügung steht

### DIFF
--- a/redaxo/src/core/lib/util/version.php
+++ b/redaxo/src/core/lib/util/version.php
@@ -69,6 +69,10 @@ class rex_version
      */
     public static function gitHash($path, ?string $repo = null): ?string
     {
+        if (!function_exists('exec')) {
+            return null;
+        }
+
         $output = [];
         $exitCode = -1;
 


### PR DESCRIPTION
fixes #5038

`exec` ist auf shared hostings öfters über die php.ini deaktiviert.