### PR TITLE
Fragmente: __toString nutzen

### DIFF
--- a/redaxo/src/core/fragments/core/Component/Alert.php
+++ b/redaxo/src/core/fragments/core/Component/Alert.php
@@ -18,7 +18,7 @@ use Redaxo\Core\Fragment\Fragment;
     'open' => $this->open,
     'closeable' => $this->closeable,
     'duration' => $this->duration,
-])->toString() ?>>
+]) ?>>
     <?= Fragment::slot($this->icon, 'icon') ?>
     <?= Fragment::slot($this->body) ?>
 </sl-alert>

--- a/redaxo/src/core/fragments/core/Component/Badge.php
+++ b/redaxo/src/core/fragments/core/Component/Badge.php
@@ -10,6 +10,6 @@ use Redaxo\Core\Fragment\Fragment;
     'variant' => $this->variant,
     'pill' => $this->pill,
     'pulse' => $this->pulse,
-])->toString() ?>>
+]) ?>>
     <?= Fragment::slot($this->body) ?>
 </sl-badge>

--- a/redaxo/src/core/fragments/core/Component/Button.php
+++ b/redaxo/src/core/fragments/core/Component/Button.php
@@ -19,7 +19,7 @@ use Redaxo\Core\Fragment\Fragment;
     'value' => $this->value,
     'href' => $this->href,
     'target' => $this->target,
-])->toString() ?>>
+]) ?>>
     <?= Fragment::slot($this->prefix, 'prefix') ?>
     <?= Fragment::slot($this->suffix, 'suffix') ?>
     <?= Fragment::slot($this->label) ?>

--- a/redaxo/src/core/fragments/core/Component/ButtonGroup.php
+++ b/redaxo/src/core/fragments/core/Component/ButtonGroup.php
@@ -7,8 +7,8 @@ use Redaxo\Core\Fragment\Component\ButtonGroup;
 
 <sl-button-group <?= $this->attributes->with([
     'label' => $this->label,
-])->toString() ?>>
+]) ?>>
     <?php foreach ($this->elements as $element): ?>
-        <?= $element->render() ?>
+        <?= $element ?>
     <?php endforeach ?>
 </sl-button-group>

--- a/redaxo/src/core/fragments/core/Component/Card.php
+++ b/redaxo/src/core/fragments/core/Component/Card.php
@@ -6,7 +6,7 @@ use Redaxo\Core\Fragment\Fragment;
 /** @var Card $this */
 ?>
 
-<sl-card <?= $this->attributes->toString() ?>>
+<sl-card <?= $this->attributes ?>>
     <?= Fragment::slot($this->image, 'image') ?>
     <?= Fragment::slot($this->header, 'header') ?>
     <?= Fragment::slot($this->footer, 'footer') ?>

--- a/redaxo/src/core/fragments/core/Component/Checkbox.php
+++ b/redaxo/src/core/fragments/core/Component/Checkbox.php
@@ -13,6 +13,6 @@ use Redaxo\Core\Fragment\Fragment;
     'checked' => $this->checked,
     'indeterminate' => $this->indeterminate,
     'required' => $this->required,
-])->toString() ?>>
+]) ?>>
     <?= $this->label instanceof Fragment ? Fragment::slot($this->label, 'label') : '' ?>
 </sl-checkbox>

--- a/redaxo/src/core/fragments/core/Component/ChoiceCheckbox.php
+++ b/redaxo/src/core/fragments/core/Component/ChoiceCheckbox.php
@@ -21,7 +21,7 @@ $values = $this->getValues();
         'form-control--has-label' => (bool) $this->label,
         'form-control--has-help-text' => (bool) $this->notice,
     ],
-])->toString() ?>>
+]) ?>>
     <?php if ($this->label): ?>
         <label class="form-control__label" id="label-<?= $random ?>" aria-hidden="false">
             <?php if (is_string($this->label)): ?>
@@ -41,12 +41,12 @@ $values = $this->getValues();
                 <small><?= rex_escape($groupLabel) ?></small>
             <?php endif ?>
             <?php foreach ($group as $label => $value): ?>
