### PR TITLE
rex_var_value deprecation warnings in PHP 8.1

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/var_value.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/var_value.php
@@ -20,6 +20,10 @@ class rex_var_value extends rex_var
             return $value ? 'true' : 'false';
         }
 
+        if (!isset($value)) {
+            $value = '';
+        }
+
         $output = $this->getArg('output');
         if ('php' == $output) {
             if ($this->environmentIs(self::ENV_BACKEND)) {


### PR DESCRIPTION
Added a check in rex_var_value to see if the value isn't null, if it is null, PHP 8.1 throws deprecation warnings;