### PR TITLE
Allow dynamic properties on rex_fragment

### DIFF
--- a/redaxo/src/core/lib/fragment.php
+++ b/redaxo/src/core/lib/fragment.php
@@ -10,6 +10,7 @@
  *
  * @package redaxo\core
  */
+#[AllowDynamicProperties]
 class rex_fragment
 {
     /**


### PR DESCRIPTION
Should fix php 8.2 deprecations

```
Deprecated: Creation of dynamic property rex_fragment::$content is deprecated in redaxo/src/core/fragments/core/page/grid.php on line 9
Deprecated: Creation of dynamic property rex_fragment::$classes is deprecated in redaxo/src/core/fragments/core/page/grid.php on line 13
```

https://stitcher.io/blog/new-in-php-82#deprecate-dynamic-properties-rfc