### PR TITLE
Cronjob-Command: nexttime nicht berücksichtigen

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -156,7 +156,6 @@
     <MixedAssignment>
       <code>$id</code>
       <code>$name</code>
-      <code>$nexttime</code>
     </MixedAssignment>
   </file>
   <file src="redaxo/src/addons/cronjob/lib/form.php">

--- a/redaxo/src/addons/cronjob/lib/command/run.php
+++ b/redaxo/src/addons/cronjob/lib/command/run.php
@@ -35,33 +35,26 @@ class rex_command_cronjob_run extends rex_console_command
             return $this->executeSingleJob($io, $job);
         }
 
-        $nexttime = rex_package::get('cronjob')->getConfig('nexttime', 0);
+        $manager = rex_cronjob_manager_sql::factory();
 
-        if (0 != $nexttime && time() >= $nexttime) {
-            $manager = rex_cronjob_manager_sql::factory();
-
-            $errors = 0;
-            $manager->check(static function (string $name, bool $success, string $message) use ($io, &$errors) {
-                /** @var int $errors */
-                if ($success) {
-                    $io->success($name . ': ' . $message);
-                } else {
-                    $io->error($name . ': ' . $message);
-                    ++$errors;
-                }
-            });
-
-            if ($errors) {
-                /** @var int $errors */
-                $io->error('Cronjobs checked, ' . $errors . ' failed.');
-                return 1;
+        $errors = 0;
+        $manager->check(static function (string $name, bool $success, string $message) use ($io, &$errors) {
+            /** @var int $errors */
+            if ($success) {
+                $io->success($name . ': ' . $message);
+            } else {
+                $io->error($name . ': ' . $message);
+                ++$errors;
             }
+        });
 
-            $io->success('Cronjobs checked.');
-            return 0;
+        if ($errors) {
+            /** @var int $errors */
+            $io->error('Cronjobs checked, ' . $errors . ' failed.');
+            return 1;
         }
 
-        $io->success('Cronjobs skipped.');
+        $io->success('Cronjobs checked.');
         return 0;
     }
 


### PR DESCRIPTION
nexttime ist eine Optimierung für die Frontend/Backend-Jobs, in der Console ist das überflüssig und führte zu Problemen.

closes #5853, closes #5854