-                <sl-checkbox <?= (new HtmlAttributes([
+                <sl-checkbox <?= new HtmlAttributes([
                     'value' => $value,
                     'name' => $this->name,
                     'disabled' => $this->disabled,
                     'checked' => in_array($value, $values),
-                ]))->toString() ?>>
+                ]) ?>>
                     <?= rex_escape($label) ?>
                 </sl-checkbox>
             <?php endforeach ?>

--- a/redaxo/src/core/fragments/core/Component/ChoiceRadio.php
+++ b/redaxo/src/core/fragments/core/Component/ChoiceRadio.php
@@ -2,6 +2,7 @@
 
 use Redaxo\Core\Fragment\Component\Choice;
 use Redaxo\Core\Fragment\Fragment;
+use Redaxo\Core\Fragment\HtmlAttributes;
 
 /** @var Choice $this */
 ?><?php
@@ -14,7 +15,7 @@ $counter = 1;
     'label' => is_string($this->label) ? $this->label : null,
     'help-text' => is_string($this->notice) ? $this->notice : null,
     'required' => $this->required,
-])->toString() ?>>
+]) ?>>
     <?php foreach ($this->getChoices() as $groupLabel => $group): ?>
         <?php if (1 !== $counter): ?>
             <sl-divider></sl-divider>
@@ -23,10 +24,10 @@ $counter = 1;
             <small><?= rex_escape($groupLabel) ?></small>
         <?php endif ?>
         <?php foreach ($group as $label => $value): ?>
-            <sl-radio
-                value="<?= rex_escape($value) ?>"
-                <?= $this->disabled ? 'disabled' : '' ?>
-            >
+            <sl-radio <?= new HtmlAttributes([
+                'value' => $value,
+                'disabled' => $this->disabled,
+            ]) ?>>
                 <?= rex_escape($label) ?>
             </sl-radio>
         <?php endforeach ?>

--- a/redaxo/src/core/fragments/core/Component/ChoiceSelect.php
+++ b/redaxo/src/core/fragments/core/Component/ChoiceSelect.php
@@ -2,6 +2,7 @@
 
 use Redaxo\Core\Fragment\Component\Choice;
 use Redaxo\Core\Fragment\Fragment;
+use Redaxo\Core\Fragment\HtmlAttributes;
 
 /** @var Choice $this */
 ?><?php
@@ -17,7 +18,7 @@ $counter = 1;
     'disabled' => $this->disabled,
     'placeholder' => $this->placeholder,
     'required' => $this->required,
-])->toString() ?>>
+]) ?>>
     <?php foreach ($this->getChoices() as $groupLabel => $group): ?>
         <?php if (1 !== $counter): ?>
             <sl-divider></sl-divider>
@@ -26,9 +27,9 @@ $counter = 1;
             <small><?= rex_escape($groupLabel) ?></small>
         <?php endif ?>
         <?php foreach ($group as $label => $value): ?>
-            <sl-option
-                value="<?= rex_escape($value) ?>"
-            >
+            <sl-option <?= new HtmlAttributes([
+                'value' => $value,
+            ]) ?>>
                 <?= rex_escape($label) ?>
             </sl-option>
         <?php endforeach ?>

--- a/redaxo/src/core/fragments/core/Component/CopyButton.php
+++ b/redaxo/src/core/fragments/core/Component/CopyButton.php
@@ -14,7 +14,7 @@ use Redaxo\Core\Fragment\Fragment;
     'error-label' => $this->errorLabel,
     'disabled' => $this->disabled,
     'tooltip-placement' => $this->tooltipPlacement,
-])->toString() ?>>
+]) ?>>
     <?= Fragment::slot($this->copyIcon, 'copy-icon') ?>
     <?= Fragment::slot($this->successIcon, 'success-icon') ?>
     <?= Fragment::slot($this->errorIcon, 'error-icon') ?>

--- a/redaxo/src/core/fragments/core/Component/Details.php
+++ b/redaxo/src/core/fragments/core/Component/Details.php
@@ -9,7 +9,7 @@ use Redaxo\Core\Fragment\Fragment;
     'summary' => is_string($this->summary) ? $this->summary : null,
     'open' => $this->open,
     'disabled' => $this->disabled,
