### PR TITLE
request: prevent exception when invoked from CLI

### DIFF
--- a/redaxo/src/core/lib/request.php
+++ b/redaxo/src/core/lib/request.php
@@ -255,7 +255,7 @@ class rex_request
         if ('cli' === PHP_SAPI) {
             return false;
         }
-        
+
         return 'true' == rex::getRequest()->headers->get('X-Pjax');
     }
 

--- a/redaxo/src/core/lib/request.php
+++ b/redaxo/src/core/lib/request.php
@@ -252,6 +252,10 @@ class rex_request
      */
     public static function isPJAXRequest()
     {
+        if ('cli' === PHP_SAPI) {
+            return false;
+        }
+        
         return 'true' == rex::getRequest()->headers->get('X-Pjax');
     }
 


### PR DESCRIPTION
```
Exception trace:
 at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/lib/rex.php:348
 rex::getRequest() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/lib/request.php:255
 rex_request::isPJAXRequest() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/addons/minibar/boot.php:61
 require() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/lib/packages/package.php:285
 rex_package->includeFile() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/lib/packages/package.php:421
 rex_package->boot() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/lib/console/application.php:93
 rex_console_application->loadPackages() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/lib/console/application.php:48
 rex_console_application->doRunCommand() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/vendor/symfony/console/Application.php:295
 Symfony\Component\Console\Application->doRun() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/lib/console/application.php:23
 rex_console_application->doRun() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/vendor/symfony/console/Application.php:167
 Symfony\Component\Console\Application->run() at /var/www/vhosts/klxm.de/httpdocs/redaxo/src/core/console.php:39
 require() at /var/www/vhosts/klxm.de/httpdocs/redaxo/bin/console:11
```