### PR TITLE
simplify `rex_login_policy`

### DIFF
--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -7316,11 +7316,6 @@ parameters:
 			path: ../../redaxo/src/core/lib/view.php
 
 		-
-			message: "#^Method rex_factory_trait_test\\:\\:testFactoryCreation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/factory_trait_test.php
-
-		-
 			message: "#^Method rex_test_factory\\:\\:callFactoryClass\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/base/factory_trait_test.php
@@ -7329,31 +7324,6 @@ parameters:
 			message: "#^Method rex_test_factory\\:\\:setFactoryClass\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/base/factory_trait_test.php
-
-		-
-			message: "#^Method rex_instance_list_pool_trait_test\\:\\:testAddHasInstanceList\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_list_pool_trait_test.php
-
-		-
-			message: "#^Method rex_instance_list_pool_trait_test\\:\\:testClearInstanceList\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_list_pool_trait_test.php
-
-		-
-			message: "#^Method rex_instance_list_pool_trait_test\\:\\:testClearInstanceListPool\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_list_pool_trait_test.php
-
-		-
-			message: "#^Method rex_instance_list_pool_trait_test\\:\\:testGetInstanceList\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_list_pool_trait_test.php
-
-		-
-			message: "#^Method rex_instance_list_pool_trait_test\\:\\:testGetInstanceListPoolKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_list_pool_trait_test.php
 
 		-
 			message: "#^Method rex_test_instance_list_pool\\:\\:addInstanceList\\(\\) has no return type specified\\.$#"
@@ -7406,31 +7376,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/base/instance_list_pool_trait_test.php
 
 		-
-			message: "#^Method rex_instance_pool_trait_test\\:\\:testAddHasInstance\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
-
-		-
-			message: "#^Method rex_instance_pool_trait_test\\:\\:testClearInstance\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
-
-		-
-			message: "#^Method rex_instance_pool_trait_test\\:\\:testClearInstancePool\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
-
-		-
-			message: "#^Method rex_instance_pool_trait_test\\:\\:testGetInstance\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
-
-		-
-			message: "#^Method rex_instance_pool_trait_test\\:\\:testGetInstancePoolKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
-
-		-
 			message: "#^Method rex_test_instance_pool_base\\:\\:addInstance\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
@@ -7456,62 +7401,7 @@ parameters:
 			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
 
 		-
-			message: "#^Method rex_singleton_trait_test\\:\\:testClone\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/singleton_trait_test.php
-
-		-
-			message: "#^Method rex_singleton_trait_test\\:\\:testGetInstance\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/base/singleton_trait_test.php
-
-		-
-			message: "#^Method rex_clang_test\\:\\:testGetValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/clang/clang_test.php
-
-		-
-			message: "#^Method rex_clang_test\\:\\:testHasValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/clang/clang_test.php
-
-		-
-			message: "#^Method rex_config_test\\:\\:testNonExistentConfig\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/config_test.php
-
-		-
-			message: "#^Method rex_config_test\\:\\:testRemoveNamespace\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/config_test.php
-
-		-
-			message: "#^Method rex_config_test\\:\\:testSaveAfterSetAndRemove\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/config_test.php
-
-		-
-			message: "#^Method rex_config_test\\:\\:testSetGetRemoveConfig\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/config_test.php
-
-		-
-			message: "#^Method rex_console_command_test\\:\\:testDecodeMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/console/command_test.php
-
-		-
-			message: "#^Method rex_console_command_test\\:\\:testDecodeMessageSingleQuotes\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/console/command_test.php
-
-		-
 			message: "#^Method rex_command_config_get_test\\:\\:dataKeyFound\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/console/config/get_test.php
-
-		-
-			message: "#^Method rex_command_config_get_test\\:\\:testKeyFound\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/console/config/get_test.php
 
@@ -7526,22 +7416,7 @@ parameters:
 			path: ../../redaxo/src/core/tests/console/config/get_test.php
 
 		-
-			message: "#^Method rex_command_config_get_test\\:\\:testKeyNotFound\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/console/config/get_test.php
-
-		-
-			message: "#^Method rex_command_config_get_test\\:\\:testPackageKeyFound\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/console/config/get_test.php
-
-		-
 			message: "#^Method rex_command_config_set_test\\:\\:dataSetBoolean\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/console/config/set_test.php
-
-		-
-			message: "#^Method rex_command_config_set_test\\:\\:testSetBoolean\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/console/config/set_test.php
 
@@ -7561,86 +7436,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/console/config/set_test.php
 
 		-
