### PR TITLE
rex_extension::registerPoint: Conditional Return-Type wieder entfernt

### DIFF
--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -126,11 +126,6 @@ parameters:
 			path: ../../redaxo/src/addons/debug/lib/debug.php
 
 		-
-			message: "#^Conditional return type uses subject type T which is not part of PHPDoc @template tags\\.$#"
-			count: 1
-			path: ../../redaxo/src/addons/debug/lib/extensions/extension_debug.php
-
-		-
 			message: "#^Method rex_extension_debug\\:\\:getExtensionPoints\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/addons/debug/lib/extensions/extension_debug.php

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -468,15 +468,11 @@
     </MixedArrayAssignment>
     <MixedAssignment>
       <code>$data['listeners']</code>
-      <code>$res</code>
     </MixedAssignment>
     <MixedOperand>
       <code>$trace['file']</code>
       <code>$trace['line']</code>
     </MixedOperand>
-    <MixedReturnStatement>
-      <code>$res</code>
-    </MixedReturnStatement>
   </file>
   <file src="redaxo/src/addons/debug/lib/extensions/logger_debug.php">
     <MixedArgument>
@@ -1022,7 +1018,6 @@
       <code>$data['file']['type']</code>
       <code>$data['height']</code>
       <code>$data['width']</code>
-      <code>$errorMessage</code>
       <code>$jpgExtensions</code>
       <code>$jpgExtensions</code>
       <code>$size[0]</code>
@@ -1036,7 +1031,6 @@
       <code>$data['file']['type']</code>
       <code>$data['height']</code>
       <code>$data['width']</code>
-      <code>$errorMessage</code>
       <code>$return['type']</code>
     </MixedAssignment>
     <PossiblyNullOperand>
@@ -2168,12 +2162,6 @@
     </MoreSpecificReturnType>
   </file>
   <file src="redaxo/src/addons/structure/plugins/content/lib/article_content_base.php">
-    <MixedArgument>
-      <code>$output</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$output</code>
-    </MixedAssignment>
     <PossiblyFalseArgument>
       <code>$TEMPLATE-&gt;getTemplate()</code>
     </PossiblyFalseArgument>
@@ -3964,9 +3952,6 @@
     <MixedOperand>
       <code>$level</code>
     </MixedOperand>
-    <MixedReturnStatement>
-      <code>$factoryClass::registerPoint($extensionPoint)</code>
-    </MixedReturnStatement>
   </file>
   <file src="redaxo/src/core/lib/form/config_form.php">
     <PossiblyNullOperand>
@@ -5049,19 +5034,6 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="redaxo/src/core/lib/util/editor.php">
-    <MixedInferredReturnType>
-      <code>string|null</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code>rex_extension::registerPoint(new rex_extension_point('EDITOR_URL', $editorUrl, [
-            'file' =&gt; $filePath,
-            'line' =&gt; $line,
-        ]))</code>
-      <code>rex_extension::registerPoint(new rex_extension_point('EDITOR_URL', $editorUrl, [
-            'file' =&gt; $filePath,
-            'line' =&gt; $line,
-        ]))</code>
-    </MixedReturnStatement>
     <PossiblyInvalidArgument>
       <code>$line</code>
     </PossiblyInvalidArgument>

--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -67,6 +67,7 @@ final class rex_media_service
         // Sobald ein Addon eine negative Entscheidung getroffen hat, sollten
         // Addons, fuer die der Extension-Point spaeter ausgefuehrt wird, diese
         // Entscheidung respektieren
+        /** @var string|null $errorMessage */
         $errorMessage = null;
         $errorMessage = rex_extension::registerPoint(new rex_extension_point('MEDIA_ADD', $errorMessage, [
             'file' => $data['file'],

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -328,7 +328,7 @@ class rex_article_content_base
     {
         $output = rex_extension::registerPoint(new rex_extension_point(
             'SLICE_OUTPUT',
-            $artDataSql->getValue(rex::getTablePrefix() . 'module.output'),
+            (string) $artDataSql->getValue(rex::getTablePrefix() . 'module.output'),
             [
                 'article_id' => $this->article_id,
                 'clang' => $this->clang,

--- a/redaxo/src/core/lib/extension.php
+++ b/redaxo/src/core/lib/extension.php
@@ -27,7 +27,7 @@ abstract class rex_extension
      *
      * @template T
      * @param rex_extension_point<T> $extensionPoint Extension point
-     * @return (T is null ? mixed : T) Subject, maybe adjusted by the extensions
+     * @return T Subject, maybe adjusted by the extensions
      *
      * @psalm-taint-specialize
      */


### PR DESCRIPTION
Dies ist ein Revert von https://github.com/redaxo/redaxo/pull/5455