### PR TITLE
Bugfix rex_logger return type

### DIFF
--- a/redaxo/src/addons/debug/lib/extensions/logger_debug.php
+++ b/redaxo/src/addons/debug/lib/extensions/logger_debug.php
@@ -7,7 +7,7 @@
  */
 class rex_logger_debug extends rex_logger
 {
-    public function log($level, $message, array $context = [], $file = null, $line = null, ?string $url = null)
+    public function log($level, $message, array $context = [], $file = null, $line = null, ?string $url = null): void
     {
         $levelType = is_int($level) ? self::getLogLevel($level) : $level;
 

--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -83,7 +83,7 @@ class rex_logger extends AbstractLogger
      *
      * @throws InvalidArgumentException
      */
-    public function log($level, $message, array $context = [], $file = null, $line = null, ?string $url = null)
+    public function log($level, $message, array $context = [], $file = null, $line = null, ?string $url = null): void
     {
         if ($factoryClass = static::getExplicitFactoryClass()) {
             $factoryClass::log($level, $message, $context, $file, $line);


### PR DESCRIPTION
Sobald ein anderes Addon eine neuere Version vom PSR Log verwendet, funktioniert die rex_logger Klasse nicht mehr ( wegen Type Hint) und wirft ein Whoops-Fehler, da das neue LoggerInterface einen Return Type erwartet und rex_logger diesen noch nicht angegeben hat.

https://github.com/php-fig/log/blob/master/src/LoggerInterface.php#L124