-			message: "#^Method rex_context_test\\:\\:testFromGet\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/context_test.php
-
-		-
-			message: "#^Method rex_context_test\\:\\:testFromPost\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/context_test.php
-
-		-
-			message: "#^Method rex_context_test\\:\\:testGetHiddenInputFields\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/context_test.php
-
-		-
-			message: "#^Method rex_context_test\\:\\:testGetUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/context_test.php
-
-		-
-			message: "#^Method rex_context_test\\:\\:testRestore\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/context_test.php
-
-		-
-			message: "#^Method rex_extension_test\\:\\:testIsRegistered\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/extension_test.php
-
-		-
-			message: "#^Method rex_extension_test\\:\\:testRegister\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/extension_test.php
-
-		-
-			message: "#^Method rex_extension_test\\:\\:testRegisterMultiple\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/extension_test.php
-
-		-
-			message: "#^Method rex_extension_test\\:\\:testRegisterPoint\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/extension_test.php
-
-		-
-			message: "#^Method rex_extension_test\\:\\:testRegisterPointReadOnly\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/extension_test.php
-
-		-
-			message: "#^Method rex_extension_test\\:\\:testRegisterPointWithParams\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/extension_test.php
-
-		-
-			message: "#^Method rex_backend_login_test\\:\\:testFailedLogin\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/login/backend_login_test.php
-
-		-
-			message: "#^Method rex_backend_login_test\\:\\:testLogout\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/login/backend_login_test.php
-
-		-
-			message: "#^Method rex_backend_login_test\\:\\:testSuccessfullLogin\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/login/backend_login_test.php
-
-		-
-			message: "#^Method rex_backend_login_test\\:\\:testSuccessfullReLogin\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/login/backend_login_test.php
-
-		-
-			message: "#^Method rex_backend_login_test\\:\\:testSuccessfullReLoginAfterLoginTries1Seconds\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/login/backend_login_test.php
-
-		-
 			message: "#^Property rex_backend_login_test\\:\\:\\$cookiekey has no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/login/backend_login_test.php
@@ -7657,11 +7452,6 @@ parameters:
 
 		-
 			message: "#^Method rex_password_policy_test\\:\\:provideCheck\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/login/password_policy_test.php
-
-		-
-			message: "#^Method rex_password_policy_test\\:\\:testCheck\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/login/password_policy_test.php
 
@@ -7686,11 +7476,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/packages/manager_test.php
 
 		-
-			message: "#^Method rex_package_manager_test\\:\\:testMatchVersionConstraints\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/packages/manager_test.php
-
-		-
 			message: "#^Method rex_package_manager_test\\:\\:testMatchVersionConstraints\\(\\) has parameter \\$constraints with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/packages/manager_test.php
@@ -7707,11 +7492,6 @@ parameters:
 
 		-
 			message: "#^Method rex_package_test\\:\\:dataSplitId\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/packages/package_test.php
-
-		-
-			message: "#^Method rex_package_test\\:\\:testSplitId\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/packages/package_test.php
 
@@ -7736,21 +7516,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/path_test.php
 
 		-
-			message: "#^Method rex_path_test\\:\\:testAbsoluteConversion\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/path_test.php
-
-		-
-			message: "#^Method rex_path_test\\:\\:testBasename\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/path_test.php
-
-		-
-			message: "#^Method rex_path_test\\:\\:testRelative\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/path_test.php
-
-		-
 			message: "#^Method rex_path_test\\:\\:testRelative\\(\\) has parameter \\$basePath with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/path_test.php
@@ -7766,272 +7531,12 @@ parameters:
 			path: ../../redaxo/src/core/tests/path_test.php
 
 		-
-			message: "#^Method rex_rex_test\\:\\:testDebugFlags\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
-			message: "#^Method rex_rex_test\\:\\:testGetServer\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
-			message: "#^Method rex_rex_test\\:\\:testGetTable\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
-			message: "#^Method rex_rex_test\\:\\:testGetTablePrefix\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
-			message: "#^Method rex_rex_test\\:\\:testGetTempPrefix\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
-			message: "#^Method rex_rex_test\\:\\:testGetVersion\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
-			message: "#^Method rex_rex_test\\:\\:testIsBackend\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
-			message: "#^Method rex_rex_test\\:\\:testIsSetup\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
-			message: "#^Method rex_rex_test\\:\\:testRexConfig\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
-			message: "#^Method rex_rex_test\\:\\:testRexProperty\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/rex_test.php
-
-		-
 			message: "#^Method rex_sql_select_test\\:\\:insertRow\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
 
 		-
-			message: "#^Method rex_sql_select_test\\:\\:testArrayFetchTypeNum\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testDBArrayFetchTypeNum\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testError\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testGetArray\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testGetArrayAfterPreparedSetQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testGetArrayAfterSetQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testGetDbArray\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testGetRow\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testGetRowAsObject\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testGetVariations\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testHasNext\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testPreparedNamedSetQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testPreparedSetQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testPreparedSetQueryWithReset\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:testUnbufferedQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
-
-		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with \\*NEVER\\* and array\\<int, \\(int\\|string\\)\\> will always evaluate to false\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testAddColumn\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testAddColumnComment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testAddForeignKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testAddIndex\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testAlter\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testChangeColumnComment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testClearInstance\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testCreate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testDrop\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testEnsure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testEnsureColumn\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testEnsureForeignKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testEnsureGlobalColumns\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testEnsureIndex\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testEnsurePrimaryIdColumn\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRemoveColumn\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRemoveColumnComment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRemoveForeignKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRemoveIndex\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRenameColumn\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRenameColumnNonExisting\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRenameColumnToAlreadyExisting\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRenameForeignKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRenameIndex\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testRenameNonExistingTable\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testSetName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
-
-		-
-			message: "#^Method rex_sql_table_test\\:\\:testSetPrimaryKey\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/sql/sql_table_test.php
 
@@ -8056,52 +7561,7 @@ parameters:
 			path: ../../redaxo/src/core/tests/sql/sql_test.php
 
 		-
