### PR TITLE
rex_escape: bei stdClass neues Objekt erzeugen

### DIFF
--- a/redaxo/src/core/functions/function_rex_escape.php
+++ b/redaxo/src/core/functions/function_rex_escape.php
@@ -42,11 +42,12 @@ function rex_escape($value, $strategy = 'html')
         }
 
         if ($value instanceof stdClass) {
+            $escaped = new stdClass();
             foreach (get_object_vars($value) as $k => $v) {
-                $value->$k = rex_escape($v, $strategy);
+                $escaped->$k = rex_escape($v, $strategy);
             }
 
-            return $value;
+            return $escaped;
         }
 
         if (is_object($value) && method_exists($value, '__toString')) {

--- a/redaxo/src/core/functions/function_rex_escape.php
+++ b/redaxo/src/core/functions/function_rex_escape.php
@@ -42,12 +42,12 @@ function rex_escape($value, $strategy = 'html')
         }
 
         if ($value instanceof stdClass) {
-            $value = clone $value;
+            $clone = clone $value;
             foreach (get_object_vars($value) as $k => $v) {
-                $value->$k = rex_escape($v, $strategy);
+                $clone->$k = rex_escape($v, $strategy);
             }
 
-            return $value;
+            return $clone;
         }
 
         if (is_object($value) && method_exists($value, '__toString')) {

--- a/redaxo/src/core/functions/function_rex_escape.php
+++ b/redaxo/src/core/functions/function_rex_escape.php
@@ -42,12 +42,12 @@ function rex_escape($value, $strategy = 'html')
         }
 
         if ($value instanceof stdClass) {
-            $escaped = new stdClass();
+            $value = clone $value;
             foreach (get_object_vars($value) as $k => $v) {
-                $escaped->$k = rex_escape($v, $strategy);
+                $value->$k = rex_escape($v, $strategy);
             }
 
-            return $escaped;
+            return $value;
         }
 
         if (is_object($value) && method_exists($value, '__toString')) {

--- a/redaxo/src/core/tests/functions_test.php
+++ b/redaxo/src/core/tests/functions_test.php
@@ -1,0 +1,25 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class rex_functions_test extends TestCase
+{
+    public function testEscapeObject(): void
+    {
+        $obj = new stdClass();
+        $obj->num = 1;
+        $str = '<b>foo</b>';
+        $obj->str = $str;
+
+        $escapped = rex_escape($obj);
+
+        static::assertSame($str, $obj->str);
+
+        static::assertInstanceOf(stdClass::class, $escapped);
+        static::assertSame(1, $escapped->num);
+        static::assertSame('&lt;b&gt;foo&lt;/b&gt;', $escapped->str);
+    }
+}

--- a/redaxo/src/core/tests/functions_test.php
+++ b/redaxo/src/core/tests/functions_test.php
@@ -16,6 +16,7 @@ class rex_functions_test extends TestCase
 
         $escapped = rex_escape($obj);
 
+        /** @psalm-suppress RedundantCondition */
         static::assertSame($str, $obj->str);
 
         static::assertInstanceOf(stdClass::class, $escapped);


### PR DESCRIPTION
`$escaped = rex_escape($object);` 
Das übergebene Objekt sollte nicht angepasst werden, sondern es sollte ein neues escapetes zurückgeliefert werden.
Betrachte ich als Bug.