### PR TITLE
fix `rex_extension::registerPoint` return type

### DIFF
--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -156,6 +156,11 @@ parameters:
 			path: ../../redaxo/src/addons/debug/lib/debug.php
 
 		-
+			message: "#^Conditional return type uses subject type T which is not part of PHPDoc @template tags\\.$#"
+			count: 1
+			path: ../../redaxo/src/addons/debug/lib/extensions/extension_debug.php
+
+		-
 			message: "#^Method rex_extension_debug\\:\\:getExtensionPoints\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/debug/lib/extensions/extension_debug.php
@@ -3962,16 +3967,6 @@ parameters:
 
 		-
 			message: "#^Method rex_editor\\:\\:callFactoryClass\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/util/editor.php
-
-		-
-			message: "#^Method rex_editor\\:\\:getUrl\\(\\) has parameter \\$filePath with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/util/editor.php
-
-		-
-			message: "#^Method rex_editor\\:\\:getUrl\\(\\) has parameter \\$line with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/util/editor.php
 

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -510,13 +510,17 @@
     <MixedArrayAssignment occurrences="1">
       <code>self::$listeners[$ep][]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment occurrences="2">
       <code>$data['listeners']</code>
+      <code>$res</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">
       <code>$trace['file']</code>
       <code>$trace['line']</code>
     </MixedOperand>
+    <MixedReturnStatement occurrences="1">
+      <code>$res</code>
+    </MixedReturnStatement>
   </file>
   <file src="redaxo/src/addons/debug/lib/extensions/logger_debug.php">
     <MixedArgument occurrences="1">
@@ -722,9 +726,23 @@
     </NullOperand>
   </file>
   <file src="redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php">
-    <MixedAssignment occurrences="1">
+    <MixedArgument occurrences="1">
+      <code>$imagick-&gt;getImageBlob()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
       <code>$color</code>
+      <code>$imagick</code>
     </MixedAssignment>
+    <MixedMethodCall occurrences="8">
+      <code>getImageBlob</code>
+      <code>mergeImageLayers</code>
+      <code>readImage</code>
+      <code>setImageAlphaChannel</code>
+      <code>setImageBackgroundColor</code>
+      <code>setImageFormat</code>
+      <code>setResolution</code>
+      <code>transformImageColorspace</code>
+    </MixedMethodCall>
     <MixedOperand occurrences="1">
       <code>$color</code>
     </MixedOperand>
@@ -1184,10 +1202,11 @@
     </MixedReturnStatement>
   </file>
   <file src="redaxo/src/addons/mediapool/lib/service_media.php">
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="8">
       <code>$data['file']['type']</code>
       <code>$data['height']</code>
       <code>$data['width']</code>
+      <code>$errorMessage</code>
       <code>$jpgExtensions</code>
       <code>$jpgExtensions</code>
       <code>$size[0]</code>
@@ -1197,10 +1216,11 @@
       <code>$allowedExtensions</code>
       <code>rex_mediapool::getBlockedExtensions()</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="5">
       <code>$data['file']['type']</code>
       <code>$data['height']</code>
       <code>$data['width']</code>
+      <code>$errorMessage</code>
       <code>$return['type']</code>
     </MixedAssignment>
     <PossiblyNullOperand occurrences="1">
@@ -2820,15 +2840,17 @@
     </MoreSpecificReturnType>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/article_content_base.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <MixedArgument occurrences="1">
       <code>$output</code>
-    </ArgumentTypeCoercion>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$output</code>
+    </MixedAssignment>
     <PossiblyFalseArgument occurrences="1">
       <code>$TEMPLATE-&gt;getTemplate()</code>
     </PossiblyFalseArgument>
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument occurrences="2">
       <code>$TEMPLATE-&gt;getTemplate()</code>
-      <code>$output</code>
       <code>$template-&gt;getKey()</code>
     </PossiblyNullArgument>
     <PossiblyNullReference occurrences="2">
@@ -4564,6 +4586,9 @@
     <MixedOperand occurrences="1">
       <code>$level</code>
     </MixedOperand>
+    <MixedReturnStatement occurrences="1">
+      <code>$factoryClass::registerPoint($extensionPoint)</code>
+    </MixedReturnStatement>
   </file>
   <file src="redaxo/src/core/lib/form/config_form.php">
     <PossiblyNullOperand occurrences="1">