-			message: "#^Method rex_sql_test\\:\\:testCheckConnection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testCheckConnectionInvalidDatabase\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testCheckConnectionInvalidHost\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testCheckConnectionInvalidLogin\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testCheckConnectionInvalidPassword\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testDeleteRow\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testFactory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testGetQueryType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
 			message: "#^Method rex_sql_test\\:\\:testGetQueryType\\(\\) has parameter \\$expectedQueryType with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testGetTables\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/sql/sql_test.php
 
@@ -8111,119 +7571,9 @@ parameters:
 			path: ../../redaxo/src/core/tests/sql/sql_test.php
 
 		-
-			message: "#^Method rex_sql_test\\:\\:testInsertOrUpdate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testInsertOrUpdateRecords\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testInsertRawValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testInsertRecords\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testInsertRow\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testInsertWithoutValues\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testReplaceRecords\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testSetGetArrayValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testSetGetValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testShowTablesAndViews\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testShowViews\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testUpdateRowByNamedWhere\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testUpdateRowByStringWhere\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_sql_test\\:\\:testUpdateRowByWhereArray\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
 			message: "#^Property class@anonymous/core/tests/sql/sql_test\\.php\\:129\\:\\:\\$version has no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/sql/sql_test.php
-
-		-
-			message: "#^Method rex_dir_test\\:\\:testCopyToExistingDir\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/dir_test.php
-
-		-
-			message: "#^Method rex_dir_test\\:\\:testCopyToNewDir\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/dir_test.php
-
-		-
-			message: "#^Method rex_dir_test\\:\\:testCreate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/dir_test.php
-
-		-
-			message: "#^Method rex_dir_test\\:\\:testCreateRecursive\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/dir_test.php
-
-		-
-			message: "#^Method rex_dir_test\\:\\:testDeleteComplete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/dir_test.php
-
-		-
-			message: "#^Method rex_dir_test\\:\\:testDeleteFilesNotRecursive\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/dir_test.php
-
-		-
-			message: "#^Method rex_dir_test\\:\\:testDeleteFilesRecursive\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/dir_test.php
-
-		-
-			message: "#^Method rex_dir_test\\:\\:testDeleteWithoutSelf\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/dir_test.php
 
 		-
 			message: "#^Method rex_file_test\\:\\:dataTestExtension\\(\\) has no return type specified\\.$#"
@@ -8236,77 +7586,12 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/file_test.php
 
 		-
-			message: "#^Method rex_file_test\\:\\:testCopyToDir\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testCopyToFile\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testDelete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testExtension\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
 			message: "#^Method rex_file_test\\:\\:testExtension\\(\\) has parameter \\$expectedExtension with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/file_test.php
 
 		-
 			message: "#^Method rex_file_test\\:\\:testExtension\\(\\) has parameter \\$file with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testGetCacheDefault\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testGetConfigDefault\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testGetDefault\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testGetOutput\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testPutGet\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testPutGetCache\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testPutGetConfig\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testPutInNewDir\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:testRequireThrows\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/file_test.php
 
@@ -8326,121 +7611,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/finder_test.php
 
 		-
-			message: "#^Method rex_finder_test\\:\\:testDefault\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/finder_test.php
-
-		-
-			message: "#^Method rex_finder_test\\:\\:testDirsOnly\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/finder_test.php
-
-		-
-			message: "#^Method rex_finder_test\\:\\:testFilesOnly\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/finder_test.php
-
-		-
-			message: "#^Method rex_finder_test\\:\\:testIgnoreDirs\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/finder_test.php
-
-		-
-			message: "#^Method rex_finder_test\\:\\:testIgnoreFiles\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/finder_test.php
-
-		-
-			message: "#^Method rex_finder_test\\:\\:testIgnoreSystemStuff\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/finder_test.php
-
-		-
-			message: "#^Method rex_finder_test\\:\\:testRecursive\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/finder_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testBytes\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testCustom\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testDate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testEmail\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testNl2br\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testNumber\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testSprintf\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testTruncate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_formatter_test\\:\\:testVersion\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/formatter_test.php
-
-		-
-			message: "#^Method rex_i18n_test\\:\\:testGetMsgFallback\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/i18n_test.php
-
-		-
-			message: "#^Method rex_i18n_test\\:\\:testGetMsgInLocaleFallback\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/i18n_test.php
-
-		-
-			message: "#^Method rex_i18n_test\\:\\:testHasMsg\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/i18n_test.php
-
-		-
-			message: "#^Method rex_i18n_test\\:\\:testHasMsgOrFallback\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/i18n_test.php
-
-		-
-			message: "#^Method rex_i18n_test\\:\\:testLoadFile\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/i18n_test.php
-
-		-
-			message: "#^Method rex_i18n_test\\:\\:testTranslateCallable\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/i18n_test.php
-
-		-
 			message: "#^Method rex_i18n_trans_cb\\:\\:mytranslate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/i18n_test.php
@@ -8451,57 +7621,7 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/i18n_test.php
 
 		-
