### PR TITLE
abort on disconnect in `rex_response->sendFile()`

### DIFF
--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -218,6 +218,12 @@ class rex_response
 
                         fseek($handle, $range->getStart());
                         while (ftell($handle) < $range->getEnd()) {
+                            // Abort on client disconnect.
+                            // With ignore_user_abort(true), the script is not aborted on client disconnect.
+                            // To avoid reading the entire stream and dismissing the data afterward, check between the chunks if the client is still there.
+                            if (1 === ignore_user_abort() && 1 === connection_aborted()) {
+                                break 2;
+                            }
                             echo fread($handle, $chunkSize);
                         }
                     }


### PR DESCRIPTION
avoid reading the entire stream and dismissing the data afterward, check between the chunks if the client is still there.

inspired by https://github.com/sabre-io/http/pull/207