### PR TITLE
use `rex_sql::escapeLikeWildcards()`

### DIFF
--- a/.tools/psalm/baseline-taint.xml
+++ b/.tools/psalm/baseline-taint.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.26.0@6998fabb2bf528b65777bf9941920888d23c03ac">
+<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
   <file src="redaxo/src/core/lib/response.php">
     <TaintedHeader occurrences="1">
       <code>$str</code>

--- a/.tools/psalm/baseline-taint.xml
+++ b/.tools/psalm/baseline-taint.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
+<files psalm-version="4.26.0@6998fabb2bf528b65777bf9941920888d23c03ac">
   <file src="redaxo/src/core/lib/response.php">
     <TaintedHeader occurrences="1">
       <code>$str</code>
     </TaintedHeader>
+  </file>
+  <file src="redaxo/src/core/lib/sql/sql.php">
+    <TaintedSql occurrences="2">
+      <code>$query</code>
+      <code>$query</code>
+    </TaintedSql>
   </file>
   <file src="redaxo/src/core/lib/util/socket/socket.php">
     <TaintedCallable occurrences="1">

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -641,8 +641,10 @@ abstract class rex_metainfo_handler
      */
     protected static function getSqlFields($prefix, $filterCondition = '')
     {
+        $sqlFields = rex_sql::factory();
+
         // replace LIKE wildcards
-        $prefix = str_replace(['_', '%'], ['\_', '\%'], $prefix);
+        $prefix = $sqlFields->escapeLikeWildcards($prefix);
 
         $qry = 'SELECT
                             *
@@ -656,7 +658,6 @@ abstract class rex_metainfo_handler
                             ORDER BY
                             priority';
 
-        $sqlFields = rex_sql::factory();
         //$sqlFields->setDebug();
         $sqlFields->setQuery($qry);
 

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -642,8 +642,6 @@ abstract class rex_metainfo_handler
     protected static function getSqlFields($prefix, $filterCondition = '')
     {
         $sqlFields = rex_sql::factory();
-
-        // replace LIKE wildcards
         $prefix = $sqlFields->escapeLikeWildcards($prefix);
 
         $qry = 'SELECT

--- a/redaxo/src/addons/metainfo/lib/table_expander.php
+++ b/redaxo/src/addons/metainfo/lib/table_expander.php
@@ -306,8 +306,8 @@ class rex_metainfo_table_expander extends rex_form
             return;
         }
 
-        // replace LIKE wildcards
-        $metaPrefix = str_replace(['_', '%'], ['\_', '\%'], $this->metaPrefix);
+        $sql = rex_sql::factory();
+        $metaPrefix = $sql->escapeLikeWildcards($this->metaPrefix);
 
         rex_sql_util::organizePriorities(
             $this->tableName,

--- a/redaxo/src/addons/metainfo/pages/field.php
+++ b/redaxo/src/addons/metainfo/pages/field.php
@@ -40,8 +40,8 @@ if ('' == $func) {
 
     $title = rex_i18n::msg('minfo_field_list_caption');
 
-    // replace LIKE wildcards
-    $likePrefix = str_replace(['_', '%'], ['\_', '\%'], $prefix);
+    $sql = rex_sql::factory();
+    $likePrefix = $sql->escapeLikeWildcards($prefix);
 
     $list = rex_list::factory('SELECT id, name FROM ' . rex::getTablePrefix() . 'metainfo_field WHERE `name` LIKE "' . $likePrefix . '%" ORDER BY priority');
     $list->addTableAttribute('class', 'table-striped table-hover');


### PR DESCRIPTION
die methode existiert seit redaxo 5.9, siehe https://github.com/redaxo/redaxo/pull/3242

metainfo erfordert aktuell `^5.13.0`, daher good to go
