### PR TITLE
added rex_template->getCtypes()

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -226,4 +226,17 @@ class rex_template
 
         return $mapping = rex_file::getCache($file);
     }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getCtypes(): array
+    {
+        $sql = rex_sql::factory();
+        $sql->setQuery('SELECT attributes FROM '. rex::getTable('template') .' WHERE id = ?', [$this->id]);
+        $attributes = $sql->getArrayValue('attributes');
+
+        /** @psalm-suppress MixedReturnStatement */
+        return $attributes['ctype'] ?? [];
+    }
 }


### PR DESCRIPTION
closes https://github.com/redaxo/redaxo/issues/5054

Beispiel
```
$t = new rex_template(9);
dump($t->getCtypes());
```

ergibt
```
array:2 [▼
    1 => "ctype-one"
    2 => "ctype-2"
]
```

getestet mit template

<img width="1206" alt="grafik" src="https://user-images.githubusercontent.com/120441/179392475-66f61033-bfa6-489c-b41f-3bba4376d06c.png">
