### PR TITLE
Return-Types ergänzt

### DIFF
--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -416,36 +416,6 @@ parameters:
 			path: ../../redaxo/src/addons/media_manager/lib/media_manager.php
 
 		-
-			message: "#^Method rex_managed_media_test\\:\\:testConstructor\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/media_manager/tests/managed_media_test.php
-
-		-
-			message: "#^Method rex_media_manager_test\\:\\:dataGetUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/media_manager/tests/media_manager_test.php
-
-		-
-			message: "#^Method rex_media_manager_test\\:\\:testCreate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/media_manager/tests/media_manager_test.php
-
-		-
-			message: "#^Method rex_media_manager_test\\:\\:testGetCacheFilename\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/media_manager/tests/media_manager_test.php
-
-		-
-			message: "#^Method rex_media_manager_test\\:\\:testGetMediaFile\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/media_manager/tests/media_manager_test.php
-
-		-
-			message: "#^Method rex_media_manager_test\\:\\:testGetUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/media_manager/tests/media_manager_test.php
-
-		-
 			message: "#^Method rex_media_manager_test\\:\\:testGetUrl\\(\\) has parameter \\$expectedBuster with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/media_manager/tests/media_manager_test.php
@@ -866,31 +836,6 @@ parameters:
 			path: ../../redaxo/src/addons/mediapool/lib/var_medialist.php
 
 		-
-			message: "#^Method rex_media_test\\:\\:testGetValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/tests/media_test.php
-
-		-
-			message: "#^Method rex_media_test\\:\\:testHasValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/tests/media_test.php
-
-		-
-			message: "#^Method rex_mediapool_test\\:\\:provideIsAllowedExtension\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/tests/mediapool_test.php
-
-		-
-			message: "#^Method rex_mediapool_test\\:\\:provideIsAllowedMimeType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/tests/mediapool_test.php
-
-		-
-			message: "#^Method rex_mediapool_test\\:\\:testIsAllowedExtension\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/tests/mediapool_test.php
-
-		-
 			message: "#^Method rex_mediapool_test\\:\\:testIsAllowedExtension\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/mediapool/tests/mediapool_test.php
@@ -902,11 +847,6 @@ parameters:
 
 		-
 			message: "#^Method rex_mediapool_test\\:\\:testIsAllowedExtension\\(\\) has parameter \\$filename with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/mediapool/tests/mediapool_test.php
-
-		-
-			message: "#^Method rex_mediapool_test\\:\\:testIsAllowedMimeType\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/mediapool/tests/mediapool_test.php
 
@@ -1399,11 +1339,6 @@ parameters:
 			message: "#^Method rex_cronjob_mailer_purge\\:\\:getParamFields\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/phpmailer/lib/cronjob.php
-
-		-
-			message: "#^Method rex_mailer\\:\\:clearAllRecipients\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/phpmailer/lib/mailer.php
 
 		-
 			message: "#^Property rex_mailer\\:\\:\\$xHeader type has no value type specified in iterable type array\\.$#"
@@ -2121,36 +2056,6 @@ parameters:
 			path: ../../redaxo/src/addons/structure/plugins/content/lib/module_perm.php
 
 		-
-			message: "#^Method rex_article_content_base_test\\:\\:testGetValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/plugins/content/tests/article_content_base_test.php
-
-		-
-			message: "#^Method rex_article_content_base_test\\:\\:testHasValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/plugins/content/tests/article_content_base_test.php
-
-		-
-			message: "#^Method rex_article_content_test\\:\\:testBcGetValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
-
-		-
-			message: "#^Method rex_article_content_test\\:\\:testBcHasValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
-
-		-
-			message: "#^Method rex_article_content_test\\:\\:testGetValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
-
-		-
-			message: "#^Method rex_article_content_test\\:\\:testHasValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
-
-		-
 			message: "#^Method rex_article_slice_history\\:\\:getSnapshots\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/structure/plugins/history/lib/article_slice_history.php
@@ -2206,16 +2111,6 @@ parameters:
 			path: ../../redaxo/src/addons/structure/plugins/version/lib/revision.php
 
 		-
-			message: "#^Method rex_article_test\\:\\:testGetValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/tests/article_test.php
-
-		-
-			message: "#^Method rex_article_test\\:\\:testHasValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/tests/article_test.php
-
-		-
 			message: "#^Method class@anonymous/addons/structure/tests/category_test\\.php\\:176\\:\\:__construct\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/structure/tests/category_test.php
@@ -2266,29 +2161,9 @@ parameters:
 			path: ../../redaxo/src/addons/structure/tests/category_test.php
 
 		-
-			message: "#^Method rex_category_test\\:\\:testGetValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/tests/category_test.php
-
-		-
-			message: "#^Method rex_category_test\\:\\:testHasValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/tests/category_test.php
-
-		-
 			message: "#^Property class@anonymous/addons/structure/tests/category_test\\.php\\:176\\:\\:\\$parent has no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/structure/tests/category_test.php
-
-		-
-			message: "#^Method rex_structure_function_url_test\\:\\:provideRedirectException\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/tests/function_rex_url_test.php
-
-		-
-			message: "#^Method rex_structure_function_url_test\\:\\:testRedirectException\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/structure/tests/function_rex_url_test.php
 
 		-
 			message: "#^Method rex_structure_function_url_test\\:\\:testRedirectException\\(\\) has parameter \\$articleId with no type specified\\.$#"
@@ -2441,11 +2316,6 @@ parameters:
 			path: ../../redaxo/src/core/lib/config_db.php
 
 		-
-			message: "#^Method rex_command_assets_sync\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/assets_sync.php
-
-		-
 			message: "#^Method rex_command_assets_sync\\:\\:sync\\(\\) has parameter \\$folder1 with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/console/assets_sync.php
@@ -2456,94 +2326,9 @@ parameters:
 			path: ../../redaxo/src/core/lib/console/assets_sync.php
 
 		-
-			message: "#^Method rex_command_config_get\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/config/get.php
-
-		-
-			message: "#^Method rex_command_config_set\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/config/set.php
-
-		-
-			message: "#^Method rex_command_db_connection_options\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/db/connection_options.php
-
-		-
-			message: "#^Method rex_command_db_dump_schema\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/db/dump_schema.php
-
-		-
-			message: "#^Method rex_command_db_set_connection\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/db/set_connection.php
-
-		-
 			message: "#^Class rex_extension_point_console_shutdown extends generic class rex_extension_point but does not specify its types\\: T$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/console/extension_point_console_shutdown.php
-
-		-
-			message: "#^Method rex_command_package_activate\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/package/activate.php
-
-		-
-			message: "#^Method rex_command_package_deactivate\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/package/deactivate.php
-
-		-
-			message: "#^Method rex_command_package_delete\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/package/delete.php
-
-		-
-			message: "#^Method rex_command_package_install\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/package/install.php
-
-		-
-			message: "#^Method rex_command_package_list\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/package/list.php
-
-		-
-			message: "#^Method rex_command_package_run_update_script\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/package/run_update_script.php
-
-		-
-			message: "#^Method rex_command_package_uninstall\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/package/uninstall.php
-
-		-
-			message: "#^Method rex_command_setup_check\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/setup/check.php
-
-		-
-			message: "#^Method rex_command_setup_run\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/setup/run.php
-
-		-
-			message: "#^Method rex_command_system_report\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/system/report.php
-
-		-
-			message: "#^Method rex_command_user_create\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/user/create.php
-
-		-
-			message: "#^Method rex_command_user_set_password\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/console/user/set_password.php
 
 		-
 			message: "#^Method rex_context\\:\\:array2inputStr\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
@@ -3001,11 +2786,6 @@ parameters:
 			path: ../../redaxo/src/core/lib/login/api_user_impersonate.php
 
 		-
-			message: "#^Method rex_backend_login\\:\\:deleteStayLoggedInCookie\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/backend_login.php
-
-		-
 			message: "#^Method rex_backend_password_policy\\:\\:callFactoryClass\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/login/backend_password_policy.php
@@ -3021,42 +2801,12 @@ parameters:
 			path: ../../redaxo/src/core/lib/login/complex_perm.php
 
 		-
-			message: "#^Method rex_complex_perm\\:\\:register\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/complex_perm.php
-
-		-
-			message: "#^Method rex_complex_perm\\:\\:removeItem\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/complex_perm.php
-
-		-
-			message: "#^Method rex_complex_perm\\:\\:replaceItem\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/complex_perm.php
-
-		-
 			message: "#^Property rex_complex_perm\\:\\:\\$perms type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/login/complex_perm.php
 
 		-
 			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:depersonate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:impersonate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:isLoggedOut\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/login/login.php
 
@@ -3091,37 +2841,7 @@ parameters:
 			path: ../../redaxo/src/core/lib/login/login.php
 
 		-
-			message: "#^Method rex_login\\:\\:regenerateSessionId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:rewriteSessionCookie\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setCache\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
 			message: "#^Method rex_login\\:\\:setCache\\(\\) has parameter \\$status with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setIdColumn\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setImpersonateQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setLogin\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/login/login.php
 
@@ -3131,37 +2851,7 @@ parameters:
 			path: ../../redaxo/src/core/lib/login/login.php
 
 		-
-			message: "#^Method rex_login\\:\\:setLoginQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setLogout\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
 			message: "#^Method rex_login\\:\\:setLogout\\(\\) has parameter \\$logout with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setPasswordColumn\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setSessionDuration\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setSessionVar\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/login/login.php
 
@@ -3171,27 +2861,7 @@ parameters:
 			path: ../../redaxo/src/core/lib/login/login.php
 
 		-
-			message: "#^Method rex_login\\:\\:setSqlDb\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
 			message: "#^Method rex_login\\:\\:setSqlDb\\(\\) has parameter \\$DB with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setSystemId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:setUserQuery\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/login.php
-
-		-
-			message: "#^Method rex_login\\:\\:startSession\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/login/login.php
 
@@ -3221,28 +2891,13 @@ parameters:
 			path: ../../redaxo/src/core/lib/login/perm.php
 
 		-
-			message: "#^Method rex_perm\\:\\:register\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/perm.php
-
-		-
 			message: "#^Property rex_perm\\:\\:\\$perms type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/login/perm.php
 
 		-
-			message: "#^Method rex_user\\:\\:clearInstance\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/login/user.php
-
-		-
 			message: "#^Method rex_user\\:\\:getComplexPerm\\(\\) should return rex_clang_perm\\|rex_media_perm\\|rex_module_perm\\|rex_structure_perm\\|null but returns rex_complex_perm\\|null\\.$#"
 			count: 2
-			path: ../../redaxo/src/core/lib/login/user.php
-
-		-
-			message: "#^Method rex_user\\:\\:setRoleClass\\(\\) has no return type specified\\.$#"
-			count: 1
 			path: ../../redaxo/src/core/lib/login/user.php
 
 		-
@@ -4181,11 +3836,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
 
 		-
-			message: "#^Method rex_command_config_get_test\\:\\:dataKeyFound\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/console/config/get_test.php
-
-		-
 			message: "#^Method rex_command_config_get_test\\:\\:testKeyFound\\(\\) has parameter \\$expectedValue with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/console/config/get_test.php
@@ -4194,11 +3844,6 @@ parameters:
 			message: "#^Method rex_command_config_get_test\\:\\:testKeyFound\\(\\) has parameter \\$key with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/console/config/get_test.php
-
-		-
-			message: "#^Method rex_command_config_set_test\\:\\:dataSetBoolean\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/console/config/set_test.php
 
 		-
 			message: "#^Method rex_command_config_set_test\\:\\:testSetBoolean\\(\\) has parameter \\$expectedValue with no type specified\\.$#"
@@ -4214,11 +3859,6 @@ parameters:
 			message: "#^Property rex_command_config_set_test\\:\\:\\$initialConfig has no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/console/config/set_test.php
-
-		-
-			message: "#^Method rex_password_policy_test\\:\\:provideCheck\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/login/password_policy_test.php
 
 		-
 			message: "#^Method rex_password_policy_test\\:\\:testCheck\\(\\) has parameter \\$expected with no type specified\\.$#"
@@ -4246,16 +3886,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/packages/package_test.php
 
 		-
-			message: "#^Method rex_path_test\\:\\:dataRelative\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/path_test.php
-
-		-
-			message: "#^Method rex_path_test\\:\\:path\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/path_test.php
-
-		-
 			message: "#^Method rex_path_test\\:\\:path\\(\\) has parameter \\$path with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/path_test.php
@@ -4274,11 +3904,6 @@ parameters:
 			message: "#^Method rex_path_test\\:\\:testRelative\\(\\) has parameter \\$path with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/path_test.php
-
-		-
-			message: "#^Method rex_sql_select_test\\:\\:insertRow\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/sql/sql_select_test.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with \\*NEVER\\* and array\\<int, \\(int\\|string\\)\\> will always evaluate to false\\.$#"
@@ -4321,16 +3946,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/sql/sql_test.php
 
 		-
-			message: "#^Method rex_file_test\\:\\:dataTestExtension\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_file_test\\:\\:dataTestMimeType\\(\\) return type has no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
 			message: "#^Method rex_file_test\\:\\:testExtension\\(\\) has parameter \\$expectedExtension with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/file_test.php
@@ -4339,11 +3954,6 @@ parameters:
 			message: "#^Method rex_file_test\\:\\:testExtension\\(\\) has parameter \\$file with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/file_test.php
-
-		-
-			message: "#^Method rex_finder_test\\:\\:assertIteratorContains\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/finder_test.php
 
 		-
 			message: "#^Method rex_finder_test\\:\\:assertIteratorContains\\(\\) has parameter \\$contains with no type specified\\.$#"
@@ -4356,19 +3966,9 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/finder_test.php
 
 		-
-			message: "#^Method rex_i18n_trans_cb\\:\\:mytranslate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/i18n_test.php
-
-		-
 			message: "#^Property rex_i18n_test\\:\\:\\$previousLocale has no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/i18n_test.php
-
-		-
-			message: "#^Method rex_markdown_test\\:\\:parseProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/markdown_test.php
 
 		-
 			message: "#^Method rex_markdown_test\\:\\:testParse\\(\\) has parameter \\$code with no type specified\\.$#"
@@ -4391,11 +3991,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/socket_response_test.php
 
 		-
-			message: "#^Method rex_socket_response_test\\:\\:getStatusProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_response_test.php
-
-		-
 			message: "#^Method rex_socket_response_test\\:\\:testGetStatus\\(\\) has parameter \\$header with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/socket_response_test.php
@@ -4414,16 +4009,6 @@ parameters:
 			message: "#^Method rex_socket_response_test\\:\\:testGetStatus\\(\\) has parameter \\$statusMessage with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/socket_response_test.php
-
-		-
-			message: "#^Method rex_socket_test\\:\\:parseUrlExceptionProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_test.php
-
-		-
-			message: "#^Method rex_socket_test\\:\\:parseUrlProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/socket_test.php
 
 		-
 			message: "#^Method rex_socket_test\\:\\:testParseUrl\\(\\) has parameter \\$expectedHost with no type specified\\.$#"
@@ -4466,17 +4051,7 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/socket_test.php
 
 		-
-			message: "#^Method rex_string_test\\:\\:buildQueryProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/string_test.php
-
-		-
-			message: "#^Method rex_string_test\\:\\:normalizeProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/string_test.php
-
-		-
-			message: "#^Method rex_string_test\\:\\:splitProvider\\(\\) has no return type specified\\.$#"
+			message: "#^Method rex_string_test\\:\\:buildQueryProvider\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/string_test.php
 
@@ -4541,16 +4116,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/timer_test.php
 
 		-
-			message: "#^Method rex_type_test\\:\\:castProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/type_test.php
-
-		-
-			message: "#^Method rex_type_test\\:\\:castWrongVartypeProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/type_test.php
-
-		-
 			message: "#^Method rex_type_test\\:\\:testCast\\(\\) has parameter \\$expectedResult with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/type_test.php
@@ -4569,21 +4134,6 @@ parameters:
 			message: "#^Method rex_type_test\\:\\:testCastWrongVartype\\(\\) has parameter \\$vartype with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/type_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:dataEmail\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:dataType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
