### PR TITLE
rex_context: Neue zusätzliche Methoden

### DIFF
--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -113,17 +113,12 @@ class rex_context implements rex_context_provider_interface
 
     /**
      * Removes a global parameter.
-     *
-     * @return bool TRUE if the parameter was found and removed, otherwise FALSE
      */
-    public function removeParam(string $name): bool
+    public function removeParam(string $name): void
     {
         if (isset($this->globalParams[$name])) {
             unset($this->globalParams[$name]);
-            return true;
         }
-
-        return false;
     }
 
     /**

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -124,9 +124,7 @@ class rex_context implements rex_context_provider_interface
      */
     public function removeParam(string $name): void
     {
-        if (isset($this->globalParams[$name])) {
-            unset($this->globalParams[$name]);
-        }
+        unset($this->globalParams[$name]);
     }
 
     /**

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -112,9 +112,7 @@ class rex_context implements rex_context_provider_interface
     }
 
     /**
-     * Removes a global parameter
-     *
-     * @param string $name
+     * Removes a global parameter.
      *
      * @return bool TRUE if the parameter was found and removed, otherwise FALSE
      */

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -113,10 +113,6 @@ class rex_context implements rex_context_provider_interface
 
     /**
      * Returns whether the given parameter exists.
-     *
-     * @param string $name
-     *
-     * @return bool
      */
     public function hasParam(string $name): bool
     {

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -104,9 +104,9 @@ class rex_context implements rex_context_provider_interface
     /**
      * Returns the global parameters.
      *
-     * @return array
+     * @return array<string, mixed>
      */
-    public function getParams()
+    public function getParams(): array
     {
         return $this->globalParams;
     }

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -71,7 +71,7 @@ class rex_context implements rex_context_provider_interface
     public function getUrl(array $params = [], $escape = true)
     {
         // combine global params with local
-        $params = array_merge($this->globalParams, $params);
+        $params = array_merge($this->getParams(), $params);
 
         return rex::isBackend() ? rex_url::backendController($params, $escape) : rex_url::frontendController($params, $escape);
     }
@@ -102,12 +102,22 @@ class rex_context implements rex_context_provider_interface
     }
 
     /**
+     * Returns the global parameters.
+     *
+     * @return array
+     */
+    public function getParams()
+    {
+        return $this->globalParams;
+    }
+
+    /**
      * @see rex_context_provider::getHiddenInputFields()
      */
     public function getHiddenInputFields(array $params = [])
     {
         // combine global params with local
-        $params = array_merge($this->globalParams, $params);
+        $params = array_merge($this->getParams(), $params);
 
         return self::array2inputStr($params);
     }

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -71,7 +71,7 @@ class rex_context implements rex_context_provider_interface
     public function getUrl(array $params = [], $escape = true)
     {
         // combine global params with local
-        $params = array_merge($this->getParams(), $params);
+        $params = array_merge($this->globalParams, $params);
 
         return rex::isBackend() ? rex_url::backendController($params, $escape) : rex_url::frontendController($params, $escape);
     }
@@ -117,7 +117,7 @@ class rex_context implements rex_context_provider_interface
     public function getHiddenInputFields(array $params = [])
     {
         // combine global params with local
-        $params = array_merge($this->getParams(), $params);
+        $params = array_merge($this->globalParams, $params);
 
         return self::array2inputStr($params);
     }

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -112,6 +112,23 @@ class rex_context implements rex_context_provider_interface
     }
 
     /**
+     * Removes a global parameter
+     *
+     * @param string $name
+     *
+     * @return bool TRUE if the parameter was found and removed, otherwise FALSE
+     */
+    public function removeParam(string $name): bool
+    {
+        if (isset($this->globalParams[$name])) {
+            unset($this->globalParams[$name]);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * @see rex_context_provider::getHiddenInputFields()
      */
     public function getHiddenInputFields(array $params = [])

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -112,6 +112,18 @@ class rex_context implements rex_context_provider_interface
     }
 
     /**
+     * Returns whether the given parameter exists.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasParam(string $name): bool
+    {
+        return isset($this->globalParams[$name]);
+    }
+
+    /**
      * Removes a global parameter.
      */
     public function removeParam(string $name): void


### PR DESCRIPTION
Um es im Frontend besser verwenden zu können

```php
$context = rex_context::fromGet();
$context->setParam('foo', 'bar');
$context->removeParam('foobar');
echo rex_getUrl('', '', $context->getParams());
```