### PR TITLE
fix debug addon when redaxo running in subfolder

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -737,25 +737,11 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php">
-    <MixedArgument occurrences="1">
-      <code>$imagick-&gt;getImageBlob()</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$color</code>
       <code>$convertPath</code>
-      <code>$imagick</code>
       <code>$path</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="8">
-      <code>getImageBlob</code>
-      <code>mergeImageLayers</code>
-      <code>readImage</code>
-      <code>setImageAlphaChannel</code>
-      <code>setImageBackgroundColor</code>
-      <code>setImageFormat</code>
-      <code>setResolution</code>
-      <code>transformImageColorspace</code>
-    </MixedMethodCall>
     <MixedOperand occurrences="2">
       <code>$color</code>
       <code>$convertPath</code>

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -441,7 +441,8 @@
     </MixedArgument>
   </file>
   <file src="redaxo/src/addons/debug/boot.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="3">
+      <code>$_SERVER['REQUEST_URI']</code>
       <code>$query['query']</code>
       <code>rex_debug_clockwork::getInstance()-&gt;getRequest()-&gt;id</code>
     </MixedArgument>
@@ -736,11 +737,25 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php">
-    <MixedAssignment occurrences="3">
+    <MixedArgument occurrences="1">
+      <code>$imagick-&gt;getImageBlob()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="4">
       <code>$color</code>
       <code>$convertPath</code>
+      <code>$imagick</code>
       <code>$path</code>
     </MixedAssignment>
+    <MixedMethodCall occurrences="8">
+      <code>getImageBlob</code>
+      <code>mergeImageLayers</code>
+      <code>readImage</code>
+      <code>setImageAlphaChannel</code>
+      <code>setImageBackgroundColor</code>
+      <code>setImageFormat</code>
+      <code>setResolution</code>
+      <code>transformImageColorspace</code>
+    </MixedMethodCall>
     <MixedOperand occurrences="2">
       <code>$color</code>
       <code>$convertPath</code>

--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -21,7 +21,7 @@ if (rex::isBackend() && 'debug' === rex_request::get('page') && rex::getUser() &
     }
 
     // prepend backend folder
-    $apiUrl = rex_path::basename(rex_path::backend()).'/'.rex_debug_clockwork::getClockworkApiUrl();
+    $apiUrl = dirname($_SERVER['REQUEST_URI']).'/'.rex_debug_clockwork::getClockworkApiUrl();
     $appearance = rex::getTheme();
     if (!$appearance) {
         $appearance = 'auto';


### PR DESCRIPTION
closes https://github.com/redaxo/redaxo/issues/5201

ich hab wenig erfahrung mit dem debug addon. nach ein bissl try&error bin ich auf diesem gelandet, inspiriert von 
https://github.com/redaxo/redaxo/blob/6f133c93d21125b58afe2f632790b38bc63ed6a3/redaxo/src/addons/debug/lib/debug_clockwork.php#L44-L55

ob das wirklich passt, kann ich nicht sagen.

es behebt das problem für mich wenn debug addon im unterordner läuft:

<img width="1512" alt="grafik" src="https://user-images.githubusercontent.com/120441/179391720-001c123c-daff-45be-8c75-170942309275.png">
