### PR TITLE
"NO_ACTION" als foreign key contraint action ergänzt

### DIFF
--- a/redaxo/src/core/lib/sql/foreign_key.php
+++ b/redaxo/src/core/lib/sql/foreign_key.php
@@ -10,6 +10,7 @@
 class rex_sql_foreign_key
 {
     public const RESTRICT = 'RESTRICT';
+    public const NO_ACTION = 'NO ACTION';
     public const CASCADE = 'CASCADE';
     public const SET_NULL = 'SET NULL';
 


### PR DESCRIPTION
In der Klasse rex_sql_foreign_key gibt es die in MySQL mögliche Action "NO INDEX" nicht als Konstante, wie die anderen Actions "RESTRICT, CASCADE und SET NULL"