### PR TITLE
Setup: Step 1 korrigiert

### DIFF
--- a/redaxo/src/core/layout/top.php
+++ b/redaxo/src/core/layout/top.php
@@ -185,10 +185,8 @@ if ('setup' == rex_be_controller::getCurrentPagePart(1)) {
         $name = '';
         if (isset($n['href']) && '' != $lang) {
             $name = rex_i18n::msg('setup_' . $i . '99');
-        } elseif ('' != $lang) {
+        } else {
             $name = '<span>' . rex_i18n::msg('setup_' . $i . '99') . '</span>';
-        } elseif (1 == $i) {
-            $name = '<span>Step 1 / Language</span>';
         }
 
         $n['title'] = $name;

--- a/redaxo/src/core/pages/setup.step1.php
+++ b/redaxo/src/core/pages/setup.step1.php
@@ -23,7 +23,7 @@ $fragment->setVar('heading', rex_i18n::msg('setup_101'), false);
 $fragment->setVar('content', $content, false);
 
 if (!$initial) {
-    $buttons = '<a class="btn btn-setup" href="' . $context->getUrl(['step' => 2]) . '">' . rex_i18n::msg('setup_110') . '</a>';
+    $buttons = '<a class="btn btn-setup" href="' . $context->getUrl(['lang' => $current, 'step' => 2]) . '">' . rex_i18n::msg('setup_110') . '</a>';
 
     $fragment->setVar('buttons', $buttons, false);
 }


### PR DESCRIPTION
* Bei erneutem Setup funktioniert nun der "Weiter zu Schritt 2"-Button, closes #5247
* Im Schritt 1 war der Navipunkt unnötig mit einem statischen Text, nun wird er aus der Übersetzung geholt (funktioniert auch im initialen Setup)