-])->toString() ?>>
+]) ?>>
     <?= $this->summary instanceof Fragment ? Fragment::slot($this->summary, 'summary') : '' ?>
     <?= Fragment::slot($this->expandIcon, 'expand-icon') ?>
     <?= Fragment::slot($this->collapseIcon, 'collapse-icon') ?>

--- a/redaxo/src/core/fragments/core/Component/Dialog.php
+++ b/redaxo/src/core/fragments/core/Component/Dialog.php
@@ -7,10 +7,8 @@ use Redaxo\Core\Fragment\Fragment;
 ?>
 <sl-dialog <?= $this->attributes->with([
     'label' => is_string($this->label) ? $this->label : null,
-])->toString() ?>>
+]) ?>>
     <?= $this->label instanceof Fragment ? Fragment::slot($this->label, 'label') : '' ?>
     <?= Fragment::slot($this->body) ?>
 </sl-dialog>
-<?php if ($this->button): ?>
-    <?= Fragment::slot($this->button) ?>
-<?php endif ?>
+<?= Fragment::slot($this->button) ?>

--- a/redaxo/src/core/fragments/core/Component/Divider.php
+++ b/redaxo/src/core/fragments/core/Component/Divider.php
@@ -7,5 +7,5 @@ use Redaxo\Core\Fragment\Component\Divider;
 
 <sl-divider <?= $this->attributes->with([
     'vertical' => $this->vertical,
-])->toString() ?>>
+]) ?>>
 </sl-divider>

--- a/redaxo/src/core/fragments/core/Component/Drawer.php
+++ b/redaxo/src/core/fragments/core/Component/Drawer.php
@@ -11,7 +11,7 @@ use Redaxo\Core\Fragment\Fragment;
     'open' => $this->open,
     'placement' => $this->placement,
     'contained' => $this->contained,
-])->toString() ?>>
+]) ?>>
     <?= $this->label instanceof Fragment ? Fragment::slot($this->label, 'label') : '' ?>
     <?= Fragment::slot($this->headerActions, 'header-actions') ?>
     <?= Fragment::slot($this->footer, 'footer') ?>

--- a/redaxo/src/core/fragments/core/Component/Icon.php
+++ b/redaxo/src/core/fragments/core/Component/Icon.php
@@ -6,7 +6,7 @@ use Redaxo\Core\Fragment\HtmlAttributes;
 
 /** @var Icon $this */
 ?>
-<sl-icon <?= (new HtmlAttributes([
+<sl-icon <?= new HtmlAttributes([
     'name' => match ($this->name) {
         IconLibrary::Add => 'plus-lg',
         IconLibrary::AlertError => 'exclamation-octagon',
@@ -22,5 +22,5 @@ use Redaxo\Core\Fragment\HtmlAttributes;
     },
     'label' => $this->label,
     'src' => $this->src,
-]))->toString() ?>>
+]) ?>>
 </sl-icon>

--- a/redaxo/src/core/fragments/core/Component/Input.php
+++ b/redaxo/src/core/fragments/core/Component/Input.php
@@ -24,7 +24,7 @@ use Redaxo\Core\Fragment\Fragment;
     'step' => $this->step,
     'autocapitalize' => $this->autocapitalize,
     'spellcheck' => null !== $this->spellcheck ? ($this->spellcheck ? 'true' : 'false') : null,
-])->toString() ?>>
+]) ?>>
     <?= $this->label instanceof Fragment ? Fragment::slot($this->label, 'label') : '' ?>
     <?= $this->notice instanceof Fragment ? Fragment::slot($this->notice, 'help-text') : '' ?>
     <?= Fragment::slot($this->prefix, 'prefix') ?>

--- a/redaxo/src/core/fragments/core/Component/Range.php
+++ b/redaxo/src/core/fragments/core/Component/Range.php
@@ -16,7 +16,7 @@ use Redaxo\Core\Fragment\Fragment;
     'max' => $this->max,
     'step' => $this->step,
     'tooltip' => $this->tooltipPlacement,
