### PR TITLE
Safemode nur für Admins oder über config.yml

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -155,19 +155,28 @@ if (rex::isSetup()) {
         }
 
         rex::setProperty('user', $user);
+
+        // Safe Mode
+        if ($user->isAdmin() && null !== ($safeMode = rex_get('safemode', 'boolean', null))) {
+            if ($safeMode) {
+                rex_set_session('safemode', true);
+            } else {
+                rex_unset_session('safemode');
+                if (rex::getProperty('safemode')) {
+                    $configFile = rex_path::coreData('config.yml');
+                    $config = array_merge(
+                        rex_file::getConfig(rex_path::core('default.config.yml')),
+                        rex_file::getConfig($configFile),
+                    );
+                    $config['safemode'] = false;
+                    rex_file::putConfig($configFile, $config);
+                }
+            }
+        }
     }
 
     if ('' === $rexUserLoginmessage && rex_get('rex_logged_out', 'boolean')) {
         $rexUserLoginmessage = rex_i18n::msg('login_logged_out');
-    }
-
-    // Safe Mode
-    if (null !== ($safeMode = rex_get('safemode', 'boolean', null))) {
-        if ($safeMode) {
-            rex_set_session('safemode', true);
-        } else {
-            rex_unset_session('safemode');
-        }
     }
 }
 

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -2,6 +2,7 @@ setup: true
 debug:
     enabled: false
     throw_always_exception: false # `true` for all error levels, `[E_WARNING, E_NOTICE]` for subset
+safemode: false
 instname: null
 server: https://www.redaxo.org/
 servername: REDAXO

--- a/redaxo/src/core/layout/top.php
+++ b/redaxo/src/core/layout/top.php
@@ -69,7 +69,7 @@ $hasNavigation = $curPage->hasNavigation();
 
 $metaItems = [];
 if ($user && $hasNavigation) {
-    if (rex::isSafeMode()) {
+    if (rex::isSafeMode() && $user->isAdmin()) {
         $item = [];
         $item['title'] = rex_i18n::msg('safemode_deactivate');
         $item['href'] = rex_url::backendController(['safemode' => 0]);

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -288,7 +288,15 @@ class rex
      */
     public static function isSafeMode()
     {
-        return self::isBackend() && PHP_SESSION_ACTIVE == session_status() && rex_session('safemode', 'boolean', false);
+        if (!self::isBackend()) {
+            return false;
+        }
+
+        if (self::getProperty('safemode')) {
+            return true;
+        }
+
+        return PHP_SESSION_ACTIVE == session_status() && rex_session('safemode', 'boolean', false);
     }
 
     /**

--- a/redaxo/src/core/schemas/config.json
+++ b/redaxo/src/core/schemas/config.json
@@ -58,6 +58,10 @@
                 }
             ]
         },
+        "safemode": {
+            "description": "Safe mode",
+            "type": "boolean"
+        },
         "instname": {
             "description": "Unique instance name",
             "type": ["null", "string"]


### PR DESCRIPTION
Aktuell kann jeder das Backend in den Safemode versetzen, auch schon auf der Loginseite.
Das ist problematisch, weil dann auch Addons bzgl. Security z.b. deaktiviert sind.

Neu können nur eingeloggte Admins über `?safemode=1` (oder den Button auf der Systempage) den Safemode aktivieren. Bei der Variante ist er weiterhin sessionbasiert, also nur für den einen Admin aktiviert.

Damit man sich aber notfalls auch im Safemode einloggen kann, kann man neu alternativ den Safemode auch über die config.yml aktivieren (`safemode: true`). So ist er dann global fürs Backend aktiviert unabhängig vom User.