### PR TITLE
prevent warning in rex_string::buildQuery()

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -6004,9 +6004,8 @@
     </MixedAssignment>
   </file>
   <file src="redaxo/src/core/lib/util/string.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$query</code>
-      <code>$value</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
       <code>$key</code>

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -176,7 +176,7 @@ class rex_string
                 if (is_array($value)) {
                     $func($value, $key);
                 } else {
-                    $query[] = $key . '=' . str_replace('%2F', '/', urlencode($value ?? ''));
+                    $query[] = $key . '=' . str_replace('%2F', '/', urlencode((string) $value));
                 }
             }
         };

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -176,7 +176,7 @@ class rex_string
                 if (is_array($value)) {
                     $func($value, $key);
                 } else {
-                    $query[] = $key . '=' . str_replace('%2F', '/', urlencode($value));
+                    $query[] = $key . '=' . str_replace('%2F', '/', urlencode($value ?? ''));
                 }
             }
         };


### PR DESCRIPTION
`urlencode(): Passing null to parameter #1 ($string) of type string is deprecated | src\core\lib\util\string.php | 179`
aktuell diese Zeile:
https://github.com/redaxo/redaxo/blob/main/redaxo/src/core/lib/util/string.php#L189

aufgetreten bei einem ydeploy::diff Lauf mit PHP 8.1