-
-		-
-			message: "#^Method rex_validator_test\\:\\:dataUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/validator_test.php
 
 		-
 			message: "#^Method rex_validator_test\\:\\:testEmail\\(\\) has parameter \\$isValid with no type specified\\.$#"
@@ -4621,16 +4171,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/util/validator_test.php
 
 		-
-			message: "#^Method rex_version_test\\:\\:compareProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/version_test.php
-
-		-
-			message: "#^Method rex_version_test\\:\\:splitProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/util/version_test.php
-
-		-
 			message: "#^Method rex_version_test\\:\\:testCompare\\(\\) has parameter \\$expected with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/version_test.php
@@ -4644,11 +4184,6 @@ parameters:
 			message: "#^Method rex_version_test\\:\\:testSplit\\(\\) has parameter \\$version with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/util/version_test.php
-
-		-
-			message: "#^Method rex_var_base_test\\:\\:assertParseOutputEquals\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_base_test.php
 
 		-
 			message: "#^Method rex_var_base_test\\:\\:assertParseOutputEquals\\(\\) has parameter \\$content with no type specified\\.$#"
@@ -4666,19 +4201,9 @@ parameters:
 			path: ../../redaxo/src/core/tests/var/var_base_test.php
 
 		-
-			message: "#^Method rex_var_base_test\\:\\:getParseOutput\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_base_test.php
-
-		-
 			message: "#^Method rex_var_base_test\\:\\:getParseOutput\\(\\) has parameter \\$content with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_base_test.php
-
-		-
-			message: "#^Method rex_var_config_test\\:\\:configReplaceProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_config_test.php
 
 		-
 			message: "#^Method rex_var_config_test\\:\\:testConfigReplace\\(\\) has parameter \\$content with no type specified\\.$#"
@@ -4691,11 +4216,6 @@ parameters:
 			path: ../../redaxo/src/core/tests/var/var_config_test.php
 
 		-
-			message: "#^Method rex_var_property_test\\:\\:propertyReplaceProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_property_test.php
-
-		-
 			message: "#^Method rex_var_property_test\\:\\:testPropertyReplace\\(\\) has parameter \\$content with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_property_test.php
@@ -4704,21 +4224,6 @@ parameters:
 			message: "#^Method rex_var_property_test\\:\\:testPropertyReplace\\(\\) has parameter \\$expectedOutput with no type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_property_test.php
-
-		-
-			message: "#^Method rex_var_test\\:\\:parseArgsSyntaxProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_test.php
-
-		-
-			message: "#^Method rex_var_test\\:\\:parseGlobalArgsProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_test.php
-
-		-
-			message: "#^Method rex_var_test\\:\\:parseTokensProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_test.php
 
 		-
 			message: "#^Method rex_var_test\\:\\:testParseArgsSyntax\\(\\) has parameter \\$content with no type specified\\.$#"
@@ -4747,11 +4252,6 @@ parameters:
 
 		-
 			message: "#^Method rex_var_test\\:\\:testParseTokens\\(\\) has parameter \\$expectedOutput with no type specified\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/tests/var/var_test.php
-
-		-
-			message: "#^Method rex_var_test\\:\\:varCallback\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/var/var_test.php
 

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -926,10 +926,6 @@
     <MixedOperand>
       <code>$expectedBuster</code>
     </MixedOperand>
-    <PossiblyNullOperand>
-      <code>$typeTimestamp</code>
-      <code>$typeTimestamp</code>
-    </PossiblyNullOperand>
   </file>
   <file src="redaxo/src/addons/mediapool/functions/function_rex_mediapool.php">
     <ArgumentTypeCoercion>
@@ -6116,9 +6112,6 @@
     <MixedArgument>
       <code>$file</code>
     </MixedArgument>
-    <MixedInferredReturnType>
-      <code>iterable</code>
-    </MixedInferredReturnType>
   </file>
   <file src="redaxo/src/core/tests/util/finder_test.php">
     <MixedArgument>
@@ -6154,9 +6147,6 @@
     <MixedArgument>
       <code>$this-&gt;previousLocale</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code>rex_i18n_trans_cb::mytranslate(...)</code>
-    </MixedArgumentTypeCoercion>
   </file>
   <file src="redaxo/src/core/tests/util/markdown_test.php">
     <MixedArgument>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -44,7 +44,3 @@ parameters:
         -
             message: '#.*deprecated.*#'
             path: '*/update.php'
-        -
-            message: '#Method .*::test.* has no return type specified.#'
-            path: '*/core/tests/*.php'
-

--- a/psalm.xml
+++ b/psalm.xml
@@ -86,7 +86,6 @@
         </MissingConstructor>
         <MissingParamType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
-        <MissingReturnType errorLevel="info" />
         <PropertyNotSetInConstructor errorLevel="info" />
         <RawObjectIteration>
             <errorLevel type="info">

