### PR TITLE
Effekt resize: Fehler vermeiden, wenn ein Wert leer ist

### DIFF
--- a/redaxo/src/addons/media_manager/lib/effects/effect_resize.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_resize.php
@@ -49,11 +49,11 @@ class rex_effect_resize extends rex_effect_abstract
             return;
         }
 
-        if (!isset($this->params['width'])) {
+        if ('' === ($this->params['width'] ?? '')) {
             $this->params['width'] = $w;
         }
 
-        if (!isset($this->params['height'])) {
+        if ('' === ($this->params['height'] ?? '')) {
             $this->params['height'] = $h;
         }
 

--- a/redaxo/src/addons/media_manager/lib/effects/effect_resize.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_resize.php
@@ -49,11 +49,11 @@ class rex_effect_resize extends rex_effect_abstract
             return;
         }
 
-        if ('' === ($this->params['width'] ?? '')) {
+        if (!isset($this->params['width']) || '' === $this->params['width']) {
             $this->params['width'] = $w;
         }
 
-        if ('' === ($this->params['height'] ?? '')) {
+        if (!isset($this->params['height']) || '' === $this->params['height']) {
             $this->params['height'] = $h;
         }
 


### PR DESCRIPTION
fixes #5694

Beim Modus `exact` macht es eigentlich nicht wirklich Sinn, einen Wert leer zu lassen.
Aber habe mich nun dafür entschieden, wenn doch, dann wird für den Wert einfach der bisherige Wert verwendet.
Denke das passt noch am ehesten zu "exact".