### PR TITLE
phpstan: added return types Addon be_style

### DIFF
--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -406,6 +406,7 @@ class rex_backup
     /**
      * @param string[] $folders
      * @param string $archivePath
+     * @return void
      */
     private static function streamExport($folders, $archivePath)
     {
@@ -430,6 +431,7 @@ class rex_backup
      *
      * @param string $path
      * @param string $dir
+     * @return void
      */
     private static function addFolderToTar(rex_backup_tar $tar, $path, $dir)
     {
@@ -485,6 +487,7 @@ class rex_backup
      * @param string $filename
      * @param self::IMPORT_ARCHIVE|self::IMPORT_DB $importType
      * @param self::IMPORT_EVENT_* $eventType
+     * @return void
      */
     private static function importScript($filename, $importType, $eventType)
     {
@@ -500,6 +503,7 @@ class rex_backup
      * @param resource $fp
      * @param string $nl
      * @param list<string> $fields
+     * @return void
      */
     private static function exportTable($table, &$start, $max, $fp, $nl, array $fields)
     {

--- a/redaxo/src/addons/backup/lib/cronjob.php
+++ b/redaxo/src/addons/backup/lib/cronjob.php
@@ -7,6 +7,9 @@ class rex_cronjob_export extends rex_cronjob
 {
     public const DEFAULT_FILENAME = '%REX_SERVER_%Y%m%d_%H%M_rex%REX_VERSION';
 
+    /**
+     * @return bool
+     */
     public function execute()
     {
         $filename = $this->getParam('filename', self::DEFAULT_FILENAME);
@@ -121,11 +124,17 @@ class rex_cronjob_export extends rex_cronjob
         return false;
     }
 
+    /**
+     * @return string
+     */
     public function getTypeName()
     {
         return rex_i18n::msg('backup_database_export');
     }
 
+    /**
+     * @return array
+     */
     public function getParamFields()
     {
         $tables = rex_backup::getTables();

--- a/redaxo/src/addons/backup/lib/tar.php
+++ b/redaxo/src/addons/backup/lib/tar.php
@@ -51,6 +51,7 @@ class rex_backup_tar
 
     /**
      * @param string $archivePath
+     * @return void
      */
     public function create($archivePath)
     {

--- a/redaxo/src/addons/be_style/lib/be_style.php
+++ b/redaxo/src/addons/be_style/lib/be_style.php
@@ -8,6 +8,7 @@ class rex_be_style
 {
     /**
      * Converts Backend SCSS files to CSS.
+     * @return void
      */
     public static function compile()
     {

--- a/redaxo/src/addons/be_style/lib/command/compile.php
+++ b/redaxo/src/addons/be_style/lib/command/compile.php
@@ -12,12 +12,18 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_be_style_command_compile extends rex_console_command
 {
+    /**
+     * @return void
+     */
     protected function configure()
     {
         $this->setAliases(['styles:compile'])
             ->setDescription('Converts Backend SCSS files to CSS');
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = $this->getStyle($input, $output);

--- a/redaxo/src/addons/be_style/lib/scss_compiler.php
+++ b/redaxo/src/addons/be_style/lib/scss_compiler.php
@@ -20,17 +20,26 @@ class rex_scss_compiler
         $this->css_file = rex_path::addon('be_style', 'assets') . 'styles.css';
         $this->formatter = Compressed::class;
     }
-
+    
+    /**
+     * @return void
+     */
     public function setRootDir($value)
     {
         $this->root_dir = $value;
     }
 
+    /**
+     * @return void
+     */
     public function setScssFile($value)
     {
         $this->scss_file = $value;
     }
 
+    /**
+     * @return void
+     */
     public function setCssFile($value)
     {
         $this->css_file = $value;
@@ -38,12 +47,16 @@ class rex_scss_compiler
 
     /**
      * @param string $value scss_formatter (default) or scss_formatter_nested or scss_formatter_compressed
+     * @return void
      */
     public function setFormatter($value)
     {
         $this->formatter = $value;
     }
 
+    /**
+     * @return void
+     */
     public function compile()
     {
         // go on even if user "stops" the script by closing the browser, closing the terminal etc.

--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -250,6 +250,7 @@ class rex_api_install_core_update extends rex_api_function
     /**
      * @param string $temppath
      * @param string $version
+     * @return void
      *
      * @throws rex_functional_exception
      */

--- a/redaxo/src/addons/install/lib/archive.php
+++ b/redaxo/src/addons/install/lib/archive.php
@@ -58,6 +58,7 @@ class rex_install_archive
 
     /**
      * @param string|string[]|null $exclude
+     * @return void
      */
     public static function copyDirToArchive(string $dir, string $archive, ?string $basename = null, $exclude = null)
     {
@@ -94,6 +95,9 @@ class rex_install_archive
         }
     }
 
+    /**
+     * @return void
+     */
     private static function setPermissions(string $dir): void
     {
         @chmod($dir, rex::getDirPerm());

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -11,6 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_install_download extends rex_console_command
 {
+    /**
+     * @return void
+     */
     protected function configure()
     {
         $this->setDescription('Download an AddOn from redaxo.org')

--- a/redaxo/src/addons/install/lib/command/list.php
+++ b/redaxo/src/addons/install/lib/command/list.php
@@ -11,6 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_install_list extends rex_console_command
 {
+    /**
+     * @return void
+     */
     protected function configure()
     {
         $this->setDescription('List available packages on redaxo.org')

--- a/redaxo/src/addons/install/lib/command/update.php
+++ b/redaxo/src/addons/install/lib/command/update.php
@@ -11,6 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_install_update extends rex_console_command
 {
+    /**
+     * @return void
+     */
     protected function configure()
     {
         $this->setDescription('Updates an AddOn from redaxo.org')

--- a/redaxo/src/addons/install/lib/package/package_add.php
+++ b/redaxo/src/addons/install/lib/package/package_add.php
@@ -14,6 +14,9 @@ class rex_install_package_add extends rex_install_package_download
         return rex_install_packages::getAddPackages();
     }
 
+    /**
+     * @return void 
+     */
     protected function checkPreConditions()
     {
         if (rex_addon::exists($this->addonkey)) {

--- a/redaxo/src/addons/install/lib/package/package_download.php
+++ b/redaxo/src/addons/install/lib/package/package_download.php
@@ -68,6 +68,9 @@ abstract class rex_install_package_download
      */
     abstract protected function getPackages();
 
+    /**
+     * @return void
+     */
     abstract protected function checkPreConditions();
 
     /**

--- a/redaxo/src/addons/install/lib/packages.php
+++ b/redaxo/src/addons/install/lib/packages.php
@@ -46,6 +46,7 @@ class rex_install_packages
     /**
      * @param string $package
      * @param int $fileId
+     * @return void
      */
     public static function updatedPackage($package, $fileId)
     {
@@ -61,6 +62,7 @@ class rex_install_packages
     /**
      * @param string $package
      * @param string $version
+     * @return void
      */
     private static function unsetOlderVersions($package, $version)
     {
@@ -92,6 +94,9 @@ class rex_install_packages
         return self::$addPackages;
     }
 
+    /**
+     * @return void
+     */
     public static function addedPackage($package)
     {
         self::$myPackages = null;
@@ -147,6 +152,7 @@ class rex_install_packages
 
     /**
      * Deletes all locally cached packages.
+     * @return void
      */
     public static function deleteCache()
     {

--- a/redaxo/src/addons/install/lib/webservice.php
+++ b/redaxo/src/addons/install/lib/webservice.php
@@ -89,7 +89,8 @@ class rex_install_webservice
      *
      * @param string      $path
      * @param string|null $archive Path to archive
-     *
+     * @return void
+     * 
      * @throws rex_functional_exception
      */
     public static function post($path, array $data, $archive = null)
@@ -127,6 +128,7 @@ class rex_install_webservice
      * Issues a http DELETE to the given path.
      *
      * @param string $path
+     * @return void
      *
      * @throws rex_functional_exception
      */
@@ -184,6 +186,7 @@ class rex_install_webservice
      * Deletes the local webservice cache.
      *
      * @param string|null $pathBegin
+     * @return void
      */
     public static function deleteCache($pathBegin = null)
     {
@@ -218,6 +221,7 @@ class rex_install_webservice
 
     /**
      * Loads the local cached data into memory (only fresh data will be loaded).
+     * @return void
      */
     private static function loadCache()
     {
@@ -237,6 +241,7 @@ class rex_install_webservice
      *
      * @param string $path
      * @param array  $data
+     * @return void
      */
     private static function setCache($path, $data)
     {


### PR DESCRIPTION
Ich habe die return types des Core-Addon Backup gemäß https://github.com/redaxo/redaxo/issues/5275 hinzugefügt.
Bei der Methode rex_scss_compiler::compile bin ich mir nicht sicher, da die Methode auch nie beendet werden kann. 