### PR TITLE
extend rex_be_style:compile(), copy vendor files too

### DIFF
--- a/redaxo/src/addons/be_style/lib/be_style.php
+++ b/redaxo/src/addons/be_style/lib/be_style.php
@@ -34,5 +34,17 @@ class rex_be_style
                 rex_file::copy($file['css_file'], $file['copy_dest']);
             }
         }
+
+        $addon = rex_addon::get('be_style');
+
+        // use path relative to __DIR__ to get correct path in update temp dir
+        $files = require __DIR__ . '/../vendor_files.php';
+
+        // copy all vendor files because the new css file could depend on it
+        // also useful for the command when CI wants to refresh the frontend assets
+        foreach ($files as $source => $destination) {
+            // ignore errors, because this file is included very early in setup, before the regular file permissions check
+            rex_file::copy(__DIR__ . '/../' . $source, $addon->getAssetsPath($destination));
+        }
     }
 }


### PR DESCRIPTION
## Hintergrund

Nachdem im neuen Release der Command `rex/bin/consolse assets:sync`  funktioniert, ist hier noch ein kleiner Fehler:
Die Vendor Assets im Frontend fehlen leider noch von `be_style`.

Nach dieser Änderung sollte Jeder folgende Commands ausführen um 100% die Frontend Assets wiederherzustellen:

```
php redaxo/bin/console assets:sync
php redaxo/bin/console be_style:compile
```

Außerdem würden wir gerne unsere CI soweit erweitern, dass die Frontend Assets immer aktuell sind.

## Verbesserung

Ich würde das gerne in den `assets:sync` Command mit reinfließen lassen, aber das neue generierte SCSS könnte neue Vendors Assets brauchen