### PR TITLE
Syslog: Debug-Meldungen nicht in rot

### DIFF
--- a/redaxo/src/core/pages/system.log.redaxo.php
+++ b/redaxo/src/core/pages/system.log.redaxo.php
@@ -61,7 +61,7 @@ foreach (new LimitIterator($file, 0, 100) as $entry) {
     $data = $entry->getData();
 
     $class = strtolower($data[0]);
-    $class = ('notice' == $class || 'warning' == $class || 'success' == $class || 'info' == $class) ? $class : 'error';
+    $class = in_array($class, ['notice', 'warning', 'success', 'info', 'debug'], true) ? $class : 'error';
 
     $path = '';
     if (isset($data[2])) {


### PR DESCRIPTION
Der Core gibt nirgends solche Meldungen aus, aber wenn man selbst welcher per 
`rex_logger:.factory()->debug('...');`
ausgibt, dann erschienen die rot (Error) im Log.

Neu erscheinen sie ohne eigene Hintergrundfarbe, also normale Tabellen-Hintergrundfarbe.
Sie haben aber eine eigene Klasse `rex-state-debug`, worüber sie gestylt werden könnten.