### PR TITLE
Löschen von Medien: Verwendungscheck bzgl Artikel/Kategorien korrigiert

### DIFF
--- a/redaxo/src/addons/metainfo/lib/handler/media_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/media_handler.php
@@ -42,6 +42,8 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
                 $key = 'media';
             } elseif (rex_metainfo_clang_handler::PREFIX === $prefix) {
                 $key = 'clangs';
+            } elseif (rex_metainfo_category_handler::PREFIX === $prefix) {
+                $key = 'categories';
             } else {
                 $key = 'articles';
             }
@@ -54,21 +56,27 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
         }
 
         $articles = '';
-        $categories = '';
         if (!empty($where['articles'])) {
             $items = $sql->getArray('SELECT id, clang_id, parent_id, name, catname, startarticle FROM ' . rex::getTablePrefix() . 'article WHERE ' . implode(' OR ', $where['articles']));
             foreach ($items as $artArr) {
                 $aid = (int) $artArr['id'];
                 $clang = (int) $artArr['clang_id'];
                 $parentId = (int) $artArr['parent_id'];
-                if ($artArr['startarticle']) {
-                    $categories .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('structure', ['edit_id' => $aid, 'function' => 'edit_cat', 'category_id' => $parentId, 'clang' => $clang]) . '\')">' . (string) $artArr['catname'] . '</a></li>';
-                } else {
-                    $articles .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('content', ['article_id' => $aid, 'mode' => 'meta', 'clang' => $clang]) . '\')">' . (string) $artArr['name'] . '</a></li>';
-                }
+                $articles .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('content', ['article_id' => $aid, 'mode' => 'meta', 'clang' => $clang]) . '\')">' . (string) $artArr['name'] . '</a></li>';
             }
             if ('' != $articles) {
                 $warning[] = rex_i18n::msg('minfo_media_in_use_art') . '<br /><ul>' . $articles . '</ul>';
+            }
+        }
+
+        $categories = '';
+        if (!empty($where['categories'])) {
+            $items = $sql->getArray('SELECT id, clang_id, parent_id, name, catname, startarticle FROM ' . rex::getTablePrefix() . 'article WHERE ' . implode(' OR ', $where['categories']));
+            foreach ($items as $artArr) {
+                $aid = (int) $artArr['id'];
+                $clang = (int) $artArr['clang_id'];
+                $parentId = (int) $artArr['parent_id'];
+                $categories .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('structure', ['edit_id' => $aid, 'function' => 'edit_cat', 'category_id' => $parentId, 'clang' => $clang]) . '\')">' . (string) $artArr['catname'] . '</a></li>';
             }
             if ('' != $categories) {
                 $warning[] = rex_i18n::msg('minfo_media_in_use_cat') . '<br /><ul>' . $categories . '</ul>';


### PR DESCRIPTION
Behebt 2 Probleme:

1. Wenn ein Metainfo Feld der Art cat_ und art_ vorhanden war und in beiden Feldern die selbe Datei eingetragen war, wurde nur auf die Verwendung in einem der Felder hingewiesen. Jetzt wird auf die Verwendung in beiden Feldern hingewiesen.
2. Wenn das Feld der Art art_ war und der Artikel ein Startartikel der Kategorie, dann war die Verlinkung falsch. Es wurde ein Link auf ein cat_ Feld erzeugt. Jetzt wird korrekt verlinkt.

fixes #5734