### PR TITLE
Assign key instead of unused comparison

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -33,7 +33,7 @@ class rex_template
 
         if (false !== $id = array_search($templateKey, $mapping, true)) {
             $template = new self($id);
-            $template->key == $templateKey;
+            $template->key = $templateKey;
 
             return $template;
         }


### PR DESCRIPTION
Keys were compared without using the result.
Assign the key to the template instead.