### PR TITLE
rex_list: refactor logic into new getRowsOnCurrentPage() method

### DIFF
--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -903,6 +903,18 @@ class rex_list implements rex_url_provider_interface
         return $this->rows;
     }
 
+    protected function getRowsOnCurrentPage():int {
+        $nbRows = $this->getRows();
+
+        if ($this->pager) {
+            $maxRows = min($this->pager->getRowsPerPage(), $nbRows - $this->pager->getCursor());
+        } else {
+            $maxRows = $nbRows;
+        }
+
+        return $maxRows;
+    }
+
     /**
      * Returns the pager for this list.
      *
@@ -1161,7 +1173,6 @@ class rex_list implements rex_url_provider_interface
         $sortType = $this->getSortType();
         $warning = $this->getWarning();
         $message = $this->getMessage();
-        $nbRows = $this->getRows();
 
         $header = $this->getHeader();
         $footer = $this->getFooter();
@@ -1226,12 +1237,8 @@ class rex_list implements rex_url_provider_interface
             $s .= '        </tfoot>' . "\n";
         }
 
-        if ($nbRows > 0) {
-            if ($this->pager) {
-                $maxRows = min($this->pager->getRowsPerPage(), $nbRows - $this->pager->getCursor());
-            } else {
-                $maxRows = $nbRows;
-            }
+        if ($this->getRows() > 0) {
+            $maxRows = $this->getRowsOnCurrentPage();
 
             $rowAttributesCallable = null;
             if (is_callable($this->rowAttributes)) {

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -903,7 +903,8 @@ class rex_list implements rex_url_provider_interface
         return $this->rows;
     }
 
-    protected function getRowsOnCurrentPage():int {
+    protected function getRowsOnCurrentPage(): int
+    {
         $nbRows = $this->getRows();
 
         if ($this->pager) {


### PR DESCRIPTION
weiterer schritt in richtung https://github.com/redaxo/redaxo/pull/5770

----

dadurch wird vermieden dass in der subclass das `$pager` objekt gebraucht wird:

https://github.com/kreatifIT/mail_sprog/commit/b6e98dbda08d07dde03cf33d72b198636d65553f#diff-e3a913a2a9ad719d61884d9259edbef97211f7d1a4cb8215842dc842f9853489R24-R26