### PR TITLE
Metainfo: Feld-Notizen

### DIFF
--- a/redaxo/src/addons/metainfo/lang/de_de.lang
+++ b/redaxo/src/addons/metainfo/lang/de_de.lang
@@ -42,7 +42,7 @@ minfo_field_params_notice_9 = Beispiel:<br /> <code>category="1"</code>
 minfo_field_params_notice_10 = Beispiel:<br /> <code>start-year="1990" end-year="2030"</code>
 minfo_field_params_notice_11 = Beispiel:<br /> <code>start-year="1990" end-year="2030"</code>
 
-minfo_field_attributes_notice = HTML-Attribute beim input-Feld und Permissions, zum Beispiel:<br /><code>style="color:red;" multiple="multiple" class="my_css_class" perm="admin[]"</code>
+minfo_field_attributes_notice = HTML-Attribute beim input-Feld und Permissions, zum Beispiel:<br /><code>style="color:red;" multiple="multiple" class="my_css_class" perm="admin[]" note="Notiz"</code>
 minfo_field_label_notice = Code, der ausgeführt wird, wenn der Wert des Feldes geändert wird.<br /> Lesbare Variablen: <code>string $fieldName, string $fieldValue, rex_sql $field</code>
 
 minfo_field_error_name = Bitte Spaltennamen eingeben!

--- a/redaxo/src/addons/metainfo/lang/sv_se.lang
+++ b/redaxo/src/addons/metainfo/lang/sv_se.lang
@@ -42,7 +42,7 @@ minfo_field_params_notice_9 = Exempel:<br /> <code>category="1"</code>
 minfo_field_params_notice_10 = Exempel:<br /> <code>start-year="1990" end-year="2030"</code>
 minfo_field_params_notice_11 = Exempel:<br /> <code>start-year="1990" end-year="2030"</code>
 
-minfo_field_attributes_notice = Exempel:<br /><code>style="color:red;" multiple="multiple" class="my_css_class" perm="admin[]"</code>
+minfo_field_attributes_notice = Exempel:<br /><code>style="color:red;" multiple="multiple" class="my_css_class" perm="admin[]" note="note"</code>
 minfo_field_label_notice = Kod som utförs om värdet av fältet ändras.<br /> Läsbara variablar: <code>string $fieldName, string $fieldValue, rex_sql $field</code>
 
 minfo_field_error_name = Vänligen ange ett spaltnamn!

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -49,6 +49,12 @@ abstract class rex_metainfo_handler
                 unset($attrArray['perm']);
             }
 
+            $note = null;
+            if (isset($attrArray['note'])) {
+                $note = $attrArray['note'];
+                unset($attrArray['note']);
+            }
+
             // `rex_string::split` transforms attributes without value (like `disabled`, `data-foo` etc.) to an int based array element
             // we transform them to array elements with the attribute name as key and empty value
             foreach ($attrArray as $key => $value) {
@@ -107,6 +113,7 @@ abstract class rex_metainfo_handler
                     $e = [];
                     $e['label'] = $label;
                     $e['field'] = $field;
+                    $e['note'] = $note;
                     $fragment = new rex_fragment();
                     $fragment->setVar('elements', [$e], false);
                     $field = $fragment->parse('core/form/form.php');
@@ -182,6 +189,7 @@ abstract class rex_metainfo_handler
                             $e['label'] = '<label for="' . $currentId . '">' . rex_escape($value) . '</label>';
                         }
                         $e['field'] = '<input type="' . rex_escape($typeLabel) . '" name="' . rex_escape($name) . '" value="' . rex_escape($key) . '" id="' . $currentId . '" ' . $attrStr . $selected . ' />';
+                        $e['note'] = $oneValue ? $note : null;
                         $formElements[] = $e;
                     }
 
@@ -202,6 +210,7 @@ abstract class rex_metainfo_handler
                         $e = [];
                         $e['label'] = $label;
                         $e['field'] = $field;
+                        $e['note'] = $note;
                         $fragment = new rex_fragment();
                         $fragment->setVar('elements', [$e], false);
                         $field = $fragment->parse('core/form/form.php');
@@ -264,6 +273,7 @@ abstract class rex_metainfo_handler
                     $e = [];
                     $e['label'] = $label;
                     $e['field'] = $field;
+                    $e['note'] = $note;
                     $fragment = new rex_fragment();
                     $fragment->setVar('elements', [$e], false);
                     $field = $fragment->parse('core/form/form.php');
@@ -320,6 +330,7 @@ abstract class rex_metainfo_handler
                     $e = [];
                     $e['label'] = $label;
                     $e['field'] = $field;
+                    $e['note'] = $note;
                     $fragment = new rex_fragment();
                     $fragment->setVar('elements', [$e], false);
                     $field = $fragment->parse('core/form/form.php');
@@ -342,6 +353,7 @@ abstract class rex_metainfo_handler
                     $e = [];
                     $e['label'] = $label;
                     $e['field'] = $field;
+                    $e['note'] = $note;
                     $fragment = new rex_fragment();
                     $fragment->setVar('elements', [$e], false);
                     $field = $fragment->parse('core/form/form.php');
@@ -387,6 +399,7 @@ abstract class rex_metainfo_handler
                     $e = [];
                     $e['label'] = $label;
                     $e['field'] = $field;
+                    $e['note'] = $note;
                     $fragment = new rex_fragment();
                     $fragment->setVar('elements', [$e], false);
                     $field = $fragment->parse('core/form/form.php');
@@ -422,6 +435,7 @@ abstract class rex_metainfo_handler
                     $e = [];
                     $e['label'] = $label;
                     $e['field'] = $field;
+                    $e['note'] = $note;
                     $fragment = new rex_fragment();
                     $fragment->setVar('elements', [$e], false);
                     $field = $fragment->parse('core/form/form.php');
@@ -452,6 +466,7 @@ abstract class rex_metainfo_handler
                     $e = [];
                     $e['label'] = $label;
                     $e['field'] = $field;
+                    $e['note'] = $note;
                     $fragment = new rex_fragment();
                     $fragment->setVar('elements', [$e], false);
                     $field = $fragment->parse('core/form/form.php');
@@ -483,6 +498,7 @@ abstract class rex_metainfo_handler
                     $e = [];
                     $e['label'] = $label;
                     $e['field'] = $field;
+                    $e['note'] = $note;
                     $fragment = new rex_fragment();
                     $fragment->setVar('elements', [$e], false);
                     $field = $fragment->parse('core/form/form.php');


### PR DESCRIPTION
closes #1221

Ich habe es mir etwas einfach gemacht. Man gibt die Notiz als virtuelles Feldattribut ein, ähnlich wie `perm`:

<img width="1103" alt="Bildschirmfoto 2022-07-18 um 00 50 50" src="https://user-images.githubusercontent.com/330436/179427998-eec798d8-4512-4d7d-9b20-7a6986c7113e.png">

