### PR TITLE
added rex_file/dir assertions

### DIFF
--- a/redaxo/src/core/lib/util/dir.php
+++ b/redaxo/src/core/lib/util/dir.php
@@ -42,6 +42,8 @@ class rex_dir
      * @param string $dir Path of the directory
      *
      * @return bool
+     *
+     * @psalm-assert-if-true =non-empty-string $dir
      */
     public static function isWritable($dir)
     {

--- a/redaxo/src/core/lib/util/dir.php
+++ b/redaxo/src/core/lib/util/dir.php
@@ -16,6 +16,8 @@ class rex_dir
      * @param bool   $recursive When FALSE, nested directories won't be created
      *
      * @return bool TRUE on success, FALSE on failure
+     *
+     * @psalm-assert-if-true =non-empty-string $dir
      */
     public static function create($dir, $recursive = true)
     {
@@ -58,6 +60,9 @@ class rex_dir
      * @param string $dstdir Path of the destination directory
      *
      * @return bool TRUE on success, FALSE on failure
+     *
+     * @psalm-assert-if-true =non-empty-string $srcdir
+     * @psalm-assert-if-true =non-empty-string $dstdir
      */
     public static function copy($srcdir, $dstdir)
     {

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -152,7 +152,8 @@ class rex_file
      *
      * @return bool TRUE on success, FALSE on failure
      *
-     * @psalm-assert-if-true =non-empty-string $file
+     * @psalm-assert-if-true =non-empty-string $srcfile
+     * @psalm-assert-if-true =non-empty-string $dstfile
      */
     public static function copy($srcfile, $dstfile)
     {

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -15,6 +15,8 @@ class rex_file
      * @throws rex_exception throws when the file cannot be read
      *
      * @return string Content of the file
+     *
+     * @psalm-assert non-empty-string $file
      */
     public static function require(string $file): string
     {
@@ -89,6 +91,8 @@ class rex_file
      * @param string $content Content for the file
      *
      * @return bool TRUE on success, FALSE on failure
+     *
+     * @psalm-assert-if-true =non-empty-string $file
      */
     public static function put($file, $content)
     {
@@ -117,6 +121,8 @@ class rex_file
      * @param int    $inline  The level where you switch to inline YAML
      *
      * @return bool TRUE on success, FALSE on failure
+     *
+     * @psalm-assert-if-true =non-empty-string $file
      */
     public static function putConfig($file, $content, $inline = 3)
     {
@@ -130,6 +136,8 @@ class rex_file
      * @param mixed  $content Content for the file
      *
      * @return bool TRUE on success, FALSE on failure
+     *
+     * @psalm-assert-if-true =non-empty-string $file
      */
     public static function putCache($file, $content)
     {
@@ -143,6 +151,8 @@ class rex_file
      * @param string $dstfile Path of the destination file or directory
      *
      * @return bool TRUE on success, FALSE on failure
+     *
+     * @psalm-assert-if-true =non-empty-string $file
      */
     public static function copy($srcfile, $dstfile)
     {
@@ -173,6 +183,9 @@ class rex_file
      * @param string $dstfile Path of the destination file or directory
      *
      * @return bool TRUE on success, FALSE on failure
+     *
+     * @psalm-assert-if-true =non-empty-string $srcfile
+     * @psalm-assert-if-true =non-empty-string $dstfile
      */
     public static function move(string $srcfile, string $dstfile): bool
     {
@@ -202,6 +215,8 @@ class rex_file
      * @param string $filename Filename
      *
      * @return string Extension of $filename
+     *
+     * @psalm-assert-if-true =non-empty-string $filename
      */
     public static function extension($filename)
     {


### PR DESCRIPTION
See https://psalm.dev/docs/annotating_code/adding_assertions/

Grundidee ist: wenn file IO operationen true liefern (und somit gesagt haben, dass der pfad im filesystem existiert), muss der übergebene pfad auch `non-empty-string` gewesen sein. daher wird im aufrufenden scope der type des parameters durch den aufruf der IO operation präzisiert.

Requires phpstan 1.9.x