### PR TITLE
Media Cache auf Windows Geräten korrekt anhand der file modified time erkennen

### DIFF
--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -247,7 +247,7 @@ class rex_media_manager
         $filetime = filemtime($mediapath);
 
         // cache is newer?
-        return $cachetime > $filetime;
+        return $cachetime >= $filetime;
     }
 
     /**


### PR DESCRIPTION
Auf Windows Geräten wird die Modified Time von Dateien nicht verändert wenn die Datei kopiert wird.
Der Check `$cachetime > $filetime` liefert also auch dann false, wenn beide Zeitstempel identisch sind und die korrekte Datei eigentlich bereits im Cache liegt.
