### PR TITLE
Fragment-Component-Klassen sollten final sein

### DIFF
--- a/redaxo/src/core/lib/Fragment/Component/Alert.php
+++ b/redaxo/src/core/lib/Fragment/Component/Alert.php
@@ -8,7 +8,7 @@ use Redaxo\Core\Fragment\HtmlAttributes;
 /**
  * @see redaxo/src/core/fragments/core/Component/Alert.php
  */
-class Alert extends Fragment
+final class Alert extends Fragment
 {
     public function __construct(
         /**

--- a/redaxo/src/core/lib/Fragment/Component/Alert/Error.php
+++ b/redaxo/src/core/lib/Fragment/Component/Alert/Error.php
@@ -9,7 +9,7 @@ use Redaxo\Core\Fragment\Component\IconLibrary;
 use Redaxo\Core\Fragment\Fragment;
 use Redaxo\Core\Fragment\HtmlAttributes;
 
-class Error extends Fragment
+final class Error extends Fragment
 {
     public function __construct(
         /** @see Alert::$body */

--- a/redaxo/src/core/lib/Fragment/Component/Alert/Info.php
+++ b/redaxo/src/core/lib/Fragment/Component/Alert/Info.php
@@ -9,7 +9,7 @@ use Redaxo\Core\Fragment\Component\IconLibrary;
 use Redaxo\Core\Fragment\Fragment;
 use Redaxo\Core\Fragment\HtmlAttributes;
 
-class Info extends Fragment
+final class Info extends Fragment
 {
     public function __construct(
         /** @see Alert::$body */

--- a/redaxo/src/core/lib/Fragment/Component/Alert/Success.php
+++ b/redaxo/src/core/lib/Fragment/Component/Alert/Success.php
@@ -9,7 +9,7 @@ use Redaxo\Core\Fragment\Component\IconLibrary;
 use Redaxo\Core\Fragment\Fragment;
 use Redaxo\Core\Fragment\HtmlAttributes;
 
-class Success extends Fragment
+final class Success extends Fragment
 {
     public function __construct(
         /** @see Alert::$body */

--- a/redaxo/src/core/lib/Fragment/Component/Alert/Warning.php
+++ b/redaxo/src/core/lib/Fragment/Component/Alert/Warning.php
@@ -9,7 +9,7 @@ use Redaxo\Core\Fragment\Component\IconLibrary;
 use Redaxo\Core\Fragment\Fragment;
 use Redaxo\Core\Fragment\HtmlAttributes;
 
-class Warning extends Fragment
+final class Warning extends Fragment
 {
     public function __construct(
         /** @see Alert::$body */

--- a/redaxo/src/core/lib/Fragment/Component/Button.php
+++ b/redaxo/src/core/lib/Fragment/Component/Button.php
@@ -8,7 +8,7 @@ use Redaxo\Core\Fragment\HtmlAttributes;
 /**
  * @see redaxo/src/core/fragments/core/Component/Button.php
  */
-class Button extends Fragment
+final class Button extends Fragment
 {
     public function __construct(
         /**

--- a/redaxo/src/core/lib/Fragment/Component/Button/Add.php
+++ b/redaxo/src/core/lib/Fragment/Component/Button/Add.php
@@ -10,7 +10,7 @@ use Redaxo\Core\Fragment\Fragment;
 use Redaxo\Core\Fragment\HtmlAttributes;
 use rex_i18n;
 
-class Add extends Fragment
+final class Add extends Fragment
 {
     public function __construct(
         public ?string $href = null,

--- a/redaxo/src/core/lib/Fragment/Component/Button/Save.php
+++ b/redaxo/src/core/lib/Fragment/Component/Button/Save.php
@@ -11,7 +11,7 @@ use Redaxo\Core\Fragment\Fragment;
 use Redaxo\Core\Fragment\HtmlAttributes;
 use rex_i18n;
 
-class Save extends Fragment
+final class Save extends Fragment
 {
     public function __construct(
         public string|Fragment|null $label = null,

--- a/redaxo/src/core/lib/Fragment/Component/Card.php
+++ b/redaxo/src/core/lib/Fragment/Component/Card.php
@@ -8,7 +8,7 @@ use Redaxo\Core\Fragment\HtmlAttributes;
 /**
  * @see redaxo/src/core/fragments/core/Component/Card.php
  */
-class Card extends Fragment
+final class Card extends Fragment
 {
     public function __construct(
         /**

--- a/redaxo/src/core/lib/Fragment/Component/Checkbox.php
+++ b/redaxo/src/core/lib/Fragment/Component/Checkbox.php
@@ -8,7 +8,7 @@ use Redaxo\Core\Fragment\HtmlAttributes;
 /**
  * @see redaxo/src/core/fragments/core/Component/Checkbox.php
  */
-class Checkbox extends Fragment
+final class Checkbox extends Fragment
 {
     public function __construct(
         /**

--- a/redaxo/src/core/lib/Fragment/Component/Choice.php
+++ b/redaxo/src/core/lib/Fragment/Component/Choice.php
@@ -18,7 +18,7 @@ use function is_int;
  * @see redaxo/src/core/fragments/core/Component/ChoiceRadio.php
  * @see redaxo/src/core/fragments/core/Component/ChoiceSelect.php
  */
-class Choice extends Fragment
+final class Choice extends Fragment
 {
     /** @var array<string|int, array<string, string|int>> */
     private array $groupedChoices = [];

--- a/redaxo/src/core/lib/Fragment/Component/Icon.php
+++ b/redaxo/src/core/lib/Fragment/Component/Icon.php
@@ -7,7 +7,7 @@ use Redaxo\Core\Fragment\Fragment;
 /**
  * @see redaxo/src/core/fragments/core/Component/Icon.php
  */
-class Icon extends Fragment
+final class Icon extends Fragment
 {
     public function __construct(
         /**

--- a/redaxo/src/core/lib/Fragment/Component/Input.php
+++ b/redaxo/src/core/lib/Fragment/Component/Input.php
@@ -10,7 +10,7 @@ use Redaxo\Core\Fragment\HtmlAttributes;
 /**
  * @see redaxo/src/core/fragments/core/Component/Input.php
  */
-class Input extends Fragment
+final class Input extends Fragment
 {
     public function __construct(
         /**

--- a/redaxo/src/core/lib/Fragment/Component/Textarea.php
+++ b/redaxo/src/core/lib/Fragment/Component/Textarea.php
@@ -9,7 +9,7 @@ use Redaxo\Core\Fragment\HtmlAttributes;
 /**
  * @see redaxo/src/core/fragments/core/Component/Textarea.php
  */
-class Textarea extends Fragment
+final class Textarea extends Fragment
 {
     public function __construct(
         /**

--- a/redaxo/src/core/lib/Fragment/Html.php
+++ b/redaxo/src/core/lib/Fragment/Html.php
@@ -7,7 +7,7 @@ use rex_type;
 
 use function is_string;
 
-class Html extends Fragment
+final class Html extends Fragment
 {
     public function __construct(
         /** @var string|list<string|Fragment|null>|Closure */


### PR DESCRIPTION
Damit wir flexibler sind bzgl. späterer Änderungen.

Wer die Components auf Klassenebene erweitern möchte, sollte neue Klassen erstellen, und die Basis-Komponente intern dann aufrufen.