### PR TITLE
Commands config:get/set und db:connection-options als Standalone-Commands

### DIFF
--- a/redaxo/src/core/lib/console/config/get.php
+++ b/redaxo/src/core/lib/console/config/get.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
-class rex_command_config_get extends rex_console_command
+class rex_command_config_get extends rex_console_command implements rex_command_standalone
 {
     protected function configure(): void
     {

--- a/redaxo/src/core/lib/console/config/set.php
+++ b/redaxo/src/core/lib/console/config/set.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
-class rex_command_config_set extends rex_console_command
+class rex_command_config_set extends rex_console_command implements rex_command_standalone
 {
     protected function configure(): void
     {

--- a/redaxo/src/core/lib/console/db/connection_options.php
+++ b/redaxo/src/core/lib/console/db/connection_options.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
-class rex_command_db_connection_options extends rex_console_command
+class rex_command_db_connection_options extends rex_console_command implements rex_command_standalone
 {
     protected function configure(): void
     {


### PR DESCRIPTION
Ähnlich wie `db:set-connection` sollten auch die drei Commands `config:get`, `config:set` und `db:connection-options` immer ausführbar sein, auch wenn die aktuelle DB-Verbindung ungültig ist, oder die DB leer ist.

Gibt auch keine Notwendigkeit, bei den Commands die Addons zu laden.