### PR TITLE
version-Plugin: bei work_to_live neue Revision vor EP setzen

### DIFF
--- a/redaxo/src/addons/structure/plugins/version/boot.php
+++ b/redaxo/src/addons/structure/plugins/version/boot.php
@@ -93,8 +93,8 @@ rex_extension::register('STRUCTURE_CONTENT_BEFORE_SLICES', static function (rex_
                 $return .= rex_view::success(rex_i18n::msg('version_info_working_version_to_live'));
 
                 $article = rex_type::instanceOf(rex_article::get($articleId, $clangId), rex_article::class);
-                $return = rex_extension::registerPoint(new rex_extension_point_art_content_updated($article, 'work_to_live', $return));
                 rex_article_revision::setSessionArticleRevision($articleId, 0);
+                $return = rex_extension::registerPoint(new rex_extension_point_art_content_updated($article, 'work_to_live', $return));
             }
         break;
         case 'copy_live_to_work':


### PR DESCRIPTION
Dadurch kann man das Verhalten von #5294 über den vorhandenen EP ändern:

```php
    rex_extension::register(rex_extension_point_art_content_updated::NAME, function (rex_extension_point_art_content_updated $ep) {
        if ('work_to_live' === $ep->getAction()) {
            rex_article_revision::setSessionArticleRevision($ep->getArticle()->getId(), rex_article_revision::WORK);
        }
    });
```

closes  #5294