-])->toString() ?>>
+]) ?>>
     <?= $this->label instanceof Fragment ? Fragment::slot($this->label, 'label') : '' ?>
     <?= $this->notice instanceof Fragment ? Fragment::slot($this->notice, 'help-text') : '' ?>
 </sl-range>

--- a/redaxo/src/core/fragments/core/Component/Switcher.php
+++ b/redaxo/src/core/fragments/core/Component/Switcher.php
@@ -13,6 +13,6 @@ use Redaxo\Core\Fragment\Fragment;
     'disabled' => $this->disabled,
     'checked' => $this->checked,
     'required' => $this->required,
-])->toString() ?>>
+]) ?>>
     <?= Fragment::slot($this->label) ?>
 </sl-switch>

--- a/redaxo/src/core/fragments/core/Component/Tab.php
+++ b/redaxo/src/core/fragments/core/Component/Tab.php
@@ -11,12 +11,12 @@ use Redaxo\Core\Fragment\Fragment;
     'active' => $this->active,
     'closable' => $this->closable,
     'disabled' => $this->disabled,
-])->toString() ?>>
+]) ?>>
     <?= Fragment::slot($this->label) ?>
 </sl-tab>
 <sl-tab-panel <?= $this->panelAttributes->with([
     'name' => $this->name,
     'active' => $this->active,
-])->toString() ?>>
+]) ?>>
     <?= Fragment::slot($this->panel) ?>
 </sl-tab-panel>

--- a/redaxo/src/core/fragments/core/Component/TabGroup.php
+++ b/redaxo/src/core/fragments/core/Component/TabGroup.php
@@ -7,8 +7,8 @@ use Redaxo\Core\Fragment\Component\TabGroup;
 
 <sl-tab-group <?= $this->attributes->with([
     'placement' => $this->placement,
-])->toString() ?>>
+]) ?>>
     <?php foreach ($this->elements as $element): ?>
-        <?= $element->render() ?>
+        <?= $element ?>
     <?php endforeach ?>
 </sl-tab-group>

--- a/redaxo/src/core/fragments/core/Component/Textarea.php
+++ b/redaxo/src/core/fragments/core/Component/Textarea.php
@@ -22,7 +22,7 @@ use Redaxo\Core\Fragment\Fragment;
     'autofocus' => $this->autofocus,
     'autocapitalize' => $this->autocapitalize,
     'spellcheck' => null !== $this->spellcheck ? ($this->spellcheck ? 'true' : 'false') : null,
-])->toString() ?>>
+]) ?>>
     <?= $this->label instanceof Fragment ? Fragment::slot($this->label, 'label') : '' ?>
     <?= $this->notice instanceof Fragment ? Fragment::slot($this->notice, 'help-text') : '' ?>
 </sl-textarea>

--- a/redaxo/src/core/fragments/core/Component/Tooltip.php
+++ b/redaxo/src/core/fragments/core/Component/Tooltip.php
@@ -13,7 +13,7 @@ use Redaxo\Core\Fragment\Fragment;
     'open' => $this->open,
     'skidding' => $this->skidding,
     'trigger' => $this->trigger,
-])->toString() ?>>
+]) ?>>
     <?= $this->content instanceof Fragment ? Fragment::slot($this->content, 'content') : '' ?>
     <?= Fragment::slot($this->body) ?>
 </sl-tooltip>

--- a/redaxo/src/core/fragments/core/page/SystemLogRedaxo.php
+++ b/redaxo/src/core/fragments/core/page/SystemLogRedaxo.php
@@ -17,22 +17,22 @@ use Redaxo\Core\Fragment\Page\SystemLogRedaxo;
 ?>
 
 <?php if ($this->error): ?>
-    <?= (new Error(
+    <?= new Error(
         body: new Html($this->error),
-    ))->render() ?>
+    ) ?>
 <?php endif ?>
 
 <?php if ($this->success): ?>
-    <?= (new Success(
+    <?= new Success(
         body: new Html($this->success),
-    ))->render() ?>
+    ) ?>
 <?php endif ?>
 
 <form action="<?= rex_url::currentBackendPage() ?>" method="post">
     <input type="hidden" name="func" value="delLog" />
     <?= $this->csrfToken->getHiddenField() ?>
 
