### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -9,8 +9,13 @@ on:
 env:
     writable: ${{ github.event_name != 'push' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && 1 || 0 }}
 
+permissions:
+  contents: read
+
 jobs:
     php-cs-fixer:
+        permissions:
+          contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
         runs-on: ubuntu-latest
         if: github.event.pull_request.draft == false
 
@@ -54,6 +59,8 @@ jobs:
                 run: vendor/bin/php-cs-fixer fix --ansi --diff --dry-run --format=checkstyle | cs2pr # check whether there are still errors left
 
     rector:
+        permissions:
+          contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
         runs-on: ubuntu-latest
         if: github.event.pull_request.draft == false
 

--- a/.github/workflows/remove-automerge-label.yml
+++ b/.github/workflows/remove-automerge-label.yml
@@ -4,8 +4,13 @@ on:
     pull_request_target:
         types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
     remove-automerge-label:
+        permissions:
+          contents: none
         runs-on: ubuntu-latest
         if: github.event.pull_request.merged == true
 

--- a/.github/workflows/rexlint.yml
+++ b/.github/workflows/rexlint.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
     rexlint:
         runs-on: ubuntu-18.04

--- a/.github/workflows/sarif-report.yml
+++ b/.github/workflows/sarif-report.yml
@@ -6,8 +6,14 @@ on:
     schedule: # runs every week at 00:00 on Sunday UTC time.
         -   cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
     psalm-taint-sarif-report:
+        permissions:
+          contents: read  # for actions/checkout to fetch code
+          security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
         name: psalm taint sarif report
         runs-on: ubuntu-latest
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,8 +9,13 @@ on:
 env:
     writable: ${{ github.event_name != 'push' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && 1 || 0 }}
 
+permissions:
+  contents: read
+
 jobs:
     psalm-analysis:
+        permissions:
+          contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
         name: psalm static code analysis
         runs-on: ubuntu-latest
 
@@ -56,6 +61,8 @@ jobs:
                     file_pattern: .tools/psalm/baseline.xml
 
     psalm-taint-analysis:
+        permissions:
+          contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
         name: psalm taint analysis
         runs-on: ubuntu-latest
         if: github.event.pull_request.draft == false
@@ -102,6 +109,8 @@ jobs:
                     file_pattern: .tools/psalm/baseline-taint.xml
 
     phpstan-analysis:
+        permissions:
+          contents: write  # for Git to git apply
         name: phpstan static code analysis
         runs-on: ubuntu-latest
 

--- a/.github/workflows/styles-compile.yml
+++ b/.github/workflows/styles-compile.yml
@@ -9,8 +9,13 @@ on:
 env:
     writable: ${{ github.event_name != 'push' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && 1 || 0 }}
 
+permissions:
+  contents: read
+
 jobs:
     compile:
+        permissions:
+          contents: write  # for Git to git apply
         name: be_style:compile
         runs-on: ubuntu-latest
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,8 +6,13 @@ on:
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
     phpunit:
+        permissions:
+          contents: write  # for Git to git apply
         runs-on: ${{ matrix.os }}
 
         strategy:

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -11,8 +11,13 @@ on:
 env:
     writable: ${{ (github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') && 1 || 0 }}
 
+permissions:
+  contents: read
+
 jobs:
     visual-tests:
+        permissions:
+          contents: write  # for Git to git apply
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
