### PR TITLE
SensitiveParemter-Attribute an weiteren Stellen nutzen

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -4167,7 +4167,7 @@
         ]]]></code>
     </InvalidArgument>
     <InvalidAttribute>
-      <code>\SensitiveParameter</code>
+      <code>SensitiveParameter</code>
     </InvalidAttribute>
     <MixedArgument>
       <code><![CDATA[rex::getProperty('session_duration')]]></code>
@@ -4193,6 +4193,11 @@
     <ArgumentTypeCoercion>
       <code>$previousPasswords</code>
     </ArgumentTypeCoercion>
+    <InvalidAttribute>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+    </InvalidAttribute>
     <MixedArgument>
       <code>$previousPasswords</code>
     </MixedArgument>
@@ -4210,13 +4215,13 @@
   </file>
   <file src="redaxo/src/core/lib/login/login.php">
     <InvalidAttribute>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
     </InvalidAttribute>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION[static::getSessionNamespace()][$this->systemId]]]></code>
@@ -4257,8 +4262,8 @@
   </file>
   <file src="redaxo/src/core/lib/login/password_policy.php">
     <InvalidAttribute>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
     </InvalidAttribute>
     <PossiblyNullArgument>
       <code><![CDATA[$this->getDescription()]]></code>
@@ -4287,7 +4292,7 @@
       <code>$role</code>
     </ArgumentTypeCoercion>
     <InvalidAttribute>
-      <code>\SensitiveParameter</code>
+      <code>SensitiveParameter</code>
     </InvalidAttribute>
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->sql->getValue($key)]]></code>
@@ -4709,10 +4714,14 @@
       <code>$value</code>
     </ArgumentTypeCoercion>
     <InvalidAttribute>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
-      <code>\SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
     </InvalidAttribute>
     <LessSpecificReturnStatement>
       <code><![CDATA[$sql->getValue('Create Table')]]></code>
@@ -5055,6 +5064,10 @@
             }
         }]]></code>
     </InvalidArgument>
+    <InvalidAttribute>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+    </InvalidAttribute>
     <MixedArgument>
       <code><![CDATA[$parts['host']]]></code>
       <code><![CDATA[$parts['path']]]></code>

--- a/redaxo/src/addons/structure/plugins/history/lib/history_login.php
+++ b/redaxo/src/addons/structure/plugins/history/lib/history_login.php
@@ -33,7 +33,7 @@ class rex_history_login extends rex_backend_login
     /**
      * @return null|string
      */
