### PR TITLE
Setup / add extension check 'gd'

### DIFF
--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -9,7 +9,7 @@ class rex_setup
 {
     // These values must be synchronized with the values in redaxo/src/core/update.php
     public const MIN_PHP_VERSION = REX_MIN_PHP_VERSION;
-    public const MIN_PHP_EXTENSIONS = ['ctype', 'fileinfo', 'filter', 'iconv', 'intl', 'mbstring', 'pcre', 'pdo', 'pdo_mysql', 'session', 'tokenizer'];
+    public const MIN_PHP_EXTENSIONS = ['ctype', 'fileinfo', 'filter', 'iconv', 'intl', 'mbstring', 'pcre', 'pdo', 'pdo_mysql', 'session', 'tokenizer', 'gd'];
     public const MIN_MYSQL_VERSION = '5.6';
     public const MIN_MARIADB_VERSION = '10.1';
 


### PR DESCRIPTION
Die Prüfung auf die Extension 'gd' fehlt.
Wird während des Setup zwingend benötigt für den media_manager.

Redaxo: 5.15.1
Datenbank sollte komplett neu eingerichtet werden. Es existierten zuvor keine Tabellen in der DB.

![grafik](https://github.com/redaxo/redaxo/assets/330686/6cccaacd-6930-4c18-86ec-76cbd24fe5f8)
