### PR TITLE
Mediapool details size fix: disable width, when $rfwidth 0

### DIFF
--- a/redaxo/src/addons/mediapool/pages/media.detail.php
+++ b/redaxo/src/addons/mediapool/pages/media.detail.php
@@ -143,7 +143,12 @@ if ($isImage) {
     $addExtInfo = $fragment->parse('core/form/form.php');
 
     $imgn = rex_url::media($fname).'?buster='.$gf->getDateTimeValue('updatedate');
-    $width = ' width="'.$rfwidth.'"';
+    $width = '';
+	
+	if($rfwidth > 0)
+	{
+		$width = ' width="'.$rfwidth.'"';
+	}
     $imgMax = rex_url::media($fname);
 
     if (rex_addon::get('media_manager')->isAvailable() && 'svg' != rex_file::extension($fname)) {

--- a/redaxo/src/addons/mediapool/pages/media.detail.php
+++ b/redaxo/src/addons/mediapool/pages/media.detail.php
@@ -144,11 +144,10 @@ if ($isImage) {
 
     $imgn = rex_url::media($fname).'?buster='.$gf->getDateTimeValue('updatedate');
     $width = '';
-	
-	if($rfwidth > 0)
-	{
-		$width = ' width="'.$rfwidth.'"';
-	}
+
+    if ($rfwidth > 0) {
+        $width = ' width="'.$rfwidth.'"';
+    }
     $imgMax = rex_url::media($fname);
 
     if (rex_addon::get('media_manager')->isAvailable() && 'svg' != rex_file::extension($fname)) {


### PR DESCRIPTION
SVG wurden nicht angezeigt und mit Breite 0 versehen. 