### PR TITLE
Neuer EP `SESSION_REGENERATED`

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -56,6 +56,8 @@ return static function (RectorConfig $rectorConfig): void {
         'redaxo/src/addons/be_style/vendor',
         'redaxo/src/addons/debug/vendor',
         'redaxo/src/addons/phpmailer/vendor',
+
+        FirstClassCallableRector::class => ['redaxo/src/core/boot.php'],
     ]);
 
     $rectorConfig->parallel();

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -139,7 +139,7 @@ if ('cli' !== PHP_SAPI && !rex::isSetup()) {
     }
 }
 
-rex_extension::register('SESSION_REGENERATED', rex_backend_login::sessionRegenerated(...));
+rex_extension::register('SESSION_REGENERATED', [rex_backend_login::class, 'sessionRegenerated']);
 
 if (isset($REX['LOAD_PAGE']) && $REX['LOAD_PAGE']) {
     unset($REX);

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -139,7 +139,7 @@ if ('cli' !== PHP_SAPI && !rex::isSetup()) {
     }
 }
 
-rex_extension::register('SESSION_REGENERATED', [rex_backend_login::class, 'sessionRegenerated']);
+rex_extension::register('SESSION_REGENERATED', rex_backend_login::sessionRegenerated(...));
 
 if (isset($REX['LOAD_PAGE']) && $REX['LOAD_PAGE']) {
     unset($REX);

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -139,7 +139,9 @@ if ('cli' !== PHP_SAPI && !rex::isSetup()) {
     }
 }
 
-rex_extension::register('SESSION_REGENERATED', rex_backend_login::sessionRegenerated(...));
+rex_extension::register('SESSION_REGENERATED', function () {
+    rex_backend_login::sessionRegenerated();
+});
 
 if (isset($REX['LOAD_PAGE']) && $REX['LOAD_PAGE']) {
     unset($REX);

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -139,9 +139,7 @@ if ('cli' !== PHP_SAPI && !rex::isSetup()) {
     }
 }
 
-rex_extension::register('SESSION_REGENERATED', function () {
-    rex_backend_login::sessionRegenerated();
-});
+rex_extension::register('SESSION_REGENERATED', [rex_backend_login::class, 'sessionRegenerated']);
 
 if (isset($REX['LOAD_PAGE']) && $REX['LOAD_PAGE']) {
     unset($REX);

--- a/redaxo/src/core/boot.php
+++ b/redaxo/src/core/boot.php
@@ -139,6 +139,8 @@ if ('cli' !== PHP_SAPI && !rex::isSetup()) {
     }
 }
 
+rex_extension::register('SESSION_REGENERATED', rex_backend_login::sessionRegenerated(...));
+
 if (isset($REX['LOAD_PAGE']) && $REX['LOAD_PAGE']) {
     unset($REX);
     require rex_path::core(rex::isBackend() ? 'backend.php' : 'frontend.php');

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -20,6 +20,8 @@ class rex_backend_login extends rex_login
     /** @var rex_backend_password_policy */
     private $passwordPolicy;
 
+    private static bool $sessionRegenerationForBackendLogin = false;
+
     public function __construct()
     {
         parent::__construct();
@@ -301,5 +303,28 @@ class rex_backend_login extends rex_login
         $loginPolicy = (array) rex::getProperty('backend_login_policy', []);
 
         return new rex_login_policy($loginPolicy);
+    }
+
+    public static function regenerateSessionId()
+    {
+        self::$sessionRegenerationForBackendLogin = true;
+        try {
+            parent::regenerateSessionId();
+        } finally {
+            self::$sessionRegenerationForBackendLogin = false;
+        }
+    }
+
+    /**
+     * @internal
+     * @param rex_extension_point<null> $ep
+     */
+    public static function sessionRegenerated(rex_extension_point $ep): void
+    {
+        if (self::$sessionRegenerationForBackendLogin) {
+            return;
+        }
+
+        rex_user_session::updateSessionId($ep->getParam('previous_id'), $ep->getParam('new_id'));
     }
 }

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -325,6 +325,6 @@ class rex_backend_login extends rex_login
             return;
         }
 
-        rex_user_session::updateSessionId($ep->getParam('previous_id'), $ep->getParam('new_id'));
+        rex_user_session::updateSessionId(rex_type::string($ep->getParam('previous_id')), rex_type::string($ep->getParam('new_id')));
     }
 }

--- a/redaxo/src/core/lib/login/user_session.php
+++ b/redaxo/src/core/lib/login/user_session.php
@@ -64,6 +64,15 @@ class rex_user_session
         $this->storeCurrentSession($login);
     }
 
+    public static function updateSessionId(string $previousId, string $newId): void
+    {
+        rex_sql::factory()
+            ->setTable(rex::getTable('user_session'))
+            ->setWhere(['session_id' => $previousId])
+            ->setValue('session_id', $newId)
+            ->update();
+    }
+
     public static function clearExpiredSessions(): void
     {
         rex_sql::factory()


### PR DESCRIPTION
Nach einem Frontend-Login sollte die Session-ID regeneriert werden.

Ab 5.15 haben wir jedoch die user_session-Tabelle mit den Backend-Sessions. 
Daher würde man bei einem Frontend-Login dann im Backend ausgeloggt werden. Das ist unschön.
Daher muss das Backend die Session-ID in der Tabelle aktualisieren, wenn durch ein Frontend-Login die Session-ID neu generiert wird.

Umgekehrt gilt das Gleiche. Ein Frontend-Login-System muss darauf reagieren können, wenn wegen des Backend-Logins die Session-ID neu generiert wurde.

Daher der neue EP `SESSION_REGENERATED`.

Mir gefällt das ganze Konstrukt hier nicht so wirklich. Aber mir ist keine simplere Lösung eingefallen.

closes #5551