### PR TITLE
rex_article_slice: fix getMediaListArray

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
@@ -524,7 +524,7 @@ class rex_article_slice
      */
     public function getMediaListArray(int $index): ?array
     {
-        $list = $this->linklists[$index - 1];
+        $list = $this->medialists[$index - 1];
 
         if (null === $list) {
             return null;


### PR DESCRIPTION
Gibt sonst immer null zurück, weil falscher Listentyp.