### PR TITLE
rex_list: refactor logic into new formatRowAttributes() method

### DIFF
--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -1081,6 +1081,24 @@ class rex_list implements rex_url_provider_interface
         return $value;
     }
 
+    protected function formatRowAttributes(): string {
+        $rowAttributesCallable = null;
+        if (is_callable($this->rowAttributes)) {
+            $rowAttributesCallable = $this->rowAttributes;
+        } elseif ($this->rowAttributes) {
+            $rowAttributes = rex_string::buildAttributes($this->rowAttributes);
+            $rowAttributesCallable = function (self $list) use ($rowAttributes) {
+                return $this->replaceVariables($rowAttributes);
+            };
+        }
+
+        if ($rowAttributesCallable) {
+            return ' ' . $rowAttributesCallable($this);
+        }
+
+        return '';
+    }
+
     /**
      * @return string
      */
@@ -1233,22 +1251,9 @@ class rex_list implements rex_url_provider_interface
                 $maxRows = $nbRows;
             }
 
-            $rowAttributesCallable = null;
-            if (is_callable($this->rowAttributes)) {
-                $rowAttributesCallable = $this->rowAttributes;
-            } elseif ($this->rowAttributes) {
-                $rowAttributes = rex_string::buildAttributes($this->rowAttributes);
-                $rowAttributesCallable = function () use ($rowAttributes) {
-                    return $this->replaceVariables($rowAttributes);
-                };
-            }
-
             $s .= '        <tbody>' . "\n";
             for ($i = 0; $i < $maxRows; ++$i) {
-                $rowAttributes = '';
-                if ($rowAttributesCallable) {
-                    $rowAttributes = ' ' . $rowAttributesCallable($this);
-                }
+                $rowAttributes = $this->formatRowAttributes();
 
                 $s .= '            <tr' . $rowAttributes . ">\n";
                 foreach ($columnNames as $columnName) {

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -1081,7 +1081,8 @@ class rex_list implements rex_url_provider_interface
         return $value;
     }
 
-    protected function formatRowAttributes(): string {
+    protected function formatRowAttributes(): string
+    {
         $rowAttributesCallable = null;
         if (is_callable($this->rowAttributes)) {
             $rowAttributesCallable = $this->rowAttributes;


### PR DESCRIPTION
weiterer schritt in richtung https://github.com/redaxo/redaxo/pull/5770

----

dadurch wird vermieden dass `$this->rowAttributes` in der subclass gebraucht wird

https://github.com/kreatifIT/mail_sprog/commit/b6e98dbda08d07dde03cf33d72b198636d65553f#diff-e3a913a2a9ad719d61884d9259edbef97211f7d1a4cb8215842dc842f9853489R32-R34


----

`$this->tableAttributes` wird in der subclass auch via reflection geholt, dafür gibts aber bereits einen `getTableAttributes`-getter 

https://github.com/kreatifIT/mail_sprog/commit/b6e98dbda08d07dde03cf33d72b198636d65553f#diff-e3a913a2a9ad719d61884d9259edbef97211f7d1a4cb8215842dc842f9853489R16-R18