### PR TITLE
Passkeys funktionierten in Chrome nicht

### DIFF
--- a/redaxo/src/core/assets/webauthn.js
+++ b/redaxo/src/core/assets/webauthn.js
@@ -123,9 +123,7 @@ if (window.PublicKeyCredential &&
             return;
         }
 
-        $(document).on('rex:ready', function (event, container) {
-            container = container.get(0);
-
+        const init = function (container) {
             let form = container.querySelector('form[data-auth-add-passkey]');
             if (form) {
                 authAddPasskey(form);
@@ -140,6 +138,14 @@ if (window.PublicKeyCredential &&
             if (form) {
                 authLogin(form);
             }
-        });
+        }
+
+        init(document.body);
+
+        setTimeout(function () {
+            $(document).on('rex:ready', function (event, container) {
+                init(container.get(0));
+            });
+        }, 1000);
     });
 }

--- a/redaxo/src/core/assets/webauthn.js
+++ b/redaxo/src/core/assets/webauthn.js
@@ -114,6 +114,12 @@ const arrayBufferToBase64 = function (buffer) {
 if (window.PublicKeyCredential &&
     PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable &&
     PublicKeyCredential.isConditionalMediationAvailable) {
+
+    let ready = false;
+    $(document).on('rex:ready', function () {
+        ready = true;
+    });
+
     // Check if user verifying platform authenticator is available.
     Promise.all([
         PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable(),
@@ -140,12 +146,12 @@ if (window.PublicKeyCredential &&
             }
         }
 
-        init(document.body);
+        if (ready) {
+            init(document.body);
+        }
 
-        setTimeout(function () {
-            $(document).on('rex:ready', function (event, container) {
-                init(container.get(0));
-            });
-        }, 1000);
+        $(document).on('rex:ready', function (event, container) {
+            init(container.get(0));
+        });
     });
 }


### PR DESCRIPTION
`rex:ready` ist im Chrome schon gelaufen, wenn der Code in der webauthn.js erreicht wird.
Daher nun ein Workaround.