### PR TITLE
Neue Methode zum ändern eines BE-Seiten-Titels

### DIFF
--- a/redaxo/src/core/lib/be/page.php
+++ b/redaxo/src/core/lib/be/page.php
@@ -77,6 +77,20 @@ class rex_be_page
     }
 
     /**
+     * Sets the page title
+     * 
+     * @param string title
+     *
+     * @return $this
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+    
+    /**
      * Returns the title.
      *
      * @returns string

--- a/redaxo/src/core/lib/be/page.php
+++ b/redaxo/src/core/lib/be/page.php
@@ -77,19 +77,17 @@ class rex_be_page
     }
 
     /**
-     * Sets the page title
-     * 
-     * @param string title
+     * Sets the page title.
      *
      * @return $this
      */
-    public function setTitle($title)
+    public function setTitle(string $title): self
     {
         $this->title = $title;
 
         return $this;
     }
-    
+
     /**
      * Returns the title.
      *


### PR DESCRIPTION
Ermöglicht es, den Titel einer Seite z.B. per EP zu ändern, um z.B. Addons projektbezogen aussagekräftige Titel zu geben.

```
rex_extension::register('PAGES_PREPARED', static function () {
    rex_be_controller::getPageObject('page')->setTitle('Custom Page Title'));
});
```