### PR TITLE
debug: check core config file to decide if clockwork should be turned on

### DIFF
--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!rex::isDebugMode() || 'debug' === rex_get(rex_api_function::REQ_CALL_PARAM)) {
+if (!rex_debug_clockwork::isRexDebugEnabled() || 'debug' === rex_get(rex_api_function::REQ_CALL_PARAM)) {
     return;
 }
 

--- a/redaxo/src/addons/debug/lib/debug_clockwork.php
+++ b/redaxo/src/addons/debug/lib/debug_clockwork.php
@@ -78,6 +78,10 @@ class rex_debug_clockwork
      */
     public static function isRexDebugEnabled(): bool
     {
+        if (PHP_SAPI !== 'cli') {
+            return rex::isDebugMode();
+        }
+
         $coreConfigCacheFile = rex_path::coreCache('config.yml.cache');
         $coreConfigCache = rex_file::getCache($coreConfigCacheFile);
         /** @var bool $debugEnabled */

--- a/redaxo/src/addons/debug/lib/debug_clockwork.php
+++ b/redaxo/src/addons/debug/lib/debug_clockwork.php
@@ -80,7 +80,9 @@ class rex_debug_clockwork
     {
         $coreConfigFile = rex_path::coreData('config.yml');
         $coreConfig = rex_file::getConfig($coreConfigFile);
+        /** @var bool $debugEnabled */
+        $debugEnabled = $coreConfig['debug']['enabled'] ?? false;
 
-        return $coreConfig['debug']['enabled'] ?? false;
+        return $debugEnabled;
     }
 }

--- a/redaxo/src/addons/debug/lib/debug_clockwork.php
+++ b/redaxo/src/addons/debug/lib/debug_clockwork.php
@@ -71,4 +71,16 @@ class rex_debug_clockwork
     {
         return rex_addon::get('debug')->getCachePath('clockwork.db');
     }
+
+    /**
+     * We cannot rely on rex::isDebugMode() because it is always true on the console.
+     * So we have to check the config file itself.
+     */
+    public static function isRexDebugEnabled(): bool
+    {
+        $coreConfigFile = rex_path::coreData('config.yml');
+        $coreConfig = rex_file::getConfig($coreConfigFile);
+
+        return $coreConfig['debug']['enabled'] ?? false;
+    }
 }

--- a/redaxo/src/addons/debug/lib/debug_clockwork.php
+++ b/redaxo/src/addons/debug/lib/debug_clockwork.php
@@ -78,10 +78,10 @@ class rex_debug_clockwork
      */
     public static function isRexDebugEnabled(): bool
     {
-        $coreConfigFile = rex_path::coreData('config.yml');
-        $coreConfig = rex_file::getConfig($coreConfigFile);
+        $coreConfigCacheFile = rex_path::coreCache('config.yml.cache');
+        $coreConfigCache = rex_file::getCache($coreConfigCacheFile);
         /** @var bool $debugEnabled */
-        $debugEnabled = $coreConfig['debug']['enabled'] ?? false;
+        $debugEnabled = $coreConfigCache['debug']['enabled'] ?? false;
 
         return $debugEnabled;
     }


### PR DESCRIPTION
We cannot rely on `rex::isDebugMode()` because it is always true on the console. So we have to check the config file itself.

fixes #5073