### PR TITLE
Mediamanager: PHP8-Kompatibilität (resource|GdImage)

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effect_abstract.php
+++ b/redaxo/src/addons/media_manager/lib/effect_abstract.php
@@ -68,7 +68,7 @@ abstract class rex_effect_abstract
     }
 
     /**
-     * @param resource $gdImage
+     * @param resource|GdImage $gdImage  ready for PHP8: switch from "resource" to "GdImage"
      */
     protected function keepTransparent($gdImage)
     {

--- a/redaxo/src/addons/media_manager/lib/effects/effect_mirror.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_mirror.php
@@ -129,7 +129,7 @@ class rex_effect_mirror extends rex_effect_abstract
     }
 
     /**
-     * @return resource
+     * @return resource|GdImage     ready for PHP8: switch from "resource" to "GdImage"
      */
     private function imagereflection(&$image, $reflectionHeight, $reflectionOpacity, $transparent, $bgColor)
     {

--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -29,7 +29,7 @@ class rex_managed_media
     /** @var bool */
     private $asImage = false;
 
-    /** @var array{width: ?int, height: ?int, src?: resource}&array<string, mixed> */
+    /** @var array{width: ?int, height: ?int, src?: resource|GdImage}&array<string, mixed> */
     private $image = [
         'width' => null,
         'height' => null,
@@ -313,7 +313,7 @@ class rex_managed_media
     }
 
     /**
-     * @return resource
+     * @return resource|GdImage     ready for PHP8: switch from "resource" to "GdImage"
      */
     public function getImage()
     {
@@ -325,7 +325,7 @@ class rex_managed_media
     }
 
     /**
-     * @param resource $src
+     * @return resource|GdImage     ready for PHP8: switch from "resource" to "GdImage"
      */
     public function setImage($src)
     {
@@ -344,7 +344,7 @@ class rex_managed_media
         if (!isset($this->image['src'])) {
             return;
         }
-        if (!is_resource($this->image['src'])) {
+        if (is_resource($this->image['src']) || $this->image['src'] instanceof \GdImage) { // ready for PHP8: switch from "resource" to "GdImage"
             return;
         }
         imagedestroy($this->image['src']);

--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -344,7 +344,7 @@ class rex_managed_media
         if (!isset($this->image['src'])) {
             return;
         }
-        if (is_resource($this->image['src']) || $this->image['src'] instanceof \GdImage) { // ready for PHP8: switch from "resource" to "GdImage"
+        if (is_resource($this->image['src'])) {
             return;
         }
         imagedestroy($this->image['src']);


### PR DESCRIPTION
In PHP8 verwaltet die GD-Library Bilder-Resourcen nicht mehr als "resource", sondern als "GdImage". Dies sind die Änderungen im PR:

* Der Variablentyp wird geändert auf resource (PHP7) oder GdImage (PHP8). Das hat technisch nur Auswirkungen
   für PHPSTAN-Analysen. Aufgefallen ist das bei Analysen mit den neuen Addon rexstan.
  ` /** var resource|GdImage $xyz */`
* In **managed_media.php** wird an einer Stelle abgefragt, ob eine Variable vom Typ "resource" ist. Da das in PHP8
  immer `false` ergibt, muss zusätzlich auf GdImage geprüft werden:
  `if (is_resource($this->image['src']) || $this->image['src'] instanceof \GdImage) {`

_Den zweiten Punkt habe ich wieder rausgenommen und in einen PR #5167 überführt. Der erste Punkt betrifft PHPDOC-Themen i.v.M. phpstan-Analysen, der zweite betrift aber die Funktionsfähigkeit des Code mit PHP8 und sollte nicht diuch die PHPDOC-Fehlermeldungen blockiert werden._

Hinweise dazu: [https://php.watch/versions/8.0/gdimage](https://php.watch/versions/8.0/gdimage)

closes #5163 