-			message: "#^Method rex_log_entry_test\\:\\:testConstruct\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/log_entry_test.php
-
-		-
-			message: "#^Method rex_log_entry_test\\:\\:testCreateFromString\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/log_entry_test.php
-
-		-
-			message: "#^Method rex_log_entry_test\\:\\:testGetTimestamp\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/log_entry_test.php
-
-		-
-			message: "#^Method rex_log_entry_test\\:\\:testToString\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/log_entry_test.php
-
-		-
-			message: "#^Method rex_log_file_test\\:\\:testAdd\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/log_file_test.php
-
-		-
-			message: "#^Method rex_log_file_test\\:\\:testConstruct\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/log_file_test.php
-
-		-
-			message: "#^Method rex_log_file_test\\:\\:testConstructWithMaxFileSize\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/log_file_test.php
-
-		-
-			message: "#^Method rex_log_file_test\\:\\:testDelete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/log_file_test.php
-
-		-
-			message: "#^Method rex_log_file_test\\:\\:testIterator\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/log_file_test.php
-
-		-
 			message: "#^Method rex_markdown_test\\:\\:parseProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/markdown_test.php
-
-		-
-			message: "#^Method rex_markdown_test\\:\\:testParse\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/markdown_test.php
 
@@ -8514,21 +7634,6 @@ parameters:
 			message: "#^Method rex_markdown_test\\:\\:testParse\\(\\) has parameter \\$expected with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/markdown_test.php
-
-		-
-			message: "#^Method rex_markdown_test\\:\\:testParseWithToc\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/markdown_test.php
-
-		-
-			message: "#^Method rex_socket_proxy_test\\:\\:testFactory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_proxy_test.php
-
-		-
-			message: "#^Method rex_socket_proxy_test\\:\\:testFactoryUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_proxy_test.php
 
 		-
 			message: "#^Property rex_socket_proxy_test\\:\\:\\$proxy has no type specified\\.$#"
@@ -8547,21 +7652,6 @@ parameters:
 
 		-
 			message: "#^Method rex_socket_response_test\\:\\:getStatusProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_response_test.php
-
-		-
-			message: "#^Method rex_socket_response_test\\:\\:testGetBody\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_response_test.php
-
-		-
-			message: "#^Method rex_socket_response_test\\:\\:testGetHeader\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_response_test.php
-
-		-
-			message: "#^Method rex_socket_response_test\\:\\:testGetStatus\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/socket_response_test.php
 
@@ -8586,42 +7676,12 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/socket_response_test.php
 
 		-
-			message: "#^Method rex_socket_response_test\\:\\:testWriteBodyTo\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_response_test.php
-
-		-
 			message: "#^Method rex_socket_test\\:\\:parseUrlExceptionProvider\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/socket_test.php
 
 		-
 			message: "#^Method rex_socket_test\\:\\:parseUrlProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_test.php
-
-		-
-			message: "#^Method rex_socket_test\\:\\:testFactory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_test.php
-
-		-
-			message: "#^Method rex_socket_test\\:\\:testFactoryProxy\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_test.php
-
-		-
-			message: "#^Method rex_socket_test\\:\\:testFactoryUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_test.php
-
-		-
-			message: "#^Method rex_socket_test\\:\\:testFactoryUrlProxy\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_test.php
-
-		-
-			message: "#^Method rex_socket_test\\:\\:testParseUrl\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/socket_test.php
 
@@ -8651,17 +7711,7 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/socket_test.php
 
 		-
-			message: "#^Method rex_socket_test\\:\\:testParseUrlException\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_test.php
-
-		-
 			message: "#^Method rex_socket_test\\:\\:testParseUrlException\\(\\) has parameter \\$url with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_test.php
-
-		-
-			message: "#^Method rex_socket_test\\:\\:testWriteRequest\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/socket_test.php
 
@@ -8674,31 +7724,6 @@ parameters:
 			message: "#^Property rex_socket_test\\:\\:\\$proxy has no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/socket_test.php
-
-		-
-			message: "#^Method rex_sortable_iterator_test\\:\\:testCallbackMode\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/sortable_iterator_test.php
-
-		-
-			message: "#^Method rex_sortable_iterator_test\\:\\:testKeysMode\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/sortable_iterator_test.php
-
-		-
-			message: "#^Method rex_sortable_iterator_test\\:\\:testValuesMode\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/sortable_iterator_test.php
-
-		-
-			message: "#^Method rex_stream_test\\:\\:testStreamInclude\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/stream_test.php
-
-		-
-			message: "#^Method rex_stream_test\\:\\:testStreamIncludeWithRealFile\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/stream_test.php
 
 		-
 			message: "#^Method rex_string_test\\:\\:buildQueryProvider\\(\\) has no return type specified\\.$#"
@@ -8716,16 +7741,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/string_test.php
 
 		-
-			message: "#^Method rex_string_test\\:\\:testBuildAttributes\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/string_test.php
-
-		-
-			message: "#^Method rex_string_test\\:\\:testBuildQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/string_test.php
-
-		-
 			message: "#^Method rex_string_test\\:\\:testBuildQuery\\(\\) has parameter \\$argSeparator with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/string_test.php
@@ -8737,11 +7752,6 @@ parameters:
 
 		-
 			message: "#^Method rex_string_test\\:\\:testBuildQuery\\(\\) has parameter \\$params with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/string_test.php
-
-		-
-			message: "#^Method rex_string_test\\:\\:testNormalize\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/string_test.php
 
@@ -8762,21 +7772,6 @@ parameters:
 
 		-
 			message: "#^Method rex_string_test\\:\\:testNormalize\\(\\) has parameter \\$string with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/string_test.php
