### PR TITLE
Suchfeld mit Value vorbelegen

### DIFF
--- a/redaxo/src/core/fragments/core/form/search.php
+++ b/redaxo/src/core/fragments/core/form/search.php
@@ -15,7 +15,7 @@ if (isset($this->autofocus) && $this->autofocus) {
 }
 $value = (string) $this->getVar('value', '');
 if ('' !== $value) {
-    $value = ' value="' . $value . '"';
+    $value = ' value="'.rex_escape($value).'"';
 }
 
 if ($this->id) {

--- a/redaxo/src/core/fragments/core/form/search.php
+++ b/redaxo/src/core/fragments/core/form/search.php
@@ -13,7 +13,7 @@ $autofocus = '';
 if (isset($this->autofocus) && $this->autofocus) {
     $autofocus = ' autofocus ';
 }
-$value = strval($this->getVar('value', ''));
+$value = (string) $this->getVar('value', '');
 if ('' !== $value) {
     $value = ' value="' . $value . '"';
 }

--- a/redaxo/src/core/fragments/core/form/search.php
+++ b/redaxo/src/core/fragments/core/form/search.php
@@ -13,8 +13,8 @@ $autofocus = '';
 if (isset($this->autofocus) && $this->autofocus) {
     $autofocus = ' autofocus ';
 }
-$value = $this->getVar('value', '');
-if ($value !== '') {
+$value = (string)$this->getVar('value', '');
+if ('' !== $value) {
     $value = ' value="' . $value . '"';
 }
 

--- a/redaxo/src/core/fragments/core/form/search.php
+++ b/redaxo/src/core/fragments/core/form/search.php
@@ -13,7 +13,7 @@ $autofocus = '';
 if (isset($this->autofocus) && $this->autofocus) {
     $autofocus = ' autofocus ';
 }
-$value = (string)$this->getVar('value', '');
+$value = strval($this->getVar('value', ''));
 if ('' !== $value) {
     $value = ' value="' . $value . '"';
 }

--- a/redaxo/src/core/fragments/core/form/search.php
+++ b/redaxo/src/core/fragments/core/form/search.php
@@ -13,6 +13,10 @@ $autofocus = '';
 if (isset($this->autofocus) && $this->autofocus) {
     $autofocus = ' autofocus ';
 }
+$value = $this->getVar('value', '');
+if ($value !== '') {
+    $value = ' value="' . $value . '"';
+}
 
 if ($this->id) {
     $id = ' id="' . $this->id .'"';
@@ -20,6 +24,6 @@ if ($this->id) {
 
 echo '<div class="'. $class . '"' . $id . '>
       <span class="input-group-addon clear-button"><i class="rex-icon rex-icon-search"></i></span>
-      <input class="form-control" type="text"' . $autofocus . $placeholder . '>
+      <input class="form-control" type="text"' . $autofocus . $placeholder . $value . '>
       <span title="' . $clear . '" class="form-control-clear rex-icon rex-icon-clear form-control-feedback hidden"></span>
 </div>';


### PR DESCRIPTION
Man kann das Suchfeld auch in anderen Addons verwenden ohne direkt per JavaScript den Output zu verändern. Bei Aufruf der Backend-Seite (refresh) sollte man den Suchbegriff auch wieder mit dem abgesendeten Suchbegriff vorbelegen können.