### PR TITLE
reflection: setAccessible nicht mehr aufrufen

### DIFF
--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -2306,7 +2306,7 @@ parameters:
 			path: ../../redaxo/src/addons/structure/tests/article_test.php
 
 		-
-			message: "#^Method class@anonymous/addons/structure/tests/category_test\\.php\\:179\\:\\:__construct\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/addons/structure/tests/category_test\\.php\\:177\\:\\:__construct\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/structure/tests/category_test.php
 
@@ -2366,7 +2366,7 @@ parameters:
 			path: ../../redaxo/src/addons/structure/tests/category_test.php
 
 		-
-			message: "#^Property class@anonymous/addons/structure/tests/category_test\\.php\\:179\\:\\:\\$parent has no type specified\\.$#"
+			message: "#^Property class@anonymous/addons/structure/tests/category_test\\.php\\:177\\:\\:\\$parent has no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/structure/tests/category_test.php
 

--- a/redaxo/src/addons/media_manager/tests/media_manager_test.php
+++ b/redaxo/src/addons/media_manager/tests/media_manager_test.php
@@ -18,7 +18,6 @@ class rex_media_manager_test extends TestCase
         $media->setMediaPath(__DIR__.'/bar.gif');
 
         $property = new ReflectionProperty(rex_media_manager::class, 'type');
-        $property->setAccessible(true);
         $property->setValue($manager, 'test');
 
         static::assertSame($cachePath.'test/foo.jpg', $manager->getCacheFilename());

--- a/redaxo/src/addons/structure/plugins/content/tests/article_content_base_test.php
+++ b/redaxo/src/addons/structure/plugins/content/tests/article_content_base_test.php
@@ -13,7 +13,6 @@ class rex_article_content_base_test extends TestCase
 
         // fake meta field in database structure
         $propArticle = new ReflectionProperty(rex_article_content_base::class, 'ARTICLE');
-        $propArticle->setAccessible(true);
         $propArticle->setValue($instance, rex_sql::factory()->setValue('art_foo', 'teststring'));
 
         static::assertTrue($instance->hasValue('foo'));
@@ -29,7 +28,6 @@ class rex_article_content_base_test extends TestCase
 
         // fake meta field in database structure
         $propArticle = new ReflectionProperty(rex_article_content_base::class, 'ARTICLE');
-        $propArticle->setAccessible(true);
         $propArticle->setValue($instance, rex_sql::factory()->setValue('art_foo', 'teststring'));
 
         static::assertEquals('teststring', $instance->getValue('foo'));

--- a/redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
+++ b/redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
@@ -37,7 +37,6 @@ class rex_article_content_test extends TestCase
         rex_article::getClassVars();
         $class = new ReflectionClass(rex_article::class);
         $classVarsProperty = $class->getProperty('classVars');
