### PR TITLE
Neue EP im Structure/Content-Plugin

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
@@ -38,9 +38,24 @@ class rex_article_content_editor extends rex_article_content
             $sliceCtype = (int) $artDataSql->getValue(rex::getTablePrefix() . 'article_slice.ctype_id');
             $sliceStatus = (int) $artDataSql->getValue(rex::getTablePrefix() . 'article_slice.status');
 
-            $moduleInput = (string) $artDataSql->getValue(rex::getTablePrefix() . 'module.input');
-            $moduleOutput = (string) $artDataSql->getValue(rex::getTablePrefix() . 'module.output');
             $moduleId = (int) $artDataSql->getValue(rex::getTablePrefix() . 'module.id');
+
+            $moduleInput = (string) $artDataSql->getValue(rex::getTablePrefix() . 'module.input');
+            $moduleInput = (string) rex_extension::registerPoint(new rex_extension_point(
+                'STRUCTURE_CONTENT_MODULE_INPUT_EDIT',
+                    $moduleInput,
+                [
+                    'module_id' => $moduleId,
+                ]
+            ));
+            $moduleOutput = (string) $artDataSql->getValue(rex::getTablePrefix() . 'module.output');
+            $moduleOutput = (string) rex_extension::registerPoint(new rex_extension_point(
+                'STRUCTURE_CONTENT_MODULE_OUTPUT',
+                    $moduleOutput,
+                [
+                    'module_id' => $moduleId,
+                ]
+            ));
 
             // ----- add select box einbauen
             $sliceContent = $this->getModuleSelect($sliceId);
@@ -411,7 +426,16 @@ class rex_article_content_editor extends rex_article_content
         $action->exec(rex_article_action::PREVIEW);
         // ----- / PRE VIEW ACTION
 
-        $moduleInput = $this->replaceVars($initDataSql, (string) $MOD->getValue('input'));
+        $moduleInput = (string) $MOD->getValue('input');
+        $moduleInput = (string) rex_extension::registerPoint(new rex_extension_point(
+            'STRUCTURE_CONTENT_MODULE_INPUT_ADD',
+                $moduleInput,
+            [
+                'module_id' => $moduleId,
+            ]
+        ));
+
+        $moduleInput = $this->replaceVars($initDataSql, $moduleInput);
         $moduleInput = $this->getStreamOutput('module/' . $moduleId . '/input', $moduleInput);
 
         $msg = '';


### PR DESCRIPTION
Hallo (nochmal),

für diverse Spielereien mit anderen Addons hätte ich gerne 3 neue EP in der Datei article_content_editor.php.

Diese EP erlauben es, den Quellcode von Input & Output zu manipulieren, bevor(!) die REX_VARS ersetzt werden.

Die drei neuen EP lauten in meinem Beispiel:
STRUCTURE_CONTENT_MODULE_INPUT_ADD
STRUCTURE_CONTENT_MODULE_INPUT_EDIT
STRUCTURE_CONTENT_MODULE_OUTPUT

Es werden am Ende nur die input & outputvariable nochmal durchgeschleift. Vorteil ggü. OUTPUT_FILTER ist, dass ich dediziert auf das jeweilige Modul zugreifen kann und das BEVOR die REX_VARS ersetzt wurden.