### PR TITLE
Deprecated: htmlspecialchars_decode(): redaxo/src/core/lib/var/var.php on line 413

### DIFF
--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -409,10 +409,7 @@ abstract class rex_var
      */
     public static function toArray($value)
     {
-        if (null === $value) {
-            return null;
-        }
-        $value = json_decode(htmlspecialchars_decode($value, ENT_QUOTES), true);
+        $value = json_decode(htmlspecialchars_decode($value ?? '', ENT_QUOTES), true);
         return is_array($value) ? $value : null;
     }
 

--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -409,6 +409,9 @@ abstract class rex_var
      */
     public static function toArray($value)
     {
+        if (null === $value) {
+            return null;
+        }
         $value = json_decode(htmlspecialchars_decode($value, ENT_QUOTES), true);
         return is_array($value) ? $value : null;
     }


### PR DESCRIPTION
Deprecated: htmlspecialchars_decode(): Passing null to parameter #1 ($string) of type string is deprecated in redaxo/src/core/lib/var/var.php on line 413