### PR TITLE
Slow Query Log: DB-Abfragen vermeiden

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -177,8 +177,8 @@ rex_be_controller::setPages($pages);
 
 // ----- Prepare Core Pages
 if (rex::getUser()) {
-    rex_be_controller::appendLoggedInPages();
     rex_be_controller::setCurrentPage(trim(rex_request('page', 'string')));
+    rex_be_controller::appendLoggedInPages();
 
     if ('profile' !== rex_be_controller::getCurrentPage() && rex::getProperty('login')->requiresPasswordChange()) {
         rex_response::sendRedirect(rex_url::backendPage('profile'));

--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -171,9 +171,11 @@ class rex_be_controller
             $logsPage->addSubpage((new rex_be_page('php', rex_i18n::msg('syslog_phperrors')))->setSubPath(rex_path::core('pages/system.log.external.php')));
         }
 
-        $slowQueryLogPath = rex_sql_util::slowQueryLogPath();
-        if (null !== $slowQueryLogPath && @is_readable($slowQueryLogPath)) {
-            $logsPage->addSubpage((new rex_be_page('slow-queries', rex_i18n::msg('syslog_slowqueries')))->setSubPath(rex_path::core('pages/system.log.slow-queries.php')));
+        if ('system' === self::getCurrentPagePart(1) && 'log' === self::getCurrentPagePart(2)) {
+            $slowQueryLogPath = rex_sql_util::slowQueryLogPath();
+            if (null !== $slowQueryLogPath && @is_readable($slowQueryLogPath)) {
+                $logsPage->addSubpage((new rex_be_page('slow-queries', rex_i18n::msg('syslog_slowqueries')))->setSubPath(rex_path::core('pages/system.log.slow-queries.php')));
+            }
         }
 
         self::$pages['system'] = (new rex_be_page_main('system', 'system', rex_i18n::msg('system')))


### PR DESCRIPTION
Aktuell wird die Abfrage bei jedem Backend-Aufruf gemacht. 
Neu wird nur noch innerhalb der Log-Page geprüft, ob das Slow Query Log vorhanden ist.