### PR TITLE
Datumsfeld fix für Edge und Chrome

### DIFF
--- a/redaxo/src/addons/be_style/plugins/redaxo/scss/_form.scss
+++ b/redaxo/src/addons/be_style/plugins/redaxo/scss/_form.scss
@@ -299,7 +299,7 @@ label.required::after {
     input[type="datetime-local"],
     input[type="month"] {
         &.form-control {
-            display: inline-flex;
+            display: flex;
             padding-left: $padding-base-horizontal - 2;
             height: $input-height-base;
             line-height: inherit


### PR DESCRIPTION
Siehe inline-Diskussion in #5120 @tbaddade 

(`display: flex;` habe ich einfach aus deinem Vorschlag übernommen)