### PR TITLE
Numeric Literal Separator nutzen

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -3315,15 +3315,15 @@
                 }
 
                 $codepoint = mb_ord($char, 'UTF-8');
-                if (0x10000 &gt; $codepoint) {
+                if (0x1_00_00 &gt; $codepoint) {
                     return sprintf('\u%04X', $codepoint);
                 }
 
                 // Split characters outside the BMP into surrogate pairs
                 // https://tools.ietf.org/html/rfc2781.html#section-2.1
-                $u = $codepoint - 0x10000;
-                $high = 0xD800 | ($u &gt;&gt; 10);
-                $low = 0xDC00 | ($u &amp; 0x3FF);
+                $u = $codepoint - 0x1_00_00;
+                $high = 0xD8_00 | ($u &gt;&gt; 10);
+                $low = 0xDC_00 | ($u &amp; 0x3_FF);
 
                 return sprintf('\u%04X\u%04X', $high, $low);
             }</code>

--- a/redaxo/src/addons/backup/pages/export.php
+++ b/redaxo/src/addons/backup/pages/export.php
@@ -1,7 +1,7 @@
 <?php
 
 // Für größere Exports den Speicher für PHP erhöhen.
-if (rex_ini_get('memory_limit') < 67108864) {
+if (rex_ini_get('memory_limit') < 67_108_864) {
     @ini_set('memory_limit', '64M');
 }
 

--- a/redaxo/src/addons/backup/pages/index.php
+++ b/redaxo/src/addons/backup/pages/index.php
@@ -1,7 +1,7 @@
 <?php
 
 // Für größere Exports den Speicher für PHP erhöhen.
-if (rex_ini_get('memory_limit') < 67108864) {
+if (rex_ini_get('memory_limit') < 67_108_864) {
     @ini_set('memory_limit', '64M');
 }
 

--- a/redaxo/src/addons/cronjob/lib/manager.php
+++ b/redaxo/src/addons/cronjob/lib/manager.php
@@ -142,7 +142,7 @@ class rex_cronjob_manager
             $environment = rex::getEnvironment();
         }
 
-        $log = new rex_log_file(rex_path::log('cronjob.log'), 2000000);
+        $log = new rex_log_file(rex_path::log('cronjob.log'), 2_000_000);
         $data = [
             $success ? 'SUCCESS' : 'ERROR',
             $this->id ?: '--',

--- a/redaxo/src/addons/media_manager/lib/effects/effect_mirror.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_mirror.php
@@ -160,7 +160,7 @@ class rex_effect_mirror extends rex_effect_abstract
         for ($y = 1; $y <= $reflectionHeight; ++$y) {
             for ($x = 0; $x < $destWidth; ++$x) {
                 $rgba = imagecolorat($image, $x, $srcHeight - $y);
-                $alpha = ($rgba & 0x7F000000) >> 24;
+                $alpha = ($rgba & 0x7F_00_00_00) >> 24;
                 $alpha = max($alpha, 47 + ($y * $alphaStep));
                 $rgba = imagecolorsforindex($image, $rgba);
                 $rgba = imagecolorallocatealpha($reflected, $rgba['red'], $rgba['green'], $rgba['blue'], $alpha);

--- a/redaxo/src/addons/metainfo/lib/table_expander.php
+++ b/redaxo/src/addons/metainfo/lib/table_expander.php
@@ -254,7 +254,7 @@ class rex_metainfo_table_expander extends rex_form
         // Dies muss hier geschehen, da in parent::save() die Werte fuer die DB mit den
         // POST werten ueberschrieben werden!
         $fieldOldName = '';
-        $fieldOldPriority = 9999999999999; // dirty, damit die prio richtig laeuft...
+        $fieldOldPriority = 9_999_999_999_999; // dirty, damit die prio richtig laeuft...
         if (1 == $this->sql->getRows()) {
             $fieldOldName = (string) $this->sql->getValue('name');
             $fieldOldPriority = (int) $this->sql->getValue('priority');

--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -178,7 +178,7 @@ class rex_mailer extends PHPMailer
             $replytos = implode(', ', array_column($this->getReplyToAddresses(), 0));
         }
 
-        $log = new rex_log_file(self::logFile(), 2000000);
+        $log = new rex_log_file(self::logFile(), 2_000_000);
         $data = [
             $success,
             $this->From.($replytos ? '; reply-to: '.$replytos : ''),

--- a/redaxo/src/addons/structure/lib/service_article.php
+++ b/redaxo/src/addons/structure/lib/service_article.php
@@ -772,7 +772,7 @@ class rex_article_service
                     $artSql->setValue('catpriority', 0);
                     $artSql->setValue('path', $path);
                     $artSql->setValue('name', $fromSql->getValue('name') . ' ' . rex_i18n::msg('structure_copy'));
-                    $artSql->setValue('priority', 99999); // Artikel als letzten Artikel in die neue Kat einfügen
+                    $artSql->setValue('priority', 99_999); // Artikel als letzten Artikel in die neue Kat einfügen
                     $artSql->setValue('status', 0); // Kopierter Artikel offline setzen
                     $artSql->setValue('startarticle', 0);
                     $artSql->addGlobalUpdateFields($user);

--- a/redaxo/src/addons/structure/plugins/content/tests/article_slice_test.php
+++ b/redaxo/src/addons/structure/plugins/content/tests/article_slice_test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_article_slice_test extends TestCase
 {
-    private const FAKE_ID = 2147483647; // max int on 32bit
+    private const FAKE_ID = 2_147_483_647; // max int on 32bit
 
     protected function tearDown(): void
     {

--- a/redaxo/src/core/fragments/core/page/section.php
+++ b/redaxo/src/core/fragments/core/page/section.php
@@ -27,7 +27,7 @@ $sectionAttributes['class'][] = 'rex-page-section';
     <?php endif; ?>
 
         <?php
-        $collapseId = (isset($this->collapse) && $this->collapse) ? 'collapse-' . random_int(100000, 999999) : '';
+        $collapseId = (isset($this->collapse) && $this->collapse) ? 'collapse-' . random_int(100_000, 999_999) : '';
         $collapsed = isset($this->collapsed) && $this->collapsed;
         $header = '';
 

--- a/redaxo/src/core/functions/function_rex_escape.php
+++ b/redaxo/src/core/functions/function_rex_escape.php
@@ -101,15 +101,15 @@ function rex_escape($value, $strategy = 'html')
                 }
 
                 $codepoint = mb_ord($char, 'UTF-8');
-                if (0x10000 > $codepoint) {
+                if (0x1_00_00 > $codepoint) {
                     return sprintf('\u%04X', $codepoint);
                 }
 
                 // Split characters outside the BMP into surrogate pairs
                 // https://tools.ietf.org/html/rfc2781.html#section-2.1
-                $u = $codepoint - 0x10000;
-                $high = 0xD800 | ($u >> 10);
-                $low = 0xDC00 | ($u & 0x3FF);
+                $u = $codepoint - 0x1_00_00;
+                $high = 0xD8_00 | ($u >> 10);
+                $low = 0xDC_00 | ($u & 0x3_FF);
 
                 return sprintf('\u%04X\u%04X', $high, $low);
             }, $string);

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -79,7 +79,7 @@ class rex_login
 
     public function __construct()
     {
-        $this->sessionMaxOverallDuration = rex::getProperty('session_max_overall_duration', 2419200); // 4 weeks
+        $this->sessionMaxOverallDuration = rex::getProperty('session_max_overall_duration', 2_419_200); // 4 weeks
 
         self::startSession();
     }

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -540,7 +540,7 @@ class rex_response
 
         $str = 'Set-Cookie: '. ($raw ? $name : urlencode($name)).'=';
         if ('' === (string) $value) {
-            $str .= 'deleted; expires='.gmdate('D, d-M-Y H:i:s T', time() - 31536001).'; Max-Age=0';
+            $str .= 'deleted; expires='.gmdate('D, d-M-Y H:i:s T', time() - 31_536_001).'; Max-Age=0';
         } else {
             $str .= $raw ? $value : rawurlencode($value);
             if (0 !== $expire) {

--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -131,7 +131,7 @@ class rex_logger extends AbstractLogger
     {
         // check if already opened
         if (!self::$file) {
-            self::$file = new rex_log_file(self::getPath(), 2000000);
+            self::$file = new rex_log_file(self::getPath(), 2_000_000);
         }
     }
 

--- a/redaxo/src/core/lib/util/timer.php
+++ b/redaxo/src/core/lib/util/timer.php
@@ -10,8 +10,8 @@
 class rex_timer
 {
     public const SEC = 1;
-    public const MILLISEC = 1000;
-    public const MICROSEC = 1000000;
+    public const MILLISEC = 1_000;
+    public const MICROSEC = 1_000_000;
 
     /**
      * @internal


### PR DESCRIPTION
Bei 4-stelligen Zahlen habe ich es erstmal weggelassen. Da bin ich mir nicht sicher, ob das überhaupt eine Verbesserung ist, also `1_024` statt `1024`. Insbesondere auch bei Jahreszahlen.. `2_005`.