### PR TITLE
Metainfo: Notiz über rex_i18n::translate

### DIFF
--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -51,7 +51,7 @@ abstract class rex_metainfo_handler
 
             $note = null;
             if (isset($attrArray['note'])) {
-                $note = $attrArray['note'];
+                $note = rex_i18n::translate($attrArray['note']);
                 unset($attrArray['note']);
             }
 


### PR DESCRIPTION
closes #5337

Es ist gleichzeitig ein Bugfix, da vorher das Escaping fehlte, wie mir jetzt aufgefallen ist. Daher in 5.14.3.