-
-		-
-			message: "#^Method rex_string_test\\:\\:testSanitizeHtml\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/string_test.php
-
-		-
-			message: "#^Method rex_string_test\\:\\:testSize\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/string_test.php
-
-		-
-			message: "#^Method rex_string_test\\:\\:testSplit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/string_test.php
 
@@ -8816,11 +7811,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/type_test.php
 
 		-
-			message: "#^Method rex_type_test\\:\\:testCast\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/type_test.php
-
-		-
 			message: "#^Method rex_type_test\\:\\:testCast\\(\\) has parameter \\$expectedResult with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/type_test.php
@@ -8832,11 +7822,6 @@ parameters:
 
 		-
 			message: "#^Method rex_type_test\\:\\:testCast\\(\\) has parameter \\$vartype with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/type_test.php
-
-		-
-			message: "#^Method rex_type_test\\:\\:testCastWrongVartype\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/type_test.php
 
@@ -8861,72 +7846,12 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/validator_test.php
 
 		-
-			message: "#^Method rex_validator_test\\:\\:testCustom\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testEmail\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
 			message: "#^Method rex_validator_test\\:\\:testEmail\\(\\) has parameter \\$isValid with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/validator_test.php
 
 		-
 			message: "#^Method rex_validator_test\\:\\:testEmail\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testGetRules\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testIsValid\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testMatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testMax\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testMaxLength\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testMin\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testMinLength\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testNotEmpty\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testNotMatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testType\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/validator_test.php
 
@@ -8946,22 +7871,12 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/validator_test.php
 
 		-
-			message: "#^Method rex_validator_test\\:\\:testUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
 			message: "#^Method rex_validator_test\\:\\:testUrl\\(\\) has parameter \\$isValid with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/validator_test.php
 
 		-
 			message: "#^Method rex_validator_test\\:\\:testUrl\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:testValues\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/validator_test.php
 
@@ -8976,22 +7891,7 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/version_test.php
 
 		-
-			message: "#^Method rex_version_test\\:\\:testCompare\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/version_test.php
-
-		-
 			message: "#^Method rex_version_test\\:\\:testCompare\\(\\) has parameter \\$expected with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/version_test.php
-
-		-
-			message: "#^Method rex_version_test\\:\\:testIsUnstable\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/version_test.php
-
-		-
-			message: "#^Method rex_version_test\\:\\:testSplit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/version_test.php
 
@@ -9041,11 +7941,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/var/var_config_test.php
 
 		-
-			message: "#^Method rex_var_config_test\\:\\:testConfigReplace\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_config_test.php
-
-		-
 			message: "#^Method rex_var_config_test\\:\\:testConfigReplace\\(\\) has parameter \\$content with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_config_test.php
@@ -9057,11 +7952,6 @@ parameters:
 
 		-
 			message: "#^Method rex_var_property_test\\:\\:propertyReplaceProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_property_test.php
-
-		-
-			message: "#^Method rex_var_property_test\\:\\:testPropertyReplace\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_property_test.php
 
@@ -9091,22 +7981,12 @@ parameters:
 			path: ../../redaxo/src/core/tests/var/var_test.php
 
 		-
-			message: "#^Method rex_var_test\\:\\:testParseArgsSyntax\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_test.php
-
-		-
 			message: "#^Method rex_var_test\\:\\:testParseArgsSyntax\\(\\) has parameter \\$content with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_test.php
 
 		-
 			message: "#^Method rex_var_test\\:\\:testParseArgsSyntax\\(\\) has parameter \\$expectedOutput with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_test.php
-
-		-
-			message: "#^Method rex_var_test\\:\\:testParseGlobalArgs\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_test.php
 
@@ -9121,27 +8001,12 @@ parameters:
 			path: ../../redaxo/src/core/tests/var/var_test.php
 
 		-
-			message: "#^Method rex_var_test\\:\\:testParseTokens\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_test.php
-
-		-
 			message: "#^Method rex_var_test\\:\\:testParseTokens\\(\\) has parameter \\$content with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_test.php
 
 		-
 			message: "#^Method rex_var_test\\:\\:testParseTokens\\(\\) has parameter \\$expectedOutput with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_test.php
-
-		-
-			message: "#^Method rex_var_test\\:\\:testQuote\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_test.php
-
-		-
-			message: "#^Method rex_var_test\\:\\:testToArray\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_test.php
 
@@ -9154,19 +8019,4 @@ parameters:
 			message: "#^Method rex_var_test\\:\\:varCallback\\(\\) has parameter \\$params with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_test.php
-
-		-
-			message: "#^Method rex_view_test\\:\\:testAddGetCss\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/view_test.php
-
-		-
-			message: "#^Method rex_view_test\\:\\:testAddGetJs\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/view_test.php
-
-		-
-			message: "#^Method rex_view_test\\:\\:testAddGetJsWithOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/view_test.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -44,3 +44,7 @@ parameters:
         -
             message: '#.*deprecated.*#'
             path: '*/update.php'
+        -
+            message: '#Method .*::test.* has no return type specified.#'
+            path: '*/core/tests/*.php'
+

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -11,10 +11,8 @@ dirperm: '0775'
 session_duration: 7200
 session_keep_alive: 21600
 backend_login_policy:
