### PR TITLE
added `@phpstandba-inference-placeholder` to `rex::getTablePrefix()`

### DIFF
--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -297,6 +297,8 @@ class rex
      * Returns the table prefix.
      *
      * @return string
+     *
+     * @phpstandba-inference-placeholder 'rex_'
      */
     public static function getTablePrefix()
     {


### PR DESCRIPTION
required for https://github.com/FriendsOfREDAXO/rexstan/issues/143

context https://staabm.github.io/2022/07/23/phpstan-dba-inference-placeholder.html