### PR TITLE
PDO: charset über DSN setzen

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -134,7 +134,7 @@ class rex_sql implements Iterator
                 self::$pdo[$db] = $conn;
 
                 // ggf. Strict Mode abschalten
-                self::factory($db)->setQuery('SET SESSION SQL_MODE="", NAMES utf8mb4');
+                self::factory($db)->setQuery('SET SESSION SQL_MODE=""');
             }
         } catch (PDOException $e) {
             if ('cli' === PHP_SAPI) {
@@ -189,6 +189,7 @@ class rex_sql implements Iterator
             $dsn .= ';port=' . $port;
         }
         $dsn .= ';dbname=' . $database;
+        $dsn .= ';charset=utf8mb4';
 
         // array_merge() doesnt work because it looses integer keys
         $options += [


### PR DESCRIPTION
Schon seit PHP 5.3.6 kann man den Zeichensatz für die Connection direkt über die DSN setzen.
https://github.com/php/php-src/blob/PHP-5.3/NEWS#L1394

`SET NAMES utf8mb4` ist dann überflüssig.