### PR TITLE
REX_VARs in PHP-Strings mit Var-Interpolation

### DIFF
--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -68,7 +68,7 @@ abstract class rex_var
                 continue;
             }
 
-            if (!in_array($token[0], [T_INLINE_HTML, T_CONSTANT_ENCAPSED_STRING, T_STRING, T_START_HEREDOC])) {
+            if (!in_array($token[0], [T_INLINE_HTML, T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_STRING, T_START_HEREDOC])) {
                 $content .= $token[1];
                 continue;
             }
@@ -97,6 +97,10 @@ abstract class rex_var
                     if (' . ""' == $end || " . ''" == $end) {
                         $add = substr($add, 0, -5);
                     }
+                    break;
+
+                case T_ENCAPSED_AND_WHITESPACE:
+                    $add = self::replaceVars($add, '" . %s . "', false, '"');
                     break;
 
                 case T_STRING:

--- a/redaxo/src/core/tests/var/var_test.php
+++ b/redaxo/src/core/tests/var/var_test.php
@@ -34,7 +34,7 @@ class rex_var_test extends rex_var_test_base
         return [
             ['aREX_TEST_VAR[content=b]c', 'abc'],
             ['a<?php echo \'bREX_TEST_VAR[content=c]d\'; ?>e', 'abcde'],
-            ['a<?php echo "bREX_TEST_VAR[content=c]d"; ?>e', 'abcde'],
+            ['a<?php $foo = "123"; echo "REX_TEST_VAR[content=b]$foo"; ?>', 'ab123'],
             ['a<?php echo REX_TEST_VAR[content=b]; ?>c', 'abc'],
             ['REX_2ND_TEST_VAR[]', '2'],
             ['a<?php echo <<<EOT


### PR DESCRIPTION
REX_VARs werden aktuell nicht ersetzt in PHP-String, die Variablen-Interpolation nutzen. Also sowas:

```php
echo "text REX_VALUE[1] $phpVariable";
```