### PR TITLE
rex_backend_loging::hasSession: Prüfen, ob Header bereits gesendet

### DIFF
--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -291,6 +291,12 @@ class rex_backend_login extends rex_login
         if (!isset($_COOKIE[session_name()])) {
             return false;
         }
+
+        // it is not possible to start a session if headers are already sent
+        if (PHP_SESSION_ACTIVE !== session_status() && headers_sent()) {
+            return false;
+        }
+
         self::startSession();
 
         return ($_SESSION[static::getSessionNamespace()][self::SYSTEM_ID][rex_login::SESSION_USER_ID] ?? 0) > 0;


### PR DESCRIPTION
Wir nutzen `rex_backend_login::createUser()` an verschiedenen Stellen in Fehlerfällen, um anders zu handeln, falls ein Backend-Admin eingeloggt ist.

Wenn so ein Fehlerfall aber auftritt, nachdem die Header schon gesendet wurden, ist es nicht mehr möglich die Session zu starten. 
Daher kommt es dann zu Folgefehlern ("headers already sent" etc.), wodurch es teils recht schwer wird, den eigentlichen Fehler zu finden.

Das Problem trat in Slack auf bei einem `class_exists`-Aufruf. Der ging an unseren Autoloader, der hat die Klasse nicht gefunden, und wollte dann die Backend-Session. Denn für Backend-Admins hätte der Autoloader den Autoload-Cache erneuert.

Daher würde ich den `headers_sent`-Check in `rex_backend_login::hasSession` aufnehmen. 
Somit liefert die Methode false, wenn Header schon gesendet.