### PR TITLE
rex_list: refactor logic into new getEnabledColumnNames() method

### DIFF
--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -1931,11 +1931,6 @@ parameters:
 			path: ../../redaxo/src/core/lib/list.php
 
 		-
-			message: "#^Method rex_list\\:\\:getColumnNames\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/list.php
-
-		-
 			message: "#^Method rex_list\\:\\:getColumnParams\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/list.php

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -4014,15 +4014,6 @@
       <code>$column</code>
       <code>$column</code>
       <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
       <code><![CDATA[$column['span'] ?? null]]></code>
       <code><![CDATA[$column['width'] ?? null]]></code>
       <code>$format[0]</code>
@@ -4040,10 +4031,6 @@
       <code>$groupColumns[]</code>
     </MixedArrayAssignment>
     <MixedArrayOffset>
-      <code>$columnFormates[$columnName]</code>
-      <code>$columnFormates[$columnName]</code>
-      <code><![CDATA[$this->customColumns[$columnName]]]></code>
-      <code><![CDATA[$this->customColumns[$columnName]]]></code>
       <code><![CDATA[$this->customColumns[$column]]]></code>
       <code><![CDATA[$this->linkAttributes[$columnName]]]></code>
       <code><![CDATA[$this->linkAttributes[$columnName][$attrName]]]></code>
@@ -4051,11 +4038,6 @@
     </MixedArrayOffset>
     <MixedAssignment>
       <code>$column</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnName</code>
-      <code>$columnNames[]</code>
       <code>$columnSortType</code>
       <code>$flatParams[$name]</code>
       <code>$flatParams[$name]</code>

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -491,11 +491,26 @@ class rex_list implements rex_url_provider_interface
     /**
      * Gibt alle Namen der Spalten als Array zurück.
      *
-     * @return array
+     * @return list<string>
      */
     public function getColumnNames()
     {
         return $this->columnNames;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function getEnabledColumnNames(): array
+    {
+        $columnNames = [];
+        foreach ($this->getColumnNames() as $columnName) {
+            if (!in_array($columnName, $this->columnDisabled)) {
+                $columnNames[] = $columnName;
+            }
+        }
+
+        return $columnNames;
     }
 
     /**
@@ -1149,12 +1164,7 @@ class rex_list implements rex_url_provider_interface
 
         // Columns vars
         $columnFormates = [];
-        $columnNames = [];
-        foreach ($this->getColumnNames() as $columnName) {
-            if (!in_array($columnName, $this->columnDisabled)) {
-                $columnNames[] = $columnName;
-            }
-        }
+        $columnNames = $this->getEnabledColumnNames();
 
         // List vars
         $sortColumn = $this->getSortColumn();


### PR DESCRIPTION
ein schritt in richtung https://github.com/redaxo/redaxo/pull/5770

---- 

dadurch wird vermieden dass `$this->columnDisabled` in der subclass gebraucht wird

https://github.com/kreatifIT/mail_sprog/commit/b6e98dbda08d07dde03cf33d72b198636d65553f#diff-e3a913a2a9ad719d61884d9259edbef97211f7d1a4cb8215842dc842f9853489R20-R22