-    <?= (new Card(
+    <?= new Card(
         header: rex_i18n::rawMsg('syslog_title', $this->logFilePath),
         body: new Html(function () { ?>
             <table class="table table-hover">
@@ -82,7 +82,7 @@ use Redaxo\Core\Fragment\Page\SystemLogRedaxo;
         <?php }),
         footer: new Html(function () { ?>
             <div>
-                <?= (new Button(
+                <?= new Button(
                     label: rex_i18n::msg('syslog_delete'),
                     name: 'del_btn',
                     variant: ButtonVariant::Danger,
@@ -90,25 +90,25 @@ use Redaxo\Core\Fragment\Page\SystemLogRedaxo;
                     attributes: new HtmlAttributes([
                         'data-confirm' => rex_i18n::msg('delete') . '?',
                     ]),
-                ))->render() ?>
+                ) ?>
                 <?php if ($url = $this->editor->getUrl($this->logFilePath, 0)): ?>
-                    <?= (new Button(
+                    <?= new Button(
                         label: rex_i18n::rawMsg('system_editor_open_file', rex_path::basename($this->logFilePath)),
                         variant: ButtonVariant::Success,
                         href: $url,
-                    ))->render() ?>
+                    ) ?>
                 <?php endif ?>
                 <?php if (is_file($this->logFilePath)): ?>
-                    <?= (new Button(
+                    <?= new Button(
                         label: rex_i18n::rawMsg('syslog_download', rex_path::basename($this->logFilePath)),
                         variant: ButtonVariant::Success,
                         href: rex_url::currentBackendPage(['func' => 'download'] + $this->csrfToken->getUrlParams()),
                         attributes: new HtmlAttributes([
                             'download' => true,
                         ]),
-                    ))->render() ?>
+                    ) ?>
                 <?php endif ?>
             </div>
         <?php }),
-    ))->render() ?>
+    ) ?>
 </form>

--- a/redaxo/src/core/fragments/core/page/SystemReport.php
+++ b/redaxo/src/core/fragments/core/page/SystemReport.php
@@ -15,7 +15,7 @@ use Redaxo\Core\Fragment\Page\SystemReport;
 ?>
 
 <?php foreach ($this->report->get() as $title => $group): ?>
-    <?= (new Card(
+    <?= new Card(
         header: $title,
         body: new Html(static function () use ($title, $group) { ?>
             <table class="table">
@@ -29,7 +29,7 @@ use Redaxo\Core\Fragment\Page\SystemReport;
                                 throw new rex_exception('Package ' . $label . ' does not define a proper version in its package.yml');
                             }
                             if (rex_version::isUnstable($value)) {
-                                echo (new Icon(IconLibrary::VersionUnstable))->render() . ' ' . rex_escape($value);
+                                echo new Icon(IconLibrary::VersionUnstable) . ' ' . rex_escape($value);
                             }
                         } elseif (is_bool($value)) {
                             echo $value ? 'yes' : 'no';
@@ -42,19 +42,19 @@ use Redaxo\Core\Fragment\Page\SystemReport;
             <?php endforeach ?>
             </table>
         <?php }),
-    ))->render() ?>
+    ) ?>
 <?php endforeach ?>
-<?= (new Details(
+<?= new Details(
     summary: new Html(static function () { ?>
         <div>
             <?= rex_i18n::msg('system_report_markdown') ?>
-            <?= (new CopyButton(
+            <?= new CopyButton(
                 from: 'rex-system-report-markdown',
                 copyLabel: rex_i18n::msg('copy_to_clipboard'),
-            ))->render() ?>
+            ) ?>
         </div>
-        <?php }),
+    <?php }),
     body: new Html(function () { ?>
         <pre><code id="rex-system-report-markdown"><?= rex_escape($this->report->asMarkdown()) ?></code></pre>
     <?php }),
-))->render() ?>
+) ?>

--- a/redaxo/src/core/fragments/core/page/SystemSettings.php
+++ b/redaxo/src/core/fragments/core/page/SystemSettings.php
@@ -24,15 +24,15 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
 ?>
 
 <?php if ($this->errors): ?>
