### PR TITLE
`$clang = 1` zu `$clang = rex_clang::getStartId();`

### DIFF
--- a/redaxo/src/addons/structure/lib/service_category.php
+++ b/redaxo/src/addons/structure/lib/service_category.php
@@ -260,7 +260,7 @@ class rex_category_service
      */
     public static function deleteCategory($categoryId)
     {
-        $clang = 1;
+        $clang = rex_clang::getStartId();
 
         $thisCat = rex_sql::factory();
         $thisCat->setQuery('SELECT * FROM ' . rex::getTablePrefix() . 'article WHERE id=? and clang_id=?', [$categoryId, $clang]);


### PR DESCRIPTION
close #5748

@gharlan du bist als Autor der rex_clang-Klasse angegeben. Ich habe in die Klasse reingeschaut und m.E. nach ist `getStartId()` das, was an der Stelle hingehört (die erste verfügbare id), ich wüsste auch nicht, was eine Start-ID in dem Kontext von Clang sonst sein soll.