### PR TITLE
Prevent error in phpstorm, when calling `rex_fragment->parse()`

### DIFF
--- a/redaxo/src/core/lib/fragment.php
+++ b/redaxo/src/core/lib/fragment.php
@@ -99,7 +99,6 @@ class rex_fragment
      * @param string $filename the filename of the fragment to parse
      *
      * @throws InvalidArgumentException
-     * @throws rex_exception
      *
      * @return string
      */
@@ -130,7 +129,7 @@ class rex_fragment
             }
         }
 
-        throw new rex_exception(sprintf('Fragmentfile "%s" not found!', $filename));
+        throw new InvalidArgumentException(sprintf('Fragmentfile "%s" not found!', $filename));
     }
 
     /**


### PR DESCRIPTION
refs https://github.com/redaxo/redaxo/issues/5336

---

ich denke es macht sinn in diesem fall eine `InvalidArgumentException` zu werfen.
auch sollten wir damit den false-positive im phpstorm beheben