@@ -5703,12 +5728,13 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="redaxo/src/core/lib/util/editor.php">
-    <MixedArgument occurrences="4">
-      <code>$filePath</code>
-      <code>$filePath</code>
-      <code>$filePath</code>
+    <MixedInferredReturnType occurrences="1">
+      <code>string|null</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="2"/>
+    <PossiblyInvalidArgument occurrences="1">
       <code>$line</code>
-    </MixedArgument>
+    </PossiblyInvalidArgument>
   </file>
   <file src="redaxo/src/core/lib/util/file.php">
     <MixedArgument occurrences="1">
@@ -6066,6 +6092,11 @@
       <code>$value</code>
     </UnusedForeachValue>
   </file>
+  <file src="redaxo/src/core/lib/var_dumper.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$line</code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="redaxo/src/core/lib/view.php">
     <MixedArgument occurrences="1">
       <code>$pageObj</code>
@@ -6235,7 +6266,8 @@
     </UnusedForeachValue>
   </file>
   <file src="redaxo/src/core/pages/system.log.external.php">
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="9">
+      <code>$logFile</code>
       <code>$logFile</code>
       <code>$logFile</code>
       <code>$logFile</code>
@@ -6254,6 +6286,11 @@
     <TypeDoesNotContainNull occurrences="1">
       <code>isset($logFile)</code>
     </TypeDoesNotContainNull>
+  </file>
+  <file src="redaxo/src/core/pages/system.log.redaxo.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$data[3] ?? 1</code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="redaxo/src/core/pages/system.report.html.php">
     <MixedArgument occurrences="1">

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -726,23 +726,9 @@
     </NullOperand>
   </file>
   <file src="redaxo/src/addons/media_manager/lib/effects/effect_convert2img.php">
-    <MixedArgument occurrences="1">
-      <code>$imagick-&gt;getImageBlob()</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$color</code>
-      <code>$imagick</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="8">
-      <code>getImageBlob</code>
-      <code>mergeImageLayers</code>
-      <code>readImage</code>
-      <code>setImageAlphaChannel</code>
-      <code>setImageBackgroundColor</code>
-      <code>setImageFormat</code>
-      <code>setResolution</code>
-      <code>transformImageColorspace</code>
-    </MixedMethodCall>
     <MixedOperand occurrences="1">
       <code>$color</code>
     </MixedOperand>

--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -67,7 +67,6 @@ final class rex_media_service
         // Sobald ein Addon eine negative Entscheidung getroffen hat, sollten
         // Addons, fuer die der Extension-Point spaeter ausgefuehrt wird, diese
         // Entscheidung respektieren
-        /** @var string|null $errorMessage */
         $errorMessage = null;
         $errorMessage = rex_extension::registerPoint(new rex_extension_point('MEDIA_ADD', $errorMessage, [
             'file' => $data['file'],

--- a/redaxo/src/core/lib/extension.php
+++ b/redaxo/src/core/lib/extension.php
@@ -27,7 +27,7 @@ abstract class rex_extension
      *
      * @template T
      * @param rex_extension_point<T> $extensionPoint Extension point
-     * @return T Subject, maybe adjusted by the extensions
+     * @return (T is null ? mixed : T) Subject, maybe adjusted by the extensions
      *
      * @psalm-taint-specialize
      */

--- a/redaxo/src/core/lib/util/editor.php
+++ b/redaxo/src/core/lib/util/editor.php
@@ -50,6 +50,9 @@ class rex_editor
     }
 
     /**
+     * @param string $filePath
+     * @param numeric-string $line
+     *
      * @return string|null
      */
     public function getUrl($filePath, $line)

--- a/redaxo/src/core/lib/util/editor.php
+++ b/redaxo/src/core/lib/util/editor.php
@@ -51,7 +51,7 @@ class rex_editor
 
     /**
      * @param string $filePath
-     * @param numeric-string $line
+     * @param int|numeric-string $line
      *
      * @return string|null
      */


### PR DESCRIPTION
damit in folgendem code kein error entsteht

```php
$name = null;
$name = rex_extension::registerPoint(new rex_extension_point(
    'NEW_NAME',
    $name,
    [
        'id' => $id,
        'output' => $output,
    ]
));
if (null !== $name) { // Strict comparison using !== between null and null will always evaluate to false.
    return $name;
}
```

siehe https://github.com/FriendsOfREDAXO/rexstan/issues/282