### PR TITLE
Fix rex_media_manager::create

### DIFF
--- a/redaxo/src/addons/media_manager/CHANGELOG.md
+++ b/redaxo/src/addons/media_manager/CHANGELOG.md
@@ -1,12 +1,20 @@
 Changelog
 =========
 
+Version 2.13.2 – 16.12.2022
+---------------------------
+
+### Bugfixes
+
+* Seit 2.13.1 kam es bei Nutzung von `rex_media_manager::create` teils zur Auslieferung der Bilder in Originalgröße (@gharlan)
+
+
 Version 2.13.1 – 13.12.2022
 ---------------------------
 
 ### Bugfixes
 
-* Wenn die Datei aus dem Cache kommt, war im Objekt der `media_path` nicht korrekt gesetzt (relevant für EPs etc.) (@dergel)
+* Wenn die Datei aus dem Cache kommt, war im Objekt der `media_path` nicht korrekt gesetzt (relevant für EPs etc.) (@dergel, @gharlan)
 
 
 Version 2.13.0 – 25.07.2022

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -64,7 +64,7 @@ class rex_media_manager
         $manager->setCachePath($cachePath);
         $manager->applyEffects($type);
 
-        if ($manager->useCache && !$manager->notFound) {
+        if (!$manager->isCached() && $manager->useCache && !$manager->notFound) {
             $media->save($manager->getCacheFilename(), $manager->getHeaderCacheFilename());
         }
 
@@ -125,14 +125,15 @@ class rex_media_manager
         }
 
         if ($this->useCache && $this->isCached()) {
-            $this->media->setSourcePath($this->getCacheFilename());
-
             $cache = $this->getHeaderCache();
             assert(null !== $cache);
 
             $this->media->setMediaPath($cache['media_path']);
             $this->media->setMediaFilename($cache['media_filename']);
             $this->media->setFormat($cache['format']);
+
+            // must be called after setMediaPath, because setMediaPath overwrites sourcePath, too
+            $this->media->setSourcePath($this->getCacheFilename());
 
             foreach ($cache['headers'] as $key => $value) {
                 $this->media->setHeader($key, $value);

--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -1,5 +1,5 @@
 package: media_manager
-version: '2.13.1'
+version: '2.13.2'
 author: 'Markus Staab, Jan Kristinus'
 supportpage: https://github.com/redaxo/redaxo
 


### PR DESCRIPTION
Seit #5415 bekam man bei dem Weg über `rex_media_manager::create` teils die Originalgrößen der Bilder.