### PR TITLE
rex_select: Optgroups können beendet werden

### DIFF
--- a/redaxo/src/core/lib/select.php
+++ b/redaxo/src/core/lib/select.php
@@ -148,6 +148,11 @@ class rex_select
         $this->optgroups[$this->currentOptgroup] = $label;
     }
 
+    public function endOptgroup(): void
+    {
+        ++$this->currentOptgroup;
+    }
+
     /**
      * Fügt eine Option hinzu.
      */


### PR DESCRIPTION
```php
$select = new rex_select();
$select->addOption('Opt 1', 1);
$select->addOptgroup('Group');
$select->addOption('Opt 2', 2);
$select->endOptgroup();
$select->addOption('Opt 3', 3);
$select->addOptgroup('Group2');
$select->addOption('Opt 4', 4);
```

ergibt:

<img width="229" alt="Bildschirmfoto 2022-07-17 um 19 24 02" src="https://user-images.githubusercontent.com/330436/179417447-372036a9-c6f2-4f7b-bb49-75f04067383b.png">

