### PR TITLE
rex_sql: fix für fehlenden `$db`-Parameter

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -135,7 +135,7 @@ class rex_sql implements Iterator
                 self::$pdo[$db] = $conn;
 
                 // ggf. Strict Mode abschalten
-                self::factory()->setQuery('SET SESSION SQL_MODE="", NAMES utf8mb4');
+                self::factory($db)->setQuery('SET SESSION SQL_MODE="", NAMES utf8mb4');
             }
         } catch (PDOException $e) {
             if ('cli' === PHP_SAPI) {


### PR DESCRIPTION
https://app.slack.com/client/T1BCPLXEE/C1BAXLN2F/thread/C1BAXLN2F-1688450024.074529, 

@gharlan schrieb:

>das sieht mir nach einem bug aus, der hier entstanden ist: https://github.com/redaxo/redaxo/pull/5545 müsste aber lokal eigentlich auch auftreten. ist lokal  die gleiche rex-version?
> der bug müsste seit 5.14.3 bestehen
> also der PR fixt ein anderes problem, und lässt dabei aber den neuen bug bei den zusätzlichen db-verbindungen entstehen
> https://github.com/redaxo/redaxo/blob/main/redaxo/src/core/lib/sql/sql.php#L137
 da müsste es self::factory($db) heißen