### PR TITLE
Addon-Update: Plugin-Entfernung ermöglichen

### DIFF
--- a/redaxo/src/addons/install/lib/package/package_update.php
+++ b/redaxo/src/addons/install/lib/package/package_update.php
@@ -96,7 +96,7 @@ class rex_install_package_update extends rex_install_package_download
         // ---- copy plugins to new addon dir
         foreach ($this->addon->getRegisteredPlugins() as $plugin) {
             $pluginPath = $temppath . '/plugins/' . $plugin->getName();
-            if (!is_dir($pluginPath) && is_dir($plugin->getPath())) {
+            if (!is_dir($pluginPath)) {
                 if (is_dir($plugin->getPath())) {
                     rex_dir::copy($plugin->getPath(), $pluginPath);
                 }

--- a/redaxo/src/addons/install/lib/package/package_update.php
+++ b/redaxo/src/addons/install/lib/package/package_update.php
@@ -96,8 +96,10 @@ class rex_install_package_update extends rex_install_package_download
         // ---- copy plugins to new addon dir
         foreach ($this->addon->getRegisteredPlugins() as $plugin) {
             $pluginPath = $temppath . '/plugins/' . $plugin->getName();
-            if (!is_dir($pluginPath)) {
-                rex_dir::copy($plugin->getPath(), $pluginPath);
+            if (!is_dir($pluginPath) && is_dir($plugin->getPath())) {
+                if (is_dir($plugin->getPath())) {
+                    rex_dir::copy($plugin->getPath(), $pluginPath);
+                }
             } elseif ($plugin->isInstalled() && is_dir($pluginPath . '/assets')) {
                 rex_dir::copy($pluginPath . '/assets', $plugin->getAssetsPath());
             }

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -1,5 +1,5 @@
 package: install
-version: '2.10.0'
+version: '2.10.1-dev'
 author: Gregor Harlan
 supportpage: https://github.com/redaxo/redaxo
 


### PR DESCRIPTION
fixes #5145

Es funktioniert nun, wenn man in der `update.php` z.b. das notiert:

```php
rex_dir::delete(rex_path::plugin($addon, $plugin);
```