### PR TITLE
rex_var::quote: support null value

### DIFF
--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -341,12 +341,16 @@ abstract class rex_var
     /**
      * Quotes the string for php context.
      *
-     * @param string $string
+     * @param string|null $string
      *
      * @return string
      */
     protected static function quote($string)
     {
+        if (null === $string) {
+            return 'null';
+        }
+
         $string = addcslashes($string, "\\'");
         $string = preg_replace('/\v+/', '\' . "$0" . \'', $string);
         $string = addcslashes($string, "\r\n");


### PR DESCRIPTION
fixes #5100

Alternative wäre, alle Stellen zu prüfen/anzupassen, wo `quote()` aufgerufen wird.
Denke aber es ist ok/gut, wenn die Methode selbst `null` auch unterstützt, da es den Aufruf-Code einfacher hält.