### PR TITLE
phar:// stream wrapper: Korrekten Dir-Separator nutzen

### DIFF
--- a/redaxo/src/addons/install/lib/archive.php
+++ b/redaxo/src/addons/install/lib/archive.php
@@ -13,7 +13,7 @@ class rex_install_archive
         rex_dir::delete($dir);
 
         if (!class_exists(ZipArchive::class)) {
-            $archive = 'phar://' . $archive . '/' . $basename;
+            $archive = 'phar://' . $archive . DIRECTORY_SEPARATOR . $basename;
             return rex_dir::copy($archive, $dir);
         }
 

--- a/redaxo/src/addons/install/lib/package/package_download.php
+++ b/redaxo/src/addons/install/lib/package/package_download.php
@@ -101,6 +101,6 @@ abstract class rex_install_package_download
             return $success;
         }
 
-        return is_dir("phar://$file/" . $this->addonkey);
+        return is_dir("phar://$file" . DIRECTORY_SEPARATOR . $this->addonkey);
     }
 }


### PR DESCRIPTION
closes #5657

Ich konnte es nicht testen unter Windows, denke aber, dass es so passen sollte.

Wir nutzen den Phar-Stream-Wrapper nur, wenn die Zip-Extension fehlt. Ich denke, deswegen ist es bisher nicht aufgefallen.