### PR TITLE
mark `rex_sql::getRows()` as impure

### DIFF
--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -3481,21 +3481,6 @@ parameters:
 			path: ../../redaxo/src/addons/structure/plugins/content/pages/content.edit.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
-
-		-
-			message: "#^Comparison operation \"\\>\" between int\\<min, 0\\>\\|null and 0 is always false\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
-
-		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/structure/plugins/content/pages/modules.modules.php

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -910,6 +910,7 @@ class rex_sql implements Iterator
      * Gibt die Anzahl der Zeilen zurueck.
      *
      * @return null|int
+     * @phpstan-impure
      */
     public function getRows()
     {


### PR DESCRIPTION
refs https://github.com/redaxo/redaxo/pull/5278#discussion_r934194028
see https://phpstan.org/blog/remembering-and-forgetting-returned-values