-    <?= (new Error(
+    <?= new Error(
         body: new Html(implode('<br>', $this->errors)),
-    ))->render() ?>
+    ) ?>
 <?php endif ?>
 
 <?php if ($this->success): ?>
-    <?= (new Success(
+    <?= new Success(
         body: new Html($this->success),
-    ))->render() ?>
+    ) ?>
 <?php endif ?>
 
 <div class="row">
@@ -41,51 +41,51 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
             <input type="hidden" name="func" value="updateinfos" />
             <?= $this->csrfToken->getHiddenField() ?>
 
-            <?= (new Card(
+            <?= new Card(
                 header: rex_i18n::msg('system_settings'),
 
                 body: new Html(function () { ?>
-                    <?= (new Input(
+                    <?= new Input(
                         label: rex_i18n::msg('server'),
                         type: InputType::Url,
                         name: 'settings[server]',
                         value: rex::getServer(),
                         required: true,
-                    ))->render() ?>
+                    ) ?>
 
-                    <?= (new Input(
+                    <?= new Input(
                         label: rex_i18n::msg('servername'),
                         name: 'settings[servername]',
                         value: rex::getServerName(),
                         required: true,
-                    ))->render() ?>
+                    ) ?>
 
-                    <?= (new Choice(
+                    <?= new Choice(
                         label: rex_i18n::msg('backend_language'),
                         name: 'settings[lang]',
                         value: rex::getProperty('lang'),
                         choices: $this->getLangChoices(),
                         required: true,
-                    ))->render() ?>
+                    ) ?>
 
-                    <?= (new Input(
+                    <?= new Input(
                         label: rex_i18n::msg('error_email'),
                         name: 'settings[error_email]',
                         value: rex::getErrorEmail(),
                         required: true,
-                    ))->render() ?>
+                    ) ?>
 
                     <?php foreach ($this->getSystemSettings() as $setting): ?>
                         <?= $setting->get() ?>
                     <?php endforeach ?>
 
                     <?php if ($url = $this->editor->getUrl($this->configYml, 0)): ?>
-                        <?= (new Button(
+                        <?= new Button(
                             label: rex_i18n::rawMsg('system_editor_open_file', rex_path::basename($this->configYml)),
                             href: $url,
                             variant: ButtonVariant::Primary,
                             size: ButtonSize::Small,
-                        ))->render() ?>
+                        ) ?>
 
                         <p>
                             <?= rex_i18n::msg('system_edit_config_note') ?>
@@ -94,88 +94,88 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
                 <?php }),
 
                 footer: new Html(static function () { ?>
-                    <?= (new Button\Save(
+                    <?= new Button\Save(
                         name: 'sendit',
-                    ))->render() ?>
+                    ) ?>
                 <?php }),
-            ))->render() ?>
+            ) ?>
         </form>
 
         <form id="rex-form-system-setup" action="<?= rex_url::currentBackendPage() ?>" method="post">
             <input type="hidden" name="func" value="update_editor" />
             <?= $this->csrfToken->getHiddenField() ?>