--- a/redaxo/src/addons/be_style/lib/command/compile.php
+++ b/redaxo/src/addons/be_style/lib/command/compile.php
@@ -12,16 +12,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_be_style_command_compile extends rex_console_command
 {
-    /**
-     * @return void
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setAliases(['styles:compile'])
             ->setDescription('Converts Backend SCSS files to CSS');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
         $io->title('be_style scss compiler');

--- a/redaxo/src/addons/cronjob/lib/command/run.php
+++ b/redaxo/src/addons/cronjob/lib/command/run.php
@@ -14,10 +14,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class rex_command_cronjob_run extends rex_console_command
 {
-    /**
-     * @return void
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Executes cronjobs of the "script" environment')
@@ -25,7 +22,7 @@ class rex_command_cronjob_run extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/addons/install/lib/command/download.php
+++ b/redaxo/src/addons/install/lib/command/download.php
@@ -11,17 +11,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_install_download extends rex_console_command
 {
-    /**
-     * @return void
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('Download an AddOn from redaxo.org')
             ->addArgument('addonkey', InputArgument::REQUIRED, 'AddOn key, e.g. "yform"')
             ->addArgument('version', InputArgument::OPTIONAL, "Version, e.g. '3.2.1', '^3.2' or '3.*'");
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/addons/install/lib/command/list.php
+++ b/redaxo/src/addons/install/lib/command/list.php
@@ -11,10 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_install_list extends rex_console_command
 {
-    /**
-     * @return void
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('List available packages on redaxo.org')
             ->addOption('search', 's', InputOption::VALUE_REQUIRED, 'filter list')
@@ -23,7 +20,7 @@ class rex_command_install_list extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/addons/install/lib/command/update.php
+++ b/redaxo/src/addons/install/lib/command/update.php
@@ -11,9 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_install_update extends rex_console_command
 {
-    /**
-     * @return void
-     */
     protected function configure(): void
     {
         $this->setDescription('Updates an AddOn from redaxo.org')

--- a/redaxo/src/addons/install/lib/command/update.php
+++ b/redaxo/src/addons/install/lib/command/update.php
@@ -14,14 +14,14 @@ class rex_command_install_update extends rex_console_command
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('Updates an AddOn from redaxo.org')
             ->addArgument('addonkey', InputArgument::REQUIRED, 'AddOn key, e.g. "yform"')
             ->addArgument('version', InputArgument::OPTIONAL, 'Version, e.g. "3.2.1"');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/addons/media_manager/tests/managed_media_test.php
+++ b/redaxo/src/addons/media_manager/tests/managed_media_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_managed_media_test extends TestCase
 {
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $filename = 'CHANGELOG.md';
         $path = rex_path::addon('media_manager', $filename);

--- a/redaxo/src/addons/media_manager/tests/media_manager_test.php
+++ b/redaxo/src/addons/media_manager/tests/media_manager_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_media_manager_test extends TestCase
 {
-    public function testGetCacheFilename()
+    public function testGetCacheFilename(): void
     {
         $media = new rex_managed_media(__DIR__.'/foo.jpg');
         $manager = new rex_media_manager($media);
@@ -23,7 +23,7 @@ class rex_media_manager_test extends TestCase
         static::assertSame($cachePath.'test/foo.jpg', $manager->getCacheFilename());
     }
 
-    public function testGetMediaFile()
+    public function testGetMediaFile(): void
     {
         $_GET['rex_media_file'] = '../foo/bar/baz.jpg';
         static::assertSame('baz.jpg', rex_media_manager::getMediaFile());
@@ -32,7 +32,7 @@ class rex_media_manager_test extends TestCase
         static::assertSame('baz.jpg', rex_media_manager::getMediaFile());
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $filename = '_media_manager_test.png';
         $path = rex_path::media($filename);
@@ -57,7 +57,7 @@ class rex_media_manager_test extends TestCase
     /**
      * @dataProvider dataGetUrl
      */
-    public function testGetUrl($expectedBuster, $type, $file, $timestamp = null)
+    public function testGetUrl($expectedBuster, $type, $file, $timestamp = null): void
     {
         $url = rex_media_manager::getUrl($type, $file, $timestamp);
 
@@ -68,7 +68,8 @@ class rex_media_manager_test extends TestCase
         }
     }
 
-    public function dataGetUrl()
+    /** @return iterable<int, array{0: false|int, 1: string, 2: string|rex_media, 3?: int}> */
+    public function dataGetUrl(): iterable
     {
         yield [false, 'non_existing', 'test.jpg', time()];
 
@@ -82,7 +83,7 @@ class rex_media_manager_test extends TestCase
 
         yield [false, $type, 'test.jpg'];
 
-        $typeTimestamp = rex_sql::factory()
+        $typeTimestamp = (int) rex_sql::factory()
             ->setQuery('SELECT updatedate FROM '.rex::getTable('media_manager_type').' WHERE name = ?', [$type])
             ->getDateTimeValue('updatedate');
 

--- a/redaxo/src/addons/mediapool/tests/media_test.php
+++ b/redaxo/src/addons/mediapool/tests/media_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_media_test extends TestCase
 {
-    public function testHasValue()
+    public function testHasValue(): void
     {
         $media = $this->createMediaWithoutConstructor();
 
@@ -21,7 +21,7 @@ class rex_media_test extends TestCase
         static::assertFalse($media->hasValue('med_bar'));
     }
 
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $media = $this->createMediaWithoutConstructor();
 

--- a/redaxo/src/addons/mediapool/tests/mediapool_test.php
+++ b/redaxo/src/addons/mediapool/tests/mediapool_test.php
@@ -10,12 +10,13 @@ class rex_mediapool_test extends TestCase
     /**
      * @dataProvider provideIsAllowedExtension
      */
-    public function testIsAllowedExtension($expected, $filename, array $args = [])
+    public function testIsAllowedExtension($expected, $filename, array $args = []): void
     {
         static::assertSame($expected, rex_mediapool::isAllowedExtension($filename, $args));
     }
 
-    public function provideIsAllowedExtension()
+    /** @return list<array{0: bool, 1: string, 2?: array{types: string}}> */
+    public function provideIsAllowedExtension(): array
     {
         return [
             [false, 'foo.bar.php'],
@@ -35,7 +36,7 @@ class rex_mediapool_test extends TestCase
     /**
      * @dataProvider provideIsAllowedMimeType
      */
-    public function testIsAllowedMimeType($expected, $path, $filename = null)
+    public function testIsAllowedMimeType($expected, $path, $filename = null): void
     {
         $addon = rex_addon::get('mediapool');
 
@@ -50,7 +51,8 @@ class rex_mediapool_test extends TestCase
         $addon->setProperty('allowed_mime_types', $allowedMimeTypes);
     }
 
-    public function provideIsAllowedMimeType()
+    /** @return list<array{0: bool, 1: string, 2?: string}> */
+    public function provideIsAllowedMimeType(): array
     {
         return [
             [false, __FILE__],

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -161,6 +161,9 @@ class rex_mailer extends PHPMailer
         unset($this->xHeader[$kind]);
     }
 
+    /**
+     * @return void
+     */
     public function clearAllRecipients()
     {
         parent::clearAllRecipients();

--- a/redaxo/src/addons/structure/plugins/content/tests/article_content_base_test.php
+++ b/redaxo/src/addons/structure/plugins/content/tests/article_content_base_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_article_content_base_test extends TestCase
 {
-    public function testHasValue()
+    public function testHasValue(): void
     {
         $instance = $this->createArticleContentBaseWithoutConstructor();
 
@@ -22,7 +22,7 @@ class rex_article_content_base_test extends TestCase
         static::assertFalse($instance->hasValue('art_bar'));
     }
 
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $instance = $this->createArticleContentBaseWithoutConstructor();
 

--- a/redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
+++ b/redaxo/src/addons/structure/plugins/content/tests/article_content_test.php
@@ -62,7 +62,7 @@ class rex_article_content_test extends TestCase
         rex_article::clearInstancePool();
     }
 
-    public function testBcHasValue()
+    public function testBcHasValue(): void
     {
         $instance = new rex_article_content(1, 1);
 
@@ -80,7 +80,7 @@ class rex_article_content_test extends TestCase
         static::assertFalse($instance->hasValue('art_bar'));
     }
 
-    public function testBcGetValue()
+    public function testBcGetValue(): void
     {
         $instance = new rex_article_content(1, 1);
 
@@ -117,7 +117,7 @@ class rex_article_content_test extends TestCase
         ];
     }
 
-    public function testHasValue()
+    public function testHasValue(): void
     {
         $instance = new rex_article_content(1, 1);
 
@@ -128,7 +128,7 @@ class rex_article_content_test extends TestCase
         static::assertFalse($instance->hasValue('art_bar'));
     }
 
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $instance = new rex_article_content(1, 1);
 

--- a/redaxo/src/addons/structure/tests/article_test.php
+++ b/redaxo/src/addons/structure/tests/article_test.php
@@ -31,7 +31,7 @@ class rex_article_test extends TestCase
         rex_article::clearInstancePool();
     }
 
-    public function testHasValue()
+    public function testHasValue(): void
     {
         $instance = $this->createArticleWithoutConstructor();
 
@@ -45,7 +45,7 @@ class rex_article_test extends TestCase
         static::assertFalse($instance->hasValue('art_bar'));
     }
 
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $instance = $this->createArticleWithoutConstructor();
 

--- a/redaxo/src/addons/structure/tests/category_test.php
+++ b/redaxo/src/addons/structure/tests/category_test.php
@@ -31,7 +31,7 @@ class rex_category_test extends TestCase
         rex_category::clearInstancePool();
     }
 
-    public function testHasValue()
+    public function testHasValue(): void
     {
         $instance = $this->createCategoryWithoutConstructor();
 
@@ -45,7 +45,7 @@ class rex_category_test extends TestCase
         static::assertFalse($instance->hasValue('cat_bar'));
     }
 
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $instance = $this->createCategoryWithoutConstructor();
 

--- a/redaxo/src/addons/structure/tests/function_rex_url_test.php
+++ b/redaxo/src/addons/structure/tests/function_rex_url_test.php
@@ -9,6 +9,7 @@ class rex_structure_function_url_test extends TestCase
 {
     /**
      * @dataProvider provideRedirectException
+     * @return never
      */
     public function testRedirectException($articleId)
     {
@@ -17,7 +18,8 @@ class rex_structure_function_url_test extends TestCase
         rex_redirect($articleId);
     }
 
-    public function provideRedirectException()
+    /** @return list<array{string}> */
+    public function provideRedirectException(): array
     {
         return [
             ['http://www.example.com'],

--- a/redaxo/src/core/lib/console/assets_sync.php
+++ b/redaxo/src/core/lib/console/assets_sync.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class rex_command_assets_sync extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Sync assets within the assets-dir with the sources-dir')
@@ -26,7 +26,7 @@ class rex_command_assets_sync extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $created = $updated = $errored = 0;
         $io = $this->getStyle($input, $output);

--- a/redaxo/src/core/lib/console/cache/clear.php
+++ b/redaxo/src/core/lib/console/cache/clear.php
@@ -13,13 +13,13 @@ class rex_command_cache_clear extends rex_console_command
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Clears the redaxo core cache');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $successMsg = rex_delete_cache();
         $io = $this->getStyle($input, $output);

--- a/redaxo/src/core/lib/console/cache/clear.php
+++ b/redaxo/src/core/lib/console/cache/clear.php
@@ -10,9 +10,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_cache_clear extends rex_console_command
 {
-    /**
-     * @return void
-     */
     protected function configure(): void
     {
         $this

--- a/redaxo/src/core/lib/console/config/get.php
+++ b/redaxo/src/core/lib/console/config/get.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_config_get extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('Get config variables')
             ->addArgument('config-key', InputArgument::REQUIRED, 'config path separated by periods, e.g. "setup" or "db.1.host"')
@@ -22,7 +22,7 @@ class rex_command_config_get extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
         $key = $input->getArgument('config-key');

--- a/redaxo/src/core/lib/console/config/set.php
+++ b/redaxo/src/core/lib/console/config/set.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_config_set extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setDescription('Set config variables')
             ->addArgument('config-key', InputArgument::REQUIRED, 'config path separated by periods, e.g. "setup" or "db.1.host"')
@@ -36,7 +36,7 @@ class rex_command_config_set extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/db/connection_options.php
+++ b/redaxo/src/core/lib/console/db/connection_options.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_db_connection_options extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Dumps the db connection options for the mysql cli tool')
@@ -32,7 +32,7 @@ class rex_command_db_connection_options extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $db = rex::getDbConfig(1);
 

--- a/redaxo/src/core/lib/console/db/dump_schema.php
+++ b/redaxo/src/core/lib/console/db/dump_schema.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_db_dump_schema extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Dumps the schema of db tables as php code')
@@ -23,7 +23,7 @@ class rex_command_db_dump_schema extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $table = rex_sql_table::get($input->getArgument('table'));
 

--- a/redaxo/src/core/lib/console/db/set_connection.php
+++ b/redaxo/src/core/lib/console/db/set_connection.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_db_set_connection extends rex_console_command implements rex_command_standalone
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Sets database connection credentials.')
@@ -24,7 +24,7 @@ class rex_command_db_set_connection extends rex_console_command implements rex_c
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Save credentials even if validation fails.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/package/activate.php
+++ b/redaxo/src/core/lib/console/package/activate.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_package_activate extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Activates the selected package')
@@ -30,7 +30,7 @@ class rex_command_package_activate extends rex_console_command
             });
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/package/deactivate.php
+++ b/redaxo/src/core/lib/console/package/deactivate.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_package_deactivate extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Deactivates the selected package')
@@ -30,7 +30,7 @@ class rex_command_package_deactivate extends rex_console_command
             });
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/package/delete.php
+++ b/redaxo/src/core/lib/console/package/delete.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_package_delete extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Deletes the selected package')
@@ -30,7 +30,7 @@ class rex_command_package_delete extends rex_console_command
             });
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/package/install.php
+++ b/redaxo/src/core/lib/console/package/install.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_package_install extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Installs the selected package')
@@ -29,7 +29,7 @@ class rex_command_package_install extends rex_console_command
             ->addOption('re-install', '-r', InputOption::VALUE_NONE, 'Allows to reinstall the Package without asking the User');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/package/list.php
+++ b/redaxo/src/core/lib/console/package/list.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_package_list extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('List available packages')
@@ -24,7 +24,7 @@ class rex_command_package_list extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/package/run_update_script.php
+++ b/redaxo/src/core/lib/console/package/run_update_script.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_package_run_update_script extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Runs the update.php of the given package with given previous version')

--- a/redaxo/src/core/lib/console/package/uninstall.php
+++ b/redaxo/src/core/lib/console/package/uninstall.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_package_uninstall extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Uninstalls the selected package')
@@ -30,7 +30,7 @@ class rex_command_package_uninstall extends rex_console_command
             });
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/setup/check.php
+++ b/redaxo/src/core/lib/console/setup/check.php
@@ -12,14 +12,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_setup_check extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Check the commandline interface (CLI) environment for REDAXO requirements')
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $exitCode = 0;
         $io = $this->getStyle($input, $output);

--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -23,7 +23,7 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
     /** @var bool */
     private $forceAsking = false;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Perform redaxo setup')
@@ -46,7 +46,7 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/system/report.php
+++ b/redaxo/src/core/lib/console/system/report.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_system_report extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Shows the system report')
@@ -22,7 +22,7 @@ class rex_command_system_report extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $formats = ['cli', 'markdown'];
 

--- a/redaxo/src/core/lib/console/user/create.php
+++ b/redaxo/src/core/lib/console/user/create.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_user_create extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Create a new user')
@@ -25,7 +25,7 @@ class rex_command_user_create extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/console/user/set_password.php
+++ b/redaxo/src/core/lib/console/user/set_password.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class rex_command_user_set_password extends rex_console_command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Sets a new password for a user')
@@ -25,7 +25,7 @@ class rex_command_user_set_password extends rex_console_command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getStyle($input, $output);
 

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -227,7 +227,7 @@ class rex_backend_login extends rex_login
         ]);
     }
 
-    private static function deleteStayLoggedInCookie()
+    private static function deleteStayLoggedInCookie(): void
     {
         rex_response::sendCookie(self::getStayLoggedInCookieName(), '');
     }

--- a/redaxo/src/core/lib/login/complex_perm.php
+++ b/redaxo/src/core/lib/login/complex_perm.php
@@ -71,8 +71,8 @@ abstract class rex_complex_perm
      * @param string $key   Key for the complex perm
      * @param string $class Class name
      * @psalm-param class-string<self> $class
-     *
      * @throws InvalidArgumentException
+     * @return void
      */
     public static function register($key, $class)
     {
@@ -116,6 +116,7 @@ abstract class rex_complex_perm
      *
      * @param string     $key  Key
      * @param string|int $item Item
+     * @return void
      */
     public static function removeItem($key, $item)
     {
@@ -128,6 +129,7 @@ abstract class rex_complex_perm
      * @param string     $key  Key
      * @param string|int $item Old item
      * @param string|int $new  New item
+     * @return void
      */
     public static function replaceItem($key, $item, $new)
     {

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -91,6 +91,8 @@ class rex_login
     /**
      * Setzt, ob die Ergebnisse der Login-Abfrage
      * pro Seitenaufruf gecached werden sollen.
+     *
+     * @return void
      */
     public function setCache($status = true)
     {
@@ -99,6 +101,8 @@ class rex_login
 
     /**
      * Setzt die Id der zu verwendenden SQL Connection.
+     *
+     * @return void
      */
     public function setSqlDb($DB)
     {
@@ -110,6 +114,7 @@ class rex_login
      * Sessions auf der gleichen Domain unterschieden werden können.
      *
      * @param string $systemId
+     * @return void
      */
     public function setSystemId($systemId)
     {
@@ -120,6 +125,7 @@ class rex_login
      * Setzt das Session Timeout.
      *
      * @param int $sessionDuration
+     * @return void
      */
     public function setSessionDuration($sessionDuration)
     {
@@ -131,6 +137,7 @@ class rex_login
      *
      * @param string $login
      * @param string $password
+     * @return void
      */
     public function setLogin(#[\SensitiveParameter] $login, #[\SensitiveParameter] $password, $isPreHashed = false)
     {
@@ -140,6 +147,8 @@ class rex_login
 
     /**
      * Markiert die aktuelle Session als ausgeloggt.
+     *
+     * @return void
      */
     public function setLogout($logout)
     {
@@ -148,6 +157,8 @@ class rex_login
 
     /**
      * Prüft, ob die aktuelle Session ausgeloggt ist.
+     *
+     * @return bool
      */
     public function isLoggedOut()
     {
@@ -161,6 +172,7 @@ class rex_login
      * im Verlauf seines Aufenthaltes auf der Webseite zu verifizieren
      *
      * @param string $userQuery
+     * @return void
      */
     public function setUserQuery($userQuery)
     {
@@ -173,6 +185,7 @@ class rex_login
      * Dieser wird benutzt, um den User abzurufen, dessen Identität ein Admin einnehmen möchte.
      *
      * @param string $impersonateQuery
+     * @return void
      */
     public function setImpersonateQuery($impersonateQuery)
     {
@@ -186,6 +199,7 @@ class rex_login
      * Hier wird das eingegebene Password und der Login eingesetzt.
      *
      * @param string $loginQuery
+     * @return void
      */
     public function setLoginQuery($loginQuery)
     {
@@ -196,6 +210,7 @@ class rex_login
      * Setzt den Namen der Spalte, der die User-Id enthält.
      *
      * @param string $idColumn
+     * @return void
      */
     public function setIdColumn($idColumn)
     {
@@ -206,6 +221,7 @@ class rex_login
      * Sets the password column.
      *
      * @param string $passwordColumn
+     * @return void
      */
     public function setPasswordColumn($passwordColumn)
     {
@@ -216,6 +232,7 @@ class rex_login
      * Setzt einen Meldungstext.
      *
      * @param string $message
+     * @return void
      */
     protected function setMessage($message)
     {
@@ -360,6 +377,7 @@ class rex_login
 
     /**
      * @param int $id
+     * @return void
      */
     public function impersonate($id)
     {
@@ -384,6 +402,9 @@ class rex_login
         $this->setSessionVar(self::SESSION_IMPERSONATOR, $this->impersonator->getValue($this->idColumn));
     }
 
+    /**
+     * @return void
+     */
     public function depersonate()
     {
         if (!$this->impersonator) {
@@ -442,6 +463,7 @@ class rex_login
      *
      * @param string $varname
      * @param scalar|array $value
+     * @return void
      */
     public function setSessionVar($varname, $value)
     {
@@ -486,8 +508,10 @@ class rex_login
         return $default;
     }
 
-    /*
-     * refresh session on permission elevation for security reasons
+    /**
+     * refresh session on permission elevation for security reasons.
+     *
+     * @return void
      */
     protected static function regenerateSessionId()
     {
@@ -508,6 +532,8 @@ class rex_login
 
     /**
      * starts a http-session if not already started.
+     *
+     * @return void
      */
     public static function startSession()
     {
@@ -570,7 +596,7 @@ class rex_login
      *
      * @param string $sameSite
      */
-    private static function rewriteSessionCookie($sameSite)
+    private static function rewriteSessionCookie($sameSite): void
     {
         $cookiesHeaders = [];
 

--- a/redaxo/src/core/lib/login/perm.php
+++ b/redaxo/src/core/lib/login/perm.php
@@ -26,6 +26,7 @@ abstract class rex_perm
      * @param string $perm  Perm key
      * @param string $name  Perm name
      * @param string $group Perm group, possible values are rex_perm::GENERAL, rex_perm::OPTIONS and rex_perm::EXTRAS
+     * @return void
      */
     public static function register($perm, $name = null, $group = self::GENERAL)
     {

--- a/redaxo/src/core/lib/login/user.php
+++ b/redaxo/src/core/lib/login/user.php
@@ -240,6 +240,7 @@ class rex_user
      * Sets the role class.
      *
      * @param class-string<rex_user_role_interface> $class Class name
+     * @return void
      */
     public static function setRoleClass($class)
     {
@@ -250,6 +251,7 @@ class rex_user
      * Removes the instance of the given key.
      *
      * @param mixed $key Key
+     * @return void
      */
     public static function clearInstance($key)
     {

--- a/redaxo/src/core/tests/base/factory_trait_test.php
+++ b/redaxo/src/core/tests/base/factory_trait_test.php
@@ -64,7 +64,7 @@ class rex_alternative_test_factory extends rex_test_factory
  */
 class rex_factory_trait_test extends TestCase
 {
-    public function testFactoryCreation()
+    public function testFactoryCreation(): void
     {
         static::assertFalse(rex_test_factory::hasFactoryClass(), 'initially no factory class is set');
         static::assertEquals(rex_test_factory::class, rex_test_factory::getFactoryClass(), 'original factory class will be returned');

--- a/redaxo/src/core/tests/base/instance_list_pool_trait_test.php
+++ b/redaxo/src/core/tests/base/instance_list_pool_trait_test.php
@@ -26,14 +26,14 @@ class rex_test_instance_list_pool
  */
 class rex_instance_list_pool_trait_test extends TestCase
 {
-    public function testAddHasInstanceList()
+    public function testAddHasInstanceList(): void
     {
         static::assertFalse(rex_test_instance_list_pool::hasInstanceList(1), 'hasInstanceList returns false for non-existing instance');
         rex_test_instance_list_pool::addInstanceList(1, [2, 3]);
         static::assertTrue(rex_test_instance_list_pool::hasInstanceList(1), 'hasInstanceList returns true for added instance');
     }
 
-    public function testGetInstanceList()
+    public function testGetInstanceList(): void
     {
         static::assertSame([], rex_test_instance_list_pool::getInstanceList(2, rex_test_instance_list_pool::get(...)), 'getInstanceList returns empty array for non-existing key');
 
@@ -72,7 +72,7 @@ class rex_instance_list_pool_trait_test extends TestCase
     /**
      * @depends testGetInstanceList
      */
-    public function testClearInstanceList()
+    public function testClearInstanceList(): void
     {
         rex_test_instance_list_pool::clearInstanceList(2);
         static::assertFalse(rex_test_instance_list_pool::hasInstanceList(2), 'instance list is cleared after clearInstanceList()');
@@ -81,13 +81,13 @@ class rex_instance_list_pool_trait_test extends TestCase
     /**
      * @depends testClearInstanceList
      */
-    public function testClearInstanceListPool()
+    public function testClearInstanceListPool(): void
     {
         rex_test_instance_list_pool::clearInstanceListPool();
         static::assertFalse(rex_test_instance_list_pool::hasInstanceList(1), 'instance lists are cleared after clearInstanceListPool()');
     }
 
-    public function testGetInstanceListPoolKey()
+    public function testGetInstanceListPoolKey(): void
     {
         static::assertEquals('1', rex_test_instance_list_pool::getInstanceListPoolKey(1));
         static::assertEquals('2###test', rex_test_instance_list_pool::getInstanceListPoolKey([2, 'test']));

--- a/redaxo/src/core/tests/base/instance_pool_trait_test.php
+++ b/redaxo/src/core/tests/base/instance_pool_trait_test.php
@@ -27,7 +27,7 @@ final class rex_test_instance_pool_2 extends rex_test_instance_pool_base
  */
 class rex_instance_pool_trait_test extends TestCase
 {
-    public function testAddHasInstance()
+    public function testAddHasInstance(): void
     {
         static::assertFalse(rex_test_instance_pool_1::hasInstance(1), 'hasInstance returns false for non-existing instance');
         rex_test_instance_pool_1::addInstance(1, new rex_test_instance_pool_1());
@@ -35,7 +35,7 @@ class rex_instance_pool_trait_test extends TestCase
         static::assertFalse(rex_test_instance_pool_2::hasInstance(1), 'hasInstance uses LSB, instance is only added for subclass 1');
     }
 
-    public function testGetInstance()
+    public function testGetInstance(): void
     {
         static::assertNull(rex_test_instance_pool_1::getInstance(2), 'getInstance returns null for non-existing key');
         $instance1 = new rex_test_instance_pool_1();
@@ -65,7 +65,7 @@ class rex_instance_pool_trait_test extends TestCase
     /**
      * @depends testGetInstance
      */
-    public function testClearInstance()
+    public function testClearInstance(): void
     {
         rex_test_instance_pool_1::clearInstance(2);
         static::assertFalse(rex_test_instance_pool_1::hasInstance(2), 'instance is cleared after clearInstance()');
@@ -75,7 +75,7 @@ class rex_instance_pool_trait_test extends TestCase
     /**
      * @depends testClearInstance
      */
-    public function testClearInstancePool()
+    public function testClearInstancePool(): void
     {
         rex_test_instance_pool_2::clearInstancePool();
         static::assertFalse(rex_test_instance_pool_2::hasInstance(2), 'instances are cleared after clearInstancePool()');
@@ -84,7 +84,7 @@ class rex_instance_pool_trait_test extends TestCase
         static::assertFalse(rex_test_instance_pool_1::hasInstance(1), 'baseClass::clearInstancePool clears all instances');
     }
 
-    public function testGetInstancePoolKey()
+    public function testGetInstancePoolKey(): void
     {
         static::assertEquals('1', rex_test_instance_pool_1::getInstancePoolKey(1));
         static::assertEquals('2###test', rex_test_instance_pool_1::getInstancePoolKey([2, 'test']));

--- a/redaxo/src/core/tests/base/singleton_trait_test.php
+++ b/redaxo/src/core/tests/base/singleton_trait_test.php
@@ -12,14 +12,14 @@ class rex_test_singleton
  */
 class rex_singleton_trait_test extends TestCase
 {
-    public function testGetInstance()
+    public function testGetInstance(): void
     {
         static::assertInstanceOf(rex_test_singleton::class, rex_test_singleton::getInstance(), 'instance of the correct class is returned');
         static::assertEquals(rex_test_singleton::class, get_class(rex_test_singleton::getInstance()), 'excact class is returned');
         static::assertTrue(rex_test_singleton::getInstance() === rex_test_singleton::getInstance(), 'the very same instance is returned on every invocation');
     }
 
-    public function testClone()
+    public function testClone(): void
     {
         $this->expectException(BadMethodCallException::class);
 

--- a/redaxo/src/core/tests/clang/clang_test.php
+++ b/redaxo/src/core/tests/clang/clang_test.php
@@ -27,7 +27,7 @@ class rex_clang_test extends TestCase
         static::assertIsBool(rex_clang::getCurrent()->isOnline());
     }
 
-    public function testHasValue()
+    public function testHasValue(): void
     {
         $clang = $this->createClangWithoutConstructor();
 
@@ -41,7 +41,7 @@ class rex_clang_test extends TestCase
         static::assertFalse($clang->hasValue('clang_bar'));
     }
 
-    public function testGetValue()
+    public function testGetValue(): void
     {
         static::assertIsInt(rex_clang::getCurrent()->getValue('id'));
 

--- a/redaxo/src/core/tests/config_test.php
+++ b/redaxo/src/core/tests/config_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_config_test extends TestCase
 {
-    public function testNonExistentConfig()
+    public function testNonExistentConfig(): void
     {
         static::assertFalse(rex_config::has('test-ns'), 'has() returns false for non-existing namespace');
         static::assertFalse(rex_config::has('test-ns', 'mykey'), 'has() returns false for non-existing key');
@@ -17,7 +17,7 @@ class rex_config_test extends TestCase
         static::assertEquals('defaultReturn', rex_config::get('test-ns', 'mykey', 'defaultReturn'), 'get returns the given default');
     }
 
-    public function testSetGetRemoveConfig()
+    public function testSetGetRemoveConfig(): void
     {
         static::assertFalse(rex_config::remove('test-ns', 'mykey1'), 'remove() returns false, when deleting an non-existing key');
         static::assertFalse(rex_config::set('test-ns', 'mykey1', 'myvalA'), 'set() returns false, when config not yet exists');
@@ -47,7 +47,7 @@ class rex_config_test extends TestCase
         static::assertNull(rex_config::get('test-ns', 'mykey1'), 'get() returns null, when getting a removed key');
     }
 
-    public function testRemoveNamespace()
+    public function testRemoveNamespace(): void
     {
         rex_config::set('test-ns', 'mykey1', 'myvalA');
         rex_config::set('test-ns', 'mykey2', 'myvalB');
@@ -62,7 +62,7 @@ class rex_config_test extends TestCase
         static::assertNull(rex_config::get('test-ns', 'mykey2'), 'removeNamespace() all keys2');
     }
 
-    public function testSaveAfterSetAndRemove()
+    public function testSaveAfterSetAndRemove(): void
     {
         rex_config::save();
 

--- a/redaxo/src/core/tests/console/command_test.php
+++ b/redaxo/src/core/tests/console/command_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_console_command_test extends TestCase
 {
-    public function testDecodeMessage()
+    public function testDecodeMessage(): void
     {
         $method = new ReflectionMethod(rex_console_command::class, 'decodeMessage');
 
@@ -16,7 +16,7 @@ class rex_console_command_test extends TestCase
         static::assertSame("\"Foo\"\nbar\nbaz\nabc\ndef", $method->invoke($command, "&quot;Foo&quot;<br><b>bar</b><br />\nbaz<br/>\rabc<br>\r\ndef"));
     }
 
-    public function testDecodeMessageSingleQuotes()
+    public function testDecodeMessageSingleQuotes(): void
     {
         $method = new ReflectionMethod(rex_console_command::class, 'decodeMessage');
 

--- a/redaxo/src/core/tests/console/config/get_test.php
+++ b/redaxo/src/core/tests/console/config/get_test.php
@@ -11,7 +11,7 @@ class rex_command_config_get_test extends TestCase
     /**
      * @dataProvider dataKeyFound
      */
-    public function testKeyFound($expectedValue, $key)
+    public function testKeyFound($expectedValue, $key): void
     {
         $commandTester = new CommandTester(new rex_command_config_get());
         $commandTester->execute([
@@ -21,7 +21,8 @@ class rex_command_config_get_test extends TestCase
         static::assertEquals(0, $commandTester->getStatusCode());
     }
 
-    public function dataKeyFound()
+    /** @return list<array{string, string}> */
+    public function dataKeyFound(): array
     {
         return [
             ["false\n", 'setup'],
@@ -29,7 +30,7 @@ class rex_command_config_get_test extends TestCase
         ];
     }
 
-    public function testKeyNotFound()
+    public function testKeyNotFound(): void
     {
         $commandTester = new CommandTester(new rex_command_config_get());
         $commandTester->execute([
@@ -38,7 +39,7 @@ class rex_command_config_get_test extends TestCase
         static::assertEquals(1, $commandTester->getStatusCode());
     }
 
-    public function testPackageKeyFound()
+    public function testPackageKeyFound(): void
     {
         $commandTester = new CommandTester(new rex_command_config_get());
         $commandTester->execute([

--- a/redaxo/src/core/tests/console/config/set_test.php
+++ b/redaxo/src/core/tests/console/config/set_test.php
@@ -25,7 +25,7 @@ class rex_command_config_set_test extends TestCase
     /**
      * @dataProvider dataSetBoolean
      */
-    public function testSetBoolean($expectedValue, $value)
+    public function testSetBoolean($expectedValue, $value): void
     {
         $commandTester = new CommandTester(new rex_command_config_set());
         $commandTester->execute([
@@ -40,7 +40,8 @@ class rex_command_config_set_test extends TestCase
         static::assertEquals(0, $commandTester->getStatusCode());
     }
 
-    public function dataSetBoolean()
+    /** @return list<array{bool, string}> */
+    public function dataSetBoolean(): array
     {
         return [
             [true, '1'],

--- a/redaxo/src/core/tests/context_test.php
+++ b/redaxo/src/core/tests/context_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_context_test extends TestCase
 {
-    public function testGetUrl()
+    public function testGetUrl(): void
     {
         $globalParams = ['int' => '25', 'str' => '<a b$c&?>'];
         $context = new rex_context($globalParams);
@@ -19,7 +19,7 @@ class rex_context_test extends TestCase
         static::assertEquals('index.php?int=25&amp;str=%3Ca+b%24c%26%3F%3E&amp;myarr[a]=xyz&amp;myarr[b]=123', $context->getUrl(['myarr' => ['a' => 'xyz', 'b' => 123]]), 'assoc arrays are handled');
     }
 
-    public function testGetHiddenInputFields()
+    public function testGetHiddenInputFields(): void
     {
         $globalParams = ['int' => '25', 'str' => '<a b$c&?>'];
         $context = new rex_context($globalParams);
@@ -61,7 +61,7 @@ class rex_context_test extends TestCase
         );
     }
 
-    public function testFromGet()
+    public function testFromGet(): void
     {
         $key = 'context_test_get';
         $_GET[$key] = 1;
@@ -71,7 +71,7 @@ class rex_context_test extends TestCase
         static::assertEquals($_GET[$key], $context->getParam($key));
     }
 
-    public function testFromPost()
+    public function testFromPost(): void
     {
         $key = 'context_test_post';
         $_POST[$key] = 'foo';
@@ -81,7 +81,7 @@ class rex_context_test extends TestCase
         static::assertEquals($_POST[$key], $context->getParam($key));
     }
 
-    public function testRestore()
+    public function testRestore(): void
     {
         $keyGet = 'context_test_restore_1';
         $keyPost = 'context_test_restore_2';

--- a/redaxo/src/core/tests/extension_test.php
+++ b/redaxo/src/core/tests/extension_test.php
@@ -17,7 +17,7 @@ class rex_extension_test extends TestCase
         parent::tearDown();
     }
 
-    public function testIsRegistered()
+    public function testIsRegistered(): void
     {
         $EP = 'TEST_IS_REGISTERED';
 
@@ -29,7 +29,7 @@ class rex_extension_test extends TestCase
         static::assertTrue(rex_extension::isRegistered($EP), 'isRegistered() returns true for registered extension points');
     }
 
-    public function testRegisterPoint()
+    public function testRegisterPoint(): void
     {
         $EP = 'TEST_EP';
 
@@ -52,7 +52,7 @@ class rex_extension_test extends TestCase
         static::assertEquals('test test2 test3', $result, 'registerPoint() returns the returned value of last extension');
     }
 
-    public function testRegisterPointReadOnly()
+    public function testRegisterPointReadOnly(): void
     {
         $EP = 'TEST_EP_READ_ONLY';
 
@@ -71,7 +71,7 @@ class rex_extension_test extends TestCase
         static::assertEquals($subject, $subjectActual, 'read-only extention points don\'t change subject param');
     }
 
-    public function testRegisterPointWithParams()
+    public function testRegisterPointWithParams(): void
     {
         $EP = 'TEST_EP_WITH_PARAMS';
 
@@ -86,7 +86,7 @@ class rex_extension_test extends TestCase
         static::assertEquals($myparam, $myparamActual, 'additional params will be available in extentions');
     }
 
-    public function testRegister()
+    public function testRegister(): void
     {
         $EP = 'TEST_EP_LEVELS';
 
@@ -109,7 +109,7 @@ class rex_extension_test extends TestCase
         static::assertEquals($expected, $actual);
     }
 
-    public function testRegisterMultiple()
+    public function testRegisterMultiple(): void
     {
         $EP1 = 'TEST_EP_MULTIPLE_1';
         $EP2 = 'TEST_EP_MULTIPLE_2';

--- a/redaxo/src/core/tests/login/backend_login_test.php
+++ b/redaxo/src/core/tests/login/backend_login_test.php
@@ -30,14 +30,14 @@ class rex_backend_login_test extends TestCase
         $deleteuser->setQuery('DELETE FROM ' . rex::getTablePrefix() . "user WHERE login = '". self::LOGIN ."' LIMIT 1");
     }
 
-    public function testSuccessfullLogin()
+    public function testSuccessfullLogin(): void
     {
         $login = new rex_backend_login();
         $login->setLogin(self::LOGIN, self::PASSWORD, false);
         static::assertTrue($login->checkLogin());
     }
 
-    public function testFailedLogin()
+    public function testFailedLogin(): void
     {
         $login = new rex_backend_login();
         $login->setLogin(self::LOGIN, 'somethingwhichisnotcorrect', false);
@@ -47,7 +47,7 @@ class rex_backend_login_test extends TestCase
     /**
      * Test if a login is allowed after one failure before.
      */
-    public function testSuccessfullReLogin()
+    public function testSuccessfullReLogin(): void
     {
         $login = new rex_backend_login();
 
@@ -61,7 +61,7 @@ class rex_backend_login_test extends TestCase
     /**
      * After LOGIN_TRIES requests, the account should be not accessible for RELOGIN_DELAY seconds.
      */
-    public function testSuccessfullReLoginAfterLoginTriesSeconds()
+    public function testSuccessfullReLoginAfterLoginTriesSeconds(): void
     {
         $login = new rex_backend_login();
         $tries = $login->getLoginPolicy()->getMaxTriesUntilDelay();
@@ -89,7 +89,7 @@ class rex_backend_login_test extends TestCase
         static::assertTrue($login->checkLogin(), 'after waiting the account should be unlocked');
     }
 
-    public function testLogout()
+    public function testLogout(): void
     {
         $login = new rex_backend_login();
         $login->setLogin(self::LOGIN, self::PASSWORD, false);

--- a/redaxo/src/core/tests/login/password_policy_test.php
+++ b/redaxo/src/core/tests/login/password_policy_test.php
@@ -10,7 +10,7 @@ class rex_password_policy_test extends TestCase
     /**
      * @dataProvider provideCheck
      */
-    public function testCheck(array $options, $expected, $password)
+    public function testCheck(array $options, $expected, $password): void
     {
         $policy = new rex_password_policy($options);
 
@@ -23,7 +23,8 @@ class rex_password_policy_test extends TestCase
         }
     }
 
-    public function provideCheck()
+    /** @return iterable<int, array{array<string, array{min?: int, max?: int}>, bool, string}> */
+    public function provideCheck(): iterable
     {
         yield [[], true, 'foo'];
 

--- a/redaxo/src/core/tests/packages/package_test.php
+++ b/redaxo/src/core/tests/packages/package_test.php
@@ -10,7 +10,7 @@ class rex_package_test extends TestCase
     /**
      * @dataProvider dataSplitId
      */
-    public function testSplitId(array $expected, string $packageId)
+    public function testSplitId(array $expected, string $packageId): void
     {
         static::assertSame($expected, rex_package::splitId($packageId));
     }

--- a/redaxo/src/core/tests/path_test.php
+++ b/redaxo/src/core/tests/path_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_path_test extends TestCase
 {
-    public function testAbsoluteConversion()
+    public function testAbsoluteConversion(): void
     {
         $path = rex_path::absolute('c:/abc/../def/./xy');
         static::assertEquals($this->path('c:/def/xy'), $path, 'resolves .. and .');
@@ -19,12 +19,13 @@ class rex_path_test extends TestCase
     /**
      * @dataProvider dataRelative
      */
-    public function testRelative($expected, $path, $basePath = null)
+    public function testRelative($expected, $path, $basePath = null): void
     {
         static::assertSame($this->path($expected), rex_path::relative($path, $basePath));
     }
 
-    public function dataRelative()
+    /** @return list<array{0: string, 1: string, 2?: string}> */
+    public function dataRelative(): array
     {
         return [
             ['redaxo/src/core/boot.php', rex_path::core('boot.php')],
@@ -38,7 +39,7 @@ class rex_path_test extends TestCase
         ];
     }
 
-    public function testBasename()
+    public function testBasename(): void
     {
         static::assertSame('config.yml', rex_path::basename('../redaxo/data/core/config.yml'));
 
@@ -57,7 +58,7 @@ class rex_path_test extends TestCase
         static::assertNull(rex_path::findBinaryPath('noone-knows'));
     }
 
-    private function path($path)
+    private function path($path): string
     {
         return str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path);
     }

--- a/redaxo/src/core/tests/rex_test.php
+++ b/redaxo/src/core/tests/rex_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_rex_test extends TestCase
 {
-    public function testRexConfig()
+    public function testRexConfig(): void
     {
         $key = 'aTestKey:'. __METHOD__;
         // initial test on empty config
@@ -32,7 +32,7 @@ class rex_rex_test extends TestCase
         static::assertEquals(rex::getConfig($key, 'defVal'), 'defVal', 'getting non existing key returns a given default');
     }
 
-    public function testRexProperty()
+    public function testRexProperty(): void
     {
         $key = 'aTestKey:'. __METHOD__;
         // initial test on empty config
@@ -57,19 +57,19 @@ class rex_rex_test extends TestCase
         static::assertEquals(rex::getProperty($key, 'defVal'), 'defVal', 'getting non existing key returns a given default');
     }
 
-    public function testIsSetup()
+    public function testIsSetup(): void
     {
         static::assertFalse(rex::isSetup(), 'test run not within the setup');
         // TODO find more appropriate tests
     }
 
-    public function testIsBackend()
+    public function testIsBackend(): void
     {
         static::assertTrue(rex::isBackend(), 'test run in the backend');
         // TODO find more appropriate tests
     }
 
-    public function testDebugFlags()
+    public function testDebugFlags(): void
     {
         $orgDebug = rex::getProperty('debug');
         try {
@@ -118,22 +118,22 @@ class rex_rex_test extends TestCase
         }
     }
 
-    public function testGetTablePrefix()
+    public function testGetTablePrefix(): void
     {
         static::assertEquals(rex::getTablePrefix(), 'rex_', 'table prefix defauts to rex_');
     }
 
-    public function testGetTable()
+    public function testGetTable(): void
     {
         static::assertEquals(rex::getTable('mytable'), 'rex_mytable', 'tablename gets properly prefixed');
     }
 
-    public function testGetTempPrefix()
+    public function testGetTempPrefix(): void
     {
         static::assertEquals(rex::getTempPrefix(), 'tmp_', 'temp prefix defaults to tmp_');
     }
 
-    public function testGetServer()
+    public function testGetServer(): void
     {
         $origServer = rex::getProperty('server');
 
@@ -147,7 +147,7 @@ class rex_rex_test extends TestCase
         }
     }
 
-    public function testGetVersion()
+    public function testGetVersion(): void
     {
         static::assertTrue('' != rex::getVersion(), 'a version string is returned');
         $vers = rex::getVersion();

--- a/redaxo/src/core/tests/sql/sql_select_test.php
+++ b/redaxo/src/core/tests/sql/sql_select_test.php
@@ -39,7 +39,7 @@ class rex_sql_select_test extends TestCase
         $sql->setQuery('DROP TABLE `' . self::TABLE . '`');
     }
 
-    public function testGetRow()
+    public function testGetRow(): void
     {
         // we need some rows for this test
         $this->insertRow();
@@ -63,7 +63,7 @@ class rex_sql_select_test extends TestCase
         }
     }
 
-    public function testGetRowAsObject()
+    public function testGetRowAsObject(): void
     {
         $this->insertRow();
         $this->insertRow();
@@ -83,7 +83,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals(2, $row->{self::TABLE.'.id'});
     }
 
-    public function testGetVariations()
+    public function testGetVariations(): void
     {
         $sql = rex_sql::factory();
         $sql->setQuery('SELECT * FROM ' . self::TABLE . ' WHERE col_int = 5');
@@ -97,7 +97,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals('abc', $sql->getValue(self::TABLE . '.col_str'), 'getValue() retrievs field by table.fieldname');
     }
 
-    public function testGetArray()
+    public function testGetArray(): void
     {
         $sql = rex_sql::factory();
         $array = $sql->getArray('SELECT * FROM ' . self::TABLE . ' WHERE col_int = 5');
@@ -111,7 +111,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals('5', $row1['col_int']);
     }
 
-    public function testGetDbArray()
+    public function testGetDbArray(): void
     {
         $sql = rex_sql::factory();
         $array = $sql->getDBArray('(DB1) SELECT * FROM ' . self::TABLE . ' WHERE col_int = 5');
@@ -125,7 +125,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals('5', $row1['col_int']);
     }
 
-    public function testPreparedSetQuery()
+    public function testPreparedSetQuery(): void
     {
         $this->insertRow();
 
@@ -135,7 +135,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals(1, $sql->getRows());
     }
 
-    public function testPreparedNamedSetQuery()
+    public function testPreparedNamedSetQuery(): void
     {
         $this->insertRow();
 
@@ -145,7 +145,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals(1, $sql->getRows());
     }
 
-    public function testPreparedSetQueryWithReset()
+    public function testPreparedSetQueryWithReset(): void
     {
         $sql = rex_sql::factory();
         $sql->setQuery('SELECT * FROM ' . self::TABLE . ' WHERE col_str = ? and col_int = ?', ['abc', 5]);
@@ -155,7 +155,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals(1, $sql->getRows());
     }
 
-    public function testGetArrayAfterPreparedSetQuery()
+    public function testGetArrayAfterPreparedSetQuery(): void
     {
         $sql = rex_sql::factory();
         $sql->setQuery('SELECT * FROM ' . self::TABLE . ' WHERE col_int = ?', [5]);
@@ -169,7 +169,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals('5', $row1['col_int']);
     }
 
-    public function testGetArrayAfterSetQuery()
+    public function testGetArrayAfterSetQuery(): void
     {
         $sql = rex_sql::factory();
         $sql->setQuery('SELECT * FROM ' . self::TABLE . ' WHERE col_int = 5');
@@ -183,7 +183,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals('5', $row1['col_int']);
     }
 
-    public function testArrayFetchTypeNum()
+    public function testArrayFetchTypeNum(): void
     {
         $sql = rex_sql::factory();
         $array = $sql->getArray('SELECT * FROM ' . self::TABLE . ' WHERE col_int = 5', [], PDO::FETCH_NUM);
@@ -195,7 +195,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals('mytext', $row1[5]);
     }
 
-    public function testDBArrayFetchTypeNum()
+    public function testDBArrayFetchTypeNum(): void
     {
         $sql = rex_sql::factory();
         $array = $sql->getDBArray('SELECT * FROM ' . self::TABLE . ' WHERE col_int = 5', [], PDO::FETCH_NUM);
@@ -207,7 +207,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals('mytext', $row1[5]);
     }
 
-    public function testHasNext()
+    public function testHasNext(): void
     {
         $sql = rex_sql::factory();
         $sql->setQuery('SELECT * FROM ' . self::TABLE);
@@ -221,7 +221,7 @@ class rex_sql_select_test extends TestCase
         static::assertFalse($sql->hasNext());
     }
 
-    public function testError()
+    public function testError(): void
     {
         $sql = rex_sql::factory();
 
@@ -268,7 +268,7 @@ class rex_sql_select_test extends TestCase
         static::assertSame(rex_sql::ERRNO_TABLE_OR_VIEW_DOESNT_EXIST, $sql->getErrno());
     }
 
-    public function testUnbufferedQuery()
+    public function testUnbufferedQuery(): void
     {
         $sql = rex_sql::factory();
 
@@ -295,7 +295,7 @@ class rex_sql_select_test extends TestCase
         static::assertEquals(1, $pdo->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY));
     }
 
-    private function insertRow()
+    private function insertRow(): void
     {
         $sql = rex_sql::factory();
         $sql->setTable(self::TABLE);

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -47,7 +47,7 @@ class rex_sql_table_test extends TestCase
         return $table;
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         static::assertFalse(rex_sql_table::get(self::TABLE)->exists());
 
@@ -110,7 +110,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame(['test1_id' => 'id'], $fk->getColumns());
     }
 
-    public function testDrop()
+    public function testDrop(): void
     {
         $table = $this->createTable();
 
@@ -126,7 +126,7 @@ class rex_sql_table_test extends TestCase
         $table->drop();
     }
 
-    public function testSetName()
+    public function testSetName(): void
     {
         $table = $this->createTable();
 
@@ -142,7 +142,7 @@ class rex_sql_table_test extends TestCase
         static::assertTrue($table->exists());
     }
 
-    public function testAddColumn()
+    public function testAddColumn(): void
     {
         $table = $this->createTable();
 
@@ -163,7 +163,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame(['pid', 'id', 'name', 'title', 'description'], array_keys($table->getColumns()));
     }
 
-    public function testAddColumnComment()
+    public function testAddColumnComment(): void
     {
         $table = $this->createTable();
 
@@ -181,7 +181,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame('new title comment', $table->getColumn('title')->getComment());
     }
 
-    public function testChangeColumnComment()
+    public function testChangeColumnComment(): void
     {
         $table = $this->createTable();
 
@@ -199,7 +199,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame('changed id comment', $table->getColumn('id')->getComment());
     }
 
-    public function testRemoveColumnComment()
+    public function testRemoveColumnComment(): void
     {
         $table = $this->createTable();
 
@@ -217,7 +217,7 @@ class rex_sql_table_test extends TestCase
         static::assertNull($table->getColumn('id')->getComment());
     }
 
-    public function testEnsureColumn()
+    public function testEnsureColumn(): void
     {
         $table = $this->createTable();
 
@@ -270,7 +270,7 @@ class rex_sql_table_test extends TestCase
         }
     }
 
-    public function testEnsurePrimaryIdColumn()
+    public function testEnsurePrimaryIdColumn(): void
     {
         $table = rex_sql_table::get(self::TABLE);
         $table
@@ -285,7 +285,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame(['id'], $table->getPrimaryKey());
     }
 
-    public function testEnsureGlobalColumns()
+    public function testEnsureGlobalColumns(): void
     {
         $table = $this->createTable();
         $table
@@ -302,7 +302,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame('varchar(255)', $table->getColumn('updateuser')->getType());
     }
 
-    public function testRenameColumn()
+    public function testRenameColumn(): void
     {
         $table = $this->createTable();
 
@@ -334,7 +334,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame(['pid'], $table->getPrimaryKey());
     }
 
-    public function testRenameColumnNonExisting()
+    public function testRenameColumnNonExisting(): void
     {
         $this->expectException(rex_exception::class);
 
@@ -342,7 +342,7 @@ class rex_sql_table_test extends TestCase
         $table->renameColumn('foo', 'bar');
     }
 
-    public function testRenameColumnToAlreadyExisting()
+    public function testRenameColumnToAlreadyExisting(): void
     {
         $this->expectException(rex_exception::class);
 
@@ -350,7 +350,7 @@ class rex_sql_table_test extends TestCase
         $table->renameColumn('id', 'title');
     }
 
-    public function testRemoveColumn()
+    public function testRemoveColumn(): void
     {
         $table = $this->createTable();
 
@@ -366,7 +366,7 @@ class rex_sql_table_test extends TestCase
         static::assertFalse($table->hasColumn('title'));
     }
 
-    public function testSetPrimaryKey()
+    public function testSetPrimaryKey(): void
     {
         $table = $this->createTable();
 
@@ -402,7 +402,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame(['id'], $table->getPrimaryKey());
     }
 
-    public function testAddIndex()
+    public function testAddIndex(): void
     {
         $table = $this->createTable();
 
@@ -430,7 +430,7 @@ class rex_sql_table_test extends TestCase
         static::assertEquals($search, $table->getIndex('i_search'));
     }
 
-    public function testEnsureIndex()
+    public function testEnsureIndex(): void
     {
         $table = $this->createTable();
 
@@ -452,7 +452,7 @@ class rex_sql_table_test extends TestCase
         static::assertEquals($title2, $table->getIndex('i_title2'));
     }
 
-    public function testRenameIndex()
+    public function testRenameIndex(): void
     {
         $table = $this->createTable();
 
@@ -473,7 +473,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame(['title'], $table->getIndex('index_title')->getColumns());
     }
 
-    public function testRemoveIndex()
+    public function testRemoveIndex(): void
     {
         $table = $this->createTable();
 
@@ -489,7 +489,7 @@ class rex_sql_table_test extends TestCase
         static::assertFalse($table->hasColumn('i_title'));
     }
 
-    public function testAddForeignKey()
+    public function testAddForeignKey(): void
     {
         $table = $this->createTable();
 
@@ -512,7 +512,7 @@ class rex_sql_table_test extends TestCase
         static::assertEquals($fk, $table->getForeignKey('test1_fk_config'));
     }
 
-    public function testEnsureForeignKey()
+    public function testEnsureForeignKey(): void
     {
         $this->createTable();
         $table2 = $this->createTable2();
@@ -543,7 +543,7 @@ class rex_sql_table_test extends TestCase
         static::assertEquals($fk2, $table2->getForeignKey('test2_fk_config'));
     }
 
-    public function testRenameForeignKey()
+    public function testRenameForeignKey(): void
     {
         $this->createTable();
         $table2 = $this->createTable2();
@@ -565,7 +565,7 @@ class rex_sql_table_test extends TestCase
         static::assertSame(['test1_id' => 'id'], $table2->getForeignKey('fk_test2_test1')->getColumns());
     }
 
-    public function testRemoveForeignKey()
+    public function testRemoveForeignKey(): void
     {
         $this->createTable();
         $table2 = $this->createTable2();
@@ -582,7 +582,7 @@ class rex_sql_table_test extends TestCase
         static::assertFalse($table2->hasForeignKey('test2_fk_test1'));
     }
 
-    public function testAlter()
+    public function testAlter(): void
     {
         $table = $this->createTable();
 
@@ -607,7 +607,7 @@ class rex_sql_table_test extends TestCase
         static::assertEquals(['name'], $table->getIndex('i_name')->getColumns());
     }
 
-    public function testEnsure()
+    public function testEnsure(): void
     {
         $table = rex_sql_table::get(self::TABLE);
         $table
@@ -692,7 +692,7 @@ class rex_sql_table_test extends TestCase
         }
     }
 
-    public function testRenameNonExistingTable()
+    public function testRenameNonExistingTable(): void
     {
         $this->expectException(rex_exception::class);
         $this->expectExceptionMessage('Table "rex_non_existing" does not exist.');
@@ -702,7 +702,7 @@ class rex_sql_table_test extends TestCase
             ->alter();
     }
 
-    public function testClearInstance()
+    public function testClearInstance(): void
     {
         $table = rex_sql_table::get(self::TABLE);
 

--- a/redaxo/src/core/tests/sql/sql_test.php
+++ b/redaxo/src/core/tests/sql/sql_test.php
@@ -40,37 +40,37 @@ class rex_sql_test extends TestCase
         $sql->setQuery('DROP VIEW `' . self::VIEW . '`');
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $sql = rex_sql::factory();
         static::assertNotNull($sql);
     }
 
-    public function testCheckConnection()
+    public function testCheckConnection(): void
     {
         $dbConfig = rex::getDbConfig();
         static::assertTrue(rex_sql::checkDbConnection($dbConfig->host, $dbConfig->login, $dbConfig->password, $dbConfig->name));
     }
 
-    public function testCheckConnectionInvalidPassword()
+    public function testCheckConnectionInvalidPassword(): void
     {
         $dbConfig = rex::getDbConfig();
         static::assertTrue(true !== rex_sql::checkDbConnection($dbConfig->host, $dbConfig->login, 'fu-password', $dbConfig->name));
     }
 
-    public function testCheckConnectionInvalidHost()
+    public function testCheckConnectionInvalidHost(): void
     {
         $dbConfig = rex::getDbConfig();
         static::assertTrue(true !== rex_sql::checkDbConnection('fu-host', $dbConfig->login, $dbConfig->password, $dbConfig->name));
     }
 
-    public function testCheckConnectionInvalidLogin()
+    public function testCheckConnectionInvalidLogin(): void
     {
         $dbConfig = rex::getDbConfig();
         static::assertTrue(true !== rex_sql::checkDbConnection($dbConfig->host, 'fu-login', $dbConfig->password, $dbConfig->name));
     }
 
-    public function testCheckConnectionInvalidDatabase()
+    public function testCheckConnectionInvalidDatabase(): void
     {
         $dbConfig = rex::getDbConfig();
         static::assertTrue(true !== rex_sql::checkDbConnection($dbConfig->host, $dbConfig->login, $dbConfig->password, 'fu-database'));
@@ -176,7 +176,7 @@ class rex_sql_test extends TestCase
         ];
     }
 
-    public function testSetGetValue()
+    public function testSetGetValue(): void
     {
         $sql = rex_sql::factory();
         $sql->setTable(self::TABLE);
@@ -190,7 +190,7 @@ class rex_sql_test extends TestCase
         static::assertEquals(5, $sql->getValue('col_int'), 'get a previous set int ');
     }
 
-    public function testSetGetArrayValue()
+    public function testSetGetArrayValue(): void
     {
         $sql = rex_sql::factory();
         $sql->setArrayValue('col_empty_array', []);
@@ -203,7 +203,7 @@ class rex_sql_test extends TestCase
         static::assertEquals([1, 2, 3], $sql->getArrayValue('col_array'), 'get a previous set array');
     }
 
-    public function testInsertRow()
+    public function testInsertRow(): void
     {
         $sql = rex_sql::factory();
         $sql->setTable(self::TABLE);
@@ -218,7 +218,7 @@ class rex_sql_test extends TestCase
         // $this->assertEquals(5, $sql->getValue('col_int'));
     }
 
-    public function testInsertRawValue()
+    public function testInsertRawValue(): void
     {
         $sql = rex_sql::factory();
         $sql->setTable(self::TABLE);
@@ -228,7 +228,7 @@ class rex_sql_test extends TestCase
         static::assertEquals(1, $sql->getRows());
     }
 
-    public function testInsertWithoutValues()
+    public function testInsertWithoutValues(): void
     {
         $sql = rex_sql::factory();
         $sql->setTable(self::TABLE);
@@ -237,7 +237,7 @@ class rex_sql_test extends TestCase
         static::assertEquals(1, $sql->getRows());
     }
 
-    public function testInsertRecords()
+    public function testInsertRecords(): void
     {
         $sql = rex_sql::factory();
         $sql->setTable(self::TABLE);
@@ -272,7 +272,7 @@ class rex_sql_test extends TestCase
         static::assertSame('lorem ipsum', $sql->getValue('col_text'));
     }
 
-    public function testInsertOrUpdate()
+    public function testInsertOrUpdate(): void
     {
         $sql = rex_sql::factory();
         $sql->setTable(self::TABLE);
@@ -300,7 +300,7 @@ class rex_sql_test extends TestCase
         static::assertEquals('foo', $sql->getValue('col_str'));
     }
 
-    public function testInsertOrUpdateRecords()
+    public function testInsertOrUpdateRecords(): void
     {
         $sql = rex_sql::factory();
         $sql->setTable(self::TABLE);
@@ -357,7 +357,7 @@ class rex_sql_test extends TestCase
         static::assertSame('baz', $sql->getValue('col_str'));
     }
 
-    public function testReplaceRecords()
+    public function testReplaceRecords(): void
     {
         $sql = rex_sql::factory();
         $sql->setTable(self::TABLE);
@@ -414,7 +414,7 @@ class rex_sql_test extends TestCase
         static::assertSame('baz', $sql->getValue('col_str'));
     }
 
-    public function testUpdateRowByWhereArray()
+    public function testUpdateRowByWhereArray(): void
     {
         // create a row we later update
         $this->testInsertRow();
@@ -433,7 +433,7 @@ class rex_sql_test extends TestCase
         static::assertEquals(6, $sql->getValue('col_int'));
     }
 
-    public function testUpdateRowByNamedWhere()
+    public function testUpdateRowByNamedWhere(): void
     {
         // create a row we later update
         $this->testInsertRow();
@@ -447,7 +447,7 @@ class rex_sql_test extends TestCase
         static::assertEquals(1, $sql->getRows());
     }
 
-    public function testUpdateRowByStringWhere()
+    public function testUpdateRowByStringWhere(): void
     {
         // create a row we later update
         $this->testInsertRow();
@@ -461,7 +461,7 @@ class rex_sql_test extends TestCase
         static::assertEquals(1, $sql->getRows());
     }
 
-    public function testDeleteRow()
+    public function testDeleteRow(): void
     {
         // create a row we later delete
         $this->testInsertRow();
@@ -521,7 +521,7 @@ class rex_sql_test extends TestCase
         static::assertSame('2', $sql->getLastId(), 'LastId still the same in other sql object');
     }
 
-    public function testGetTables()
+    public function testGetTables(): void
     {
         $tables = rex_sql::factory()->getTables();
 
@@ -529,7 +529,7 @@ class rex_sql_test extends TestCase
         static::assertNotContains(self::VIEW, $tables);
     }
 
-    public function testShowViews()
+    public function testShowViews(): void
     {
         $views = rex_sql::factory()->getViews();
 
@@ -537,7 +537,7 @@ class rex_sql_test extends TestCase
         static::assertContains(self::VIEW, $views);
     }
 
-    public function testShowTablesAndViews()
+    public function testShowTablesAndViews(): void
     {
         $tables = rex_sql::factory()->getTablesAndViews();
 
@@ -548,7 +548,7 @@ class rex_sql_test extends TestCase
     /**
      * @dataProvider provideGetQueryTypes
      */
-    public function testGetQueryType(string $query, $expectedQueryType)
+    public function testGetQueryType(string $query, $expectedQueryType): void
     {
         $actualQueryType = rex_sql::getQueryType($query);
         static::assertSame($expectedQueryType, $actualQueryType);

--- a/redaxo/src/core/tests/util/dir_test.php
+++ b/redaxo/src/core/tests/util/dir_test.php
@@ -26,7 +26,7 @@ class rex_dir_test extends TestCase
         return rex_path::addonData('tests', 'rex_dir_test/' . $file);
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $path = $this->getPath('create');
         static::assertTrue(rex_dir::create($path), 'create() returns true on success');
@@ -34,14 +34,14 @@ class rex_dir_test extends TestCase
         static::assertTrue(rex_dir::create($path), 'create() on existing dirs returns also true');
     }
 
-    public function testCreateRecursive()
+    public function testCreateRecursive(): void
     {
         $path = $this->getPath('create_recursive/test/test');
         static::assertTrue(rex_dir::create($path), 'create() returns true on success');
         static::assertDirectoryExists($path, 'dir exists after create()');
     }
 
-    public function testCopyToNewDir()
+    public function testCopyToNewDir(): void
     {
         $orig = $this->getPath('orig1');
         $copy = $this->getPath('copy1');
@@ -55,7 +55,7 @@ class rex_dir_test extends TestCase
         static::assertTrue(is_file($copy . '/dir2/file.txt'), 'file in subdir exists after copy()');
     }
 
-    public function testCopyToExistingDir()
+    public function testCopyToExistingDir(): void
     {
         $orig = $this->getPath('orig2');
         $copy = $this->getPath('copy2');
@@ -83,7 +83,7 @@ class rex_dir_test extends TestCase
         static::assertEquals('file2_new', rex_file::get($copy . '/dir3/file2.txt'), 'existing file in destination dir will be replaced');
     }
 
-    public function testDeleteComplete()
+    public function testDeleteComplete(): void
     {
         $dir = $this->getPath('deleteComplete');
         $file = $this->getPath('deleteComplete/subdir/file.txt');
@@ -94,7 +94,7 @@ class rex_dir_test extends TestCase
         static::assertDirectoryDoesNotExist($dir, 'dir does not exist after complete delete()');
     }
 
-    public function testDeleteWithoutSelf()
+    public function testDeleteWithoutSelf(): void
     {
         $dir = $this->getPath('deleteCompleteWithoutSelf');
         $file = $this->getPath('deleteCompleteWithoutSelf/subdir/file.txt');
@@ -107,7 +107,7 @@ class rex_dir_test extends TestCase
         static::assertDirectoryExists($dir, 'main dir still exists after delete() without self');
     }
 
-    public function testDeleteFilesNotRecursive()
+    public function testDeleteFilesNotRecursive(): void
     {
         $dir = $this->getPath('deleteFilesNotRecursive');
         $file1 = $this->getPath('deleteFilesNotRecursive/file.txt');
@@ -122,7 +122,7 @@ class rex_dir_test extends TestCase
         static::assertTrue(is_file($file2), 'file in subdir still exists after non-recursive deleteFiles()');
     }
 
-    public function testDeleteFilesRecursive()
+    public function testDeleteFilesRecursive(): void
     {
         $dir = $this->getPath('deleteFilesRecursive');
         $file1 = $this->getPath('deleteFilesRecursive/file.txt');

--- a/redaxo/src/core/tests/util/file_test.php
+++ b/redaxo/src/core/tests/util/file_test.php
@@ -26,7 +26,7 @@ class rex_file_test extends TestCase
         return rex_path::addonData('tests', 'rex_file_test/' . $file);
     }
 
-    public function testRequireThrows()
+    public function testRequireThrows(): void
     {
         $this->expectException(rex_exception::class);
 
@@ -34,7 +34,7 @@ class rex_file_test extends TestCase
         rex_file::require($file);
     }
 
-    public function testGetDefault()
+    public function testGetDefault(): void
     {
         $file = $this->getPath('non_existing.txt');
         static::assertNull(rex_file::get($file), 'get() returns null for non-existing files');
@@ -42,7 +42,7 @@ class rex_file_test extends TestCase
         static::assertEquals($myDefault, rex_file::get($file, $myDefault), 'get() returns given default value for non-existing files');
     }
 
-    public function testGetConfigDefault()
+    public function testGetConfigDefault(): void
     {
         $file = $this->getPath('non_existing.txt');
         static::assertEquals([], rex_file::getConfig($file), 'getConfig() returns empty array for non-existing files');
@@ -50,7 +50,7 @@ class rex_file_test extends TestCase
         static::assertEquals($myDefault, rex_file::getConfig($file, $myDefault), 'getConfig() returns given default value for non-existing files');
     }
 
-    public function testGetCacheDefault()
+    public function testGetCacheDefault(): void
     {
         $file = $this->getPath('non_existing.txt');
         static::assertEquals([], rex_file::getCache($file), 'getCache() returns empty array for non-existing files');
@@ -58,7 +58,7 @@ class rex_file_test extends TestCase
         static::assertEquals($myDefault, rex_file::getCache($file, $myDefault), 'getCache() returns given default value for non-existing files');
     }
 
-    public function testPutGet()
+    public function testPutGet(): void
     {
         $file = $this->getPath('putget.txt');
         $content = 'test';
@@ -66,7 +66,7 @@ class rex_file_test extends TestCase
         static::assertEquals($content, rex_file::get($file), 'get() returns content of file');
     }
 
-    public function testPutGetConfig()
+    public function testPutGetConfig(): void
     {
         $file = $this->getPath('putgetcache.txt');
         $content = ['test', 'key' => 'value'];
@@ -74,7 +74,7 @@ class rex_file_test extends TestCase
         static::assertEquals($content, rex_file::getConfig($file), 'getConfig() returns content of file');
     }
 
-    public function testPutGetCache()
+    public function testPutGetCache(): void
     {
         $file = $this->getPath('putgetcache.txt');
         $content = ['test', 'key' => 'value'];
@@ -82,7 +82,7 @@ class rex_file_test extends TestCase
         static::assertEquals($content, rex_file::getCache($file), 'getCache() returns content of file');
     }
 
-    public function testPutInNewDir()
+    public function testPutInNewDir(): void
     {
         $file = $this->getPath('subdir/test.txt');
         $content = 'test';
@@ -90,7 +90,7 @@ class rex_file_test extends TestCase
         static::assertEquals($content, rex_file::get($file), 'get() returns content of file');
     }
 
-    public function testCopyToFile()
+    public function testCopyToFile(): void
     {
         $orig = $this->getPath('orig.txt');
         $copy = $this->getPath('sub/copy.txt');
@@ -101,7 +101,7 @@ class rex_file_test extends TestCase
         static::assertEquals($content, rex_file::get($copy), 'content of new file is the same as of original file');
     }
 
-    public function testCopyToDir()
+    public function testCopyToDir(): void
     {
         $orig = $this->getPath('file.txt');
         $copyDir = $this->getPath('copy');
@@ -113,7 +113,7 @@ class rex_file_test extends TestCase
         static::assertEquals($content, rex_file::get($copyFile), 'content of new file is the same as of original file');
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $file = $this->getPath('delete.txt');
         rex_file::put($file, '');
@@ -123,7 +123,8 @@ class rex_file_test extends TestCase
         static::assertTrue(rex_file::delete($file), 'delete() returns true when the file is already deleted');
     }
 
-    public function dataTestExtension()
+    /** @return list<array{string, string}> */
+    public function dataTestExtension(): array
     {
         return [
             ['test.txt',      'txt'],
@@ -136,12 +137,13 @@ class rex_file_test extends TestCase
     /**
      * @dataProvider dataTestExtension
      */
-    public function testExtension($file, $expectedExtension)
+    public function testExtension($file, $expectedExtension): void
     {
         static::assertEquals($expectedExtension, rex_file::extension($file), 'extension() returns file extension');
     }
 
-    public function dataTestMimeType(): iterable
+    /** @return list<array{string, string}> */
+    public function dataTestMimeType(): array
     {
         return [
             ['image/png', rex_path::pluginAssets('be_style', 'redaxo', 'icons/apple-touch-icon.png')],
@@ -160,7 +162,7 @@ class rex_file_test extends TestCase
         static::assertEquals($expectedMimeType, rex_file::mimeType($file));
     }
 
-    public function testGetOutput()
+    public function testGetOutput(): void
     {
         $file = $this->getPath('test.php');
         rex_file::put($file, 'a<?php echo "b";');

--- a/redaxo/src/core/tests/util/finder_test.php
+++ b/redaxo/src/core/tests/util/finder_test.php
@@ -35,7 +35,7 @@ class rex_finder_test extends TestCase
         return rex_path::addonData('tests', 'rex_finder_test/' . $file);
     }
 
-    private function assertIteratorContains($iterator, $contains)
+    private function assertIteratorContains($iterator, $contains): void
     {
         $array = iterator_to_array($iterator, true);
         static::assertCount(count($contains), $array);
@@ -44,31 +44,31 @@ class rex_finder_test extends TestCase
         }
     }
 
-    public function testDefault()
+    public function testDefault(): void
     {
         $iterator = rex_finder::factory($this->getPath());
         $this->assertIteratorContains($iterator, ['file1.txt', 'file2.yml', 'dir1', 'dir2', 'dir']);
     }
 
-    public function testRecursive()
+    public function testRecursive(): void
     {
         $iterator = rex_finder::factory($this->getPath())->recursive();
         $this->assertIteratorContains($iterator, ['file1.txt', 'file2.yml', 'dir1', 'dir1/file3.txt', 'dir1/dir', 'dir2', 'dir2/file4.yml', 'dir2/dir', 'dir2/dir/file5.yml', 'dir2/dir1', 'dir']);
     }
 
-    public function testFilesOnly()
+    public function testFilesOnly(): void
     {
         $iterator = rex_finder::factory($this->getPath())->recursive()->filesOnly();
         $this->assertIteratorContains($iterator, ['file1.txt', 'file2.yml', 'dir1/file3.txt', 'dir2/file4.yml', 'dir2/dir/file5.yml']);
     }
 
-    public function testDirsOnly()
+    public function testDirsOnly(): void
     {
         $iterator = rex_finder::factory($this->getPath())->recursive()->dirsOnly();
         $this->assertIteratorContains($iterator, ['dir1', 'dir1/dir', 'dir2', 'dir2/dir', 'dir2/dir1', 'dir']);
     }
 
-    public function testIgnoreFiles()
+    public function testIgnoreFiles(): void
     {
         $iterator = rex_finder::factory($this->getPath())
             ->recursive()
@@ -77,7 +77,7 @@ class rex_finder_test extends TestCase
         $this->assertIteratorContains($iterator, ['dir1', 'dir1/file3.txt', 'dir1/dir', 'dir2', 'dir2/dir', 'dir2/dir/file5.yml', 'dir2/dir1', 'dir']);
     }
 
-    public function testIgnoreDirs()
+    public function testIgnoreDirs(): void
     {
         $iterator = rex_finder::factory($this->getPath())
             ->recursive()
@@ -86,7 +86,7 @@ class rex_finder_test extends TestCase
         $this->assertIteratorContains($iterator, ['file1.txt', 'file2.yml', 'dir2', 'dir2/file4.yml', 'dir2/dir', 'dir2/dir/file5.yml']);
     }
 
-    public function testIgnoreSystemStuff()
+    public function testIgnoreSystemStuff(): void
     {
         $iterator = rex_finder::factory($this->getPath())->recursive()->ignoreSystemStuff(false);
         $this->assertIteratorContains($iterator, ['file1.txt', 'file2.yml', 'dir1', 'dir1/file3.txt', 'dir1/dir', 'dir2', 'dir2/file4.yml', 'dir2/dir', 'dir2/dir/file5.yml', 'dir2/dir1', 'dir', '.DS_Store', 'dir1/Thumbs.db']);

--- a/redaxo/src/core/tests/util/formatter_test.php
+++ b/redaxo/src/core/tests/util/formatter_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_formatter_test extends TestCase
 {
-    public function testDate()
+    public function testDate(): void
     {
         $format = 'd.m.Y H:i';
 
@@ -163,7 +163,7 @@ class rex_formatter_test extends TestCase
         ];
     }
 
-    public function testNumber()
+    public function testNumber(): void
     {
         $value = 1336811080.23;
 
@@ -180,7 +180,7 @@ class rex_formatter_test extends TestCase
         );
     }
 
-    public function testBytes()
+    public function testBytes(): void
     {
         $value = 1000;
 
@@ -224,7 +224,7 @@ class rex_formatter_test extends TestCase
         }
     }
 
-    public function testSprintf()
+    public function testSprintf(): void
     {
         $value = 'hallo';
         $format = 'X%sX';
@@ -235,7 +235,7 @@ class rex_formatter_test extends TestCase
         );
     }
 
-    public function testNl2br()
+    public function testNl2br(): void
     {
         $value = "very\nloooooong\ntext lala";
 
@@ -245,7 +245,7 @@ class rex_formatter_test extends TestCase
         );
     }
 
-    public function testTruncate()
+    public function testTruncate(): void
     {
         $value = 'very loooooong text lala';
 
@@ -271,7 +271,7 @@ class rex_formatter_test extends TestCase
         );
     }
 
-    public function testVersion()
+    public function testVersion(): void
     {
         $value = '5.1.2-alpha1';
 
@@ -286,7 +286,7 @@ class rex_formatter_test extends TestCase
         );
     }
 
-    public function testUrl()
+    public function testUrl(): void
     {
         $value = 'http://example.org';
 
@@ -300,7 +300,7 @@ class rex_formatter_test extends TestCase
         );
     }
 
-    public function testEmail()
+    public function testEmail(): void
     {
         $value = 'dude@example.org';
 
@@ -314,7 +314,7 @@ class rex_formatter_test extends TestCase
         );
     }
 
-    public function testCustom()
+    public function testCustom(): void
     {
         $format = 'strtoupper';
         static::assertEquals(

--- a/redaxo/src/core/tests/util/i18n_test.php
+++ b/redaxo/src/core/tests/util/i18n_test.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\TestCase;
 
 class rex_i18n_trans_cb
 {
-    public static function mytranslate()
+    public static function mytranslate(): string
     {
         return 'translated';
     }
@@ -48,7 +48,7 @@ class rex_i18n_test extends TestCase
         return rex_path::addonData('tests', 'lang');
     }
 
-    public function testLoadFile()
+    public function testLoadFile(): void
     {
         rex_i18n::addDirectory($this->getPath());
 
@@ -59,7 +59,7 @@ class rex_i18n_test extends TestCase
         static::assertSame('abc def', rex_i18n::msg('rex_i18n_test_5'));
     }
 
-    public function testHasMsg()
+    public function testHasMsg(): void
     {
         rex_i18n::addDirectory($this->getPath());
 
@@ -68,7 +68,7 @@ class rex_i18n_test extends TestCase
         static::assertFalse(rex_i18n::hasMsg('rex_i18n_test_6'));
     }
 
-    public function testHasMsgOrFallback()
+    public function testHasMsgOrFallback(): void
     {
         rex_i18n::addDirectory($this->getPath());
 
@@ -77,7 +77,7 @@ class rex_i18n_test extends TestCase
         static::assertTrue(rex_i18n::hasMsgOrFallback('rex_i18n_test_6'));
     }
 
-    public function testGetMsgFallback()
+    public function testGetMsgFallback(): void
     {
         rex_i18n::addDirectory($this->getPath());
 
@@ -85,7 +85,7 @@ class rex_i18n_test extends TestCase
         static::assertSame('[translate:rex_i18n_test_7]', rex_i18n::msg('rex_i18n_test_7'));
     }
 
-    public function testGetMsgInLocaleFallback()
+    public function testGetMsgInLocaleFallback(): void
     {
         rex_i18n::addDirectory($this->getPath());
 
@@ -93,7 +93,7 @@ class rex_i18n_test extends TestCase
         static::assertSame('EN', rex_i18n::msgInLocale('my', 'en_gb'));
     }
 
-    public function testTranslateCallable()
+    public function testTranslateCallable(): void
     {
         static::assertSame('translated', rex_i18n::translate('translate:my_cb', false, rex_i18n_trans_cb::mytranslate(...)));
     }

--- a/redaxo/src/core/tests/util/log_entry_test.php
+++ b/redaxo/src/core/tests/util/log_entry_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_log_entry_test extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $time = time();
         $data = ['test1', 'test2'];
@@ -17,7 +17,7 @@ class rex_log_entry_test extends TestCase
         static::assertSame($data, $entry->getData());
     }
 
-    public function testCreateFromString()
+    public function testCreateFromString(): void
     {
         $time = time();
         $entry = rex_log_entry::createFromString(date(rex_log_entry::DATE_FORMAT, $time) . ' | test1 |  |  test2\nt \| test3 |');
@@ -30,7 +30,7 @@ class rex_log_entry_test extends TestCase
     /**
      * @depends testConstruct
      */
-    public function testGetTimestamp()
+    public function testGetTimestamp(): void
     {
         $time = time();
         $entry = new rex_log_entry($time, []);
@@ -46,7 +46,7 @@ class rex_log_entry_test extends TestCase
     /**
      * @depends testConstruct
      */
-    public function testToString()
+    public function testToString(): void
     {
         $time = time();
         $entry = new rex_log_entry($time, ['test1', ' ', " test2\nt | test3\r\ntest4 "]);

--- a/redaxo/src/core/tests/util/log_file_test.php
+++ b/redaxo/src/core/tests/util/log_file_test.php
@@ -17,14 +17,14 @@ class rex_log_file_test extends TestCase
         return rex_path::addonData('tests', 'rex_log_file_test/' . $file);
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $path = $this->getPath('test1.log');
         new rex_log_file($path);
         static::assertStringEqualsFile($path, '');
     }
 
-    public function testConstructWithMaxFileSize()
+    public function testConstructWithMaxFileSize(): void
     {
         $path = $this->getPath('test2.log');
         $path2 = $path . '.2';
@@ -48,7 +48,7 @@ class rex_log_file_test extends TestCase
     /**
      * @depends testConstruct
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $path = $this->getPath('test3.log');
         $log = new rex_log_file($path);
@@ -65,7 +65,7 @@ class rex_log_file_test extends TestCase
     /**
      * @depends testConstruct
      */
-    public function testIterator()
+    public function testIterator(): void
     {
         $path = $this->getPath('test4.log');
         $log = new rex_log_file($path);
@@ -99,7 +99,7 @@ class rex_log_file_test extends TestCase
         static::assertEquals($expected, iterator_to_array($log));
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $path = $this->getPath('delete.log');
         $path2 = $path . '.2';

--- a/redaxo/src/core/tests/util/markdown_test.php
+++ b/redaxo/src/core/tests/util/markdown_test.php
@@ -10,12 +10,13 @@ class rex_markdown_test extends TestCase
     /**
      * @dataProvider parseProvider
      */
-    public function testParse($expected, $code)
+    public function testParse($expected, $code): void
     {
         static::assertSame($expected, rex_markdown::factory()->parse($code));
     }
 
-    public function parseProvider()
+    /** @return list<array{string, string}> */
+    public function parseProvider(): array
     {
         return [
             ['', ''],
@@ -37,7 +38,7 @@ class rex_markdown_test extends TestCase
         ];
     }
 
-    public function testParseWithToc()
+    public function testParseWithToc(): void
     {
         $input = <<<'MARKDOWN'
             Test

--- a/redaxo/src/core/tests/util/socket_proxy_test.php
+++ b/redaxo/src/core/tests/util/socket_proxy_test.php
@@ -20,13 +20,13 @@ class rex_socket_proxy_test extends TestCase
         rex::setProperty('socket_proxy', $this->proxy);
     }
 
-    public function testFactory()
+    public function testFactory(): void
     {
         $socket = rex_socket_proxy::factory('www.example.com');
         static::assertEquals(rex_socket_proxy::class, $socket::class);
     }
 
-    public function testFactoryUrl()
+    public function testFactoryUrl(): void
     {
         $socket = rex_socket_proxy::factoryUrl('www.example.com');
         static::assertEquals(rex_socket_proxy::class, $socket::class);

--- a/redaxo/src/core/tests/util/socket_response_test.php
+++ b/redaxo/src/core/tests/util/socket_response_test.php
@@ -16,7 +16,8 @@ class rex_socket_response_test extends TestCase
         return new rex_socket_response($stream);
     }
 
-    public function getStatusProvider()
+    /** @return list<array{string, ?int, ?string, string}> */
+    public function getStatusProvider(): array
     {
         return [
             ['',                              null, null,                'isInvalid'],
@@ -35,7 +36,7 @@ class rex_socket_response_test extends TestCase
     /**
      * @dataProvider getStatusProvider
      */
-    public function testGetStatus($header, $statusCode, $statusMessage, $positiveMethod)
+    public function testGetStatus($header, $statusCode, $statusMessage, $positiveMethod): void
     {
         $response = $this->getResponse($header . "\r\n");
 
@@ -49,7 +50,7 @@ class rex_socket_response_test extends TestCase
         }
     }
 
-    public function testGetHeader()
+    public function testGetHeader(): void
     {
         $header = "HTTP/1.1 200 OK\r\nKey1: Value1\r\nkey2: Value2";
         $response = $this->getResponse($header . "\r\n\r\nbody\r\nbody");
@@ -61,7 +62,7 @@ class rex_socket_response_test extends TestCase
         static::assertSame('default', $response->getHeader('Key3', 'default'), 'getHeader($key, $default) returns $default for non-existing keys');
     }
 
-    public function testGetBody()
+    public function testGetBody(): void
     {
         $body = "body1\r\nbody2";
         $response = $this->getResponse("HTTP/1.1 200 OK\r\nKey: Value\r\n\r\n" . $body);
@@ -69,7 +70,7 @@ class rex_socket_response_test extends TestCase
         static::assertSame($body, $response->getBody());
     }
 
-    public function testWriteBodyTo()
+    public function testWriteBodyTo(): void
     {
         $body = "body1\r\nbody2";
         $response = $this->getResponse("HTTP/1.1 200 OK\r\nKey: Value\r\n\r\n" . $body);
@@ -81,7 +82,7 @@ class rex_socket_response_test extends TestCase
         fclose($temp);
     }
 
-    public function testGetBodyWithEncoding()
+    public function testGetBodyWithEncoding(): void
     {
         $body = "This is the\r\noriginal content";
 
@@ -104,7 +105,7 @@ class rex_socket_response_test extends TestCase
         )->decompressContent(true)->getBody());
     }
 
-    public function testEncodingHeader()
+    public function testEncodingHeader(): void
     {
         static::assertIsArray($this->getResponse("HTTP/1.1 200 OK\r\nKey: Value\r\n\r\nTest")
             ->getContentEncodings(), );

--- a/redaxo/src/core/tests/util/socket_test.php
+++ b/redaxo/src/core/tests/util/socket_test.php
@@ -20,7 +20,7 @@ class rex_socket_test extends TestCase
         rex::setProperty('socket_proxy', $this->proxy);
     }
 
-    public function testFactory()
+    public function testFactory(): rex_socket
     {
         $socket = rex_socket::factory('www.example.com');
         $socket->setOptions([]);
@@ -28,7 +28,7 @@ class rex_socket_test extends TestCase
         return $socket;
     }
 
-    public function testFactoryProxy()
+    public function testFactoryProxy(): void
     {
         rex::setProperty('socket_proxy', 'proxy.example.com:8888');
         $socket = rex_socket::factory('www.example.com');
@@ -36,14 +36,14 @@ class rex_socket_test extends TestCase
         static::assertEquals(rex_socket_proxy::class, $socket::class);
     }
 
-    public function testFactoryUrl()
+    public function testFactoryUrl(): void
     {
         $socket = rex_socket::factoryUrl('www.example.com');
         $socket->setOptions([]);
         static::assertEquals(rex_socket::class, $socket::class);
     }
 
-    public function testFactoryUrlProxy()
+    public function testFactoryUrlProxy(): void
     {
         rex::setProperty('socket_proxy', 'proxy.example.com:8888');
         $socket = rex_socket::factoryUrl('www.example.com');
@@ -54,7 +54,7 @@ class rex_socket_test extends TestCase
     /**
      * @depends testFactory
      */
-    public function testWriteRequest($socket)
+    public function testWriteRequest($socket): void
     {
         $class = new ReflectionClass(rex_socket::class);
         $property = $class->getProperty('stream');
@@ -79,7 +79,8 @@ class rex_socket_test extends TestCase
         fclose($stream);
     }
 
-    public function parseUrlProvider()
+    /** @return list<array{string, string, int, bool, string}> */
+    public function parseUrlProvider(): array
     {
         return [
             ['example.com',                             'example.com', 80,  false, '/'],
@@ -98,7 +99,7 @@ class rex_socket_test extends TestCase
     /**
      * @dataProvider parseUrlProvider
      */
-    public function testParseUrl($url, $expectedHost, $expectedPort, $expectedSsl, $expectedPath)
+    public function testParseUrl($url, $expectedHost, $expectedPort, $expectedSsl, $expectedPath): void
     {
         $method = new ReflectionMethod(rex_socket::class, 'parseUrl');
         $result = $method->invoke(null, $url);
@@ -111,7 +112,8 @@ class rex_socket_test extends TestCase
         static::assertEquals($expected, $result);
     }
 
-    public function parseUrlExceptionProvider()
+    /** @return list<array{string}> */
+    public function parseUrlExceptionProvider(): array
     {
         return [
             [''],
@@ -123,7 +125,7 @@ class rex_socket_test extends TestCase
     /**
      * @dataProvider parseUrlExceptionProvider
      */
-    public function testParseUrlException($url)
+    public function testParseUrlException($url): void
     {
         $this->expectException(rex_socket_exception::class);
 

--- a/redaxo/src/core/tests/util/sortable_iterator_test.php
+++ b/redaxo/src/core/tests/util/sortable_iterator_test.php
@@ -17,7 +17,7 @@ class rex_sortable_iterator_test extends TestCase
         parent::tearDown();
     }
 
-    public function testValuesMode()
+    public function testValuesMode(): void
     {
         $array = [2, 'a10', 'a2', 1, "a\xcc\x884", 'ä3', 'b'];
         $iterator = new rex_sortable_iterator(new ArrayIterator($array));
@@ -28,14 +28,14 @@ class rex_sortable_iterator_test extends TestCase
         );
     }
 
-    public function testKeysMode()
+    public function testKeysMode(): void
     {
         $array = [2 => 0, 'a' => 1, 1 => 2, 'b' => 3];
         $iterator = new rex_sortable_iterator(new ArrayIterator($array), rex_sortable_iterator::KEYS);
         static::assertEquals(['a' => 1, 'b' => 3, 1 => 2, 2 => 0], iterator_to_array($iterator), 'In KEYS mode the iterator sorts by keys');
     }
 
-    public function testCallbackMode()
+    public function testCallbackMode(): void
     {
         $array = [2, 'a', 1, 'b'];
         $callback = static function ($a, $b) {

--- a/redaxo/src/core/tests/util/stream_test.php
+++ b/redaxo/src/core/tests/util/stream_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_stream_test extends TestCase
 {
-    public function testStreamInclude()
+    public function testStreamInclude(): void
     {
         $content = 'foo <?php echo "bar";';
         $streamUrl = rex_stream::factory('test-stream/1', $content);
@@ -18,7 +18,7 @@ class rex_stream_test extends TestCase
         static::assertEquals('foo bar', $result);
     }
 
-    public function testStreamIncludeWithRealFile()
+    public function testStreamIncludeWithRealFile(): void
     {
         $property = new ReflectionProperty(rex_stream::class, 'useRealFiles');
         $property->setValue(true);

--- a/redaxo/src/core/tests/util/string_test.php
+++ b/redaxo/src/core/tests/util/string_test.php
@@ -7,12 +7,13 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_string_test extends TestCase
 {
-    public function testSize()
+    public function testSize(): void
     {
         static::assertEquals(3, rex_string::size('aä'));
     }
 
-    public function normalizeProvider()
+    /** @return list<array{0: string, 1: string, 2?: string, 3?: string}> */
+    public function normalizeProvider(): array
     {
         return [
             [
@@ -28,12 +29,13 @@ class rex_string_test extends TestCase
     /**
      * @dataProvider normalizeProvider
      */
-    public function testNormalize($expected, $string, $replaceChar = '_', $allowedChars = '')
+    public function testNormalize($expected, $string, $replaceChar = '_', $allowedChars = ''): void
     {
         static::assertEquals($expected, rex_string::normalize($string, $replaceChar, $allowedChars));
     }
 
-    public function splitProvider()
+    /** @return list<array{string, array<int|string, string>}> */
+    public function splitProvider(): array
     {
         return [
             ['',                                          []],
@@ -50,12 +52,13 @@ class rex_string_test extends TestCase
     /**
      * @dataProvider splitProvider
      */
-    public function testSplit($string, $expectedArray)
+    public function testSplit($string, $expectedArray): void
     {
         static::assertEquals($expectedArray, rex_string::split($string));
     }
 
-    public function buildQueryProvider()
+    /** @return list<array{0: string, 1: array, 2?: string}> */
+    public function buildQueryProvider(): array
     {
         return [
             ['', []],
@@ -68,12 +71,12 @@ class rex_string_test extends TestCase
     /**
      * @dataProvider buildQueryProvider
      */
-    public function testBuildQuery($expected, $params, $argSeparator = '&')
+    public function testBuildQuery($expected, $params, $argSeparator = '&'): void
     {
         static::assertEquals($expected, rex_string::buildQuery($params, $argSeparator));
     }
 
-    public function testBuildAttributes()
+    public function testBuildAttributes(): void
     {
         static::assertEquals(
             ' id="rex-test" class="a b" alt="" checked data-foo="&lt;foo&gt; &amp; &quot;bar&quot;" href="index.php?foo=1&amp;bar=2"',
@@ -88,7 +91,7 @@ class rex_string_test extends TestCase
         );
     }
 
-    public function testSanitizeHtml()
+    public function testSanitizeHtml(): void
     {
         $input = <<<'INPUT'
             <p align=center><img src="foo.jpg" style="width: 200px"></p>

--- a/redaxo/src/core/tests/util/type_test.php
+++ b/redaxo/src/core/tests/util/type_test.php
@@ -7,7 +7,8 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_type_test extends TestCase
 {
-    public function castProvider()
+    /** @return list<array{mixed, string|callable(mixed):mixed|list<array{string, string, mixed}>, mixed}> */
+    public function castProvider(): array
     {
         $callback = static function ($var) {
             return $var . 'b';
@@ -45,12 +46,13 @@ class rex_type_test extends TestCase
     /**
      * @dataProvider castProvider
      */
-    public function testCast($var, $vartype, $expectedResult)
+    public function testCast($var, $vartype, $expectedResult): void
     {
         static::assertSame($expectedResult, rex_type::cast($var, $vartype));
     }
 
-    public function castWrongVartypeProvider()
+    /** @return list<array{mixed}> */
+    public function castWrongVartypeProvider(): array
     {
         return [
             ['wrongVartype'],
@@ -66,7 +68,7 @@ class rex_type_test extends TestCase
     /**
      * @dataProvider castWrongVartypeProvider
      */
-    public function testCastWrongVartype($vartype)
+    public function testCastWrongVartype($vartype): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/redaxo/src/core/tests/util/validator_test.php
+++ b/redaxo/src/core/tests/util/validator_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_validator_test extends TestCase
 {
-    public function testNotEmpty()
+    public function testNotEmpty(): void
     {
         $validator = rex_validator::factory();
         static::assertFalse($validator->notEmpty(''));
@@ -15,7 +15,8 @@ class rex_validator_test extends TestCase
         static::assertTrue($validator->notEmpty('aaa'));
     }
 
-    public function dataType()
+    /** @return list<array{string, string, bool}> */
+    public function dataType(): array
     {
         return [
             ['',      'int', false],
@@ -34,40 +35,41 @@ class rex_validator_test extends TestCase
     /**
      * @dataProvider dataType
      */
-    public function testType($value, $type, $expected)
+    public function testType($value, $type, $expected): void
     {
         static::assertEquals($expected, rex_validator::factory()->type($value, $type));
     }
 
-    public function testMinLength()
+    public function testMinLength(): void
     {
         $validator = rex_validator::factory();
         static::assertFalse($validator->minLength('ab', 3));
         static::assertTrue($validator->minLength('abc', 3));
     }
 
-    public function testMaxLength()
+    public function testMaxLength(): void
     {
         $validator = rex_validator::factory();
         static::assertFalse($validator->maxLength('abc', 2));
         static::assertTrue($validator->maxLength('ab', 2));
     }
 
-    public function testMin()
+    public function testMin(): void
     {
         $validator = rex_validator::factory();
         static::assertFalse($validator->min('4', 5));
         static::assertTrue($validator->min('5', 5));
     }
 
-    public function testMax()
+    public function testMax(): void
     {
         $validator = rex_validator::factory();
         static::assertFalse($validator->max('5', 4));
         static::assertTrue($validator->max('4', 4));
     }
 
-    public function dataUrl()
+    /** @return list<array{string, bool}> */
+    public function dataUrl(): array
     {
         return [
             ['', false],
@@ -82,12 +84,13 @@ class rex_validator_test extends TestCase
     /**
      * @dataProvider dataUrl
      */
-    public function testUrl($value, $isValid)
+    public function testUrl($value, $isValid): void
     {
         static::assertEquals($isValid, rex_validator::factory()->url($value));
     }
 
-    public function dataEmail()
+    /** @return list<array{string, bool}> */
+    public function dataEmail(): array
     {
         return [
             ['', false],
@@ -101,26 +104,26 @@ class rex_validator_test extends TestCase
     /**
      * @dataProvider dataEmail
      */
-    public function testEmail($value, $isValid)
+    public function testEmail($value, $isValid): void
     {
         static::assertEquals($isValid, rex_validator::factory()->email($value));
     }
 
-    public function testMatch()
+    public function testMatch(): void
     {
         $validator = rex_validator::factory();
         static::assertFalse($validator->match('aa', '/^.$/'));
         static::assertTrue($validator->match('a', '/^.$/'));
     }
 
-    public function testNotMatch()
+    public function testNotMatch(): void
     {
         $validator = rex_validator::factory();
         static::assertTrue($validator->notMatch('aa', '/^.$/'));
         static::assertFalse($validator->notMatch('a', '/^.$/'));
     }
 
-    public function testValues()
+    public function testValues(): void
     {
         $validator = rex_validator::factory();
         static::assertFalse($validator->values('abc', ['def', 'ghi']));
@@ -130,7 +133,7 @@ class rex_validator_test extends TestCase
     /**
      * @dataProvider dataCustom
      */
-    public function testCustom(bool $expected, string $value)
+    public function testCustom(bool $expected, string $value): void
     {
         $validator = rex_validator::factory();
 
@@ -155,7 +158,7 @@ class rex_validator_test extends TestCase
         ];
     }
 
-    public function testIsValid()
+    public function testIsValid(): void
     {
         $validator = rex_validator::factory();
 
@@ -175,7 +178,7 @@ class rex_validator_test extends TestCase
         static::assertNull($validator->getMessage());
     }
 
-    public function testGetRules()
+    public function testGetRules(): void
     {
         $validator = rex_validator::factory();
         // mix of add/addRule should be returned in getRules()

--- a/redaxo/src/core/tests/util/version_test.php
+++ b/redaxo/src/core/tests/util/version_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_version_test extends TestCase
 {
-    public function testIsUnstable()
+    public function testIsUnstable(): void
     {
         static::assertTrue(rex_version::isUnstable('1.0-dev'));
         static::assertTrue(rex_version::isUnstable('2.1.0beta'));
@@ -22,7 +22,8 @@ class rex_version_test extends TestCase
         static::assertFalse(rex_version::isUnstable('1.0 codename starship'));
     }
 
-    public function splitProvider()
+    /** @return list<array{string, list<string>}> */
+    public function splitProvider(): array
     {
         return [
             ['1.1.2',      ['1', '1', '2']],
@@ -35,12 +36,13 @@ class rex_version_test extends TestCase
     /**
      * @dataProvider splitProvider
      */
-    public function testSplit($version, $expected)
+    public function testSplit($version, $expected): void
     {
         static::assertEquals($expected, rex_version::split($version));
     }
 
-    public function compareProvider()
+    /** @return list<array{bool, string, string, null|'='|'=='|'!='|'<>'|'<'|'<='|'>'|'>='}> */
+    public function compareProvider(): array
     {
         return [
             [true, '1',      '1',      '='],
@@ -78,7 +80,7 @@ class rex_version_test extends TestCase
      *
      * @param null|'='|'=='|'!='|'<>'|'<'|'<='|'>'|'>=' $comparator
      */
-    public function testCompare($expected, string $version1, string $version2, ?string $comparator)
+    public function testCompare($expected, string $version1, string $version2, ?string $comparator): void
     {
         static::assertSame($expected, rex_version::compare($version1, $version2, $comparator));
     }
@@ -93,7 +95,7 @@ class rex_version_test extends TestCase
     /**
      * @dataProvider dataMatchVersionConstraints
      */
-    public function testMatchVersionConstraints(bool $expected, string $version, string $constraints)
+    public function testMatchVersionConstraints(bool $expected, string $version, string $constraints): void
     {
         static::assertSame($expected, rex_version::matchesConstraints($version, $constraints));
     }

--- a/redaxo/src/core/tests/var/var_base_test.php
+++ b/redaxo/src/core/tests/var/var_base_test.php
@@ -4,12 +4,12 @@ use PHPUnit\Framework\TestCase;
 
 abstract class rex_var_base_test extends TestCase
 {
-    protected function getParseOutput($content)
+    protected function getParseOutput($content): string
     {
         return rex_file::getOutput(rex_stream::factory('rex-var-test', rex_var::parse($content)));
     }
 
-    protected function assertParseOutputEquals($expected, $content, $msg = 'Parsed content has not expected output.')
+    protected function assertParseOutputEquals($expected, $content, $msg = 'Parsed content has not expected output.'): void
     {
         static::assertEquals($expected, $this->getParseOutput($content), $msg);
     }

--- a/redaxo/src/core/tests/var/var_config_test.php
+++ b/redaxo/src/core/tests/var/var_config_test.php
@@ -14,7 +14,8 @@ class rex_var_config_test extends rex_var_base_test
         rex_addon::get('project')->removeConfig('tests');
     }
 
-    public function configReplaceProvider()
+    /** @return list<array{string, string}> */
+    public function configReplaceProvider(): array
     {
         return [
             ['REX_CONFIG[key=myCoreConfig]', 'myCoreConfigValue'],
@@ -25,7 +26,7 @@ class rex_var_config_test extends rex_var_base_test
     /**
      * @dataProvider configReplaceProvider
      */
-    public function testConfigReplace($content, $expectedOutput)
+    public function testConfigReplace($content, $expectedOutput): void
     {
         $this->assertParseOutputEquals($expectedOutput, $content);
     }

--- a/redaxo/src/core/tests/var/var_property_test.php
+++ b/redaxo/src/core/tests/var/var_property_test.php
@@ -14,7 +14,8 @@ class rex_var_property_test extends rex_var_base_test
         rex_addon::get('project')->removeProperty('tests');
     }
 
-    public function propertyReplaceProvider()
+    /** @return list<array{string, string}> */
+    public function propertyReplaceProvider(): array
     {
         return [
             ['REX_PROPERTY[key=myCoreProperty]', 'myCorePropertyValue'],
@@ -25,7 +26,7 @@ class rex_var_property_test extends rex_var_base_test
     /**
      * @dataProvider propertyReplaceProvider
      */
-    public function testPropertyReplace($content, $expectedOutput)
+    public function testPropertyReplace($content, $expectedOutput): void
     {
         $this->assertParseOutputEquals($expectedOutput, $content);
     }

--- a/redaxo/src/core/tests/var/var_test.php
+++ b/redaxo/src/core/tests/var/var_test.php
@@ -24,7 +24,8 @@ class rex_var_2nd_test_var extends rex_var
 
 class rex_var_test extends rex_var_base_test
 {
-    public function parseTokensProvider()
+    /** @return list<array{string, string}> */
+    public function parseTokensProvider(): array
     {
         return [
             ['aREX_TEST_VAR[content=b]c', 'abc'],
@@ -49,12 +50,13 @@ c', "a\nb\nc"],
     /**
      * @dataProvider parseTokensProvider
      */
-    public function testParseTokens($content, $expectedOutput)
+    public function testParseTokens($content, $expectedOutput): void
     {
         $this->assertParseOutputEquals($expectedOutput, $content);
     }
 
-    public function parseArgsSyntaxProvider()
+    /** @return list<array{string, string}> */
+    public function parseArgsSyntaxProvider(): array
     {
         return [
             ['REX_TEST_VAR[]', 'default'],
@@ -116,12 +118,13 @@ c', "a\nb\nc"],
     /**
      * @dataProvider parseArgsSyntaxProvider
      */
-    public function testParseArgsSyntax($content, $expectedOutput)
+    public function testParseArgsSyntax($content, $expectedOutput): void
     {
         $this->assertParseOutputEquals($expectedOutput, $content);
     }
 
-    public function parseGlobalArgsProvider()
+    /** @return list<array{string, string}> */
+    public function parseGlobalArgsProvider(): array
     {
         return [
             ['REX_TEST_VAR[content=ab instead=cd]', 'cd'],
@@ -145,7 +148,7 @@ c', "a\nb\nc"],
         ];
     }
 
-    public static function varCallback($params)
+    public static function varCallback($params): string
     {
         return sprintf('var:%s class:%s subject:%s content:%s suffix:%s', $params['var'], $params['class'], $params['subject'], $params['content'], $params['suffix']);
     }
@@ -153,12 +156,12 @@ c', "a\nb\nc"],
     /**
      * @dataProvider parseGlobalArgsProvider
      */
-    public function testParseGlobalArgs($content, $expectedOutput)
+    public function testParseGlobalArgs($content, $expectedOutput): void
     {
         $this->assertParseOutputEquals($expectedOutput, $content);
     }
 
-    public function testToArray()
+    public function testToArray(): void
     {
         $content = '<?php echo rex_var::toArray("REX_TEST_VAR[content=\'test\']") === null ? "null" : "";';
         $this->assertParseOutputEquals('null', $content, 'toArray() returns null for non-arrays');
@@ -182,7 +185,7 @@ c', "a\nb\nc"],
         $this->assertParseOutputEquals(print_r($unescapedArray, true), $content, 'toArray() rebuilds HTML');
     }
 
-    public function testQuote()
+    public function testQuote(): void
     {
         $string = "abc 'de' \"fg\" \\ \nh\r\ni";
         $expected = <<<'EOD'

--- a/redaxo/src/core/tests/view_test.php
+++ b/redaxo/src/core/tests/view_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_view_test extends TestCase
 {
-    public function testAddGetCss()
+    public function testAddGetCss(): void
     {
         rex_view::addCssFile('my.css');
         $files = rex_view::getCssFiles()['all'];
@@ -18,14 +18,14 @@ class rex_view_test extends TestCase
         static::assertTrue('print.css' == end($files));
     }
 
-    public function testAddGetJs()
+    public function testAddGetJs(): void
     {
         rex_view::addJsFile('my.js');
         $files = rex_view::getJsFiles();
         static::assertTrue('my.js' == end($files));
     }
 
-    public function testAddGetJsWithOptions()
+    public function testAddGetJsWithOptions(): void
     {
         rex_view::addJsFile('my.js');
         $files = rex_view::getJsFilesWithOptions();


### PR DESCRIPTION
Sind überwiegend Test-Dateien. Bei den anderen haben wir ja die Return-Types bereits weitestgehend vervollständigt.

Einen Großteil habe ich per `psalm --alter ...` erstellt.

Per psalm erfordern wir neu nun auch überall Return-Types.