### PR TITLE
Fix php deprecation warning

### DIFF
--- a/redaxo/src/core/lib/packages/package.php
+++ b/redaxo/src/core/lib/packages/package.php
@@ -305,7 +305,7 @@ abstract class rex_package implements rex_package_interface
                 }
                 if ('supportpage' !== $key) {
                     $value = rex_i18n::translateArray($value, false, $this->i18n(...));
-                } elseif (null !== $value && !preg_match('@^https?://@i', $value)) {
+                } elseif (null !== $value && !preg_match('@^https?://@i', $value ?? '')) {
                     $value = 'https://' . $value;
                 }
                 $this->properties[$key] = $value;


### PR DESCRIPTION
bei ollie am rechner kommt eine php deprecation warning "passing null to preg_match() is deprecated", was in seiner installation ausgelöst vom addon "base/documentation"