### PR TITLE
Feature/redaxo5/ldap auth

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -74,7 +74,8 @@ if (rex::isSetup()) {
     rex_i18n::setLocale(rex::getProperty('lang'));
 
     // ---- prepare login
-    $login = new rex_backend_login();
+    $loginClass = rex::getProperty('backend_login_class', 'rex_backend_login');
+    $login = new $loginClass();
     rex::setProperty('login', $login);
 
     $passkey = rex_post('rex_user_passkey', 'string', null);

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -19,6 +19,7 @@ backend_login_policy:
 # e.g. rex_backend_login or rex_backend_login_ldap
 backend_login_class: rex_backend_login
 backend_login_ldap:
+    create_users: true
     allow_fallback: false
     ldap_uri: 'ldap://ldap.my.org:389'
     starttls: true
@@ -26,6 +27,10 @@ backend_login_ldap:
         - 'uid=%USER%,ou=People,dc=my,dc=org'
         - 'cn=%USER%,dc=my,dc=org'
         - 'cn=%USER%,ou=Roles,dc=my,dc=org'
+    attributes:
+        name: displayname
+        email: mail
+        description: description
 # using separate cookie domains for frontend and backend is more secure,
 # but be warned that some features like detecting a backend user in the frontend
 # will no longer work.

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -16,6 +16,16 @@ backend_login_policy:
     login_tries_until_delay: 3
     relogin_delay: 5
     enable_stay_logged_in: true
+# e.g. rex_backend_login or rex_backend_login_ldap
+backend_login_class: rex_backend_login
+backend_login_ldap:
+    allow_fallback: false
+    ldap_uri: 'ldap://ldap.my.org:389'
+    starttls: true
+    bind_dns:
+        - 'uid=%USER%,ou=People,dc=my,dc=org'
+        - 'cn=%USER%,dc=my,dc=org'
+        - 'cn=%USER%,ou=Roles,dc=my,dc=org'
 # using separate cookie domains for frontend and backend is more secure,
 # but be warned that some features like detecting a backend user in the frontend
 # will no longer work.

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -31,6 +31,20 @@ backend_login_ldap:
         name: displayname
         email: mail
         description: description
+        roles: employeeType
+    roles:
+        admin: cms-admin
+        editor: cms-editor
+        dummy: cms-dummy
+# or e.g. multi-valued
+#        roles:
+#            - employeeType
+#            - memberOf
+#   roles:
+#       admin:
+#          - 'cn=admin,ou=Groups,dc=my,dc=org'
+#          - cms-admin
+#       editor: 'cn=people,ou=Groups,dc=my,dc=org'
 # using separate cookie domains for frontend and backend is more secure,
 # but be warned that some features like detecting a backend user in the frontend
 # will no longer work.

--- a/redaxo/src/core/lib/login/backend_login_ldap.php
+++ b/redaxo/src/core/lib/login/backend_login_ldap.php
@@ -1,0 +1,81 @@
+<?php
+
+class rex_backend_login_ldap extends rex_backend_login
+{
+    private $clearTextPassword;
+    private static $ignorePassword = false;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /** {@inheritdoc} */
+    public function setLogin(#[SensitiveParameter] $login, #[SensitiveParameter] $password, $isPreHashed = false)
+    {
+        if (!$isPreHashed) {
+            $this->clearTextPassword = $password;
+        }
+        parent::setLogin($login, $password, $isPreHashed);
+    }
+
+    /** {@inheritdoc} */
+    public function checkLogin()
+    {
+        if (($this->cache && $this->loginStatus != 0) || $this->logout || $this->userLogin == '') {
+            // directly to parent class
+            return parent::checkLogin();
+        }
+
+        if ($this->doAuthLdap()) {
+            // we have overridden the passwordVerify method
+            self::$ignorePassword = true;
+            $result = parent::checkLogin();
+            self::$ignorePassword = false;
+            return $result;
+        } elseif (rex::getProperty('backend_login_ldap', [])['allow_fallback'] ?? false) {
+            return parent::checkLogin();
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Validate user via ownCloud. We use the provisioning API
+     * available since OC 8. The user counts as authenticated if the
+     * API call succeeds and contains all relevant fields.
+     */
+    private function doAuthLdap()
+    {
+        $config = rex::getProperty('backend_login_ldap', []);
+        $uri = $config['ldap_uri'] ?? '';
+        $bound = false;
+        $ds = ldap_connect($uri);
+        if ($ds) {
+            if (ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3)) {
+                if (ldap_set_option($ds, LDAP_OPT_REFERRALS, 0)) {
+                    if (empty($config['starttls']) || ldap_start_tls($ds)) {
+                        foreach (($config['bind_dns'] ?? []) as $bind_dn) {
+                            $bind_dn = preg_replace('/%USER%/', $this->userLogin, $bind_dn);
+                            $bound = ldap_bind($ds, $bind_dn, $this->clearTextPassword);
+                            if ($bound) {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            ldap_close($ds);
+        }
+        return $bound;
+    }
+
+    /** {@inheritdoc} */
+    public static function passwordVerify(#[SensitiveParameter] $password, #[SensitiveParameter] $hash, $isPreHashed = false)
+    {
+        if (self::$ignorePassword) {
+            return true;
+        }
+        return parent::passwordVerify($password, $hash, $isPreHashed);
+    }
+}

--- a/redaxo/src/core/lib/login/backend_login_ldap.php
+++ b/redaxo/src/core/lib/login/backend_login_ldap.php
@@ -2,6 +2,7 @@
 
 class rex_backend_login_ldap extends rex_backend_login
 {
+    private $bindDn = null;
     private $clearTextPassword;
     private static $ignorePassword = false;
 
@@ -28,6 +29,14 @@ class rex_backend_login_ldap extends rex_backend_login
         }
 
         if ($this->doAuthLdap()) {
+            $config = rex::getProperty('backend_login_ldap', []);
+            if ($config['create_users']) {
+                $user = rex_sql::factory();
+                $user->setQuery('SELECT * FROM ' . rex::getTablePrefix() . 'user WHERE login = ?', [$this->userLogin]);
+                if ($user->getRows() === 0) {
+                    $this->addLdapUser();
+                }
+            }
             // we have overridden the passwordVerify method
             self::$ignorePassword = true;
             $result = parent::checkLogin();
@@ -47,27 +56,97 @@ class rex_backend_login_ldap extends rex_backend_login
      */
     private function doAuthLdap()
     {
-        $config = rex::getProperty('backend_login_ldap', []);
-        $uri = $config['ldap_uri'] ?? '';
         $bound = false;
-        $ds = ldap_connect($uri);
+        $this->bindDn = null;
+        $ds = $this->openLdapConnection();
         if ($ds) {
-            if (ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3)) {
-                if (ldap_set_option($ds, LDAP_OPT_REFERRALS, 0)) {
-                    if (empty($config['starttls']) || ldap_start_tls($ds)) {
-                        foreach (($config['bind_dns'] ?? []) as $bind_dn) {
-                            $bind_dn = preg_replace('/%USER%/', $this->userLogin, $bind_dn);
-                            $bound = ldap_bind($ds, $bind_dn, $this->clearTextPassword);
-                            if ($bound) {
-                                break;
-                            }
-                        }
-                    }
+            $config = rex::getProperty('backend_login_ldap', []);
+            foreach (($config['bind_dns'] ?? []) as $bindDn) {
+                $bindDn = preg_replace('/%USER%/', $this->userLogin, $bindDn);
+                $bound = ldap_bind($ds, $bindDn, $this->clearTextPassword);
+                if ($bound) {
+                    $this->bindDn = $bindDn;
+                    break;
                 }
             }
             ldap_close($ds);
         }
         return $bound;
+    }
+
+    private function openLdapConnection()
+    {
+        $config = rex::getProperty('backend_login_ldap', []);
+        $uri = $config['ldap_uri'] ?? '';
+        $ds = ldap_connect($uri);
+        if ($ds) {
+            if (ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3)) {
+                if (ldap_set_option($ds, LDAP_OPT_REFERRALS, 0)) {
+                    if (empty($config['starttls']) || ldap_start_tls($ds)) {
+                        return $ds;
+                    }
+                }
+            }
+            ldap_close($ds);
+        }
+        return null;
+    }
+
+    private function addLdapUser()
+    {
+        $ldapValues = [
+            'name' => $this->userLogin,
+            'email' => null,
+            'description' => null,
+        ];
+
+        $ds = $this->openLdapConnection();
+        if ($ds && ldap_bind($ds, $this->bindDn, $this->clearTextPassword)) {
+            $config = rex::getProperty('backend_login_ldap', []);
+            $ldapFilter = '(objectClass=*)'; // ldap command requires some filter
+            $attributes = array_values($config['attributes']);
+            $searchResult = ldap_read($ds, $this->bindDn, $ldapFilter, $attributes);
+            if ($searchResult) {
+                $ldapEntry = ldap_get_entries($ds, $searchResult);
+                foreach (array_keys($ldapValues) as $key) {
+                    $ldapAttribute = strtolower($config['attributes'][$key] ?? '');
+                    $ldapValue = $ldapEntry[0][$ldapAttribute][0] ?? null;
+                    if (!empty($ldapValue)) {
+                        $ldapValues[$key] = $ldapValue;
+                    }
+                }
+            }
+            ldap_close($ds);
+        }
+
+        $userStatus = 1;
+        $userPswHash = rex_login::passwordHash($this->clearTextPassword);
+
+        $addUser = rex_sql::factory();
+        $addUser->setTable(rex::getTablePrefix() . 'user');
+        $addUser->setValue('name', $ldapValues['name']);
+        $addUser->setValue('password', $userPswHash);
+        $addUser->setValue('login', $this->userLogin);
+        $addUser->setValue('description', $ldapValues['description']);
+        $addUser->setValue('email', $ldapValues['email']);
+        $addUser->setValue('admin', 0);
+        $addUser->setValue('language', '');
+        $addUser->setValue('startpage', '');
+        $addUser->setValue('role', null);
+        $addUser->addGlobalCreateFields();
+        $addUser->addGlobalUpdateFields();
+        $addUser->setDateTimeValue('password_changed', time());
+        $addUser->setArrayValue('previous_passwords', []);
+        $addUser->setValue('password_change_required', 0);
+        $addUser->setValue('status', 1);
+
+        $addUser->insert();
+
+        rex_extension::registerPoint(new rex_extension_point('USER_ADDED', '', [
+            'id' => $addUser->getLastId(),
+            'user' => rex_user::require((int) $addUser->getLastId()),
+            'password' => $this->clearTextPassword,
+        ], true));
     }
 
     /** {@inheritdoc} */

--- a/redaxo/src/core/lib/login/login.php
+++ b/redaxo/src/core/lib/login/login.php
@@ -277,7 +277,7 @@ class rex_login
                 $this->user = rex_sql::factory($this->DB);
 
                 $this->user->setQuery($this->loginQuery, [':login' => $this->userLogin]);
-                if (1 == $this->user->getRows() && self::passwordVerify($this->userPassword, (string) $this->user->getValue($this->passwordColumn), true)) {
+                if (1 == $this->user->getRows() && static::passwordVerify($this->userPassword, (string) $this->user->getValue($this->passwordColumn), true)) {
                     $ok = true;
                     static::regenerateSessionId();
                     $this->setSessionVar(self::SESSION_START_TIME, time());

--- a/redaxo/src/core/pages/login.php
+++ b/redaxo/src/core/pages/login.php
@@ -119,7 +119,7 @@ $content = '
 <script type="text/javascript" nonce="' . rex_response::getNonce() . '">
      <!--
     jQuery(function($) {
-        $("#rex-form-login")
+        /* $("#rex-form-login")
             .submit(function(){
                 var pwInp = $("#rex-id-login-password");
                 if(pwInp.val() != "") {
@@ -127,7 +127,7 @@ $content = '
                 }
         });
 
-        $("#javascript").val("1");
+        $("#javascript").val("1"); */
         ' . $js . '
     });
      //-->


### PR DESCRIPTION
So this is a pull request which could add authentication against an LDAP directory to Redaxo. There are some traces in the old support forums like this

https://redaxo.org/forum/jobs-anfragen-f21/ldap-schnittstelle-t20238.html?sid=a58e08ca0175d2d1836b4485a32eecb4

but no traces in Slack, at least not in the last 90 dasy (and Slack requests payments in order to extend the search period beyond the last 90 days).

In its current state of this PR LDAP auth has to be configured by editing the YAML config file.

The general idea is to delegate the password authentication to LDAP via a bind request with a configurable DN, if the bind succeeds the user is authenticated.

- optionally a "fresh" LDAP-authenticated user is automatically added to the Redaxo user-base
- a subset of the LDAP properties (display name ...) may be synced to the Redaxo user table
- provisioning of roles can be configured, e.g. alll member of a certain LDAP group are mapped to a certain Redaxo rule

My impression was that authentication against alternative authentication backends  cannot be realized by writing an addon as there are no extensions points for delegating just the password authentication. I may very well be wrong.

Anyhow: the code in its current state works for me. I am submitting this PR in the hope that it might be useful also for someone else.
