### PR TITLE
PHPMailer: archiving not sent mails with prefix not_sent

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -129,6 +129,9 @@ class rex_mailer extends PHPMailer
                 if ($addon->getConfig('logging')) {
                     $this->log('ERROR');
                 }
+                if ($this->archive) {
+                $this->archive($this->getSentMIMEMessage(),'not_sent_');
+                }
                 return false;
             }
 
@@ -195,7 +198,7 @@ class rex_mailer extends PHPMailer
         $this->archive = $status;
     }
 
-    private function archive(string $archivedata = ''): void
+    private function archive(string $archivedata = '', string $status = ''): void
     {
         $dir = self::logFolder().'/'.date('Y').'/'.date('m');
         $count = 1;

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -202,9 +202,9 @@ class rex_mailer extends PHPMailer
     {
         $dir = self::logFolder().'/'.date('Y').'/'.date('m');
         $count = 1;
-        $archiveFile = $dir.'/'.date('Y-m-d_H_i_s').'.eml';
+        $archiveFile = $dir.'/'.$status.date('Y-m-d_H_i_s').'.eml';
         while (is_file($archiveFile)) {
-            $archiveFile = $dir.'/'.date('Y-m-d_H_i_s').'_'.(++$count).'.eml';
+            $archiveFile = $dir.'/'.$status.date('Y-m-d_H_i_s').'_'.(++$count).'.eml';
         }
 
         rex_file::put($archiveFile, $archivedata);

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -130,7 +130,7 @@ class rex_mailer extends PHPMailer
                     $this->log('ERROR');
                 }
                 if ($this->archive) {
-                $this->archive($this->getSentMIMEMessage(),'not_sent_');
+                    $this->archive($this->getSentMIMEMessage(), 'not_sent_');
                 }
                 return false;
             }


### PR DESCRIPTION
fixes: https://github.com/redaxo/redaxo/issues/5319

Mails werden auch bei nicht erfolgreichem Versand archiviert. Gerade bei längerem Ausfall eines Mail-Servers kann dies helfen. Die Archiv-Funktion sollte aber auch nur dafür kommuniziert werden. Das werde ich entsprechend dokumentieren in einem weiteren PR. Erkennbar sind die Mails am Prefix not_sent im Archiv-Ordner.
<img width="349" alt="Bildschirmfoto 2022-08-25 um 13 09 08 (1)" src="https://user-images.githubusercontent.com/791247/186874574-7f2669ca-168f-4c24-92f0-06da3f0dacad.png">
 