### PR TITLE
Session-Liste: intlDateTime nutzen

### DIFF
--- a/redaxo/src/core/pages/profile.sessions.php
+++ b/redaxo/src/core/pages/profile.sessions.php
@@ -23,10 +23,10 @@ $list->setColumnFormat('last_activity', 'custom', static function () use ($list)
     if (session_id() === $list->getValue('session_id')) {
         return rex_i18n::msg('active_session');
     }
-    return rex_formatter::date((string) $list->getValue('last_activity'), 'd.m.Y H:i');
+    return rex_formatter::intlDateTime((string) $list->getValue('last_activity'), IntlDateFormatter::SHORT);
 });
 $list->setColumnFormat('starttime', 'custom', static function () use ($list) {
-    return rex_formatter::date((string) $list->getValue('starttime'), 'd.m.Y H:i');
+    return rex_formatter::intlDateTime((string) $list->getValue('starttime'), IntlDateFormatter::SHORT);
 });
 $content = $list->get();
 


### PR DESCRIPTION
Wir sollten nicht das deutsche Format erzwingen, sondern das Format sollte entsprechend der Sprache gewählt werden. Daher intlDateTime.