-            <?= (new Card(
+            <?= new Card(
                 header: rex_i18n::msg('system_editor'),
 
                 body: new Html(function () { ?>
                     <p><?= rex_i18n::msg('system_editor_note') ?></p>
 
-                    <?= (new Choice(
+                    <?= new Choice(
                         label: rex_i18n::msg('system_editor_name'),
                         name: 'editor[name]',
                         value: $this->editor->getName(),
                         choices: [rex_i18n::msg('system_editor_no_editor') => ''] + array_flip($this->editor->getSupportedEditors()),
-                    ))->render() ?>
+                    ) ?>
 
-                    <?= (new Input(
+                    <?= new Input(
                         label: rex_i18n::msg('system_editor_basepath'),
                         name: 'editor[basepath]',
                         value: rex_escape($this->editor->getBasepath()),
                         notice: rex_i18n::msg('system_editor_basepath_note'),
-                    ))->render() ?>
+                    ) ?>
 
-                    <?= $this->editorViaCookie ? (new Info(
+                    <?= $this->editorViaCookie ? new Info(
                         body: rex_i18n::msg('system_editor_note_cookie'),
-                    ))->render() : '' ?>
+                    ) : '' ?>
                 <?php }),
 
                 footer: new Html(function () { ?>
                     <div>
-                        <?= (new Button\Save(
+                        <?= new Button\Save(
                             label: rex_i18n::rawMsg('system_editor_update_cookie'),
                             name: 'editor[update_cookie]',
                             value: '1',
-                        ))->render() ?>
+                        ) ?>
 
                         <?php if ($this->editorViaCookie): ?>
-                            <?= (new Button(
+                            <?= new Button(
                                 label: rex_i18n::rawMsg('system_editor_delete_cookie'),
                                 variant: ButtonVariant::Danger,
                                 type: ButtonType::Submit,
                                 name: 'editor[delete_cookie]',
                                 value: '1',
-                            ))->render() ?>
+                            ) ?>
                         <?php else: ?>
-                            <?= (new Button\Save(
+                            <?= new Button\Save(
                                 label: rex_i18n::rawMsg('system_editor_update_configyml'),
                                 name: 'editor[update_cookie]',
                                 value: '0',
-                            ))->render() ?>
+                            ) ?>
                         <?php endif ?>
                     </div>
                 <?php }),
-            ))->render() ?>
+            ) ?>
         </form>
     </div>
     <div class="col-lg-4">
-        <?= (new Card(
+        <?= new Card(
             header: rex_i18n::msg('system_features'),
 
             body: new Html(function () { ?>
                 <h3><?= rex_i18n::msg('delete_cache') ?></h3>
                 <p><?= rex_i18n::msg('delete_cache_description') ?></p>
                 <p>
-                    <?= (new Button(
+                    <?= new Button(
                         label: rex_i18n::rawMsg('delete_cache'),
                         href: rex_url::currentBackendPage(['func' => 'generate'] + $this->csrfToken->getUrlParams()),
                         variant: ButtonVariant::Danger,
-                    ))->render() ?>
+                    ) ?>
                 </p>
 
                 <h3><?= rex_i18n::msg('debug_mode') ?></h3>
                 <p><?= rex_i18n::msg('debug_mode_note') ?></p>
                 <p>
-                    <?= (new Button(
+                    <?= new Button(
                         label: rex_i18n::rawMsg('debug_mode_' . (rex::isDebugMode() ? 'off' : 'on')),
                         prefix: new Icon(IconLibrary::Debug),
                         href: (rex_url::currentBackendPage(['func' => 'debugmode'] + $this->csrfToken->getUrlParams())),
@@ -184,13 +184,13 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
                             'data-pjax' => 'false',
                             'data-confirm' => rex::isDebugMode() ? null : rex_i18n::msg('debug_confirm'),
                         ]),
-                    ))->render() ?>
+                    ) ?>
                 </p>
 
                 <h3><?= rex_i18n::msg('safemode') ?></h3>
                 <p><?= rex_i18n::msg('safemode_text') ?></p>
                 <p>
-                    <?= (new Button(
+                    <?= new Button(
                         label: rex_i18n::rawMsg('safemode_' . (rex::isSafeMode() ? 'deactivate' : 'activate')),
                         href: rex_url::currentBackendPage(['safemode' => (rex::isSafeMode() ? '0' : '1')] + $this->csrfToken->getUrlParams()),
                         variant: ButtonVariant::Warning,
@@ -198,13 +198,13 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
                             'data-pjax' => 'false',
                             'class' => 'rex-toggle-safemode',
                         ]),
-                    ))->render() ?>
+                    ) ?>
                 </p>
 
                 <h3><?= rex_i18n::msg('setup') ?></h3>
                 <p><?= rex_i18n::msg('setup_text') ?></p>
                 <p>
-                    <?= (new Button(
+                    <?= new Button(
                         label: rex_i18n::rawMsg('setup'),
                         href: rex_url::currentBackendPage(['func' => 'setup'] + $this->csrfToken->getUrlParams()),
                         variant: ButtonVariant::Primary,
@@ -212,12 +212,12 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
                             'data-pjax' => 'false',
                             'data-confirm' => rex_i18n::msg('setup_restart'),
                         ]),
-                    ))->render() ?>
+                    ) ?>
                 </p>
             <?php }),
