### PR TITLE
rename `webservice.cache` to `webservice_cache.json`

### DIFF
--- a/redaxo/src/addons/install/lib/webservice.php
+++ b/redaxo/src/addons/install/lib/webservice.php
@@ -198,7 +198,7 @@ class rex_install_webservice
         } else {
             self::$cache = [];
         }
-        rex_file::putCache(rex_path::addonCache('install', 'webservice.cache'), self::$cache);
+        rex_file::putCache(rex_path::addonCache('install', 'webservice_cache.json'), self::$cache);
     }
 
     /**
@@ -225,7 +225,7 @@ class rex_install_webservice
     {
         if (null === self::$cache) {
             /** @var array<string, array{stamp: int, data: array}> $cache */
-            $cache = (array) rex_file::getCache(rex_path::addonCache('install', 'webservice.cache'));
+            $cache = (array) rex_file::getCache(rex_path::addonCache('install', 'webservice_cache.json'));
             foreach ($cache as $path => $pathCache) {
                 if ($pathCache['stamp'] > time() - self::REFRESH_CACHE) {
                     self::$cache[$path] = $pathCache;
@@ -245,6 +245,6 @@ class rex_install_webservice
     {
         self::$cache[$path]['stamp'] = time();
         self::$cache[$path]['data'] = $data;
-        rex_file::putCache(rex_path::addonCache('install', 'webservice.cache'), self::$cache);
+        rex_file::putCache(rex_path::addonCache('install', 'webservice_cache.json'), self::$cache);
     }
 }


### PR DESCRIPTION
Aus Gründen der Praktikabilität, wenn anhand der Dateiendung das Format klar wird und man sich das im Editor entsprechend unkompliziert formatieren/darstellen lassen kann. Aufgefallen durch #5452