-        $classVarsProperty->setAccessible(true);
         $classVarsProperty->setValue(
             array_merge(
                 $classVarsProperty->getValue(),
@@ -58,7 +57,6 @@ class rex_article_content_test extends TestCase
         // reset static properties
         $class = new ReflectionClass(rex_article::class);
         $classVarsProperty = $class->getProperty('classVars');
-        $classVarsProperty->setAccessible(true);
         $classVarsProperty->setValue(null);
 
         rex_article::clearInstancePool();
@@ -69,12 +67,10 @@ class rex_article_content_test extends TestCase
         $instance = new rex_article_content(1, 1);
 
         $viaSql = new ReflectionProperty(rex_article_content::class, 'viasql');
-        $viaSql->setAccessible(true);
         $viaSql->setValue($instance, true);
 
         // fake meta field in database structure
         $propArticle = new ReflectionProperty(rex_article_content_base::class, 'ARTICLE');
-        $propArticle->setAccessible(true);
         $propArticle->setValue($instance, rex_sql::factory()->setValue('art_foo', 'teststring'));
 
         static::assertTrue($instance->hasValue('foo'));
@@ -89,12 +85,10 @@ class rex_article_content_test extends TestCase
         $instance = new rex_article_content(1, 1);
 
         $viaSql = new ReflectionProperty(rex_article_content::class, 'viasql');
-        $viaSql->setAccessible(true);
         $viaSql->setValue($instance, true);
 
         // fake meta field in database structure
         $propArticle = new ReflectionProperty(rex_article_content_base::class, 'ARTICLE');
-        $propArticle->setAccessible(true);
         $propArticle->setValue($instance, rex_sql::factory()->setValue('art_foo', 'teststring'));
 
         static::assertEquals('teststring', $instance->getValue('foo'));
@@ -107,7 +101,6 @@ class rex_article_content_test extends TestCase
         $instance = new rex_article_content(1, 1);
 
         $viaSql = new ReflectionProperty(rex_article_content::class, 'viasql');
-        $viaSql->setAccessible(true);
         $viaSql->setValue($instance, true);
 
         $this->expectException(rex_exception::class);

--- a/redaxo/src/addons/structure/tests/article_test.php
+++ b/redaxo/src/addons/structure/tests/article_test.php
@@ -13,7 +13,6 @@ class rex_article_test extends TestCase
         rex_article::getClassVars();
         $class = new ReflectionClass(rex_article::class);
         $classVarsProperty = $class->getProperty('classVars');
-        $classVarsProperty->setAccessible(true);
         $classVarsProperty->setValue(
             array_merge(
                 $classVarsProperty->getValue(),
@@ -27,7 +26,6 @@ class rex_article_test extends TestCase
         // reset static properties
         $class = new ReflectionClass(rex_article::class);
         $classVarsProperty = $class->getProperty('classVars');
-        $classVarsProperty->setAccessible(true);
         $classVarsProperty->setValue(null);
 
         rex_article::clearInstancePool();

--- a/redaxo/src/addons/structure/tests/category_test.php
+++ b/redaxo/src/addons/structure/tests/category_test.php
@@ -13,7 +13,6 @@ class rex_category_test extends TestCase
         rex_category::getClassVars();
         $class = new ReflectionClass(rex_category::class);
         $classVarsProperty = $class->getProperty('classVars');
-        $classVarsProperty->setAccessible(true);
         $classVarsProperty->setValue(
             array_merge(
                 $classVarsProperty->getValue(),
@@ -27,7 +26,6 @@ class rex_category_test extends TestCase
         // reset static properties
         $class = new ReflectionClass(rex_article::class);
         $classVarsProperty = $class->getProperty('classVars');
-        $classVarsProperty->setAccessible(true);
         $classVarsProperty->setValue(null);
 
         rex_category::clearInstancePool();

--- a/redaxo/src/core/tests/console/command_test.php
+++ b/redaxo/src/core/tests/console/command_test.php
@@ -10,7 +10,6 @@ class rex_console_command_test extends TestCase
     public function testDecodeMessage()
     {
         $method = new ReflectionMethod(rex_console_command::class, 'decodeMessage');
-        $method->setAccessible(true);
 
         $command = $this->getMockForAbstractClass(rex_console_command::class);
 
@@ -20,7 +19,6 @@ class rex_console_command_test extends TestCase
     public function testDecodeMessageSingleQuotes()
     {
         $method = new ReflectionMethod(rex_console_command::class, 'decodeMessage');
-        $method->setAccessible(true);
 
         $command = $this->getMockForAbstractClass(rex_console_command::class);
 

--- a/redaxo/src/core/tests/list_test.php
+++ b/redaxo/src/core/tests/list_test.php
@@ -10,7 +10,6 @@ class rex_list_test extends TestCase
     public function testPrepareCountQuery(): void
     {
         $method = new ReflectionMethod(rex_list::class, 'prepareCountQuery');
-        $method->setAccessible(true);
 
         $query = 'SELECT *, IF(foo = 1, 0, (SELECT x FROM bar)) as qux FROM foo ORDER qux';
         $expected = 'SELECT COUNT(*) AS `rows` FROM (SELECT *, IF(foo = 1, 0, (SELECT x FROM bar)) as qux FROM foo ORDER qux) t';

--- a/redaxo/src/core/tests/login/password_policy_test.php
+++ b/redaxo/src/core/tests/login/password_policy_test.php
@@ -54,7 +54,6 @@ class rex_password_policy_test extends TestCase
     public function testGetRule(): void
     {
         $getRule = new ReflectionMethod(rex_password_policy::class, 'getRule');
-        $getRule->setAccessible(true);
 
         $policy = new rex_password_policy(['length' => ['min' => 5, 'max' => 25]]);
         $rule = $getRule->invoke($policy);

--- a/redaxo/src/core/tests/sql/sql_select_test.php
+++ b/redaxo/src/core/tests/sql/sql_select_test.php
@@ -274,7 +274,6 @@ class rex_sql_select_test extends TestCase
 
         // get DB 1 PDO object
         $property = new ReflectionProperty(rex_sql::class, 'pdo');
-        $property->setAccessible(true);
         /** @var PDO $pdo */
         $pdo = $property->getValue()[1];
 

--- a/redaxo/src/core/tests/util/socket_test.php
+++ b/redaxo/src/core/tests/util/socket_test.php
@@ -58,9 +58,7 @@ class rex_socket_test extends TestCase
     {
         $class = new ReflectionClass(rex_socket::class);
         $property = $class->getProperty('stream');
-        $property->setAccessible(true);
         $method = $class->getMethod('writeRequest');
-        $method->setAccessible(true);
 
         $stream = fopen('php://temp', 'r+');
         $property->setValue($socket, $stream);
@@ -103,7 +101,6 @@ class rex_socket_test extends TestCase
     public function testParseUrl($url, $expectedHost, $expectedPort, $expectedSsl, $expectedPath)
     {
         $method = new ReflectionMethod(rex_socket::class, 'parseUrl');
-        $method->setAccessible(true);
         $result = $method->invoke(null, $url);
         $expected = [
             'host' => $expectedHost,
@@ -131,7 +128,6 @@ class rex_socket_test extends TestCase
         $this->expectException(rex_socket_exception::class);
 
         $method = new ReflectionMethod(rex_socket::class, 'parseUrl');
-        $method->setAccessible(true);
         $method->invoke(null, $url);
     }
 }

--- a/redaxo/src/core/tests/util/stream_test.php
+++ b/redaxo/src/core/tests/util/stream_test.php
@@ -21,7 +21,6 @@ class rex_stream_test extends TestCase
     public function testStreamIncludeWithRealFile()
     {
         $property = new ReflectionProperty(rex_stream::class, 'useRealFiles');
-        $property->setAccessible(true);
         $property->setValue(true);
 
         $content = 'foo <?php echo "bar";';


### PR DESCRIPTION
Da seit PHP 8.1 nicht mehr notwendig.