### PR TITLE
fix error pages on huge errors

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -270,9 +270,14 @@ abstract class rex_error_handler
             $errPage,
         );
 
-        $errPage = preg_replace('@<button id="copy-button" .*?</button>@s', '$0<button class="rightButton clipboard" data-clipboard-text="'.rex_escape(self::getMarkdownReport($exception)).'" title="Copy exception details and system report as markdown to clipboard">
-      COPY MARKDOWN
-    </button>', $errPage);
+        $errPageMarkdownBtn = preg_replace(
+            '@<button id="copy-button" .*?</button>@s',
+            '$0<button class="rightButton clipboard" data-clipboard-text="'.rex_escape(self::getMarkdownReport($exception)).'" title="Copy exception details and system report as markdown to clipboard">COPY MARKDOWN</button>',
+            $errPage
+        );
+        if ($errPageMarkdownBtn !== null) {
+            $errPage = $errPageMarkdownBtn;
+        }
         $errPage = str_replace('<button id="copy-button"', '<button ', $errPage);
         $errPage = preg_replace('@<button id="hide-error" .*?</button>@s', '', $errPage);
 

--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -273,9 +273,9 @@ abstract class rex_error_handler
         $errPageMarkdownBtn = preg_replace(
             '@<button id="copy-button" .*?</button>@s',
             '$0<button class="rightButton clipboard" data-clipboard-text="'.rex_escape(self::getMarkdownReport($exception)).'" title="Copy exception details and system report as markdown to clipboard">COPY MARKDOWN</button>',
-            $errPage
+            $errPage,
         );
-        if ($errPageMarkdownBtn !== null) {
+        if (null !== $errPageMarkdownBtn) {
             $errPage = $errPageMarkdownBtn;
         }
         $errPage = str_replace('<button id="copy-button"', '<button ', $errPage);


### PR DESCRIPTION
ich hatte lokal einen fall in dem `preg_replace()` `NULL` returned hat wg einem `Backtrack limit exhausted` error.
dies führte dann dazu dass gar keine whoops error page gerendert wurde wg. folge-fehler

```
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in [redaxo/src/core/lib/error_handler.php](phpstorm://open?file=/Users/staabm/workspace/redaxo/redaxo/src/core/lib/error_handler.php&line=277) on line 277
Warning: Cannot modify header information - headers already sent by (output started at /Users/staabm/workspace/redaxo/redaxo/src/core/lib/error_handler.php:276) in [redaxo/src/core/lib/response.php](phpstorm://open?file=/Users/staabm/workspace/redaxo/redaxo/src/core/lib/response.php&line=378) on line 378
Warning: Cannot modify header information - headers already sent by (output started at /Users/staabm/workspace/redaxo/redaxo/src/core/lib/error_handler.php:276) in [redaxo/src/core/lib/response.php](phpstorm://open?file=/Users/staabm/workspace/redaxo/redaxo/src/core/lib/response.php&line=389) on line 389
Warning: Cannot modify header information - headers already sent by (output started at /Users/staabm/workspace/redaxo/redaxo/src/core/lib/error_handler.php:276) in [redaxo/src/core/lib/response.php](phpstorm://open?file=/Users/staabm/workspace/redaxo/redaxo/src/core/lib/response.php&line=334) on line 334
Warning: Cannot modify header information - headers already sent by (output started at /Users/staabm/workspace/redaxo/redaxo/src/core/lib/error_handler.php:276) in [redaxo/src/core/lib/response.php](phpstorm://open?file=/Users/staabm/workspace/redaxo/redaxo/src/core/lib/response.php&line=337) on line 337
```

repro für den bug mit https://github.com/FriendsOfREDAXO/rexstan/pull/462