### PR TITLE
EP `SESSION_REGENERATED` auch nach `PACKAGES_INCLUDED` aufrufen

### DIFF
--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -20,8 +20,6 @@ class rex_backend_login extends rex_login
     /** @var rex_backend_password_policy */
     private $passwordPolicy;
 
-    private static bool $sessionRegenerationForBackendLogin = false;
-
     public function __construct()
     {
         parent::__construct();
@@ -305,23 +303,13 @@ class rex_backend_login extends rex_login
         return new rex_login_policy($loginPolicy);
     }
 
-    public static function regenerateSessionId()
-    {
-        self::$sessionRegenerationForBackendLogin = true;
-        try {
-            parent::regenerateSessionId();
-        } finally {
-            self::$sessionRegenerationForBackendLogin = false;
-        }
-    }
-
     /**
      * @internal
      * @param rex_extension_point<null> $ep
      */
     public static function sessionRegenerated(rex_extension_point $ep): void
     {
-        if (self::$sessionRegenerationForBackendLogin) {
+        if (self::class === $ep->getParam('class')) {
             return;
         }
 

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -533,10 +533,18 @@ class rex_login
 
             rex_csrf_token::removeAll();
 
-            rex_extension::registerPoint(new rex_extension_point('SESSION_REGENERATED', null, [
+            $extensionPoint = new rex_extension_point('SESSION_REGENERATED', null, [
                 'previous_id' => $previous,
                 'new_id' => session_id(),
-            ], true));
+                'class' => static::class,
+            ], true);
+
+            // We don't know here if packages have already been loaded
+            // Therefore we call the extension point twice, directly and after PACKAGES_INCLUDED
+            rex_extension::registerPoint($extensionPoint);
+            rex_extension::register('PACKAGES_INCLUDED', static function () use ($extensionPoint) {
+                rex_extension::registerPoint($extensionPoint);
+            }, rex_extension::EARLY);
         }
 
         // session-id is shared between frontend/backend or even redaxo instances per server because it's the same http session


### PR DESCRIPTION
Der Core-Login passiert vor dem Laden der Addons. Die konnten sich also gar nicht rechtzeitig an den EP hängen.