### PR TITLE
support `non-falsy-string` in rex_sql::escape()

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1405,7 +1405,10 @@ class rex_sql implements Iterator
      * @param string $value den zu escapenden Wert
      *
      * @return string
-     * @psalm-return ($value is numeric-string ? numeric-string : ($value is non-empty-string ? non-empty-string : string))
+     * @psalm-return ($value is numeric-string ? numeric-string :
+     *   ($value is non-falsy-string ? non-falsy-string :
+     *   ($value is non-empty-string ? non-empty-string : string
+     * )))
      */
     public function escape($value)
     {


### PR DESCRIPTION
ich hab kein konretes issue oder nutzen, aber `non-falsy-string` ist ein präziserer type wie `non-empty-string` und sollte daher wenn möglich erhalten bleiben