### PR TITLE
Version Addon: Direkter Wechsel in Arbeitsversion

### DIFF
--- a/redaxo/src/addons/structure/plugins/version/lang/de_de.lang
+++ b/redaxo/src/addons/structure/plugins/version/lang/de_de.lang
@@ -6,6 +6,7 @@ version_working_to_live = als Liveversion freigeben
 version_preview = Voransicht
 version_clear_workingversion = Arbeitsversion leeren
 version_copy_live_to_workingversion = in Arbeitsversion kopieren
+version_copy_live_to_workingversion_switch = in Arbeitsversion kopieren und direkt wechseln
 version_copy_from_liveversion = aus Liveversion übernehmen
 version_confirm_copy_live_to_workingversion = Liveversion in Arbeitsversion kopieren? Alle bestehenden Inhalte der Arbeitsversion werden überschrieben.
 version_info_working_version_to_live = Arbeitsversion wurde live gestellt


### PR DESCRIPTION
Neue Funktion: Liveversion in Arbeitsversion kopieren und direkt wechseln
Es wird oft vergessen, nach dem Kopieren der Live-Version in die Arbeitsversion zu wechseln, sodass aus Versehen die Live-Version bearbeitet wird.