-    login_tries_1: 3
-    relogin_delay_1: 5
-    login_tries_2: 50
-    relogin_delay_2: 3600
+    login_tries: 50
+    relogin_delay: 5
     enable_stay_logged_in: true
 # using separate cookie domains for frontend and backend is more secure,
 # but be warned that some features like detecting a backend user in the frontend

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -11,7 +11,7 @@ dirperm: '0775'
 session_duration: 7200
 session_keep_alive: 21600
 backend_login_policy:
-    login_tries: 50
+    login_tries: 3
     relogin_delay: 5
     enable_stay_logged_in: true
 # using separate cookie domains for frontend and backend is more secure,

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -11,7 +11,8 @@ dirperm: '0775'
 session_duration: 7200
 session_keep_alive: 21600
 backend_login_policy:
-    login_tries: 3
+    login_tries_until_blocked: 50
+    login_tries_until_delay: 3
     relogin_delay: 5
     enable_stay_logged_in: true
 # using separate cookie domains for frontend and backend is more secure,

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -43,9 +43,11 @@ class rex_backend_login extends rex_login
         $qry .= ' WHERE
             status = 1
             AND login = :login
-            AND login_tries < ' . $loginPolicy->getMaxTries() . '
-            AND lasttrydate < "' . rex_sql::datetime(time() - $loginPolicy->getReloginDelay()) . '"
-            ';
+            AND (
+                login_tries < ' . $loginPolicy->getMaxTries() . '
+                OR
+                login_tries >= ' . $loginPolicy->getMaxTries() . ' AND lasttrydate < "' . rex_sql::datetime(time() - $loginPolicy->getReloginDelay()) . '"
+            )';
 
         if ($blockAccountAfter = $this->passwordPolicy->getBlockAccountAfter()) {
             $datetime = (new DateTimeImmutable())->sub($blockAccountAfter);

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -43,10 +43,11 @@ class rex_backend_login extends rex_login
         $qry .= ' WHERE
             status = 1
             AND login = :login
+            AND login_tries < '. $loginPolicy->getMaxTriesUntilBlock() .'
             AND (
-                login_tries < ' . $loginPolicy->getMaxTries() . '
+                login_tries < ' . $loginPolicy->getMaxTriesUntilDelay() . '
                 OR
-                login_tries >= ' . $loginPolicy->getMaxTries() . ' AND lasttrydate < "' . rex_sql::datetime(time() - $loginPolicy->getReloginDelay()) . '"
+                login_tries >= ' . $loginPolicy->getMaxTriesUntilDelay() . ' AND lasttrydate < "' . rex_sql::datetime(time() - $loginPolicy->getReloginDelay()) . '"
             )';
 
         if ($blockAccountAfter = $this->passwordPolicy->getBlockAccountAfter()) {
@@ -145,7 +146,7 @@ class rex_backend_login extends rex_login
 
                     $loginTries = $sql->getValue('login_tries');
                     $this->increaseLoginTries();
-                    if ($loginTries >= $loginPolify->getMaxTries() - 1) {
+                    if ($loginTries >= $loginPolify->getMaxTriesUntilDelay() - 1) {
                         $time = $loginPolify->getReloginDelay();
                         $hours = floor($time / 3600);
                         $mins = floor(($time - ($hours * 3600)) / 60);

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -43,10 +43,9 @@ class rex_backend_login extends rex_login
         $qry .= ' WHERE
             status = 1
             AND login = :login
-            AND (login_tries < ' . $loginPolicy->getSetting('login_tries_1') . '
-                OR login_tries < ' . $loginPolicy->getSetting('login_tries_2') . ' AND lasttrydate < "' . rex_sql::datetime(time() - $loginPolicy->getSetting('relogin_delay_1')) . '"
-                OR lasttrydate < "' . rex_sql::datetime(time() - $loginPolicy->getSetting('relogin_delay_2')) . '"
-            )';
+            AND login_tries < ' . $loginPolicy->getMaxTries() . '
+            AND lasttrydate < "' . rex_sql::datetime(time() - $loginPolicy->getReloginDelay()) . '"
+            ';
 
         if ($blockAccountAfter = $this->passwordPolicy->getBlockAccountAfter()) {
             $datetime = (new DateTimeImmutable())->sub($blockAccountAfter);
@@ -144,8 +143,8 @@ class rex_backend_login extends rex_login
 
                     $loginTries = $sql->getValue('login_tries');
                     $this->increaseLoginTries();
-                    if ($loginTries >= $loginPolify->getSetting('login_tries_1') - 1) {
-                        $time = $loginTries < $loginPolify->getSetting('login_tries_2') ? $loginPolify->getSetting('relogin_delay_1') : $loginPolify->getSetting('relogin_delay_2');
+                    if ($loginTries >= $loginPolify->getMaxTries() - 1) {
+                        $time = $loginPolify->getReloginDelay();
                         $hours = floor($time / 3600);
                         $mins = floor(($time - ($hours * 3600)) / 60);
                         $secs = $time % 60;

--- a/redaxo/src/core/lib/login/login_policy.php
+++ b/redaxo/src/core/lib/login/login_policy.php
@@ -21,7 +21,9 @@ class rex_login_policy
     }
 
     /**
-     * Returns the number of allowed login tries, until a account will be blocked.
+     * Returns the number of allowed login tries, until login will be delayed.
+     *
+     * Additional rules might apply via `rex_backend_password_policy`.
      */
     public function getMaxTries():int {
         $key = 'login_tries';

--- a/redaxo/src/core/lib/login/login_policy.php
+++ b/redaxo/src/core/lib/login/login_policy.php
@@ -25,7 +25,8 @@ class rex_login_policy
      *
      * Additional rules might apply via `rex_backend_password_policy`.
      */
-    public function getMaxTries():int {
+    public function getMaxTries(): int
+    {
         $key = 'login_tries';
 
         if (array_key_exists($key, $this->options)) {
@@ -38,9 +39,10 @@ class rex_login_policy
     }
 
     /**
-     * Returns the relogin delay in seconds
+     * Returns the relogin delay in seconds.
      */
-    public function getReloginDelay():int {
+    public function getReloginDelay(): int
+    {
         $key = 'relogin_delay';
 
         if (array_key_exists($key, $this->options)) {
@@ -50,7 +52,6 @@ class rex_login_policy
         // defaults, in case config.yml does not define values
         // e.g. because of a redaxo core update from a version.
         return 5;
-
     }
 
     public function isStayLoggedInEnabled(): bool

--- a/redaxo/src/core/lib/login/login_policy.php
+++ b/redaxo/src/core/lib/login/login_policy.php
@@ -24,13 +24,19 @@ final class rex_login_policy
      * Returns the number of allowed login tries, until login will be delayed.
      *
      * Additional rules might apply via `rex_backend_password_policy`.
+     *
+     * @return positive-int
      */
     public function getMaxTries(): int
     {
         $key = 'login_tries';
 
         if (array_key_exists($key, $this->options)) {
-            return (int) $this->options[$key];
+            $val = (int) $this->options[$key];
+            if ($val <= 0) {
+                throw new InvalidArgumentException('Invalid value for option "' . $key . '": ' . $val);
+            }
+            return $val;
         }
 
         // defaults, in case config.yml does not define values
@@ -40,13 +46,19 @@ final class rex_login_policy
 
     /**
      * Returns the relogin delay in seconds.
+     *
+     * @return positive-int
      */
     public function getReloginDelay(): int
     {
         $key = 'relogin_delay';
 
         if (array_key_exists($key, $this->options)) {
-            return (int) $this->options[$key];
+            $val = (int) $this->options[$key];
+            if ($val <= 0) {
+                throw new InvalidArgumentException('Invalid value for option "' . $key . '": ' . $val);
+            }
+            return $val;
         }
 
         // defaults, in case config.yml does not define values

--- a/redaxo/src/core/lib/login/login_policy.php
+++ b/redaxo/src/core/lib/login/login_policy.php
@@ -21,28 +21,34 @@ class rex_login_policy
     }
 
     /**
-     * @param 'login_tries_1'|'relogin_delay_1'|'login_tries_2'|'relogin_delay_2' $key
+     * Returns the number of allowed login tries, until a account will be blocked.
      */
-    public function getSetting(string $key): int
-    {
+    public function getMaxTries():int {
+        $key = 'login_tries';
+
         if (array_key_exists($key, $this->options)) {
             return (int) $this->options[$key];
         }
 
         // defaults, in case config.yml does not define values
         // e.g. because of a redaxo core update from a version.
-        switch ($key) {
-            case 'login_tries_1':
-                return 3;
-            case 'relogin_delay_1':
-                return 5;
-            case 'login_tries_2':
-                return 50;
-            case 'relogin_delay_2':
-                return 3600;
+        return 50;
+    }
+
+    /**
+     * Returns the relogin delay in seconds
+     */
+    public function getReloginDelay():int {
+        $key = 'relogin_delay';
+
+        if (array_key_exists($key, $this->options)) {
+            return (int) $this->options[$key];
         }
 
-        throw new rex_exception('Invalid login policy key: ' . $key);
+        // defaults, in case config.yml does not define values
+        // e.g. because of a redaxo core update from a version.
+        return 5;
+
     }
 
     public function isStayLoggedInEnabled(): bool

--- a/redaxo/src/core/lib/login/login_policy.php
+++ b/redaxo/src/core/lib/login/login_policy.php
@@ -5,7 +5,7 @@
  *
  * @package redaxo\core\login
  */
-class rex_login_policy
+final class rex_login_policy
 {
     /**
      * @var array<string, int|bool>

--- a/redaxo/src/core/lib/login/login_policy.php
+++ b/redaxo/src/core/lib/login/login_policy.php
@@ -23,13 +23,33 @@ final class rex_login_policy
     /**
      * Returns the number of allowed login tries, until login will be delayed.
      *
-     * Additional rules might apply via `rex_backend_password_policy`.
+     * @return positive-int
+     */
+    public function getMaxTriesUntilDelay(): int
+    {
+        $key = 'login_tries_until_delay';
+
+        if (array_key_exists($key, $this->options)) {
+            $val = (int) $this->options[$key];
+            if ($val <= 0) {
+                throw new InvalidArgumentException('Invalid value for option "' . $key . '": ' . $val);
+            }
+            return $val;
+        }
+
+        // defaults, in case config.yml does not define values
+        // e.g. because of a redaxo core update from a version.
+        return 5;
+    }
+
+    /**
+     * Returns the number of allowed login tries, until login will be blocked.
      *
      * @return positive-int
      */
-    public function getMaxTries(): int
+    public function getMaxTriesUntilBlock(): int
     {
-        $key = 'login_tries';
+        $key = 'login_tries_until_blocked';
 
         if (array_key_exists($key, $this->options)) {
             $val = (int) $this->options[$key];

--- a/redaxo/src/core/lib/login/login_policy.php
+++ b/redaxo/src/core/lib/login/login_policy.php
@@ -39,7 +39,7 @@ final class rex_login_policy
 
         // defaults, in case config.yml does not define values
         // e.g. because of a redaxo core update from a version.
-        return 5;
+        return 3;
     }
 
     /**

--- a/redaxo/src/core/schemas/config.json
+++ b/redaxo/src/core/schemas/config.json
@@ -98,16 +98,10 @@
             "description": "backend login policy",
             "type": "object",
             "properties": {
-                "login_tries_1": {
+                "login_tries": {
                     "type": "integer"
                 },
-                "relogin_delay_1": {
-                    "type": "integer"
-                },
-                "login_tries_2": {
-                    "type": "integer"
-                },
-                "relogin_delay_2": {
+                "relogin_delay": {
                     "type": "integer"
                 },
                 "enable_stay_logged_in": {

--- a/redaxo/src/core/schemas/config.json
+++ b/redaxo/src/core/schemas/config.json
@@ -98,7 +98,10 @@
             "description": "backend login policy",
             "type": "object",
             "properties": {
-                "login_tries": {
+                "login_tries_until_blocked": {
+                    "type": "integer"
+                },
+                "login_tries_until_delay": {
                     "type": "integer"
                 },
                 "relogin_delay": {

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -59,9 +59,9 @@ class rex_backend_login_test extends TestCase
     }
 
     /**
-     * After LOGIN_TRIES_1 requests, the account should be not accessible for RELOGIN_DELAY_1 seconds.
+     * After LOGIN_TRIES requests, the account should be not accessible for RELOGIN_DELAY seconds.
      */
-    public function testSuccessfullReLoginAfterLoginTries1Seconds()
+    public function testSuccessfullReLoginAfterLoginTriesSeconds()
     {
         $login = new rex_backend_login();
         $tries = $login->getLoginPolicy()->getMaxTries();

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -64,7 +64,7 @@ class rex_backend_login_test extends TestCase
     public function testSuccessfullReLoginAfterLoginTriesSeconds()
     {
         $login = new rex_backend_login();
-        $tries = $login->getLoginPolicy()->getMaxTries();
+        $tries = $login->getLoginPolicy()->getMaxTriesUntilDelay();
 
         for ($i = 0; $i < $tries; ++$i) {
             $login->setLogin($this->login, 'somethingwhichisnotcorrect', false);

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -86,7 +86,7 @@ class rex_backend_login_test extends TestCase
 
         $login = new rex_backend_login();
         $login->setLogin($this->login, $this->password, false);
-        $this->assertTrue($login->checkLogin(), 'after waiting the account should be unlocked');
+        static::assertTrue($login->checkLogin(), 'after waiting the account should be unlocked');
     }
 
     public function testLogout()

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -64,9 +64,9 @@ class rex_backend_login_test extends TestCase
     public function testSuccessfullReLoginAfterLoginTries1Seconds()
     {
         $login = new rex_backend_login();
-        $tries1 = $login->getLoginPolicy()->getSetting('login_tries_1');
+        $tries = $login->getLoginPolicy()->getSetting('login_tries');
 
-        for ($i = 0; $i < $tries1; ++$i) {
+        for ($i = 0; $i < $tries; ++$i) {
             $login->setLogin($this->login, 'somethingwhichisnotcorrect', false);
             static::assertFalse($login->checkLogin());
         }

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -64,7 +64,7 @@ class rex_backend_login_test extends TestCase
     public function testSuccessfullReLoginAfterLoginTries1Seconds()
     {
         $login = new rex_backend_login();
-        $tries = $login->getLoginPolicy()->getSetting('login_tries');
+        $tries = $login->getLoginPolicy()->getMaxTries();
 
         for ($i = 0; $i < $tries; ++$i) {
             $login->setLogin($this->login, 'somethingwhichisnotcorrect', false);

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -82,12 +82,11 @@ class rex_backend_login_test extends TestCase
         $login->setLogin($this->login, $this->password, false);
         static::assertFalse($login->checkLogin(), 'even seconds later account is locked');
 
-        // FIXME Does not work at travis
-        //sleep(rex_backend_login::RELOGIN_DELAY_1 + 2);
+        sleep($login->getLoginPolicy()->getReloginDelay() + 1);
 
-        //$login = new rex_backend_login();
-        //$login->setLogin($this->login, $this->password, false);
-        //$this->assertTrue($login->checkLogin(), 'after waiting the account should be unlocked');
+        $login = new rex_backend_login();
+        $login->setLogin($this->login, $this->password, false);
+        $this->assertTrue($login->checkLogin(), 'after waiting the account should be unlocked');
     }
 
     public function testLogout()


### PR DESCRIPTION
followup to https://github.com/redaxo/redaxo/pull/5197

refs https://github.com/redaxo/redaxo/issues/5194

Verhalten nach dem PR:
- man hat `login_tries_until_delay` versuche, ohne verzögerung
- nach `login_tries_until_delay` versuchen, kommt bei jedem weiteren versuch ein `relogin_delay` sodass man nicht mehr so schnell weitere passworte ausprobieren kann
- nach `login_tries_until_blocked` versuchen, kann man sich mit einem account nicht mehr einloggen

