### PR TITLE
backend durch coreData ersetzt

### DIFF
--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -106,7 +106,7 @@ class rex_console_application extends Application
 
         if (function_exists('posix_getuid')) {
             $currentuser = posix_getpwuid(posix_getuid());
-            $webuser = posix_getpwuid(fileowner(rex_path::backend()));
+            $webuser = posix_getpwuid(fileowner(rex_path::coreData()));
             if ($currentuser['name'] !== $webuser['name']) {
                 $io->warning([
                     'Current user: ' . $currentuser['name'] . "\nOwner of redaxo: " . $webuser['name'],


### PR DESCRIPTION
Die Benutzerprüfung auf das Verzeichnis redaxo/ schlägt fehl, wenn der in der Console aufrufende Benutzer auch der ist, der den Redaxo-Download entpackt hat.  Das Verzeichnis redaxo/core/data wird hingegen mit den Benutzerrechten des Webservers angelegt. Damit erscheint dann die Warnung.