-    public static function createSessionKey(#[\SensitiveParameter] $login, $session, $validtime)
+    public static function createSessionKey(#[SensitiveParameter] $login, $session, $validtime)
     {
         return password_hash($login . $session . $validtime, PASSWORD_DEFAULT);
     }

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -224,7 +224,7 @@ class rex_backend_login extends rex_login
         return (bool) $this->getSessionVar(self::SESSION_PASSWORD_CHANGE_REQUIRED, false);
     }
 
-    public function changedPassword(#[\SensitiveParameter] ?string $passwordHash = null): void
+    public function changedPassword(#[SensitiveParameter] ?string $passwordHash = null): void
     {
         $this->setSessionVar(self::SESSION_PASSWORD_CHANGE_REQUIRED, false);
 

--- a/redaxo/src/core/lib/login/backend_password_policy.php
+++ b/redaxo/src/core/lib/login/backend_password_policy.php
@@ -76,7 +76,7 @@ class rex_backend_password_policy extends rex_password_policy
         return new $class();
     }
 
-    public function check($password, $id = null)
+    public function check(#[SensitiveParameter] $password, $id = null)
     {
         if (true !== $msg = parent::check($password, $id)) {
             return $msg;
@@ -121,7 +121,7 @@ class rex_backend_password_policy extends rex_password_policy
      *
      * @return list<array{string, int}>
      */
-    public function updatePreviousPasswords(?rex_user $user, string $password): array
+    public function updatePreviousPasswords(?rex_user $user, #[SensitiveParameter] string $password): array
     {
         if (!isset($this->noReuseOfLast) && !isset($this->noReuseWithin)) {
             return [];
@@ -142,7 +142,7 @@ class rex_backend_password_policy extends rex_password_policy
      * @param list<array{string, int}> $previousPasswords
      * @return list<array{string, int}>
      */
-    private function cleanUpPreviousPasswords(array $previousPasswords): array
+    private function cleanUpPreviousPasswords(#[SensitiveParameter] array $previousPasswords): array
     {
         if (!isset($this->noReuseOfLast) && !isset($this->noReuseWithin)) {
             return [];

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -136,7 +136,7 @@ class rex_login
      * @param bool $isPreHashed
      * @return void
      */
-    public function setLogin(#[\SensitiveParameter] $login, #[\SensitiveParameter] $password, $isPreHashed = false)
+    public function setLogin(#[SensitiveParameter] $login, #[SensitiveParameter] $password, $isPreHashed = false)
     {
         $this->userLogin = $login;
         $this->userPassword = $isPreHashed ? $password : sha1($password);
@@ -418,7 +418,7 @@ class rex_login
         $this->setSessionVar(self::SESSION_IMPERSONATOR, null);
     }
 
-    public function changedPassword(#[\SensitiveParameter] ?string $passwordHash): void
+    public function changedPassword(#[SensitiveParameter] ?string $passwordHash): void
     {
         $this->setSessionVar(self::SESSION_PASSWORD, $passwordHash);
     }
@@ -663,7 +663,7 @@ class rex_login
      * @param bool $isPreHashed
      * @return string Returns the hashed password
      */
-    public static function passwordHash(#[\SensitiveParameter] $password, $isPreHashed = false)
+    public static function passwordHash(#[SensitiveParameter] $password, $isPreHashed = false)
     {
         $password = $isPreHashed ? $password : sha1($password);
 
@@ -676,7 +676,7 @@ class rex_login
      * @param bool $isPreHashed
      * @return bool returns TRUE if the password and hash match, or FALSE otherwise
      */
-    public static function passwordVerify(#[\SensitiveParameter] $password, #[\SensitiveParameter] $hash, $isPreHashed = false)
+    public static function passwordVerify(#[SensitiveParameter] $password, #[SensitiveParameter] $hash, $isPreHashed = false)
     {
         $password = $isPreHashed ? $password : sha1($password);
         return password_verify($password, $hash);
@@ -686,7 +686,7 @@ class rex_login
      * @param string $hash
      * @return bool returns TRUE if the hash should be rehashed to match the given algo and options, or FALSE otherwise
      */
-    public static function passwordNeedsRehash(#[\SensitiveParameter] $hash)
+    public static function passwordNeedsRehash(#[SensitiveParameter] $hash)
     {
         return password_needs_rehash($hash, PASSWORD_DEFAULT);
     }

--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -26,7 +26,7 @@ class rex_password_policy
      *
      * @return true|string `true` on success, otherwise an error message
      */
-    public function check(#[\SensitiveParameter] $password, $id = null)
+    public function check(#[SensitiveParameter] $password, $id = null)
     {
         if ($this->isValid($password)) {
             return true;
@@ -112,7 +112,7 @@ class rex_password_policy
      * @param string $password
      * @return bool
      */
-    protected function isValid(#[\SensitiveParameter] $password)
+    protected function isValid(#[SensitiveParameter] $password)
     {
         foreach ($this->options as $key => $options) {
             $count = match ($key) {

--- a/redaxo/src/core/lib/login/user.php
+++ b/redaxo/src/core/lib/login/user.php
@@ -57,7 +57,7 @@ class rex_user
         });
     }
 
-    public static function forLogin(#[\SensitiveParameter] string $login): ?self
+    public static function forLogin(#[SensitiveParameter] string $login): ?self
     {
         return static::getInstance('login_' . $login, static function () use ($login) {
             $sql = rex_sql::factory()->setQuery('SELECT * FROM '.rex::getTable('user').' WHERE login = ?', [$login]);

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -169,10 +169,10 @@ class rex_sql implements Iterator
      * @return PDO
      */
     protected static function createConnection(
-        #[\SensitiveParameter] $host,
-        #[\SensitiveParameter] $database,
-        #[\SensitiveParameter] $login,
-        #[\SensitiveParameter] $password,
+        #[SensitiveParameter] $host,
+        #[SensitiveParameter] $database,
+        #[SensitiveParameter] $login,
+        #[SensitiveParameter] $password,
         $persistent = false,
         array $options = [],
     ) {
@@ -1910,7 +1910,12 @@ class rex_sql implements Iterator
      *
      * @return true|string
      */
-    public static function checkDbConnection($host, $login, $password, $database, $createDb = false)
+    public static function checkDbConnection(
+        #[SensitiveParameter] $host,
+        #[SensitiveParameter] $login,
+        #[SensitiveParameter] $password,
+        #[SensitiveParameter] $database,
+        $createDb = false)
     {
         if (!$database) {
             return rex_i18n::msg('sql_database_name_missing');

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -171,7 +171,7 @@ class rex_socket
      *
      * @return $this Current socket
      */
-    public function addBasicAuthorization($user, $password)
+    public function addBasicAuthorization(#[SensitiveParameter] $user, #[SensitiveParameter] $password)
     {
         $this->addHeader('Authorization', 'Basic ' . base64_encode($user . ':' . $password));
 


### PR DESCRIPTION
und einheitlich ohne Backslash vorne