-        ))->render() ?>
+        ) ?>
 
-        <?= (new Card(
+        <?= new Card(
             header: rex_i18n::msg('installation'),
 
             body: new Html(function () { ?>
@@ -226,10 +226,10 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
                         <th class="rex-table-width-3">REDAXO</th>
                         <td>
                             <?php if (rex_version::isUnstable($this->rexVersion)): ?>
-                                <?= (new Icon(
+                                <?= new Icon(
                                     name: IconLibrary::VersionUnstable,
                                     label: rex_i18n::msg('unstable_version'),
-                                ))->render() ?>
+                                ) ?>
                             <?php endif ?>
                             <?= rex_escape($this->rexVersion) ?>
                         </td>
@@ -237,15 +237,14 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
                     <tr>
                         <th>PHP</th>
                         <td>
-                            <?= (new Button(
+                            <?= new Button(
                                 label: PHP_VERSION,
                                 suffix: new Icon(IconLibrary::PhpInfo),
                                 href: rex_url::backendPage('system/phpinfo'),
                                 attributes: new HtmlAttributes([
                                     'onclick' => 'newWindow("phpinfo", this.href, 1000,800,",status=yes,resizable=yes"); return false;',
                                 ]),
-                            ))->render();
-                            ?>
+                            ) ?>
                         </td>
                     </tr>
                     <tr>
@@ -256,9 +255,9 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
                     </tr>
                 </table>
             <?php }),
-        ))->render() ?>
+        ) ?>
 
-        <?= (new Card(
+        <?= new Card(
             header: rex_i18n::msg('database'),
 
             body: new Html(function () { ?>
@@ -277,6 +276,6 @@ use Redaxo\Core\Fragment\Page\SystemSettings;
                     </tr>
                 </table>
             <?php }),
-        ))->render() ?>
+        ) ?>
     </div>
 </div>

--- a/redaxo/src/core/lib/Fragment/Fragment.php
+++ b/redaxo/src/core/lib/Fragment/Fragment.php
@@ -7,10 +7,11 @@ use rex_exception;
 use rex_fragment;
 use rex_timer;
 use rex_type;
+use Stringable;
 
 use function is_string;
 
-abstract class Fragment
+abstract class Fragment implements Stringable
 {
     public function render(): string
     {
@@ -28,6 +29,11 @@ abstract class Fragment
         $ouput = rex_timer::measure('Fragment: ' . $path, $closure);
 
         return rex_type::string($ouput);
+    }
+
+    public function __toString(): string
+    {
+        return $this->render();
     }
 
     protected function getPath(): string

--- a/redaxo/src/core/lib/Fragment/HtmlAttributes.php
+++ b/redaxo/src/core/lib/Fragment/HtmlAttributes.php
@@ -4,6 +4,7 @@ namespace Redaxo\Core\Fragment;
 
 use BackedEnum;
 use rex_type;
+use Stringable;
 
 use function array_key_exists;
 use function is_array;
@@ -32,7 +33,7 @@ use function is_string;
  * The example will result in this attributes string:
  *    ` attr1="my_value" attr2="5" attr3="my_enum_value" disabled class="cls1 cls2 cls4"`
  */
-final class HtmlAttributes
+final class HtmlAttributes implements Stringable
 {
     public function __construct(
         /** @var array<literal-string, null|bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>> */
@@ -117,7 +118,11 @@ final class HtmlAttributes
         }
 
         return ltrim($attr);
+    }
 
+    public function __toString(): string
+    {
+        return $this->toString();
     }
 
     /** @param array<string|int, string|bool>|list<BackedEnum> $array */


### PR DESCRIPTION
Wir hatten beim Treffen diskutiert, ob wir vielleicht doch `__toString()` nutzen im Fragment-Kontext.
Ich habe das hier mal umgesetzt. Finde es besser, denke ich.