### PR TITLE
fix dump function

### DIFF
--- a/redaxo/src/core/lib/var_dumper.php
+++ b/redaxo/src/core/lib/var_dumper.php
@@ -91,13 +91,13 @@ abstract class rex_var_dumper
 
             $dumper->setDisplayOptions([
                 'fileLinkFormat' => new class() {
-                    public function format(string $file, string $line): ?string
+                    public function format(string $file, string $line): string|false
                     {
                         /** @var rex_editor|null $editor */
                         static $editor;
                         $editor ??= rex_editor::factory();
 
-                        return $editor->getUrl($file, $line);
+                        return $editor->getUrl($file, $line) ?? false;
                     }
                 },
             ]);


### PR DESCRIPTION
Seit https://github.com/redaxo/redaxo/commit/796993347a3025d03ef7823ee0218c7bf778aa35 funktioniert unsere dump()-Funktion nicht mehr, wenn man unter System keinen Editor ausgewählt hat (das Problem ist somit noch in keinem Release).
Vorher war Symfony da toleranter. Neu erwartet es `string|false`, unsere Editor-Klasse liefert aber `string|null`.