### PR TITLE
Erneutes Setup: Sprache vorauswählen

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -62,7 +62,7 @@ $pages = [];
 // ----------------- SETUP
 if (rex::isSetup()) {
     // ----------------- SET SETUP LANG
-    $requestLang = rex_request('lang', 'string');
+    $requestLang = rex_request('lang', 'string', rex::getProperty('lang'));
     if (in_array($requestLang, rex_i18n::getLocales())) {
         rex::setProperty('lang', $requestLang);
     } else {

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -45,7 +45,7 @@ password_policy:
     # no_reuse_within: P6W
     # force_renew_after: P6W
     # block_account_after: P3M
-lang: de_de
+lang: en_gb
 lang_fallback: [en_gb, de_de]
 use_https: false
 use_hsts: false

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -174,7 +174,8 @@ setup_error2 = Leider konnte die config.yml nicht beschrieben werden. Bitte trag
 
 
 setup_100 = Setup: Schritt 1 von 6 / Sprache
-setup_101 = bitte wähle eine Sprache
+setup_101 = Sprache wählen
+setup_110 = Weiter zu Schritt 2
 setup_199 = 1 / Sprache
 
 setup_200 = Setup: Schritt 2 von 6 / Systemcheck

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -174,7 +174,8 @@ setup_error2 = Unfortunately, the configuration file could not be written to. Pl
 
 
 setup_100 = Setup: step 1 of 6 / Language
-setup_101 = Please select a language
+setup_101 = Select a language
+setup_110 = Continue with step 2
 setup_199 = 1 / Language
 
 setup_200 = Setup: step 2 of 6 / System check

--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -74,7 +74,7 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         ksort($langs);
 
         $config['lang'] = $this->getOptionOrAsk(
-            new ChoiceQuestion('Please select a language', $langs),
+            new ChoiceQuestion('Please select a language', $langs, $config['lang'] ?? null),
             'lang',
             null,
             'Language "%s" selected.',

--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -248,17 +248,24 @@ class rex_setup
      */
     public static function isInitialSetup(): bool
     {
+        /** @var bool $initial */
+        static $initial;
+
+        if (null !== $initial) {
+            return $initial;
+        }
+
         try {
             $userSql = rex_sql::factory();
             $userSql->setQuery('select * from ' . rex::getTable('user') . ' LIMIT 1');
 
-            return 0 == $userSql->getRows();
+            return $initial = 0 == $userSql->getRows();
         } catch (rex_sql_could_not_connect_exception $e) {
-            return true;
+            return $initial = true;
         } catch (rex_sql_exception $e) {
             $sql = $e->getSql();
             if ($sql && rex_sql::ERRNO_TABLE_OR_VIEW_DOESNT_EXIST === $sql->getErrno()) {
-                return true;
+                return $initial = true;
             }
             throw $e;
         }

--- a/redaxo/src/core/pages/setup.step1.php
+++ b/redaxo/src/core/pages/setup.step1.php
@@ -5,10 +5,14 @@ assert(isset($cancelSetupBtn));
 
 rex_setup::init();
 
+$initial = rex_setup::isInitialSetup();
+$current = rex_i18n::getLocale();
+
 $langs = [];
 foreach (rex_i18n::getLocales() as $locale) {
     $label = rex_i18n::msgInLocale('lang', $locale);
-    $langs[$label] = '<a class="list-group-item" href="' . $context->getUrl(['lang' => $locale, 'step' => 2]) . '">' . $label . '</a>';
+    $active = !$initial && $current === $locale ? ' active' : '';
+    $langs[$label] = '<a class="list-group-item'.$active.'" href="' . $context->getUrl(['lang' => $locale, 'step' => 2]) . '">' . $label . '</a>';
 }
 ksort($langs);
 echo rex_view::title(rex_i18n::msg('setup_100').$cancelSetupBtn);
@@ -17,4 +21,11 @@ $content = '<div class="list-group">' . implode('', $langs) . '</div>';
 $fragment = new rex_fragment();
 $fragment->setVar('heading', rex_i18n::msg('setup_101'), false);
 $fragment->setVar('content', $content, false);
+
+if (!$initial) {
+    $buttons = '<a class="btn btn-setup" href="' . $context->getUrl(['step' => 2]) . '">' . rex_i18n::msg('setup_110') . '</a>';
+
+    $fragment->setVar('buttons', $buttons, false);
+}
+
 echo $fragment->parse('core/page/section.php');


### PR DESCRIPTION
refs #3745

Bei erneutem Setup wird die vorhandene Sprache im Web vorausgewählt und es erscheint ein neuer zusätzlicher Button "Weiter zu Schritt 2":

<img width="558" alt="Bildschirmfoto 2022-07-18 um 02 31 23" src="https://user-images.githubusercontent.com/330436/179431119-c2ddf59f-15fc-4d2a-9ac0-063fea5fe6b3.png">

Auch in der Console wird die vorhandene Sprache als Auswahl vorgeschlagen.
