### PR TITLE
Core Lib List Neue Extension Points

### DIFF
--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -1267,7 +1267,7 @@ class rex_list implements rex_url_provider_interface
                 $s .= '            </tr>' . "\n";
                 $s = rex_extension::registerPoint(new rex_extension_point('REX_LIST_TABLE_ROW', $s, [
                     'list' => $this,
-                    'sql' => $this->sql
+                    'sql' => $this->sql,
                 ]));
 
                 $this->sql->next();
@@ -1278,7 +1278,7 @@ class rex_list implements rex_url_provider_interface
 
             $s = rex_extension::registerPoint(new rex_extension_point('REX_LIST_TABLE_ROW', $s, [
                 'list' => $this,
-                'sql' => $this->sql
+                'sql' => $this->sql,
             ]));
         }
 

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -1265,12 +1265,21 @@ class rex_list implements rex_url_provider_interface
                     $s .= '        ' . $columnValue . "\n";
                 }
                 $s .= '            </tr>' . "\n";
+                $s = rex_extension::registerPoint(new rex_extension_point('REX_LIST_TABLE_ROW', $s, [
+                    'list' => $this,
+                    'sql' => $this->sql
+                ]));
 
                 $this->sql->next();
             }
             $s .= '        </tbody>' . "\n";
         } else {
             $s .= '<tr class="table-no-results"><td colspan="' . count($columnNames) . '">' . $this->getNoRowsMessage() . '</td></tr>';
+
+            $s = rex_extension::registerPoint(new rex_extension_point('REX_LIST_TABLE_ROW', $s, [
+                'list' => $this,
+                'sql' => $this->sql
+            ]));
         }
 
         $s .= '    </table>' . "\n";


### PR DESCRIPTION
Hi Community, 

in manchen Fällen wäre es praktisch, wenn man die rex_list View Darstellung für bestimmte Addons etwas modifizieren kann. Leider ist die rex_list mit ihrer get Funktion momentan noch nicht komponentenbasiert und somit auch nicht gut erweiterbar.
Mit diesen EPs hat man die Möglichkeit, in der List-View Darstellungen einzugreifen, z.B. inline Darstellungen zu erstellen, was bei uns in der Kreatif im MailSprog addon (Addon für die Erstellung von Mails mit Platzhaltern) bereits der Fall ist (siehe Screenshot).
![Screenshot 2023-08-09 at 17 23 22](https://github.com/redaxo/redaxo/assets/97452939/0885a95a-5af7-439b-a7ad-dc05cea4e17d)

Wäre es möglich, diese EPs zu integrieren? (oder in ähnlicher Art die rex_list view mit EP auszustatten?)

P. S. Diese EPs waren leider zudem schon recht lange in unserem Core-Fork drin und somit funktioniert das MailSprog addon im normalen Redaxo-Core gar nicht (obwohl repo public ist).[](url)