### PR TITLE
escapeLikeWildcards: Backslash auch escapen

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -1429,7 +1429,7 @@ class rex_sql implements Iterator
      */
     public function escapeLikeWildcards(string $value): string
     {
-        return str_replace(['_', '%'], ['\_', '\%'], $value);
+        return str_replace(['\\', '_', '%'], ['\\\\', '\_', '\%'], $value);
     }
 
     /**

--- a/redaxo/src/core/tests/sql/sql_test.php
+++ b/redaxo/src/core/tests/sql/sql_test.php
@@ -153,7 +153,7 @@ class rex_sql_test extends TestCase
     {
         $sql = rex_sql::factory();
 
-        static::assertSame('\\%foo\\_bar\\\\baz', $sql->escapeLikeWildcards('%foo_bar\\baz'));
+        static::assertSame('\\%foo\\_bar\\\\baz\\\\\\_qux', $sql->escapeLikeWildcards('%foo_bar\\baz\\_qux'));
     }
 
     /** @dataProvider dataIn */

--- a/redaxo/src/core/tests/sql/sql_test.php
+++ b/redaxo/src/core/tests/sql/sql_test.php
@@ -153,7 +153,7 @@ class rex_sql_test extends TestCase
     {
         $sql = rex_sql::factory();
 
-        static::assertSame('\\%foo\\_bar', $sql->escapeLikeWildcards('%foo_bar'));
+        static::assertSame('\\%foo\\_bar\\\\baz', $sql->escapeLikeWildcards('%foo_bar\\baz'));
     }
 
     /** @dataProvider dataIn */


### PR DESCRIPTION
Mir ist aufgefallen, dass in DBAL auch der Backslash noch escaped wird: https://github.com/doctrine/dbal/blob/d3530a4d6e857942d87b730b2f9255bf72fc0245/src/Platforms/AbstractPlatform.php#L4426-L4433

Das leuchtet auch ein. Beispiel: Man möchte explizit nach `foo\_bar` suchen (also wirklich ein Backslash und ein Unterstrich). Aktuell würde aus `escapeLikeWildcards` dann `foo\\_bar` rauskommen, also ein escapeter Backslash und ein Unterstrich-Wildcard-Zeichen. Daher müssen auch Backslashes escaped werden, damit dann `foo\\\_bar` rauskommt (ein escapter Backslash und ein escapter Unterstrich).

Ich denke aber, dass es nicht wirklich ein Security-Problem ist. Also es waren dadurch keine SQL-Injections oder so möglich, denn `escapeLikeWildcards` ist und bleibt ja eine unsichere Methode, die allein nicht fürs Escaping reicht.