### PR TITLE
Faster `rex_version::gitHash()`

### DIFF
--- a/redaxo/src/core/lib/util/version.php
+++ b/redaxo/src/core/lib/util/version.php
@@ -151,10 +151,8 @@ class rex_version
             $gitPath = '`which git`';
         }
 
-        $gitDir = rtrim($path, '\/', ). DIRECTORY_SEPARATOR.'.git';
-
         if (null !== $repo) {
-            $command = $gitPath .' --git-dir=' . escapeshellarg($gitDir) . ' ls-remote --get-url';
+            $command = $gitPath .' -C ' . escapeshellarg($path) . ' ls-remote --get-url';
             $remote = @exec($command, $output, $exitCode);
 
             if (0 !== $exitCode || !preg_match('{github.com[:/]' . preg_quote($repo) . '\.git$}i', $remote)) {
@@ -162,7 +160,7 @@ class rex_version
             }
         }
 
-        $command = $gitPath .' --git-dir=' . escapeshellarg($gitDir) . ' log -1 --pretty=format:%h';
+        $command = $gitPath .' -C ' . escapeshellarg($path) . ' log -1 --pretty=format:%h';
         $version = @exec($command, $output, $exitCode);
 
         return 0 === $exitCode ? $version : null;

--- a/redaxo/src/core/lib/util/version.php
+++ b/redaxo/src/core/lib/util/version.php
@@ -152,7 +152,7 @@ class rex_version
         }
 
         if (null !== $repo) {
-            $command = $gitPath .' -C ' . escapeshellarg($path) . ' ls-remote --get-url';
+            $command = $gitPath . ' -C ' . escapeshellarg($path) . ' ls-remote --get-url';
             $remote = @exec($command, $output, $exitCode);
 
             if (0 !== $exitCode || !preg_match('{github.com[:/]' . preg_quote($repo) . '\.git$}i', $remote)) {
@@ -160,7 +160,7 @@ class rex_version
             }
         }
 
-        $command = $gitPath .' -C ' . escapeshellarg($path) . ' log -1 --pretty=format:%h';
+        $command = $gitPath . ' -C ' . escapeshellarg($path) . ' log -1 --pretty=format:%h';
         $version = @exec($command, $output, $exitCode);
 
         return 0 === $exitCode ? $version : null;

--- a/redaxo/src/core/lib/util/version.php
+++ b/redaxo/src/core/lib/util/version.php
@@ -139,20 +139,8 @@ class rex_version
         $output = [];
         $exitCode = -1;
 
-        if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
-            $command = 'where git';
-            $git = @exec($command, $output, $exitCode);
-
-            if (0 !== $exitCode) {
-                return null;
-            }
-            $gitPath = escapeshellarg($git);
-        } else {
-            $gitPath = '`which git`';
-        }
-
         if (null !== $repo) {
-            $command = $gitPath . ' -C ' . escapeshellarg($path) . ' ls-remote --get-url';
+            $command = 'git -C ' . escapeshellarg($path) . ' ls-remote --get-url';
             $remote = @exec($command, $output, $exitCode);
 
             if (0 !== $exitCode || !preg_match('{github.com[:/]' . preg_quote($repo) . '\.git$}i', $remote)) {
@@ -160,7 +148,7 @@ class rex_version
             }
         }
 
-        $command = $gitPath . ' -C ' . escapeshellarg($path) . ' log -1 --pretty=format:%h';
+        $command = 'git -C ' . escapeshellarg($path) . ' log -1 --pretty=format:%h';
         $version = @exec($command, $output, $exitCode);
 
         return 0 === $exitCode ? $version : null;

--- a/redaxo/src/core/lib/util/version.php
+++ b/redaxo/src/core/lib/util/version.php
@@ -141,18 +141,20 @@ class rex_version
 
         if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
             $command = 'where git';
+            $git = @exec($command, $output, $exitCode);
+
+            if (0 !== $exitCode) {
+                return null;
+            }
+            $gitPath = escapeshellarg($git);
         } else {
-            $command = 'which git';
+            $gitPath = '`which git`';
         }
 
-        $git = @exec($command, $output, $exitCode);
-
-        if (0 !== $exitCode) {
-            return null;
-        }
+        $gitDir = rtrim($path, '\/', ). DIRECTORY_SEPARATOR.'.git';
 
         if (null !== $repo) {
-            $command = 'cd ' . escapeshellarg($path) . ' && ' . escapeshellarg($git) . ' ls-remote --get-url';
+            $command = $gitPath .' --git-dir=' . escapeshellarg($gitDir) . ' ls-remote --get-url';
             $remote = @exec($command, $output, $exitCode);
 
             if (0 !== $exitCode || !preg_match('{github.com[:/]' . preg_quote($repo) . '\.git$}i', $remote)) {
@@ -160,7 +162,7 @@ class rex_version
             }
         }
 
-        $command = 'cd ' . escapeshellarg($path) . ' && ' . escapeshellarg($git) . ' log -1 --pretty=format:%h';
+        $command = $gitPath .' --git-dir=' . escapeshellarg($gitDir) . ' log -1 --pretty=format:%h';
         $version = @exec($command, $output, $exitCode);
 
         return 0 === $exitCode ? $version : null;


### PR DESCRIPTION
on linux/macos we can now determine the git hash in a single command, see https://medium.com/@heba.waly/run-git-from-any-directory-git-c-vs-git-dir-2b6a3936582b

should speedup the slowest part of some requests:

<img width="1001" alt="grafik" src="https://github.com/redaxo/redaxo/assets/120441/a2ca595b-5e88-4454-be80-4d2ac1ec3dd1">
