### PR TITLE
Unalign phpdocs

### DIFF
--- a/redaxo/src/addons/backup/lib/backup.php
+++ b/redaxo/src/addons/backup/lib/backup.php
@@ -253,7 +253,7 @@ class rex_backup
      * Dieser wird in der Datei $filename gespeichert.
      *
      * @param string $filename
-     * @param string[]  $tables
+     * @param string[] $tables
      *
      * @return bool TRUE wenn ein Dump erstellt wurde, sonst FALSE
      */

--- a/redaxo/src/addons/cronjob/lib/form.php
+++ b/redaxo/src/addons/cronjob/lib/form.php
@@ -22,7 +22,7 @@ class rex_cronjob_form extends rex_form
      * @param string $fieldset
      * @param string $whereCondition
      * @param 'post'|'get' $method
-     * @param bool   $debug
+     * @param bool $debug
      * @param positive-int $db DB connection ID
      */
     public function __construct($tableName, $fieldset, $whereCondition, $method = 'post', $debug = false, $db = 1)

--- a/redaxo/src/addons/cronjob/lib/manager.php
+++ b/redaxo/src/addons/cronjob/lib/manager.php
@@ -121,7 +121,7 @@ class rex_cronjob_manager
     }
 
     /**
-     * @param bool   $success
+     * @param bool $success
      * @param string $message
      * @return void
      */

--- a/redaxo/src/addons/install/lib/install.php
+++ b/redaxo/src/addons/install/lib/install.php
@@ -10,7 +10,7 @@ class rex_install
      * Installation and Activation needs to be triggered in a separate step.
      *
      * @param non-empty-string $addonKey e.g. "yform"
-     * @param string $version  e.g. "3.2.1"
+     * @param string $version e.g. "3.2.1"
      *
      * @throws rex_exception
      */
@@ -54,7 +54,7 @@ class rex_install
      * The AddOn is not required to be installed beforehand.
      *
      * @param non-empty-string $addonKey e.g. "yform"
-     * @param string $version  e.g. "3.2.1"
+     * @param string $version e.g. "3.2.1"
      *
      * @throws rex_exception
      */

--- a/redaxo/src/addons/install/lib/webservice.php
+++ b/redaxo/src/addons/install/lib/webservice.php
@@ -87,7 +87,7 @@ class rex_install_webservice
     /**
      * POSTs the given data to the redaxo.org webservice.
      *
-     * @param string      $path
+     * @param string $path
      * @param string|null $archive Path to archive
      * @throws rex_functional_exception
      * @return void
@@ -240,7 +240,7 @@ class rex_install_webservice
      * Writes the given data into the local cache.
      *
      * @param string $path
-     * @param array  $data
+     * @param array $data
      * @return void
      */
     private static function setCache($path, $data)

--- a/redaxo/src/addons/media_manager/lib/managed_media.php
+++ b/redaxo/src/addons/media_manager/lib/managed_media.php
@@ -519,7 +519,7 @@ class rex_managed_media
     }
 
     /**
-     * @param string $src             Source content
+     * @param string $src Source content
      * @param string $sourceCachePath
      * @param string $headerCachePath
      * @return void

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -539,11 +539,11 @@ class rex_media_manager
     }
 
     /**
-     * @param string           $type      Media type
-     * @param string|rex_media $file      Media file
-     * @param null|int         $timestamp Last change timestamp of given file, for cache buster parameter
-     *                                    (not nessary when the file is given by a `rex_media` object)
-     * @param bool             $escape
+     * @param string $type Media type
+     * @param string|rex_media $file Media file
+     * @param null|int $timestamp Last change timestamp of given file, for cache buster parameter
+     *                            (not nessary when the file is given by a `rex_media` object)
+     * @param bool $escape
      *
      * @return string
      */

--- a/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
+++ b/redaxo/src/addons/mediapool/functions/function_rex_mediapool.php
@@ -9,8 +9,8 @@
 /**
  * Erstellt einen Filename der eindeutig ist für den Medienpool.
  *
- * @param string $mediaName      Dateiname
- * @param bool   $doSubindexing
+ * @param string $mediaName Dateiname
+ * @param bool $doSubindexing
  *
  * @deprecated since 2.11, use `rex_mediapool::filename` instead
  */
@@ -24,11 +24,11 @@ function rex_mediapool_filename($mediaName, $doSubindexing = true): string
  * Dabei wird kontrolliert ob das File schon vorhanden ist und es
  * wird eventuell angepasst, weiterhin werden die Fileinformationen übergeben.
  *
- * @param array  $FILE
- * @param int    $rexFileCategory
- * @param array  $FILEINFOS
+ * @param array $FILE
+ * @param int $rexFileCategory
+ * @param array $FILEINFOS
  * @param string $userlogin
- * @param bool   $doSubindexing
+ * @param bool $doSubindexing
  *
  * @return array
  * @deprecated since 2.11, use `rex_media_service::addMedia` instead
@@ -74,8 +74,8 @@ function rex_mediapool_saveMedia($FILE, $rexFileCategory, $FILEINFOS, $userlogin
  * Dabei wird kontrolliert ob das File schon vorhanden ist und es
  * wird eventuell angepasst, weiterhin werden die Fileinformationen übergeben.
  *
- * @param array  $FILE
- * @param array  $FILEINFOS
+ * @param array $FILE
+ * @param array $FILEINFOS
  * @param string $userlogin
  *
  * @return array
@@ -106,10 +106,10 @@ function rex_mediapool_updateMedia($FILE, &$FILEINFOS, $userlogin = null)
  * Synchronisiert die Datei $physical_filename des Mediafolders in den
  * Medienpool.
  *
- * @param string      $physicalFilename
- * @param int         $categoryId
- * @param string      $title
- * @param null|int    $filesize
+ * @param string $physicalFilename
+ * @param int $categoryId
+ * @param string $title
+ * @param null|int $filesize
  * @param null|string $filetype
  * @param null|string $userlogin
  *
@@ -338,7 +338,7 @@ function rex_mediapool_isAllowedMediaType($filename, array $args = [])
 /**
  * Checks file against optional property `allowed_mime_types`.
  *
- * @param string      $path     Path to the physical file
+ * @param string $path Path to the physical file
  * @param null|string $filename Optional filename, will be used for extracting the file extension.
  *                              If not given, the extension is extracted from `$path`.
  *

--- a/redaxo/src/addons/mediapool/lib/mediapool.php
+++ b/redaxo/src/addons/mediapool/lib/mediapool.php
@@ -8,8 +8,8 @@ final class rex_mediapool
     /**
      * Erstellt einen Filename der eindeutig ist für den Medienpool.
      *
-     * @param string $mediaName      Dateiname
-     * @param bool   $doSubindexing
+     * @param string $mediaName Dateiname
+     * @param bool $doSubindexing
      */
     public static function filename(string $mediaName, $doSubindexing = true): string
     {
@@ -134,7 +134,7 @@ final class rex_mediapool
     /**
      * Checks file against optional property `allowed_mime_types`.
      *
-     * @param string      $path     Path to the physical file
+     * @param string $path Path to the physical file
      * @param null|string $filename Optional filename, will be used for extracting the file extension.
      *                              If not given, the extension is extracted from `$path`.
      */

--- a/redaxo/src/addons/mediapool/lib/service_media_category.php
+++ b/redaxo/src/addons/mediapool/lib/service_media_category.php
@@ -6,7 +6,7 @@
 class rex_media_category_service
 {
     /**
-     * @param string                  $name   The name of the new category
+     * @param string $name The name of the new category
      * @param rex_media_category|null $parent The category in which the new category should be created, or null for a top/root level category
      *
      * @return string A success message
@@ -95,8 +95,8 @@ class rex_media_category_service
     }
 
     /**
-     * @param int   $categoryId The id of the category to edit
-     * @param array $data       The category data
+     * @param int $categoryId The id of the category to edit
+     * @param array $data The category data
      *
      * @return string A success message
      */

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -11,7 +11,7 @@ abstract class rex_metainfo_handler
      * Erstellt den nötigen HTML Code um ein Formular zu erweitern.
      *
      * @param rex_sql $sqlFields rex_sql-objekt, dass die zu verarbeitenden Felder enthält
-     * @param array   $epParams  Array of all EP parameters
+     * @param array $epParams Array of all EP parameters
      *
      * @return string
      */
@@ -534,8 +534,8 @@ abstract class rex_metainfo_handler
     /**
      * Übernimmt die gePOSTeten werte in ein rex_sql-Objekt.
      *
-     * @param array   $params
-     * @param rex_sql $sqlSave   rex_sql-objekt, in das die aktuellen Werte gespeichert werden sollen
+     * @param array $params
+     * @param rex_sql $sqlSave rex_sql-objekt, in das die aktuellen Werte gespeichert werden sollen
      * @param rex_sql $sqlFields rex_sql-objekt, dass die zu verarbeitenden Felder enthält
      * @return void
      */
@@ -573,8 +573,8 @@ abstract class rex_metainfo_handler
     /**
      * Retrieves the posted value for the given field and converts it into a saveable format.
      *
-     * @param string $fieldName       The name of the field
-     * @param int    $fieldType       One of the rex_metainfo_table_manager::FIELD_* constants
+     * @param string $fieldName The name of the field
+     * @param int $fieldType One of the rex_metainfo_table_manager::FIELD_* constants
      * @param string $fieldAttributes The attributes of the field
      *
      * @return string|int|null
@@ -634,7 +634,7 @@ abstract class rex_metainfo_handler
     /**
      * Ermittelt die metainfo felder mit dem Prefix $prefix limitiert auf die Kategorien $restrictions.
      *
-     * @param string $prefix          Feldprefix
+     * @param string $prefix Feldprefix
      * @param string $filterCondition SQL Where-Bedingung zum einschränken der Metafelder
      *
      * @return rex_sql Metainfofelder
@@ -666,7 +666,7 @@ abstract class rex_metainfo_handler
      * Erweitert das Meta-Formular um die neuen Meta-Felder.
      *
      * @param string $prefix Feldprefix
-     * @param array  $params EP Params
+     * @param array $params EP Params
      *
      * @return string
      */
@@ -719,12 +719,12 @@ abstract class rex_metainfo_handler
     /**
      * Renders a field of the metaform. The rendered html will be returned.
      *
-     * @param string $field     The html-source of the field itself
-     * @param string $tag       The html-tag for the elements container, e.g. "p"
-     * @param string $tagAttr  Attributes for the elements container, e.g. " class='rex-widget'"
-     * @param string $id        The id of the field, used for current label or field-specific javascripts
-     * @param string $label     The textlabel of the field
-     * @param bool   $labelIt   True when an additional label needs to be rendered, otherweise False
+     * @param string $field The html-source of the field itself
+     * @param string $tag The html-tag for the elements container, e.g. "p"
+     * @param string $tagAttr Attributes for the elements container, e.g. " class='rex-widget'"
+     * @param string $id The id of the field, used for current label or field-specific javascripts
+     * @param string $label The textlabel of the field
+     * @param bool $labelIt True when an additional label needs to be rendered, otherweise False
      * @param string $inputType The input type, e.g. "checkbox", "radio",..
      *
      * @return string The rendered html

--- a/redaxo/src/addons/structure/functions/function_rex_url.php
+++ b/redaxo/src/addons/structure/functions/function_rex_url.php
@@ -10,9 +10,9 @@
  * Gibt eine Url zu einem Artikel zurück.
  *
  * @param int|string|null $id
- * @param int|string|null $clang     SprachId des Artikels
- * @param array           $params    Array von Parametern
- * @param string          $separator
+ * @param int|string|null $clang SprachId des Artikels
+ * @param array $params Array von Parametern
+ * @param string $separator
  *
  * @return string
  *
@@ -58,7 +58,7 @@ function rex_getUrl($id = null, $clang = null, array $params = [], $separator = 
  * Leitet auf einen anderen Artikel weiter.
  *
  * @param null|int|string $articleId
- * @param null|int|string $clang      SprachId des Artikels
+ * @param null|int|string $clang SprachId des Artikels
  *
  * @throws InvalidArgumentException
  * @return never

--- a/redaxo/src/addons/structure/lib/article.php
+++ b/redaxo/src/addons/structure/lib/article.php
@@ -77,7 +77,7 @@ class rex_article extends rex_structure_element
      * Return a list of top-level articles.
      *
      * @param bool $ignoreOfflines
-     * @param int  $clang
+     * @param int $clang
      *
      * @return self[]
      */

--- a/redaxo/src/addons/structure/lib/cache_article.php
+++ b/redaxo/src/addons/structure/lib/cache_article.php
@@ -9,7 +9,7 @@ class rex_article_cache
      * Löscht die gecachten Dateien eines Artikels. Wenn keine clang angegeben, wird
      * der Artikel-Cache in allen Sprachen gelöscht.
      *
-     * @param int $id      ArtikelId des Artikels
+     * @param int $id ArtikelId des Artikels
      * @param int $clangId ClangId des Artikels
      *
      * @return bool True on success, False on errro
@@ -38,7 +38,7 @@ class rex_article_cache
      * Löscht die gecachten Meta-Dateien eines Artikels. Wenn keine clang angegeben, wird
      * der Artikel in allen Sprachen gelöscht.
      *
-     * @param int $id      ArtikelId des Artikels
+     * @param int $id ArtikelId des Artikels
      * @param int $clangId ClangId des Artikels
      *
      * @return bool True on success, False on errro
@@ -69,7 +69,7 @@ class rex_article_cache
      * Löscht die gecachten Content-Dateien eines Artikels. Wenn keine clang angegeben, wird
      * der Artikel in allen Sprachen gelöscht.
      *
-     * @param int $id      ArtikelId des Artikels
+     * @param int $id ArtikelId des Artikels
      * @param int $clangId ClangId des Artikels
      *
      * @return bool True on success, False on errro
@@ -123,7 +123,7 @@ class rex_article_cache
      * Generiert den Artikel-Cache der Metainformationen.
      *
      * @param int $articleId Id des zu generierenden Artikels
-     * @param int $clangId    ClangId des Artikels
+     * @param int $clangId ClangId des Artikels
      *
      * @return bool|string TRUE bei Erfolg, FALSE wenn eine ungütlige article_id übergeben wird, sonst eine Fehlermeldung
      */

--- a/redaxo/src/addons/structure/lib/category.php
+++ b/redaxo/src/addons/structure/lib/category.php
@@ -31,7 +31,7 @@ class rex_category extends rex_structure_element
      * excempt from this list!
      *
      * @param bool $ignoreOfflines
-     * @param int  $clang
+     * @param int $clang
      *
      * @return self[]
      */

--- a/redaxo/src/addons/structure/lib/linkmap/renderer.php
+++ b/redaxo/src/addons/structure/lib/linkmap/renderer.php
@@ -39,8 +39,8 @@ abstract class rex_linkmap_tree_renderer
     /**
      * Returns the markup of a tree structure, with $children as root categories and respecing $activeTreeIds as the active path.
      *
-     * @param rex_category[] $children      A array of rex_category objects representing the top level objects
-     * @param int[]          $activeTreeIds
+     * @param rex_category[] $children A array of rex_category objects representing the top level objects
+     * @param int[] $activeTreeIds
      *
      * @return string the rendered markup
      */

--- a/redaxo/src/addons/structure/lib/navigation.php
+++ b/redaxo/src/addons/structure/lib/navigation.php
@@ -80,9 +80,9 @@ class rex_navigation
     /**
      * Generiert eine Navigation.
      *
-     * @param int  $categoryId     Id der Wurzelkategorie
-     * @param int  $depth           Anzahl der Ebenen die angezeigt werden sollen
-     * @param bool $open            True, wenn nur Elemente der aktiven Kategorie angezeigt werden sollen, sonst FALSE
+     * @param int $categoryId Id der Wurzelkategorie
+     * @param int $depth Anzahl der Ebenen die angezeigt werden sollen
+     * @param bool $open True, wenn nur Elemente der aktiven Kategorie angezeigt werden sollen, sonst FALSE
      * @param bool $ignoreOfflines FALSE, wenn offline Elemente angezeigt werden, sonst TRUE
      *
      * @return string
@@ -120,8 +120,8 @@ class rex_navigation
      * Generiert eine Breadcrumb-Navigation.
      *
      * @param string|false $startPageLabel Label der Startseite, falls FALSE keine Start-Page anzeigen
-     * @param bool   $includeCurrent True wenn der aktuelle Artikel enthalten sein soll, sonst FALSE
-     * @param int    $categoryId    Id der Wurzelkategorie
+     * @param bool $includeCurrent True wenn der aktuelle Artikel enthalten sein soll, sonst FALSE
+     * @param int $categoryId Id der Wurzelkategorie
      *
      * @return string
      */
@@ -225,10 +225,10 @@ class rex_navigation
     /**
      * Fügt einen Filter hinzu.
      *
-     * @param string     $metafield Datenbankfeld der Kategorie
-     * @param int|string $value    Wert für den Vergleich
-     * @param string     $type     art des Vergleichs =/</
-     * @param int|''     $depth    "" wenn auf allen Ebenen, wenn definiert, dann wird der Filter nur auf dieser Ebene angewendet
+     * @param string $metafield Datenbankfeld der Kategorie
+     * @param int|string $value Wert für den Vergleich
+     * @param string $type art des Vergleichs =/</
+     * @param int|'' $depth "" wenn auf allen Ebenen, wenn definiert, dann wird der Filter nur auf dieser Ebene angewendet
      * @return void
      */
     public function addFilter($metafield = 'id', $value = '1', $type = '=', $depth = '')
@@ -240,7 +240,7 @@ class rex_navigation
      * Fügt einen Callback hinzu.
      *
      * @param callable(rex_category,int,array<int|string, int|string|list<string>>,array<int|string, int|string|list<string>>,string):bool $callback z.B. myFunc oder myClass::myMethod
-     * @param int|''  $depth    "" wenn auf allen Ebenen, wenn definiert, dann wird der Filter nur auf dieser Ebene angewendet
+     * @param int|'' $depth "" wenn auf allen Ebenen, wenn definiert, dann wird der Filter nur auf dieser Ebene angewendet
      *
      * @return $this
      */

--- a/redaxo/src/addons/structure/lib/service_article.php
+++ b/redaxo/src/addons/structure/lib/service_article.php
@@ -111,9 +111,9 @@ class rex_article_service
     /**
      * Bearbeitet einen Artikel.
      *
-     * @param int   $articleId Id des Artikels der verändert werden soll
-     * @param int   $clang      Id der Sprache
-     * @param array $data       Array mit den Daten des Artikels
+     * @param int $articleId Id des Artikels der verändert werden soll
+     * @param int $clang Id der Sprache
+     * @param array $data Array mit den Daten des Artikels
      *
      * @throws rex_api_exception
      *
@@ -329,9 +329,9 @@ class rex_article_service
     /**
      * Ändert den Status des Artikels.
      *
-     * @param int      $articleId Id des Artikels die gelöscht werden soll
-     * @param int      $clang      Id der Sprache
-     * @param int|null $status     Status auf den der Artikel gesetzt werden soll, oder NULL wenn zum nächsten Status weitergeschaltet werden soll
+     * @param int $articleId Id des Artikels die gelöscht werden soll
+     * @param int $clang Id der Sprache
+     * @param int|null $status Status auf den der Artikel gesetzt werden soll, oder NULL wenn zum nächsten Status weitergeschaltet werden soll
      *
      * @throws rex_api_exception
      *
@@ -427,9 +427,9 @@ class rex_article_service
      * Berechnet die Prios der Artikel in einer Kategorie neu.
      *
      * @param int $parentId KategorieId der Kategorie, die erneuert werden soll
-     * @param int $clang     ClangId der Kategorie, die erneuert werden soll
-     * @param int $newPrio  Neue PrioNr der Kategorie
-     * @param int $oldPrio  Alte PrioNr der Kategorie
+     * @param int $clang ClangId der Kategorie, die erneuert werden soll
+     * @param int $newPrio Neue PrioNr der Kategorie
+     * @param int $oldPrio Alte PrioNr der Kategorie
      * @return void
      */
     public static function newArtPrio($parentId, $clang, $newPrio, $oldPrio)
@@ -680,11 +680,11 @@ class rex_article_service
     /**
      * Kopiert die Metadaten eines Artikels in einen anderen Artikel.
      *
-     * @param int   $fromId    ArtikelId des Artikels, aus dem kopiert werden (Quell ArtikelId)
-     * @param int   $toId      ArtikelId des Artikel, in den kopiert werden sollen (Ziel ArtikelId)
-     * @param int   $fromClang ClangId des Artikels, aus dem kopiert werden soll (Quell ClangId)
-     * @param int   $toClang   ClangId des Artikels, in den kopiert werden soll (Ziel ClangId)
-     * @param array $params     Array von Spaltennamen, welche kopiert werden sollen
+     * @param int $fromId ArtikelId des Artikels, aus dem kopiert werden (Quell ArtikelId)
+     * @param int $toId ArtikelId des Artikel, in den kopiert werden sollen (Ziel ArtikelId)
+     * @param int $fromClang ClangId des Artikels, aus dem kopiert werden soll (Quell ClangId)
+     * @param int $toClang ClangId des Artikels, in den kopiert werden soll (Ziel ClangId)
+     * @param array $params Array von Spaltennamen, welche kopiert werden sollen
      *
      * @return bool TRUE bei Erfolg, sonst FALSE
      */
@@ -727,7 +727,7 @@ class rex_article_service
     /**
      * Kopieren eines Artikels von einer Kategorie in eine andere.
      *
-     * @param int $id        ArtikelId des zu kopierenden Artikels
+     * @param int $id ArtikelId des zu kopierenden Artikels
      * @param int $toCatId KategorieId in die der Artikel kopiert werden soll
      *
      * @return bool|int FALSE bei Fehler, sonst die Artikel Id des neue kopierten Artikels
@@ -825,9 +825,9 @@ class rex_article_service
     /**
      * Verschieben eines Artikels von einer Kategorie in eine Andere.
      *
-     * @param int $id          ArtikelId des zu verschiebenden Artikels
+     * @param int $id ArtikelId des zu verschiebenden Artikels
      * @param int $fromCatId KategorieId des Artikels, der Verschoben wird
-     * @param int $toCatId   KategorieId in die der Artikel verschoben werden soll
+     * @param int $toCatId KategorieId in die der Artikel verschoben werden soll
      *
      * @return bool TRUE bei Erfolg, sonst FALSE
      */
@@ -910,7 +910,7 @@ class rex_article_service
     /**
      * Checks whether the required array key $keyName isset.
      *
-     * @param array  $array   The array
+     * @param array $array The array
      * @param string $keyName The key
      *
      * @throws rex_api_exception

--- a/redaxo/src/addons/structure/lib/service_category.php
+++ b/redaxo/src/addons/structure/lib/service_category.php
@@ -10,8 +10,8 @@ class rex_category_service
     /**
      * Erstellt eine neue Kategorie.
      *
-     * @param int   $categoryId KategorieId in der die neue Kategorie erstellt werden soll
-     * @param array $data        Array mit den Daten der Kategorie
+     * @param int $categoryId KategorieId in der die neue Kategorie erstellt werden soll
+     * @param array $data Array mit den Daten der Kategorie
      *
      * @throws rex_api_exception
      *
@@ -145,9 +145,9 @@ class rex_category_service
     /**
      * Bearbeitet einer Kategorie.
      *
-     * @param int   $categoryId Id der Kategorie die verändert werden soll
-     * @param int   $clang       Id der Sprache
-     * @param array $data        Array mit den Daten der Kategorie
+     * @param int $categoryId Id der Kategorie die verändert werden soll
+     * @param int $clang Id der Sprache
+     * @param array $data Array mit den Daten der Kategorie
      *
      * @throws rex_api_exception
      *
@@ -315,9 +315,9 @@ class rex_category_service
     /**
      * Ändert den Status der Kategorie.
      *
-     * @param int      $categoryId Id der Kategorie die gelöscht werden soll
-     * @param int      $clang       Id der Sprache
-     * @param int|null $status      Status auf den die Kategorie gesetzt werden soll, oder NULL wenn zum nächsten Status weitergeschaltet werden soll
+     * @param int $categoryId Id der Kategorie die gelöscht werden soll
+     * @param int $clang Id der Sprache
+     * @param int|null $status Status auf den die Kategorie gesetzt werden soll, oder NULL wenn zum nächsten Status weitergeschaltet werden soll
      *
      * @throws rex_api_exception
      *
@@ -413,7 +413,7 @@ class rex_category_service
      * Kopiert eine Kategorie in eine andere.
      *
      * @param int $fromCat KategorieId der Kategorie, die kopiert werden soll (Quelle)
-     * @param int $toCat   KategorieId der Kategorie, IN die kopiert werden soll (Ziel)
+     * @param int $toCat KategorieId der Kategorie, IN die kopiert werden soll (Ziel)
      * @return void
      */
     public static function copyCategory($fromCat, $toCat)
@@ -425,9 +425,9 @@ class rex_category_service
      * Berechnet die Prios der Kategorien in einer Kategorie neu.
      *
      * @param int $parentId KategorieId der Kategorie, die erneuert werden soll
-     * @param int $clang     ClangId der Kategorie, die erneuert werden soll
-     * @param int $newPrio  Neue PrioNr der Kategorie
-     * @param int $oldPrio  Alte PrioNr der Kategorie
+     * @param int $clang ClangId der Kategorie, die erneuert werden soll
+     * @param int $newPrio Neue PrioNr der Kategorie
+     * @param int $oldPrio Alte PrioNr der Kategorie
      * @return void
      */
     public static function newCatPrio($parentId, $clang, $newPrio, $oldPrio)
@@ -460,7 +460,7 @@ class rex_category_service
      * Verschieben einer Kategorie in eine andere.
      *
      * @param int $fromCat KategorieId der Kategorie, die verschoben werden soll (Quelle)
-     * @param int $toCat   KategorieId der Kategorie, IN die verschoben werden soll (Ziel)
+     * @param int $toCat KategorieId der Kategorie, IN die verschoben werden soll (Ziel)
      *
      * @return bool TRUE bei Erfolg, sonst FALSE
      */
@@ -568,7 +568,7 @@ class rex_category_service
     /**
      * Checks whether the required array key $keyName isset.
      *
-     * @param array  $array   The array
+     * @param array $array The array
      * @param string $keyName The key
      *
      * @throws rex_api_exception

--- a/redaxo/src/addons/structure/lib/structure_context.php
+++ b/redaxo/src/addons/structure/lib/structure_context.php
@@ -110,7 +110,7 @@ class rex_structure_context
 
     /**
      * @param string $key
-     * @param mixed  $default
+     * @param mixed $default
      *
      * @return mixed
      */

--- a/redaxo/src/addons/structure/lib/structure_element.php
+++ b/redaxo/src/addons/structure/lib/structure_element.php
@@ -163,7 +163,7 @@ abstract class rex_structure_element
      * Return an rex_structure_element object based on an id.
      * The instance will be cached in an instance-pool and therefore re-used by a later call.
      *
-     * @param int $id    the article id
+     * @param int $id the article id
      * @param int $clang the clang id
      *
      * @return static|null A rex_structure_element instance typed to the late-static binding type of the caller
@@ -208,10 +208,10 @@ abstract class rex_structure_element
     }
 
     /**
-     * @param int    $parentId
+     * @param int $parentId
      * @param string $listType
-     * @param bool   $ignoreOfflines
-     * @param int    $clang
+     * @param bool $ignoreOfflines
+     * @param int $clang
      *
      * @return static[]
      */
@@ -430,10 +430,10 @@ abstract class rex_structure_element
     /**
      * Returns a link to this article.
      *
-     * @param array  $params             Parameter für den Link
-     * @param array  $attributes         Attribute die dem Link hinzugefügt werden sollen. Default: array
-     * @param string $sorroundTag        HTML-Tag-Name mit dem der Link umgeben werden soll, z.b. 'li', 'div'. Default: null
-     * @param array  $sorroundAttributes Attribute die Umgebenden-Element hinzugefügt werden sollen. Default: array
+     * @param array $params Parameter für den Link
+     * @param array $attributes Attribute die dem Link hinzugefügt werden sollen. Default: array
+     * @param string $sorroundTag HTML-Tag-Name mit dem der Link umgeben werden soll, z.b. 'li', 'div'. Default: null
+     * @param array $sorroundAttributes Attribute die Umgebenden-Element hinzugefügt werden sollen. Default: array
      *
      * @return string
      */

--- a/redaxo/src/addons/structure/plugins/content/fragments/module_select.php
+++ b/redaxo/src/addons/structure/plugins/content/fragments/module_select.php
@@ -10,7 +10,7 @@
  * Manipulate this fragment to influence the selection of modules on the slice.
  * By default the core fragment is used.
  *
- * @var bool   $block
+ * @var bool $block
  * @var string $button_label
  * @var array<int, array{id: string, key: string, title: string, href: string}> $items array contains all modules
  *             [0]        the index of array

--- a/redaxo/src/addons/structure/plugins/content/lib/api_template.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_template.php
@@ -145,7 +145,7 @@ class rex_template
      * if the category_id is non-positive all templates in the system are returned.
      * if the category_id is invalid an empty array is returned.
      *
-     * @param int  $categoryId
+     * @param int $categoryId
      * @param bool $ignoreInactive
      *
      * @return array<int, string>

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_base.php
@@ -302,8 +302,8 @@ class rex_article_content_base
     /**
      * Outputs a slice.
      *
-     * @param rex_sql $artDataSql    A rex_sql instance containing all slice and module data
-     * @param int     $moduleIdToAdd The id of the module, which was selected using the ModuleSelect
+     * @param rex_sql $artDataSql A rex_sql instance containing all slice and module data
+     * @param int $moduleIdToAdd The id of the module, which was selected using the ModuleSelect
      *
      * @return string
      */
@@ -399,7 +399,7 @@ class rex_article_content_base
      * Method which gets called, before the slices of the article are processed.
      *
      * @param string $articleContent The content of the article
-     * @param int    $moduleId       A module id
+     * @param int $moduleId A module id
      *
      * @return string
      */
@@ -413,7 +413,7 @@ class rex_article_content_base
      * Method which gets called, after all slices have been processed.
      *
      * @param string $articleContent The content of the article
-     * @param int    $moduleId       A module id
+     * @param int $moduleId A module id
      *
      * @return string
      */

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
@@ -264,7 +264,7 @@ class rex_article_content_editor extends rex_article_content
     /**
      * Wraps the output of a module.
      *
-     * @param int    $moduleId     The id of the module
+     * @param int $moduleId The id of the module
      * @param string $moduleOutput The output of the module
      *
      * @return string
@@ -472,10 +472,10 @@ class rex_article_content_editor extends rex_article_content
     // ----- EDIT Slice
 
     /**
-     * @param int     $sliceId
-     * @param string  $moduleInput
-     * @param int     $ctypeId
-     * @param int     $moduleId
+     * @param int $sliceId
+     * @param string $moduleInput
+     * @param int $ctypeId
+     * @param int $moduleId
      * @param rex_sql $artDataSql
      * @return string
      */

--- a/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
@@ -65,18 +65,18 @@ class rex_article_slice
     private $linklists;
 
     /**
-     * @param int    $id
-     * @param int    $articleId
-     * @param int    $clang
-     * @param int    $ctype
-     * @param int    $moduleId
-     * @param int    $priority
-     * @param int    $status
-     * @param int    $createdate
-     * @param int    $updatedate
+     * @param int $id
+     * @param int $articleId
+     * @param int $clang
+     * @param int $ctype
+     * @param int $moduleId
+     * @param int $priority
+     * @param int $status
+     * @param int $createdate
+     * @param int $updatedate
      * @param string $createuser
      * @param string $updateuser
-     * @param int    $revision
+     * @param int $revision
      * @param array<int, string|null> $values
      * @param array<int, string|null> $media
      * @param array<int, string|null> $medialists
@@ -146,9 +146,9 @@ class rex_article_slice
     /**
      * Return an ArticleSlice by its id.
      *
-     * @param int      $anId
+     * @param int $anId
      * @param false|int $clang
-     * @param int      $revision
+     * @param int $revision
      *
      * @return self|null
      */
@@ -170,10 +170,10 @@ class rex_article_slice
      * slices in the order as they appear using the
      * getNextSlice() function.
      *
-     * @param int      $anArticleId
+     * @param int $anArticleId
      * @param false|int $clang
-     * @param int      $revision
-     * @param bool     $ignoreOfflines
+     * @param int $revision
+     * @param bool $ignoreOfflines
      *
      * @return self|null
      */
@@ -196,11 +196,11 @@ class rex_article_slice
     /**
      * Returns the first slice of the given ctype of an article.
      *
-     * @param int      $ctype
-     * @param int      $anArticleId
+     * @param int $ctype
+     * @param int $anArticleId
      * @param false|int $clang
-     * @param int      $revision
-     * @param bool     $ignoreOfflines
+     * @param int $revision
+     * @param bool $ignoreOfflines
      *
      * @return self|null
      */
@@ -220,10 +220,10 @@ class rex_article_slice
      * Return all slices for an article that have a certain
      * clang or revision.
      *
-     * @param int      $anArticleId
+     * @param int $anArticleId
      * @param false|int $clang
-     * @param int      $revision
-     * @param bool     $ignoreOfflines
+     * @param int $revision
+     * @param bool $ignoreOfflines
      *
      * @return self[]
      */
@@ -243,11 +243,11 @@ class rex_article_slice
      * Return all slices for an article that have a certain
      * module type.
      *
-     * @param int      $anArticleId
-     * @param int      $aModuletypeId
+     * @param int $anArticleId
+     * @param int $aModuletypeId
      * @param false|int $clang
-     * @param int      $revision
-     * @param bool     $ignoreOfflines
+     * @param int $revision
+     * @param bool $ignoreOfflines
      *
      * @return self[]
      */

--- a/redaxo/src/addons/structure/plugins/content/lib/content_service.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/content_service.php
@@ -77,8 +77,8 @@ class rex_content_service
     /**
      * Verschiebt einen Slice.
      *
-     * @param int    $sliceId  Id des Slices
-     * @param int    $clang     Id der Sprache
+     * @param int $sliceId Id des Slices
+     * @param int $clang Id der Sprache
      * @param string $direction Richtung in die verschoben werden soll
      *
      * @throws rex_exception
@@ -225,10 +225,10 @@ class rex_content_service
     /**
      * Kopiert die Inhalte eines Artikels in einen anderen Artikel.
      *
-     * @param int $fromId    ArtikelId des Artikels, aus dem kopiert werden (Quell ArtikelId)
-     * @param int $toId      ArtikelId des Artikel, in den kopiert werden sollen (Ziel ArtikelId)
+     * @param int $fromId ArtikelId des Artikels, aus dem kopiert werden (Quell ArtikelId)
+     * @param int $toId ArtikelId des Artikel, in den kopiert werden sollen (Ziel ArtikelId)
      * @param int $fromClang ClangId des Artikels, aus dem kopiert werden soll (Quell ClangId)
-     * @param int $toClang   ClangId des Artikels, in den kopiert werden soll (Ziel ClangId)
+     * @param int $toClang ClangId des Artikels, in den kopiert werden soll (Ziel ClangId)
      * @param null|int $revision If null, slices of all revisions are copied
      *
      * @return bool TRUE bei Erfolg, sonst FALSE
@@ -329,7 +329,7 @@ class rex_content_service
      * Generiert den Artikel-Cache des Artikelinhalts.
      *
      * @param int $articleId Id des zu generierenden Artikels
-     * @param int $clang      ClangId des Artikels
+     * @param int $clang ClangId des Artikels
      *
      * @throws rex_exception
      *

--- a/redaxo/src/core/functions/function_rex_globals.php
+++ b/redaxo/src/core/functions/function_rex_globals.php
@@ -8,8 +8,8 @@
  * Returns the variable $varname of $_GET and casts the value.
  *
  * @param string $varname Variable name
- * @param mixed  $vartype Variable type
- * @param mixed  $default Default value
+ * @param mixed $vartype Variable type
+ * @param mixed $default Default value
  *
  * @return mixed
  *
@@ -28,8 +28,8 @@ function rex_get($varname, $vartype = '', $default = '')
  * Returns the variable $varname of $_POST and casts the value.
  *
  * @param string $varname Variable name
- * @param mixed  $vartype Variable type
- * @param mixed  $default Default value
+ * @param mixed $vartype Variable type
+ * @param mixed $default Default value
  *
  * @return mixed
  *
@@ -48,8 +48,8 @@ function rex_post($varname, $vartype = '', $default = '')
  * Returns the variable $varname of $_REQUEST and casts the value.
  *
  * @param string $varname Variable name
- * @param mixed  $vartype Variable type
- * @param mixed  $default Default value
+ * @param mixed $vartype Variable type
+ * @param mixed $default Default value
  *
  * @return mixed
  *
@@ -68,8 +68,8 @@ function rex_request($varname, $vartype = '', $default = '')
  * Returns the variable $varname of $_SERVER and casts the value.
  *
  * @param string $varname Variable name
- * @param mixed  $vartype Variable type
- * @param mixed  $default Default value
+ * @param mixed $vartype Variable type
+ * @param mixed $default Default value
  *
  * @return mixed
  *
@@ -86,8 +86,8 @@ function rex_server($varname, $vartype = '', $default = '')
  * Returns the variable $varname of $_SESSION and casts the value.
  *
  * @param string $varname Variable name
- * @param mixed  $vartype Variable type
- * @param mixed  $default Default value
+ * @param mixed $vartype Variable type
+ * @param mixed $default Default value
  *
  * @throws rex_exception
  *
@@ -106,7 +106,7 @@ function rex_session($varname, $vartype = '', $default = '')
  * Sets a session variable.
  *
  * @param string $varname Variable name
- * @param mixed  $value   Value
+ * @param mixed $value Value
  *
  * @throws rex_exception
  *
@@ -141,8 +141,8 @@ function rex_unset_session($varname)
  * Returns the variable $varname of $_COOKIE and casts the value.
  *
  * @param string $varname Variable name
- * @param mixed  $vartype Variable type
- * @param mixed  $default Default value
+ * @param mixed $vartype Variable type
+ * @param mixed $default Default value
  *
  * @return mixed
  *
@@ -161,8 +161,8 @@ function rex_cookie($varname, $vartype = '', $default = '')
  * Returns the variable $varname of $_FILES and casts the value.
  *
  * @param string $varname Variable name
- * @param mixed  $vartype Variable type
- * @param mixed  $default Default value
+ * @param mixed $vartype Variable type
+ * @param mixed $default Default value
  *
  * @return mixed
  *
@@ -179,8 +179,8 @@ function rex_files($varname, $vartype = '', $default = '')
  * Returns the variable $varname of $_ENV and casts the value.
  *
  * @param string $varname Variable name
- * @param mixed  $vartype Variable type
- * @param mixed  $default Default value
+ * @param mixed $vartype Variable type
+ * @param mixed $default Default value
  *
  * @return mixed
  *

--- a/redaxo/src/core/lib/base/factory_trait.php
+++ b/redaxo/src/core/lib/base/factory_trait.php
@@ -89,8 +89,8 @@ trait rex_factory_trait
     /**
      * Calls the factory class with the given method and arguments.
      *
-     * @param string $method    Method name
-     * @param array  $arguments Array of arguments
+     * @param string $method Method name
+     * @param array $arguments Array of arguments
      *
      * @return mixed Result of the callback
      *

--- a/redaxo/src/core/lib/base/instance_list_pool_trait.php
+++ b/redaxo/src/core/lib/base/instance_list_pool_trait.php
@@ -15,7 +15,7 @@ trait rex_instance_list_pool_trait
     /**
      * Adds an instance list.
      *
-     * @param mixed $key             Key
+     * @param mixed $key Key
      * @param array $instanceKeyList Array of instance keys
      * @return void
      */
@@ -43,9 +43,9 @@ trait rex_instance_list_pool_trait
      *
      * If the instance list does not exist it will be created by calling the $createListCallback
      *
-     * @param mixed         $key                 Key
-     * @param callable      $getInstanceCallback Callback, will be called for every list item to get the instance
-     * @param callable|null $createListCallback  Callback, will be called to create the list of instance keys
+     * @param mixed $key Key
+     * @param callable $getInstanceCallback Callback, will be called for every list item to get the instance
+     * @param callable|null $createListCallback Callback, will be called to create the list of instance keys
      *
      * @return array
      *

--- a/redaxo/src/core/lib/base/instance_pool_trait.php
+++ b/redaxo/src/core/lib/base/instance_pool_trait.php
@@ -20,8 +20,8 @@ trait rex_instance_pool_trait
     /**
      * Adds an instance.
      *
-     * @param mixed $key      Key
-     * @param self  $instance Instance
+     * @param mixed $key Key
+     * @param self $instance Instance
      * @return void
      */
     protected static function addInstance($key, self $instance)
@@ -50,7 +50,7 @@ trait rex_instance_pool_trait
      *
      * If the instance does not exist it will be created by calling the $createCallback
      *
-     * @param mixed    $key            Key
+     * @param mixed $key Key
      * @param callable $createCallback Callback, will be called to create a new instance
      * @psalm-param callable(mixed...):?static $createCallback
      *

--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -255,9 +255,9 @@ class rex_be_controller
 
     /**
      * @param rex_be_page|array $page
-     * @param bool              $createMainPage
-     * @param string            $pageKey
-     * @param bool|string       $prefix
+     * @param bool $createMainPage
+     * @param string $pageKey
+     * @param bool|string $prefix
      *
      * @return null|rex_be_page
      */

--- a/redaxo/src/core/lib/clang/service.php
+++ b/redaxo/src/core/lib/clang/service.php
@@ -8,10 +8,10 @@ class rex_clang_service
     /**
      * Erstellt eine Clang.
      *
-     * @param string $code     Clang Code
-     * @param string $name     Name
-     * @param int    $priority Priority
-     * @param bool   $status   Status
+     * @param string $code Clang Code
+     * @param string $name Name
+     * @param int $priority Priority
+     * @param bool $status Status
      * @return void
      */
     public static function addCLang($code, $name, $priority, $status = false)
@@ -42,11 +42,11 @@ class rex_clang_service
     /**
      * Ändert eine Clang.
      *
-     * @param int       $id       Id der Clang
-     * @param string    $code     Clang Code
-     * @param string    $name     Name der Clang
-     * @param int       $priority Priority
-     * @param bool|null $status   Status
+     * @param int $id Id der Clang
+     * @param string $code Clang Code
+     * @param string $name Name der Clang
+     * @param int $priority Priority
+     * @param bool|null $status Status
      *
      * @throws rex_exception
      *

--- a/redaxo/src/core/lib/config.php
+++ b/redaxo/src/core/lib/config.php
@@ -58,9 +58,9 @@ class rex_config
      *
      * The set-method returns TRUE when an existing value was overridden, otherwise FALSE is returned.
      *
-     * @param string       $namespace The namespace e.g. an addon name
-     * @param string|array<string, mixed> $key       The associated key or an associative array of key/value pairs
-     * @param mixed        $value     The value to save
+     * @param string $namespace The namespace e.g. an addon name
+     * @param string|array<string, mixed> $key The associated key or an associative array of key/value pairs
+     * @param mixed $value The value to save
      *
      * @throws InvalidArgumentException
      *
@@ -115,7 +115,7 @@ class rex_config
      * @template T as ?string
      * @param string $namespace The namespace e.g. an addon name
      * @param T $key The associated key
-     * @param mixed $default   Default return value if no associated-value can be found
+     * @param mixed $default Default return value if no associated-value can be found
      * @throws InvalidArgumentException
      * @return mixed the value for $key or $default if $key cannot be found in the given $namespace
      * @psalm-return (T is string ? mixed|null : array<string, mixed>)
@@ -141,8 +141,8 @@ class rex_config
     /**
      * Returns if the given key is set.
      *
-     * @param string      $namespace The namespace e.g. an addon name
-     * @param string|null $key       The associated key
+     * @param string $namespace The namespace e.g. an addon name
+     * @param string|null $key The associated key
      *
      * @throws InvalidArgumentException
      *
@@ -171,7 +171,7 @@ class rex_config
      * Removes the setting associated with the given namespace and key.
      *
      * @param string $namespace The namespace e.g. an addon name
-     * @param string $key       The associated key
+     * @param string $key The associated key
      *
      * @throws InvalidArgumentException
      *

--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -491,10 +491,10 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
      * Helper function for getting values by option or ask()
      * Respects non-/interactive mode.
      *
-     * @param string|Question  $question       provide question string or full question object for ask()
-     * @param string           $option         cli option name
-     * @param string|bool|null $default        default value for ask()
-     * @param string|null      $successMessage success message for using the option value
+     * @param string|Question $question provide question string or full question object for ask()
+     * @param string $option cli option name
+     * @param string|bool|null $default default value for ask()
+     * @param string|null $successMessage success message for using the option value
      * @param callable(mixed):mixed|null $validator validator callback for option value and ask()
      *
      * @return mixed

--- a/redaxo/src/core/lib/context.php
+++ b/redaxo/src/core/lib/context.php
@@ -13,7 +13,7 @@ interface rex_url_provider_interface
      * Returns a Url which contains the given parameters.
      *
      * @param array $params A scalar array containing key value pairs for the parameter and its value
-     * @param bool  $escape Flag whether the argument separator "&" should be escaped (&amp;)
+     * @param bool $escape Flag whether the argument separator "&" should be escaped (&amp;)
      *
      * @return string The generated Url
      */
@@ -74,7 +74,7 @@ class rex_context implements rex_context_provider_interface
      * Set a global parameter.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      * @return void
      */
     public function setParam($name, $value)
@@ -87,7 +87,7 @@ class rex_context implements rex_context_provider_interface
      * When no value is set, $default will be returned.
      *
      * @param string $name
-     * @param mixed  $default
+     * @param mixed $default
      *
      * @return mixed
      */

--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -287,10 +287,10 @@ abstract class rex_error_handler
     /**
      * Handles a error message.
      *
-     * @param int    $errno   The error code to handle
-     * @param string $errstr  The error message
+     * @param int $errno The error code to handle
+     * @param string $errstr The error message
      * @param string $errfile The file in which the error occured
-     * @param int    $errline The line of the file in which the error occured
+     * @param int $errline The line of the file in which the error occured
      *
      * @throws ErrorException
      * @return bool

--- a/redaxo/src/core/lib/exception.php
+++ b/redaxo/src/core/lib/exception.php
@@ -6,7 +6,7 @@
 class rex_exception extends Exception
 {
     /**
-     * @param string    $message
+     * @param string $message
      */
     public function __construct($message, ?Exception $previous = null)
     {

--- a/redaxo/src/core/lib/extension_point.php
+++ b/redaxo/src/core/lib/extension_point.php
@@ -76,7 +76,7 @@ class rex_extension_point
      * Sets a param.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @throws rex_exception
      * @return void
@@ -114,7 +114,7 @@ class rex_extension_point
      * Returns the param for the given key.
      *
      * @param string $key
-     * @param mixed  $default
+     * @param mixed $default
      *
      * @return mixed
      */

--- a/redaxo/src/core/lib/form/config_form.php
+++ b/redaxo/src/core/lib/form/config_form.php
@@ -13,9 +13,9 @@ class rex_config_form extends rex_form_base
     private $namespace;
 
     /**
-     * @param string      $namespace `rex_config` namespace, usually the package key
+     * @param string $namespace `rex_config` namespace, usually the package key
      * @param null|string $fieldset
-     * @param bool        $debug
+     * @param bool $debug
      */
     protected function __construct($namespace, $fieldset = null, $debug = false)
     {
@@ -30,9 +30,9 @@ class rex_config_form extends rex_form_base
     }
 
     /**
-     * @param string      $namespace `rex_config` namespace, usually the package key
+     * @param string $namespace `rex_config` namespace, usually the package key
      * @param null|string $fieldset
-     * @param bool        $debug
+     * @param bool $debug
      *
      * @return static
      */

--- a/redaxo/src/core/lib/form/elements/options.php
+++ b/redaxo/src/core/lib/form/elements/options.php
@@ -20,7 +20,7 @@ abstract class rex_form_options_element extends rex_form_element
     }
 
     /**
-     * @param string     $name
+     * @param string $name
      * @param string|int $value
      * @return void
      */
@@ -31,7 +31,7 @@ abstract class rex_form_options_element extends rex_form_element
 
     /**
      * @param array<string|array{0: string, 1?: string|int}> $options
-     * @param bool                                           $useOnlyValues
+     * @param bool $useOnlyValues
      * @return void
      */
     public function addOptions(array $options, $useOnlyValues = false)
@@ -52,7 +52,7 @@ abstract class rex_form_options_element extends rex_form_element
 
     /**
      * @param string[] $options
-     * @param bool     $useKeys
+     * @param bool $useKeys
      * @return void
      */
     public function addArrayOptions(array $options, $useKeys = true)

--- a/redaxo/src/core/lib/form/form.php
+++ b/redaxo/src/core/lib/form/form.php
@@ -42,7 +42,7 @@ class rex_form extends rex_form_base
      * @param string $fieldset
      * @param string $whereCondition
      * @param 'post'|'get' $method
-     * @param bool   $debug
+     * @param bool $debug
      * @param positive-int $db DB connection ID
      */
     protected function __construct($tableName, $fieldset, $whereCondition, $method = 'post', $debug = false, $db = 1)
@@ -86,7 +86,7 @@ class rex_form extends rex_form_base
      * @param string $fieldset
      * @param string $whereCondition
      * @param 'post'|'get' $method
-     * @param bool   $debug
+     * @param bool $debug
      * @param positive-int $db DB connection ID
      *
      * @return static a rex_form instance
@@ -157,7 +157,7 @@ class rex_form extends rex_form_base
      * Fuegt dem Formular ein Feld hinzu mitdem die Prioritaet von Datensaetzen verwaltet werden kann.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_prio_element
      */
@@ -254,8 +254,8 @@ class rex_form extends rex_form_base
      * Callbackfunktion, damit in subklassen der Value noch beeinflusst werden kann
      * kurz vorm speichern.
      *
-     * @param string          $fieldsetName
-     * @param string          $fieldName
+     * @param string $fieldsetName
+     * @param string $fieldName
      * @param string|int|null $fieldValue
      *
      * @return string|int|null

--- a/redaxo/src/core/lib/form/form_base.php
+++ b/redaxo/src/core/lib/form/form_base.php
@@ -139,8 +139,8 @@ abstract class rex_form_base
      *
      * @param string $tag
      * @param string $name
-     * @param mixed  $value
-     * @param bool   $addElement
+     * @param mixed $value
+     * @param bool $addElement
      *
      * @return rex_form_element
      */
@@ -162,7 +162,7 @@ abstract class rex_form_base
      * Ein Container-Feld wiederrum kann weitere Felder enthalten.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_container_element
      */
@@ -183,8 +183,8 @@ abstract class rex_form_base
      *
      * @param string $type
      * @param string $name
-     * @param mixed  $value
-     * @param bool   $addElement
+     * @param mixed $value
+     * @param bool $addElement
      *
      * @return rex_form_element
      */
@@ -198,7 +198,7 @@ abstract class rex_form_base
      * Fuegt dem Formular ein Text-Feld hinzu.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_element
      */
@@ -215,7 +215,7 @@ abstract class rex_form_base
      * Dazu wird ein input-Element verwendet.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_element
      */
@@ -233,7 +233,7 @@ abstract class rex_form_base
      * Dazu wird ein span-Element verwendet.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_element
      */
@@ -254,7 +254,7 @@ abstract class rex_form_base
      * Fuegt dem Fomular ein Hidden-Feld hinzu.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_element
      */
@@ -268,7 +268,7 @@ abstract class rex_form_base
      * Dies ermoeglicht die Mehrfach-Selektion aus einer vorgegeben Auswahl an Werten.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_checkbox_element
      */
@@ -285,7 +285,7 @@ abstract class rex_form_base
      * Dies ermoeglicht eine Einfache-Selektion aus einer vorgegeben Auswahl an Werten.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_radio_element
      */
@@ -301,7 +301,7 @@ abstract class rex_form_base
      * Fuegt dem Formular ein Textarea-Feld hinzu.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_element
      */
@@ -326,7 +326,7 @@ abstract class rex_form_base
      * Fuegt dem Formular ein Select/Auswahl-Feld hinzu.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_select_element
      */
@@ -346,7 +346,7 @@ abstract class rex_form_base
      * Es kann nur ein Element aus dem Medienpool eingefuegt werden.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @throws rex_exception
      *
@@ -368,7 +368,7 @@ abstract class rex_form_base
      * Damit koennen mehrere Elemente aus dem Medienpool eingefuegt werden.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @throws rex_exception
      *
@@ -390,7 +390,7 @@ abstract class rex_form_base
      * Es kann nur ein Element aus der Struktur eingefuegt werden.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @throws rex_exception
      *
@@ -412,7 +412,7 @@ abstract class rex_form_base
      * Damit koennen mehrere Elemente aus der Struktur eingefuegt werden.
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @throws rex_exception
      *
@@ -478,7 +478,7 @@ abstract class rex_form_base
      * Fuegt dem Formular einen Parameter hinzu.
      * Diese an den Stellen eingefuegt, an denen das Fomular neue Requests erzeugt.
      *
-     * @param string          $name
+     * @param string $name
      * @param string|int|bool $value
      * @return void
      */
@@ -502,7 +502,7 @@ abstract class rex_form_base
      * oder $default kein Parameter mit dem Namen exisitiert.
      *
      * @param string $name
-     * @param mixed  $default
+     * @param mixed $default
      *
      * @return mixed
      */
@@ -527,7 +527,7 @@ abstract class rex_form_base
      *
      * @param string $inputType
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_element
      */
@@ -546,7 +546,7 @@ abstract class rex_form_base
      *
      * @param string $tag
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return rex_form_element
      */
@@ -1042,8 +1042,8 @@ abstract class rex_form_base
     }
 
     /**
-     * @param string      $fieldsetName
-     * @param string      $fieldName
+     * @param string $fieldsetName
+     * @param string $fieldName
      * @param string|null $default
      *
      * @return string|null

--- a/redaxo/src/core/lib/fragment.php
+++ b/redaxo/src/core/lib/fragment.php
@@ -53,8 +53,8 @@ class rex_fragment
     /**
      * Returns the value of the given variable $name.
      *
-     * @param string $name    Variable name
-     * @param mixed  $default Default value
+     * @param string $name Variable name
+     * @param mixed $default Default value
      *
      * @return mixed
      */
@@ -66,9 +66,9 @@ class rex_fragment
     /**
      * Set the variable $name to the given value.
      *
-     * @param string $name   The name of the variable
-     * @param mixed  $value  The value for the variable
-     * @param bool   $escape Flag which indicates if the value should be escaped or not
+     * @param string $name The name of the variable
+     * @param mixed $value The value for the variable
+     * @param bool $escape Flag which indicates if the value should be escaped or not
      *
      * @throws InvalidArgumentException
      *
@@ -196,7 +196,7 @@ class rex_fragment
     /**
      * Translate the given key $key.
      *
-     * @param string     $key             The key to translate
+     * @param string $key The key to translate
      * @param string|int ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return string Translation for the key

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -120,10 +120,10 @@ class rex_list implements rex_url_provider_interface
     /**
      * Erstellt ein rex_list Objekt.
      *
-     * @param string      $query       SELECT Statement
+     * @param string $query SELECT Statement
      * @param int|self::DISABLE_PAGINATION $rowsPerPage
-     * @param string|null $listName    Name der Liste
-     * @param bool        $debug
+     * @param string|null $listName Name der Liste
+     * @param bool $debug
      * @param positive-int $db
      */
     protected function __construct($query, $rowsPerPage = 30, $listName = null, $debug = false, $db = 1)
@@ -205,10 +205,10 @@ class rex_list implements rex_url_provider_interface
     }
 
     /**
-     * @param string      $query
+     * @param string $query
      * @param int|self::DISABLE_PAGINATION $rowsPerPage
      * @param string|null $listName
-     * @param bool        $debug
+     * @param bool $debug
      * @param positive-int $db DB connection ID
      *
      * @return static
@@ -299,7 +299,7 @@ class rex_list implements rex_url_provider_interface
     }
 
     /**
-     * @param string     $name
+     * @param string $name
      * @param string|int $value
      * @return void
      */
@@ -325,7 +325,7 @@ class rex_list implements rex_url_provider_interface
     }
 
     /**
-     * @param string     $name
+     * @param string $name
      * @param string|int $value
      * @return void
      */
@@ -343,7 +343,7 @@ class rex_list implements rex_url_provider_interface
     }
 
     /**
-     * @param string     $name
+     * @param string $name
      * @param string|int $value
      * @return void
      */
@@ -409,10 +409,10 @@ class rex_list implements rex_url_provider_interface
     /**
      * Methode, um eine Spalte einzufügen.
      *
-     * @param string $columnHead   Titel der Spalte
-     * @param string $columnBody   Text/Format der Spalte
-     * @param int    $columnIndex  Stelle, an der die neue Spalte erscheinen soll
-     * @param array  $columnLayout Layout der Spalte
+     * @param string $columnHead Titel der Spalte
+     * @param string $columnBody Text/Format der Spalte
+     * @param int $columnIndex Stelle, an der die neue Spalte erscheinen soll
+     * @param array $columnLayout Layout der Spalte
      * @return void
      */
     public function addColumn($columnHead, $columnBody, $columnIndex = -1, $columnLayout = null)
@@ -441,8 +441,8 @@ class rex_list implements rex_url_provider_interface
     /**
      * Methode, um das Layout einer Spalte zu setzen.
      *
-     * @param string $columnHead   Titel der Spalte
-     * @param array  $columnLayout Layout der Spalte
+     * @param string $columnHead Titel der Spalte
+     * @param array $columnLayout Layout der Spalte
      * @return void
      */
     public function setColumnLayout($columnHead, $columnLayout)
@@ -478,8 +478,8 @@ class rex_list implements rex_url_provider_interface
     /**
      * Gibt den Namen einer Spalte zurück.
      *
-     * @param int   $columnIndex Nummer der Spalte
-     * @param mixed $default     Defaultrückgabewert, falls keine Spalte mit der angegebenen Nummer vorhanden ist
+     * @param int $columnIndex Nummer der Spalte
+     * @param mixed $default Defaultrückgabewert, falls keine Spalte mit der angegebenen Nummer vorhanden ist
      *
      * @return string|null
      */
@@ -532,7 +532,7 @@ class rex_list implements rex_url_provider_interface
      * Setzt ein Label für eine Spalte.
      *
      * @param string $columnName Name der Spalte
-     * @param string $label      Label für die Spalte
+     * @param string $label Label für die Spalte
      * @return void
      */
     public function setColumnLabel($columnName, $label)
@@ -562,8 +562,8 @@ class rex_list implements rex_url_provider_interface
      *
      * @param string $columnName Name der Spalte
      * @param string $formatType Formatierungstyp
-     * @param mixed  $format     Zu verwendentes Format
-     * @param array  $params     Custom params für callback func bei format_type 'custom'
+     * @param mixed $format Zu verwendentes Format
+     * @param array $params Custom params für callback func bei format_type 'custom'
      * @return void
      */
     public function setColumnFormat($columnName, $formatType, $format = '', array $params = [])
@@ -577,7 +577,7 @@ class rex_list implements rex_url_provider_interface
      * @template T
      *
      * @param string $columnName Name der Spalte
-     * @param T      $default    Defaultrückgabewert, falls keine Formatierung gesetzt ist
+     * @param T $default Defaultrückgabewert, falls keine Formatierung gesetzt ist
      *
      * @return array{string, mixed, array<mixed>}|T
      */
@@ -590,7 +590,7 @@ class rex_list implements rex_url_provider_interface
      * Markiert eine Spalte als sortierbar.
      *
      * @param string $columnName Name der Spalte
-     * @param string $direction  Startsortierrichtung der Spalte [ASC|DESC]
+     * @param string $direction Startsortierrichtung der Spalte [ASC|DESC]
      * @return void
      */
     public function setColumnSortable($columnName, $direction = 'asc')
@@ -603,9 +603,9 @@ class rex_list implements rex_url_provider_interface
      * Setzt eine Option für eine Spalte
      * (z.b. Sortable,..).
      *
-     * @param string     $columnName Name der Spalte
-     * @param string|int $option     Name/Id der Option
-     * @param mixed      $value      Wert der Option
+     * @param string $columnName Name der Spalte
+     * @param string|int $option Name/Id der Option
+     * @param mixed $value Wert der Option
      * @return void
      */
     public function setColumnOption($columnName, $option, $value)
@@ -616,9 +616,9 @@ class rex_list implements rex_url_provider_interface
     /**
      * Gibt den Wert einer Option für eine Spalte zurück.
      *
-     * @param string     $columnName Name der Spalte
-     * @param string|int $option     Name/Id der Option
-     * @param mixed      $default    Defaultrückgabewert, falls die Option nicht gesetzt ist
+     * @param string $columnName Name der Spalte
+     * @param string|int $option Name/Id der Option
+     * @param mixed $default Defaultrückgabewert, falls die Option nicht gesetzt ist
      *
      * @return mixed|null
      */
@@ -633,8 +633,8 @@ class rex_list implements rex_url_provider_interface
     /**
      * Gibt zurück, ob für eine Spalte eine Option gesetzt wurde.
      *
-     * @param string     $columnName Name der Spalte
-     * @param string|int $option     Name/Id der Option
+     * @param string $columnName Name der Spalte
+     * @param string|int $option Name/Id der Option
      *
      * @return bool
      */
@@ -647,7 +647,7 @@ class rex_list implements rex_url_provider_interface
      * Verlinkt eine Spalte mit den übergebenen Parametern.
      *
      * @param string $columnName Name der Spalte
-     * @param array  $params     Array von Parametern
+     * @param array $params Array von Parametern
      * @return void
      */
     public function setColumnParams($columnName, array $params = [])
@@ -685,11 +685,11 @@ class rex_list implements rex_url_provider_interface
     /**
      * Verschiebt eine Spalte an eine andere Position in der Spaltenliste.
      *
-     * @param string        $columnName   Name der Spalte
-     * @param int|string    $columnIndex  Einfügen vor der angegebenen Spalte
-     *                                    (Spalten-Index analog zu addColumn oder Spaltenname)
+     * @param string $columnName Name der Spalte
+     * @param int|string $columnIndex Einfügen vor der angegebenen Spalte
+     *                                (Spalten-Index analog zu addColumn oder Spaltenname)
      *
-     * @return int          Spaltennummer der neuen Position
+     * @return int Spaltennummer der neuen Position
      */
     public function setColumnPosition(string $columnName, $columnIndex): int
     {
@@ -713,11 +713,11 @@ class rex_list implements rex_url_provider_interface
     /**
      * Gibt die Position einer Spalte zurück.
      *
-     * @param string     $columnName   Name der Spalte
+     * @param string $columnName Name der Spalte
      *
-     * @throws InvalidArgumentException   $columnName kommt in $this->columnNames nicht vor
+     * @throws InvalidArgumentException $columnName kommt in $this->columnNames nicht vor
      *
-     * @return int       Index der Spalte
+     * @return int Index der Spalte
      */
     public function getColumnPosition(string $columnName): int
     {
@@ -753,8 +753,8 @@ class rex_list implements rex_url_provider_interface
      *     ['class' => 'classname-c']
      * ]);
      *
-     * @param array $columns         Array von Spalten
-     * @param int   $columnGroupSpan Span der Columngroup
+     * @param array $columns Array von Spalten
+     * @param int $columnGroupSpan Span der Columngroup
      * @return void
      */
     public function addTableColumnGroup(array $columns, $columnGroupSpan = null)
@@ -786,7 +786,7 @@ class rex_list implements rex_url_provider_interface
      * Fügt der zuletzte eingefügten TableColumnGroup eine weitere Spalte hinzu.
      *
      * @param int|'*' $width Breite der Spalte
-     * @param int     $span  Span der Spalte
+     * @param int $span Span der Spalte
      * @return void
      */
     public function addTableColumn($width, $span = null, $class = null)
@@ -857,7 +857,7 @@ class rex_list implements rex_url_provider_interface
      * @see #replaceVariable, #replaceVariables
      *
      * @param array $params
-     * @param bool  $escape Flag whether the argument separator "&" should be escaped (&amp;)
+     * @param bool $escape Flag whether the argument separator "&" should be escaped (&amp;)
      *
      * @return string
      */
@@ -1099,10 +1099,10 @@ class rex_list implements rex_url_provider_interface
     /**
      * Formatiert einen übergebenen String anhand der rexFormatter Klasse.
      *
-     * @param string     $value  Zu formatierender String
+     * @param string $value Zu formatierender String
      * @param null|array $format mit den Formatierungsinformationen
-     * @param bool       $escape Flag, Ob escapen von $value erlaubt ist
-     * @param string     $field
+     * @param bool $escape Flag, Ob escapen von $value erlaubt ist
+     * @param string $field
      *
      * @return string
      */

--- a/redaxo/src/core/lib/login/complex_perm.php
+++ b/redaxo/src/core/lib/login/complex_perm.php
@@ -35,8 +35,8 @@ abstract class rex_complex_perm
     private static $classes = [];
 
     /**
-     * @param rex_user $user  User instance
-     * @param mixed    $perms Permissions
+     * @param rex_user $user User instance
+     * @param mixed $perms Permissions
      */
     protected function __construct(rex_user $user, $perms)
     {
@@ -93,9 +93,9 @@ abstract class rex_complex_perm
     /**
      * Returns the complex perm.
      *
-     * @param rex_user $user  User instance
-     * @param string   $key   Complex perm key
-     * @param mixed    $perms Permissions
+     * @param rex_user $user User instance
+     * @param string $key Complex perm key
+     * @param mixed $perms Permissions
      *
      * @return self|null
      */
@@ -111,7 +111,7 @@ abstract class rex_complex_perm
     /**
      * Should be called if an item is removed.
      *
-     * @param string     $key  Key
+     * @param string $key Key
      * @param string|int $item Item
      * @return void
      */
@@ -123,9 +123,9 @@ abstract class rex_complex_perm
     /**
      * Should be called if an item is replaced.
      *
-     * @param string     $key  Key
+     * @param string $key Key
      * @param string|int $item Old item
-     * @param string|int $new  New item
+     * @param string|int $new New item
      * @return void
      */
     public static function replaceItem($key, $item, $new)

--- a/redaxo/src/core/lib/login/password_policy.php
+++ b/redaxo/src/core/lib/login/password_policy.php
@@ -19,7 +19,7 @@ class rex_password_policy
     }
 
     /**
-     * @param string   $password
+     * @param string $password
      * @param null|int $id
      *
      * @throws rex_exception

--- a/redaxo/src/core/lib/login/perm.php
+++ b/redaxo/src/core/lib/login/perm.php
@@ -23,8 +23,8 @@ abstract class rex_perm
     /**
      * Registers a new permission.
      *
-     * @param string $perm  Perm key
-     * @param string $name  Perm name
+     * @param string $perm Perm key
+     * @param string $name Perm name
      * @param string $group Perm group, possible values are rex_perm::GENERAL, rex_perm::OPTIONS and rex_perm::EXTRAS
      * @return void
      */

--- a/redaxo/src/core/lib/login/role.php
+++ b/redaxo/src/core/lib/login/role.php
@@ -21,7 +21,7 @@ interface rex_user_role_interface
      * Returns the complex perm.
      *
      * @param rex_user $user User instance
-     * @param string   $key  Complex perm key
+     * @param string $key Complex perm key
      *
      * @return rex_complex_perm|null Complex perm
      */

--- a/redaxo/src/core/lib/packages/addons/addon.php
+++ b/redaxo/src/core/lib/packages/addons/addon.php
@@ -303,7 +303,7 @@ class rex_addon extends rex_package implements rex_addon_interface
      *
      * @template T of rex_package
      * @param array<non-empty-string, T> $packages Array of packages
-     * @param string $method   A rex_package method
+     * @param string $method A rex_package method
      * @return array<non-empty-string, T>
      */
     private static function filterPackages(array $packages, $method)

--- a/redaxo/src/core/lib/packages/interface.php
+++ b/redaxo/src/core/lib/packages/interface.php
@@ -114,8 +114,8 @@ interface rex_package_interface
     /**
      * Sets a property.
      *
-     * @param non-empty-string $key   Key of the property
-     * @param mixed  $value New value for the property
+     * @param non-empty-string $key Key of the property
+     * @param mixed $value New value for the property
      * @return void
      */
     public function setProperty($key, $value);
@@ -123,8 +123,8 @@ interface rex_package_interface
     /**
      * Returns a property.
      *
-     * @param non-empty-string $key     Key of the property
-     * @param mixed  $default Default value, will be returned if the property isn't set
+     * @param non-empty-string $key Key of the property
+     * @param mixed $default Default value, will be returned if the property isn't set
      *
      * @return mixed
      */
@@ -198,8 +198,8 @@ interface rex_package_interface
     /**
      * Includes a file in the package context.
      *
-     * @param non-empty-string $file    Filename
-     * @param array  $context Context values, available as variables in given file
+     * @param non-empty-string $file Filename
+     * @param array $context Context values, available as variables in given file
      * @return mixed
      */
     public function includeFile($file, array $context = []);
@@ -207,7 +207,7 @@ interface rex_package_interface
     /**
      * Adds the package prefix to the given key and returns the translation for it.
      *
-     * @param string     $key             Key
+     * @param string $key Key
      * @param string|int ...$replacements A arbritary number of strings used for interpolating within the resolved messag
      *
      * @return non-empty-string Translation for the key

--- a/redaxo/src/core/lib/packages/plugins/plugin.php
+++ b/redaxo/src/core/lib/packages/plugins/plugin.php
@@ -17,7 +17,7 @@ class rex_plugin extends rex_package implements rex_plugin_interface
     private $addon;
 
     /**
-     * @param string    $name  Name
+     * @param string $name Name
      * @param rex_addon $addon Parent addon
      */
     public function __construct($name, rex_addon $addon)
@@ -29,7 +29,7 @@ class rex_plugin extends rex_package implements rex_plugin_interface
     /**
      * Returns the plugin by the given name.
      *
-     * @param string $addon  Name of the addon
+     * @param string $addon Name of the addon
      * @param string $plugin Name of the plugin
      *
      * @throws InvalidArgumentException
@@ -73,7 +73,7 @@ class rex_plugin extends rex_package implements rex_plugin_interface
     /**
      * Returns if the plugin exists.
      *
-     * @param string $addon  Name of the addon
+     * @param string $addon Name of the addon
      * @param string $plugin Name of the plugin
      *
      * @return bool

--- a/redaxo/src/core/lib/request.php
+++ b/redaxo/src/core/lib/request.php
@@ -11,8 +11,8 @@ class rex_request
      * Returns the variable $varname of $_GET and casts the value.
      *
      * @param string $varname Variable name
-     * @param mixed  $vartype Variable type
-     * @param mixed  $default Default value
+     * @param mixed $vartype Variable type
+     * @param mixed $default Default value
      *
      * @return mixed
      *
@@ -27,8 +27,8 @@ class rex_request
      * Returns the variable $varname of $_POST and casts the value.
      *
      * @param string $varname Variable name
-     * @param mixed  $vartype Variable type
-     * @param mixed  $default Default value
+     * @param mixed $vartype Variable type
+     * @param mixed $default Default value
      *
      * @return mixed
      *
@@ -43,8 +43,8 @@ class rex_request
      * Returns the variable $varname of $_REQUEST and casts the value.
      *
      * @param string $varname Variable name
-     * @param mixed  $vartype Variable type
-     * @param mixed  $default Default value
+     * @param mixed $vartype Variable type
+     * @param mixed $default Default value
      *
      * @return mixed
      *
@@ -59,8 +59,8 @@ class rex_request
      * Returns the variable $varname of $_SERVER and casts the value.
      *
      * @param string $varname Variable name
-     * @param mixed  $vartype Variable type
-     * @param mixed  $default Default value
+     * @param mixed $vartype Variable type
+     * @param mixed $default Default value
      *
      * @return mixed
      */
@@ -73,8 +73,8 @@ class rex_request
      * Returns the variable $varname of $_SESSION and casts the value.
      *
      * @param string $varname Variable name
-     * @param mixed  $vartype Variable type
-     * @param mixed  $default Default value
+     * @param mixed $vartype Variable type
+     * @param mixed $default Default value
      *
      * @throws rex_exception
      *
@@ -100,7 +100,7 @@ class rex_request
      * Sets a session variable.
      *
      * @param string $varname Variable name
-     * @param mixed  $value   Value
+     * @param mixed $value Value
      *
      * @throws rex_exception
      * @return void
@@ -150,8 +150,8 @@ class rex_request
      * Returns the variable $varname of $_COOKIE and casts the value.
      *
      * @param string $varname Variable name
-     * @param mixed  $vartype Variable type
-     * @param mixed  $default Default value
+     * @param mixed $vartype Variable type
+     * @param mixed $default Default value
      *
      * @return mixed
      *
@@ -166,8 +166,8 @@ class rex_request
      * Returns the variable $varname of $_FILES and casts the value.
      *
      * @param string $varname Variable name
-     * @param mixed  $vartype Variable type
-     * @param mixed  $default Default value
+     * @param mixed $vartype Variable type
+     * @param mixed $default Default value
      *
      * @return mixed
      */
@@ -180,8 +180,8 @@ class rex_request
      * Returns the variable $varname of $_ENV and casts the value.
      *
      * @param string $varname Variable name
-     * @param mixed  $vartype Variable type
-     * @param mixed  $default Default value
+     * @param mixed $vartype Variable type
+     * @param mixed $default Default value
      *
      * @return mixed
      */
@@ -193,10 +193,10 @@ class rex_request
     /**
      * Searches the value $needle in array $haystack and returns the casted value.
      *
-     * @param array      $haystack Array
-     * @param string|int $needle   Value to search
-     * @param mixed      $vartype  Variable type
-     * @param mixed      $default  Default value
+     * @param array $haystack Array
+     * @param string|int $needle Value to search
+     * @param mixed $vartype Variable type
+     * @param mixed $default Default value
      *
      * @throws InvalidArgumentException
      *

--- a/redaxo/src/core/lib/response.php
+++ b/redaxo/src/core/lib/response.php
@@ -158,10 +158,10 @@ class rex_response
     /**
      * Sends a file to client.
      *
-     * @param string      $file               File path
-     * @param string      $contentType        Content type
-     * @param string      $contentDisposition Content disposition ("inline" or "attachment")
-     * @param null|string $filename           Custom Filename
+     * @param string $file File path
+     * @param string $contentType Content type
+     * @param string $contentDisposition Content disposition ("inline" or "attachment")
+     * @param null|string $filename Custom Filename
      * @return void|never
      */
     public static function sendFile($file, $contentType, $contentDisposition = 'inline', $filename = null)
@@ -244,12 +244,12 @@ class rex_response
     /**
      * Sends a resource to the client.
      *
-     * @param string      $content            Content
-     * @param null|string $contentType        Content type
-     * @param null|int    $lastModified       HTTP Last-Modified Timestamp
-     * @param null|string $etag               HTTP Cachekey to identify the cache
+     * @param string $content Content
+     * @param null|string $contentType Content type
+     * @param null|int $lastModified HTTP Last-Modified Timestamp
+     * @param null|string $etag HTTP Cachekey to identify the cache
      * @param null|string $contentDisposition Content disposition ("inline" or "attachment")
-     * @param null|string $filename           Filename
+     * @param null|string $filename Filename
      * @return void
      */
     public static function sendResource($content, $contentType = null, $lastModified = null, $etag = null, $contentDisposition = null, $filename = null)
@@ -269,8 +269,8 @@ class rex_response
      *
      * The page content can be modified by the Extension Point OUTPUT_FILTER
      *
-     * @param string $content      Content of page
-     * @param int    $lastModified HTTP Last-Modified Timestamp
+     * @param string $content Content of page
+     * @param int $lastModified HTTP Last-Modified Timestamp
      * @return void
      */
     public static function sendPage($content, $lastModified = null)
@@ -297,10 +297,10 @@ class rex_response
     /**
      * Sends content to the client.
      *
-     * @param string      $content      Content
-     * @param string|null $contentType  Content type
-     * @param int|null    $lastModified HTTP Last-Modified Timestamp
-     * @param string|null $etag         HTTP Cachekey to identify the cache
+     * @param string $content Content
+     * @param string|null $contentType Content type
+     * @param int|null $lastModified HTTP Last-Modified Timestamp
+     * @param string|null $etag HTTP Cachekey to identify the cache
      * @return void
      */
     public static function sendContent($content, $contentType = null, $lastModified = null, $etag = null)
@@ -353,9 +353,9 @@ class rex_response
     }
 
     /**
-     * @param mixed       $data         data to be json encoded and sent
-     * @param int|null    $lastModified HTTP Last-Modified Timestamp
-     * @param string|null $etag         HTTP Cachekey to identify the cache
+     * @param mixed $data data to be json encoded and sent
+     * @param int|null $lastModified HTTP Last-Modified Timestamp
+     * @param string|null $etag HTTP Cachekey to identify the cache
      */
     public static function sendJson($data, ?int $lastModified = null, ?string $etag = null): void
     {
@@ -492,8 +492,8 @@ class rex_response
     // method inspired by https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Cookie.php
 
     /**
-     * @param string      $name    The name of the cookie
-     * @param string|null $value   the value of the cookie, a empty value to delete the cookie
+     * @param string $name The name of the cookie
+     * @param string|null $value the value of the cookie, a empty value to delete the cookie
      * @param array{expires?: int|string|DateTimeInterface, path?: string, domain?: ?string, secure?: bool, httponly?: bool, samesite?: ?string, raw?: bool} $options Different cookie Options. Supported keys are:
      *                             "expires" int|string|DateTimeInterface The time the cookie expires
      *                             "path" string                          The path on the server in which the cookie will be available on
@@ -578,7 +578,7 @@ class rex_response
      *
      * You might pass additional options in case the name is not unique or the cookie is not stored on the current domain.
      *
-     * @param string $name    The name of the cookie
+     * @param string $name The name of the cookie
      * @param array{path?: string, domain?: ?string, secure?: bool, httponly?: bool, samesite?: ?string} $options Different cookie Options. Supported keys are:
      *                        "path" string          The path on the server in which the cookie will be available on
      *                        "domain" string|null   The domain that the cookie is available to

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -70,8 +70,8 @@ class rex
     /**
      * Sets a property. Changes will not be persisted accross http request boundaries.
      *
-     * @param string $key   Key of the property
-     * @param mixed  $value Value for the property
+     * @param string $key Key of the property
+     * @param mixed $value Value for the property
      *
      * @throws InvalidArgumentException on invalid parameters
      *
@@ -128,8 +128,8 @@ class rex
     /**
      * Returns a property.
      *
-     * @param string $key     Key of the property
-     * @param mixed  $default Default value, will be returned if the property isn't set
+     * @param string $key Key of the property
+     * @param mixed $default Default value, will be returned if the property isn't set
      *
      * @throws InvalidArgumentException on invalid parameters
      *
@@ -496,7 +496,7 @@ class rex
      * Returns the title tag and if the property "use_accesskeys" is true, the accesskey tag.
      *
      * @param string $title Title
-     * @param string $key   Key for the accesskey
+     * @param string $key Key for the accesskey
      *
      * @return string
      */

--- a/redaxo/src/core/lib/setup/setup.php
+++ b/redaxo/src/core/lib/setup/setup.php
@@ -136,8 +136,8 @@ class rex_setup
      * Checks the version of the connected database server.
      * When validation of the database configs succeeds the settings will be used for rex_sql.
      *
-     * @param array $config   array of database config
-     * @param bool  $createDb Should the database be created, if it not exists
+     * @param array $config array of database config
+     * @param bool $createDb Should the database be created, if it not exists
      *
      * @return string Error message
      */

--- a/redaxo/src/core/lib/sql/column.php
+++ b/redaxo/src/core/lib/sql/column.php
@@ -31,9 +31,9 @@ class rex_sql_column
     private $modified = false;
 
     /**
-     * @param string      $name
-     * @param string      $type
-     * @param bool        $nullable
+     * @param string $name
+     * @param string $type
+     * @param bool $nullable
      * @param null|string $default
      * @param null|string $extra
      * @param null|string $comment

--- a/redaxo/src/core/lib/sql/foreign_key.php
+++ b/redaxo/src/core/lib/sql/foreign_key.php
@@ -35,7 +35,7 @@ class rex_sql_foreign_key
     /**
      * @param string $name
      * @param string $table
-     * @param array<string, string> $columns  Mapping of locale column to column in foreign table
+     * @param array<string, string> $columns Mapping of locale column to column in foreign table
      * @param self::RESTRICT|self::NO_ACTION|self::CASCADE|self::SET_NULL $onUpdate
      * @param self::RESTRICT|self::NO_ACTION|self::CASCADE|self::SET_NULL $onDelete
      */

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -159,11 +159,11 @@ class rex_sql implements Iterator
     }
 
     /**
-     * @param string $host       the host. might optionally include a port.
+     * @param string $host the host. might optionally include a port.
      * @param string $database
      * @param string $login
      * @param string $password
-     * @param bool   $persistent
+     * @param bool $persistent
      *
      * @return PDO
      */
@@ -292,9 +292,9 @@ class rex_sql implements Iterator
      *
      * Beispiel-Query: '(DB1) SELECT * FROM my_table WHERE my_col_int = 5'
      *
-     * @param string $query   The sql-query
-     * @param array  $params  An optional array of statement parameter
-     * @param array  $options For possible option keys view `rex_sql::OPT_*` constants
+     * @param string $query The sql-query
+     * @param array $params An optional array of statement parameter
+     * @param array $options For possible option keys view `rex_sql::OPT_*` constants
      *
      * @throws rex_sql_exception on errors
      *
@@ -363,7 +363,7 @@ class rex_sql implements Iterator
     /**
      * Executes the prepared statement with the given input parameters.
      *
-     * @param array $params  Array of input parameters
+     * @param array $params Array of input parameters
      * @param array $options For possible option keys view `rex_sql::OPT_*` constants
      *
      * @throws rex_sql_exception
@@ -427,9 +427,9 @@ class rex_sql implements Iterator
      *
      * NOTE: named-parameters/?-placeholders are not supported in LIMIT clause!
      *
-     * @param string $query   The sql-query
-     * @param array  $params  An optional array of statement parameter
-     * @param array  $options For possible option keys view `rex_sql::OPT_*` constants
+     * @param string $query The sql-query
+     * @param array $params An optional array of statement parameter
+     * @param array $options For possible option keys view `rex_sql::OPT_*` constants
      *
      * @throws rex_sql_exception on errors
      *
@@ -469,7 +469,7 @@ class rex_sql implements Iterator
      * Sets the raw value of a column.
      *
      * @param string $column Name of the column
-     * @param string $value  The raw value
+     * @param string $value The raw value
      *
      * @return $this the current rex_sql object
      *
@@ -487,7 +487,7 @@ class rex_sql implements Iterator
      * Set the value of a column.
      *
      * @param string $column Name of the column
-     * @param scalar|null  $value  The value
+     * @param scalar|null $value The value
      *
      * @return $this the current rex_sql object
      */
@@ -503,7 +503,7 @@ class rex_sql implements Iterator
      * Set the array value of a column (json encoded).
      *
      * @param string $column Name of the column
-     * @param array  $value  The value
+     * @param array $value The value
      *
      * @return $this the current rex_sql object
      */
@@ -515,7 +515,7 @@ class rex_sql implements Iterator
     /**
      * Sets the datetime value of a column.
      *
-     * @param string   $column    Name of the column
+     * @param string $column Name of the column
      * @param int|null $timestamp Unix timestamp (if `null` is given, the current time is used)
      *
      * @return $this the current rex_sql object
@@ -555,7 +555,7 @@ class rex_sql implements Iterator
      * Prueft den Wert der Spalte $column der aktuellen Zeile, ob $value enthalten ist.
      *
      * @param string $column Spaltenname des zu pruefenden Feldes
-     * @param string $value  Wert, der enthalten sein soll
+     * @param string $value Wert, der enthalten sein soll
      *
      * @throws rex_sql_exception
      *
@@ -610,7 +610,7 @@ class rex_sql implements Iterator
      *    $sql->setWhere('myid="35" OR abc="zdf"');
      *
      * @param string|array $where
-     * @param array        $params
+     * @param array $params
      *
      * @throws rex_sql_exception
      *
@@ -1178,8 +1178,8 @@ class rex_sql implements Iterator
      *
      * @template TFetchType as PDO::FETCH_ASSOC|PDO::FETCH_NUM|PDO::FETCH_KEY_PAIR
      *
-     * @param string $query     The sql-query
-     * @param array  $params    An optional array of statement parameter
+     * @param string $query The sql-query
+     * @param array $params An optional array of statement parameter
      * @param TFetchType $fetchType
      *
      * @throws rex_sql_exception on errors
@@ -1216,8 +1216,8 @@ class rex_sql implements Iterator
      *
      * @template TFetchType as PDO::FETCH_ASSOC|PDO::FETCH_NUM|PDO::FETCH_KEY_PAIR
      *
-     * @param string $query     The sql-query
-     * @param array  $params    An optional array of statement parameter
+     * @param string $query The sql-query
+     * @param array $params An optional array of statement parameter
      * @param TFetchType $fetchType
      *
      * @throws rex_sql_exception on errors
@@ -1296,7 +1296,7 @@ class rex_sql implements Iterator
      * Gibt die letzte Fehlermeldung aus.
      *
      * @param string $query
-     * @param array  $params
+     * @param array $params
      * @return void
      */
     protected function printError($query, $params)
@@ -1343,8 +1343,8 @@ class rex_sql implements Iterator
     /**
      * Setzt eine Spalte auf den naechst moeglich auto_increment Wert.
      *
-     * @param string $column  Name der Spalte
-     * @param int    $startId
+     * @param string $column Name der Spalte
+     * @param int $startId
      *
      * @throws rex_sql_exception
      *
@@ -1928,11 +1928,11 @@ class rex_sql implements Iterator
      * Prueft die uebergebenen Zugangsdaten auf gueltigkeit und legt ggf. die
      * Datenbank an.
      *
-     * @param string $host     the host. might optionally include a port.
+     * @param string $host the host. might optionally include a port.
      * @param string $login
      * @param string $password
      * @param string $database
-     * @param bool   $createDb
+     * @param bool $createDb
      *
      * @return true|string
      */
@@ -2035,7 +2035,7 @@ class rex_sql implements Iterator
 
     /**
      * @param string $verb
-     * @param bool   $onDuplicateKeyUpdate
+     * @param bool $onDuplicateKeyUpdate
      *
      * @throws rex_sql_exception
      *

--- a/redaxo/src/core/lib/sql/util.php
+++ b/redaxo/src/core/lib/sql/util.php
@@ -74,11 +74,11 @@ class rex_sql_util
      * Allgemeine funktion die eine Datenbankspalte fortlaufend durchnummeriert.
      * Dies ist z.B. nützlich beim Umgang mit einer Prioritäts-Spalte.
      *
-     * @param non-empty-string $tableName      Name der Datenbanktabelle
+     * @param non-empty-string $tableName Name der Datenbanktabelle
      * @param non-empty-string $prioColumnName Name der Spalte in der Tabelle, in der die Priorität (Integer) gespeichert wird
      * @param string $whereCondition Where-Bedingung zur Einschränkung des ResultSets
-     * @param string $orderBy        Sortierung des ResultSets
-     * @param int    $startBy        Startpriorität
+     * @param string $orderBy Sortierung des ResultSets
+     * @param int $startBy Startpriorität
      * @return void
      */
     public static function organizePriorities($tableName, $prioColumnName, $whereCondition = '', $orderBy = '', $startBy = 1)
@@ -106,7 +106,7 @@ class rex_sql_util
      * Importiert die gegebene SQL-Datei in die Datenbank.
      *
      * @param non-empty-string $file
-     * @param bool   $debug
+     * @param bool $debug
      *
      * @throws rex_sql_exception
      *
@@ -187,10 +187,10 @@ class rex_sql_util
      *
      * Last revision: September 23, 2001 - gandon
      *
-     * @param array  $queries the splitted sql commands
-     * @param string $sql     the sql commands
-     * @param int    $release the MySQL release number (because certains php3 versions
-     *                        can't get the value of a constant from within a function)
+     * @param array $queries the splitted sql commands
+     * @param string $sql the sql commands
+     * @param int $release the MySQL release number (because certains php3 versions
+     *                     can't get the value of a constant from within a function)
      *
      * @return bool always true
      */

--- a/redaxo/src/core/lib/util/dir.php
+++ b/redaxo/src/core/lib/util/dir.php
@@ -12,8 +12,8 @@ class rex_dir
     /**
      * Creates a directory.
      *
-     * @param string $dir       Path of the new directory
-     * @param bool   $recursive When FALSE, nested directories won't be created
+     * @param string $dir Path of the new directory
+     * @param bool $recursive When FALSE, nested directories won't be created
      *
      * @return bool TRUE on success, FALSE on failure
      *
@@ -90,8 +90,8 @@ class rex_dir
     /**
      * Deletes a directory.
      *
-     * @param string $dir        Path of the directory
-     * @param bool   $deleteSelf When FALSE, only subdirectories and files will be deleted
+     * @param string $dir Path of the directory
+     * @param bool $deleteSelf When FALSE, only subdirectories and files will be deleted
      *
      * @return bool TRUE on success, FALSE on failure
      */
@@ -112,8 +112,8 @@ class rex_dir
     /**
      * Deletes the files in a directory.
      *
-     * @param string $dir       Path of the directory
-     * @param bool   $recursive When FALSE, files in subdirectories won't be deleted
+     * @param string $dir Path of the directory
+     * @param bool $recursive When FALSE, files in subdirectories won't be deleted
      *
      * @return bool TRUE on success, FALSE on failure
      */

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -65,8 +65,8 @@ class rex_file
      * Returns the content of a cache file.
      *
      * @template T
-     * @param string $file    Path to the file
-     * @param T  $default Default value
+     * @param string $file Path to the file
+     * @param T $default Default value
      * @return array|T Content of the file or default value if the file isn't readable
      */
     public static function getCache($file, $default = [])
@@ -78,7 +78,7 @@ class rex_file
     /**
      * Puts content in a file.
      *
-     * @param string $file    Path to the file
+     * @param string $file Path to the file
      * @param string $content Content for the file
      *
      * @return bool TRUE on success, FALSE on failure
@@ -107,7 +107,7 @@ class rex_file
     /**
      * Appends content to a file.
      *
-     * @param string $file    Path to the file
+     * @param string $file Path to the file
      * @param string $content Content for the file
      * @param string $delimiter delimiter for new Content
      *
@@ -143,9 +143,9 @@ class rex_file
     /**
      * Puts content in a config file.
      *
-     * @param string $file    Path to the file
-     * @param array  $content Content for the file
-     * @param int    $inline  The level where you switch to inline YAML
+     * @param string $file Path to the file
+     * @param array $content Content for the file
+     * @param int $inline The level where you switch to inline YAML
      *
      * @return bool TRUE on success, FALSE on failure
      *
@@ -159,8 +159,8 @@ class rex_file
     /**
      * Puts content in a cache file.
      *
-     * @param string $file    Path to the file
-     * @param array  $content Content for the file
+     * @param string $file Path to the file
+     * @param array $content Content for the file
      *
      * @return bool TRUE on success, FALSE on failure
      *
@@ -294,8 +294,8 @@ class rex_file
     /**
      * Formates the filesize of the given file into a userfriendly form.
      *
-     * @param string $file   Path to the file
-     * @param array  $format
+     * @param string $file Path to the file
+     * @param array $format
      *
      * @return string Formatted filesize
      */

--- a/redaxo/src/core/lib/util/finder.php
+++ b/redaxo/src/core/lib/util/finder.php
@@ -131,8 +131,8 @@ class rex_finder implements IteratorAggregate, Countable
     /**
      * Ignore all files which match the given glob pattern.
      *
-     * @param string|string[] $glob      Glob pattern or an array of glob patterns
-     * @param bool         $recursive When FALSE the patterns won't be checked in child directories
+     * @param string|string[] $glob Glob pattern or an array of glob patterns
+     * @param bool $recursive When FALSE the patterns won't be checked in child directories
      *
      * @return $this
      */
@@ -151,8 +151,8 @@ class rex_finder implements IteratorAggregate, Countable
     /**
      * Ignore all directories which match the given glob pattern.
      *
-     * @param string|string[] $glob      Glob pattern or an array of glob patterns
-     * @param bool         $recursive When FALSE the patterns won't be checked in child directories
+     * @param string|string[] $glob Glob pattern or an array of glob patterns
+     * @param bool $recursive When FALSE the patterns won't be checked in child directories
      *
      * @return $this
      */

--- a/redaxo/src/core/lib/util/formatter.php
+++ b/redaxo/src/core/lib/util/formatter.php
@@ -15,9 +15,9 @@ abstract class rex_formatter
     /**
      * Formats a string by the given format type.
      *
-     * @param string $value      Value
+     * @param string $value Value
      * @param string $formatType Format type (any method name of this class)
-     * @param mixed  $format     For possible values look at the other methods of this class
+     * @param mixed $format For possible values look at the other methods of this class
      *
      * @throws InvalidArgumentException
      *
@@ -36,8 +36,8 @@ abstract class rex_formatter
      *
      * @see https://www.php.net/manual/en/function.date.php
      *
-     * @param string|int|null $value  Unix timestamp or datetime string for `strtotime`
-     * @param string     $format Default format is `d.m.Y`
+     * @param string|int|null $value Unix timestamp or datetime string for `strtotime`
+     * @param string $format Default format is `d.m.Y`
      *
      * @return string
      */
@@ -65,8 +65,8 @@ abstract class rex_formatter
      *
      * @see https://www.php.net/manual/en/function.strftime.php
      *
-     * @param string|int|null $value  Unix timestamp or datetime string for `strtotime`
-     * @param string     $format Possible values are format strings like in `strftime` or "date" or "datetime", default is "date"
+     * @param string|int|null $value Unix timestamp or datetime string for `strtotime`
+     * @param string $format Possible values are format strings like in `strftime` or "date" or "datetime", default is "date"
      *
      * @return string
      *
@@ -111,7 +111,7 @@ abstract class rex_formatter
      *
      * @see https://www.php.net/manual/en/class.intldateformatter.php
      *
-     * @param string|int|DateTimeInterface|null $value  Unix timestamp, datetime string for `strtotime` or DateTimeInterface object
+     * @param string|int|DateTimeInterface|null $value Unix timestamp, datetime string for `strtotime` or DateTimeInterface object
      * @param IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|array{0: IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|IntlDateFormatter::NONE, 1: IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|IntlDateFormatter::NONE}|string|null $format
      *              Possible format values:
      *                  - `IntlDateFormatter` constant, like `IntlDateFormatter::MEDIUM`
@@ -187,7 +187,7 @@ abstract class rex_formatter
      *
      * @see https://www.php.net/manual/en/class.intldateformatter.php
      *
-     * @param string|int|DateTimeInterface|null $value  Unix timestamp, date string for `strtotime` or DateTimeInterface object
+     * @param string|int|DateTimeInterface|null $value Unix timestamp, date string for `strtotime` or DateTimeInterface object
      * @param IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|string|null $format
      *              Possible format values:
      *                  - `IntlDateFormatter` constant, like `IntlDateFormatter::MEDIUM`
@@ -208,7 +208,7 @@ abstract class rex_formatter
      *
      * @see https://www.php.net/manual/en/class.intldateformatter.php
      *
-     * @param string|int|DateTimeInterface|null $value  Unix timestamp, time string for `strtotime` or DateTimeInterface object
+     * @param string|int|DateTimeInterface|null $value Unix timestamp, time string for `strtotime` or DateTimeInterface object
      * @param IntlDateFormatter::FULL|IntlDateFormatter::LONG|IntlDateFormatter::MEDIUM|IntlDateFormatter::SHORT|string|null $format
      *              Possible format values:
      *                  - `IntlDateFormatter` constant, like `IntlDateFormatter::MEDIUM`
@@ -229,8 +229,8 @@ abstract class rex_formatter
      *
      * @see https://www.php.net/manual/en/function.number-format.php
      *
-     * @param string|float $value  Value
-     * @param array        $format Array with number of decimals, decimals point and thousands separator, default is `array(2, ',', ' ')`
+     * @param string|float $value Value
+     * @param array $format Array with number of decimals, decimals point and thousands separator, default is `array(2, ',', ' ')`
      *
      * @return string
      */
@@ -258,8 +258,8 @@ abstract class rex_formatter
     /**
      * Formats a string as bytes.
      *
-     * @param string|int $value  Value
-     * @param array      $format Same as {@link rex_formatter::number()}
+     * @param string|int $value Value
+     * @param array $format Same as {@link rex_formatter::number()}
      *
      * @return string
      */
@@ -295,7 +295,7 @@ abstract class rex_formatter
      *
      * @see https://www.php.net/manual/en/function.sprintf.php
      *
-     * @param string $value  Value
+     * @param string $value Value
      * @param string $format
      *
      * @return string
@@ -325,7 +325,7 @@ abstract class rex_formatter
     /**
      * Truncates a string.
      *
-     * @param string $value  Value
+     * @param string $value Value
      * @param array{length?: int, etc?: string, break_words?: bool} $format Default format is `['length' => 80, 'etc' => '…', 'break_words' => false]`
      *
      * @return string
@@ -386,7 +386,7 @@ abstract class rex_formatter
      *
      * @see https://www.php.net/manual/en/function.sprintf.php
      *
-     * @param string $value  Version
+     * @param string $value Version
      * @param string $format Version format, e.g. "%s.%s"
      *
      * @return string
@@ -399,8 +399,8 @@ abstract class rex_formatter
     /**
      * Formats a string as link.
      *
-     * @param string $value  URL
-     * @param array  $format Array with link attributes and params
+     * @param string $value URL
+     * @param array $format Array with link attributes and params
      *
      * @return string Link
      */
@@ -437,8 +437,8 @@ abstract class rex_formatter
     /**
      * Formats a string as email link.
      *
-     * @param string $value  Email
-     * @param array  $format Array with link attributes and params
+     * @param string $value Email
+     * @param array $format Array with link attributes and params
      *
      * @return string Email link
      */
@@ -467,7 +467,7 @@ abstract class rex_formatter
     /**
      * Formats a string by a custom callable.
      *
-     * @param string         $value  Value
+     * @param string $value Value
      * @param callable|array $format A callable or an array of a callable and additional params
      * @psalm-param callable(string):string|array{0: callable(non-empty-array):string, 1: mixed} $format
      *

--- a/redaxo/src/core/lib/util/i18n.php
+++ b/redaxo/src/core/lib/util/i18n.php
@@ -21,8 +21,8 @@ class rex_i18n
     /**
      * Switches the current locale.
      *
-     * @param string $locale       The new locale
-     * @param bool   $phpSetLocale When TRUE, php function setlocale() will be called
+     * @param string $locale The new locale
+     * @param bool $phpSetLocale When TRUE, php function setlocale() will be called
      *
      * @return string The last locale
      */
@@ -107,7 +107,7 @@ class rex_i18n
     /**
      * Returns the translation htmlspecialchared for the given key.
      *
-     * @param string     $key             A Language-Key
+     * @param string $key A Language-Key
      * @param string|int ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return non-empty-string Translation for the key
@@ -123,7 +123,7 @@ class rex_i18n
     /**
      * Returns the translation for the given key.
      *
-     * @param string     $key             A Language-Key
+     * @param string $key A Language-Key
      * @param string|int ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return non-empty-string Translation for the key
@@ -138,8 +138,8 @@ class rex_i18n
     /**
      * Returns the translation htmlspecialchared for the given key and locale.
      *
-     * @param string     $key             A Language-Key
-     * @param string     $locale          A Locale
+     * @param string $key A Language-Key
+     * @param string $locale A Locale
      * @param string|int ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return non-empty-string Translation for the key
@@ -159,8 +159,8 @@ class rex_i18n
     /**
      * Returns the translation for the given key and locale.
      *
-     * @param string     $key             A Language-Key
-     * @param string     $locale          A Locale
+     * @param string $key A Language-Key
+     * @param string $locale A Locale
      * @param string|int ...$replacements A arbritary number of strings used for interpolating within the resolved message
      *
      * @return non-empty-string Translation for the key
@@ -177,9 +177,9 @@ class rex_i18n
     /**
      * Returns the message fallback for a missing key in main locale.
      *
-     * @param string         $key          A Language-Key
+     * @param string $key A Language-Key
      * @param list<string|int> $replacements A arbritary number of strings/ints used for interpolating within the resolved message
-     * @param string         $locale       A Locale
+     * @param string $locale A Locale
      *
      * @return non-empty-string
      */
@@ -228,10 +228,10 @@ class rex_i18n
     /**
      * Returns the translation for the given key.
      *
-     * @param string         $key
-     * @param bool           $escape
+     * @param string $key
+     * @param bool $escape
      * @param list<string|int> $replacements A arbritary number of strings/ints used for interpolating within the resolved message
-     * @param string         $locale       A Locale
+     * @param string $locale A Locale
      *
      * @psalm-taint-escape ($escape is true ? "html" : null)
      *
@@ -311,7 +311,7 @@ class rex_i18n
     /**
      * Adds a new translation to the catalogue.
      *
-     * @param string $key     Key
+     * @param string $key Key
      * @param non-empty-string $message Message for the key
      * @return void
      */
@@ -343,8 +343,8 @@ class rex_i18n
     /**
      * Translates the $text, if it begins with 'translate:', else it returns $text.
      *
-     * @param string   $text         The text for translation
-     * @param bool     $escape       Flag whether the translated text should be escaped
+     * @param string $text The text for translation
+     * @param bool $escape Flag whether the translated text should be escaped
      * @param null|callable(string):string $i18nFunction Function that returns the translation for the i18n key
      *
      * @throws InvalidArgumentException
@@ -381,8 +381,8 @@ class rex_i18n
     /**
      * Translates all array elements.
      *
-     * @param mixed    $array        The Array of Strings for translation
-     * @param bool     $escape       Flag whether the translated text should be escaped
+     * @param mixed $array The Array of Strings for translation
+     * @param bool $escape Flag whether the translated text should be escaped
      * @param callable $i18nFunction Function that returns the translation for the i18n key
      *
      * @throws InvalidArgumentException
@@ -415,7 +415,7 @@ class rex_i18n
     /**
      * Loads the translation definitions of the given file.
      *
-     * @param string $dir    Path to the directory
+     * @param string $dir Path to the directory
      * @param string $locale Locale
      * @return void
      */

--- a/redaxo/src/core/lib/util/log_file.php
+++ b/redaxo/src/core/lib/util/log_file.php
@@ -38,7 +38,7 @@ class rex_log_file implements Iterator
     private $bufferPos;
 
     /**
-     * @param string   $path        File path
+     * @param string $path File path
      * @param int|null $maxFileSize Maximum file size
      */
     public function __construct($path, $maxFileSize = null)

--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -46,10 +46,10 @@ class rex_logger extends AbstractLogger
     /**
      * Shorthand: Logs a error message.
      *
-     * @param int    $errno   The error code to log, e.g. E_WARNING
-     * @param string $errstr  The error message
+     * @param int $errno The error code to log, e.g. E_WARNING
+     * @param string $errstr The error message
      * @param string $errfile The file in which the error occured
-     * @param int    $errline The line of the file in which the error occured
+     * @param int $errline The line of the file in which the error occured
      *
      * @throws InvalidArgumentException
      * @return void
@@ -76,10 +76,10 @@ class rex_logger extends AbstractLogger
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed  $level   either one of LogLevel::* or also any other string
+     * @param mixed $level either one of LogLevel::* or also any other string
      * @param string $message
      * @param string $file
-     * @param int    $line
+     * @param int $line
      *
      * @throws InvalidArgumentException
      */

--- a/redaxo/src/core/lib/util/markdown.php
+++ b/redaxo/src/core/lib/util/markdown.php
@@ -48,9 +48,9 @@ class rex_markdown
     /**
      * Parses markdown code and extracts a table-of-content.
      *
-     * @param string $code        Markdown code
-     * @param int    $topLevel    Top included headline level for TOC, e.g. `1` for `<h1>`
-     * @param int    $bottomLevel Bottom included headline level for TOC, e.g. `6` for `<h6>`
+     * @param string $code Markdown code
+     * @param int $topLevel Top included headline level for TOC, e.g. `1` for `<h1>`
+     * @param int $bottomLevel Bottom included headline level for TOC, e.g. `6` for `<h6>`
      * @param array<self::*, bool>|bool $options
      *
      * @return array tupel of table-of-content and content

--- a/redaxo/src/core/lib/util/pager.php
+++ b/redaxo/src/core/lib/util/pager.php
@@ -22,8 +22,8 @@ class rex_pager
     /**
      * Constructs a rex_pager.
      *
-     * @param int    $rowsPerPage The number of rows which should be displayed on one page
-     * @param string $cursorName  The name of the parameter used for pagination
+     * @param int $rowsPerPage The number of rows which should be displayed on one page
+     * @param string $cursorName The name of the parameter used for pagination
      */
     public function __construct($rowsPerPage = 30, $cursorName = 'start')
     {

--- a/redaxo/src/core/lib/util/path.php
+++ b/redaxo/src/core/lib/util/path.php
@@ -119,7 +119,7 @@ class rex_path
      * Returns the path to the public assets folder of the given addon.
      *
      * @param non-empty-string $addon Addon
-     * @param string $file  File
+     * @param string $file File
      *
      * @return non-empty-string
      *
@@ -133,9 +133,9 @@ class rex_path
     /**
      * Returns the path to the public assets folder of the given plugin of the given addon.
      *
-     * @param non-empty-string $addon  Addon
+     * @param non-empty-string $addon Addon
      * @param non-empty-string $plugin Plugin
-     * @param string $file   File
+     * @param string $file File
      *
      * @return non-empty-string
      *
@@ -186,7 +186,7 @@ class rex_path
      * Returns the path to the data folder of the given addon.
      *
      * @param non-empty-string $addon Addon
-     * @param string $file  File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -198,9 +198,9 @@ class rex_path
     /**
      * Returns the path to the data folder of the given plugin of the given addon.
      *
-     * @param non-empty-string $addon  Addon
+     * @param non-empty-string $addon Addon
      * @param non-empty-string $plugin Plugin
-     * @param string $file   File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -252,7 +252,7 @@ class rex_path
      * Returns the path to the cache folder of the given addon.
      *
      * @param non-empty-string $addon Addon
-     * @param string $file  File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -264,9 +264,9 @@ class rex_path
     /**
      * Returns the path to the cache folder of the given plugin.
      *
-     * @param non-empty-string $addon  Addon
+     * @param non-empty-string $addon Addon
      * @param non-empty-string $plugin Plugin
-     * @param string $file   File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -303,7 +303,7 @@ class rex_path
      * Returns the base path to the folder of the given addon.
      *
      * @param non-empty-string $addon Addon
-     * @param string $file  File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -315,9 +315,9 @@ class rex_path
     /**
      * Returns the base path to the folder of the plugin of the given addon.
      *
-     * @param non-empty-string $addon  Addon
+     * @param non-empty-string $addon Addon
      * @param non-empty-string $plugin Plugin
-     * @param string $file   File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -363,7 +363,7 @@ class rex_path
      *
      * If the path is outside of the base path, the absolute path will be kept.
      *
-     * @param string      $absPath
+     * @param string $absPath
      * @param null|string $basePath Defaults to `rex_path::base()`
      *
      * @return string

--- a/redaxo/src/core/lib/util/path_default_provider.php
+++ b/redaxo/src/core/lib/util/path_default_provider.php
@@ -19,9 +19,9 @@ class rex_path_default_provider
     /**
      * Initializes the class.
      *
-     * @param non-empty-string $htdocs           Htdocs path
-     * @param non-empty-string $backend          Backend folder name
-     * @param bool   $provideAbsolutes Flag whether to return absolute path, or relative ones
+     * @param non-empty-string $htdocs Htdocs path
+     * @param non-empty-string $backend Backend folder name
+     * @param bool $provideAbsolutes Flag whether to return absolute path, or relative ones
      */
     public function __construct($htdocs, $backend, $provideAbsolutes)
     {
@@ -145,7 +145,7 @@ class rex_path_default_provider
      * Returns the path to the assets folder of the given addon, which contains all assets required by the addon to work properly.
      *
      * @param string $addon Addon
-     * @param string $file  File
+     * @param string $file File
      *
      * @return non-empty-string
      *
@@ -159,9 +159,9 @@ class rex_path_default_provider
     /**
      * Returns the path to the assets folder of the given plugin of the given addon.
      *
-     * @param string $addon  Addon
+     * @param string $addon Addon
      * @param string $plugin Plugin
-     * @param string $file   File
+     * @param string $file File
      *
      * @return non-empty-string
      *
@@ -212,7 +212,7 @@ class rex_path_default_provider
      * Returns the path to the data folder of the given addon.
      *
      * @param non-empty-string $addon Addon
-     * @param string $file  File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -224,9 +224,9 @@ class rex_path_default_provider
     /**
      * Returns the path to the data folder of the given plugin of the given addon.
      *
-     * @param non-empty-string $addon  Addon
+     * @param non-empty-string $addon Addon
      * @param non-empty-string $plugin Plugin
-     * @param string $file   File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -273,7 +273,7 @@ class rex_path_default_provider
      * Returns the path to the cache folder of the given addon.
      *
      * @param string $addon Addon
-     * @param string $file  File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -285,9 +285,9 @@ class rex_path_default_provider
     /**
      * Returns the path to the cache folder of the given plugin.
      *
-     * @param string $addon  Addon
+     * @param string $addon Addon
      * @param string $plugin Plugin
-     * @param string $file   File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -324,7 +324,7 @@ class rex_path_default_provider
      * Returns the base path to the folder of the given addon.
      *
      * @param non-empty-string $addon Addon
-     * @param string $file  File
+     * @param string $file File
      *
      * @return non-empty-string
      */
@@ -336,9 +336,9 @@ class rex_path_default_provider
     /**
      * Returns the base path to the folder of the plugin of the given addon.
      *
-     * @param non-empty-string $addon  Addon
+     * @param non-empty-string $addon Addon
      * @param non-empty-string $plugin Plugin
-     * @param string $file   File
+     * @param string $file File
      *
      * @return non-empty-string
      */

--- a/redaxo/src/core/lib/util/socket/socket.php
+++ b/redaxo/src/core/lib/util/socket/socket.php
@@ -58,8 +58,8 @@ class rex_socket
 
     /**
      * @param string $host Host name
-     * @param int    $port Port number
-     * @param bool   $ssl  SSL flag
+     * @param int $port Port number
+     * @param bool $ssl SSL flag
      */
     protected function __construct($host, $port = 80, $ssl = false)
     {
@@ -76,8 +76,8 @@ class rex_socket
      * Factory method.
      *
      * @param string $host Host name
-     * @param int    $port Port number
-     * @param bool   $ssl  SSL flag
+     * @param int $port Port number
+     * @param bool $ssl SSL flag
      *
      * @return static Socket instance
      *
@@ -397,9 +397,9 @@ class rex_socket
     /**
      * Writes a request to the opened connection.
      *
-     * @param string          $method  HTTP method, e.g. "GET"
-     * @param string          $path    Path
-     * @param array           $headers Headers
+     * @param string $method HTTP method, e.g. "GET"
+     * @param string $path Path
+     * @param array $headers Headers
      * @param string|callable(resource): void $data Body data as string or a callback for writing the body
      *
      * @throws rex_socket_exception

--- a/redaxo/src/core/lib/util/socket/socket_proxy.php
+++ b/redaxo/src/core/lib/util/socket/socket_proxy.php
@@ -20,8 +20,8 @@ class rex_socket_proxy extends rex_socket
      * Sets the destination.
      *
      * @param string $host Host name
-     * @param int    $port Port number
-     * @param bool   $ssl  SSL flag
+     * @param int $port Port number
+     * @param bool $ssl SSL flag
      *
      * @return $this Current socket
      */

--- a/redaxo/src/core/lib/util/socket/socket_response.php
+++ b/redaxo/src/core/lib/util/socket/socket_response.php
@@ -154,7 +154,7 @@ class rex_socket_response
     /**
      * Returns the header for the given key, or the entire header if no key is given.
      *
-     * @param string $key     Header key
+     * @param string $key Header key
      * @param string $default Default value (is returned if the header is not set)
      *
      * @return string|null

--- a/redaxo/src/core/lib/util/sortable_iterator.php
+++ b/redaxo/src/core/lib/util/sortable_iterator.php
@@ -22,7 +22,7 @@ class rex_sortable_iterator implements IteratorAggregate
     private $sort;
 
     /**
-     * @param Traversable<TKey, TValue>  $iterator Inner iterator
+     * @param Traversable<TKey, TValue> $iterator Inner iterator
      * @param self::VALUES|self::KEYS|callable(mixed,mixed):int $sort Sort mode, possible values are rex_sortable_iterator::VALUES (default), rex_sortable_iterator::KEYS or a callable
      */
     public function __construct(Traversable $iterator, $sort = self::VALUES)

--- a/redaxo/src/core/lib/util/stream.php
+++ b/redaxo/src/core/lib/util/stream.php
@@ -40,7 +40,7 @@ class rex_stream
     /**
      * Prepares a new stream.
      *
-     * @param string $path    Virtual path which should describe the content (e.g. "template/1"), only relevant for error messages
+     * @param string $path Virtual path which should describe the content (e.g. "template/1"), only relevant for error messages
      * @param string $content Content which will be included
      *
      * @throws InvalidArgumentException

--- a/redaxo/src/core/lib/util/string.php
+++ b/redaxo/src/core/lib/util/string.php
@@ -40,8 +40,8 @@ class rex_string
      * Makes the string lowercase, replaces umlauts by their ascii representation (ä -> ae etc.), and replaces all
      * other chars that do not match a-z, 0-9 or $allowedChars by $replaceChar.
      *
-     * @param string $string       Input string
-     * @param string $replaceChar  Character that is used to replace not allowed chars
+     * @param string $string Input string
+     * @param string $replaceChar Character that is used to replace not allowed chars
      * @param string $allowedChars Allowed character list
      *
      * @return string
@@ -132,8 +132,8 @@ class rex_string
     /**
      * Returns a string containing the YAML representation of $value.
      *
-     * @param array $value  The value being encoded
-     * @param int   $inline The level where you switch to inline YAML
+     * @param array $value The value being encoded
+     * @param int $inline The level where you switch to inline YAML
      *
      * @return string
      */

--- a/redaxo/src/core/lib/util/timer.php
+++ b/redaxo/src/core/lib/util/timer.php
@@ -120,7 +120,7 @@ class rex_timer
      * Returns the formatted time difference.
      *
      * @param int $precision Factor which will be multiplied, for convertion into different units (e.g. 1000 for milli,...)
-     * @param int $decimals  Number of decimals points
+     * @param int $decimals Number of decimals points
      *
      * @return string Formatted time difference
      */

--- a/redaxo/src/core/lib/util/url.php
+++ b/redaxo/src/core/lib/util/url.php
@@ -51,7 +51,7 @@ class rex_url
      * Returns the url to the frontend-controller (index.php from frontend).
      *
      * @param array $params Params
-     * @param bool  $escape Flag whether the argument separator "&" should be escaped (&amp;)
+     * @param bool $escape Flag whether the argument separator "&" should be escaped (&amp;)
      *
      * @return non-empty-string
      */
@@ -78,7 +78,7 @@ class rex_url
      * Returns the url to the backend-controller (index.php from backend).
      *
      * @param array $params Params
-     * @param bool  $escape Flag whether the argument separator "&" should be escaped (&amp;)
+     * @param bool $escape Flag whether the argument separator "&" should be escaped (&amp;)
      *
      * @return non-empty-string
      */
@@ -92,9 +92,9 @@ class rex_url
     /**
      * Returns the url to a backend page.
      *
-     * @param string $page   Page
-     * @param array  $params Params
-     * @param bool   $escape Flag whether the argument separator "&" should be escaped (&amp;)
+     * @param string $page Page
+     * @param array $params Params
+     * @param bool $escape Flag whether the argument separator "&" should be escaped (&amp;)
      *
      * @return non-empty-string
      */
@@ -107,7 +107,7 @@ class rex_url
      * Returns the url to the current backend page.
      *
      * @param array $params Params
-     * @param bool  $escape Flag whether the argument separator "&" should be escaped (&amp;)
+     * @param bool $escape Flag whether the argument separator "&" should be escaped (&amp;)
      *
      * @return non-empty-string
      */
@@ -156,7 +156,7 @@ class rex_url
      * Returns the url to the assets folder of the given addon, which contains all assets required by the addon to work properly.
      *
      * @param string $addon Addon
-     * @param string $file  File
+     * @param string $file File
      *
      * @return non-empty-string
      *
@@ -170,9 +170,9 @@ class rex_url
     /**
      * Returns the url to the assets folder of the given plugin of the given addon.
      *
-     * @param string $addon  Addon
+     * @param string $addon Addon
      * @param string $plugin Plugin
-     * @param string $file   File
+     * @param string $file File
      *
      * @return non-empty-string
      *

--- a/redaxo/src/core/lib/util/validation_rule.php
+++ b/redaxo/src/core/lib/util/validation_rule.php
@@ -27,7 +27,7 @@ final class rex_validation_rule
     /**
      * @param rex_validation_rule::*|string $type Validator type, e.g. one of rex_validation_rule::* but could also be extended via rex-factory
      * @param null|string $message Message which is used if this validator type does not match
-     * @param mixed       $option  Type specific option
+     * @param mixed $option Type specific option
      */
     public function __construct(string $type, ?string $message = null, $option = null)
     {

--- a/redaxo/src/core/lib/util/validator.php
+++ b/redaxo/src/core/lib/util/validator.php
@@ -35,9 +35,9 @@ class rex_validator
     /**
      * Adds a validation rule.
      *
-     * @param string      $type    Validator type (any static method name of this class)
+     * @param string $type Validator type (any static method name of this class)
      * @param null|string $message Message which is used if this validator type does not match
-     * @param mixed       $option  Type specific option
+     * @param mixed $option Type specific option
      *
      * @throws InvalidArgumentException
      *
@@ -146,7 +146,7 @@ class rex_validator
      * Checks whether the value has the given min length.
      *
      * @param string $value
-     * @param int    $minLength
+     * @param int $minLength
      *
      * @return bool
      */
@@ -159,7 +159,7 @@ class rex_validator
      * Checks whether the value has the given max value.
      *
      * @param string $value
-     * @param int    $maxLength
+     * @param int $maxLength
      *
      * @return bool
      */
@@ -172,7 +172,7 @@ class rex_validator
      * Checks whether the value is equal or greater than the given min value.
      *
      * @param string $value
-     * @param int    $min
+     * @param int $min
      *
      * @return bool
      */
@@ -185,7 +185,7 @@ class rex_validator
      * Checks whether the value is equal or lower than the given max value.
      *
      * @param string $value
-     * @param int    $max
+     * @param int $max
      *
      * @return bool
      */

--- a/redaxo/src/core/lib/util/version.php
+++ b/redaxo/src/core/lib/util/version.php
@@ -21,7 +21,7 @@ class rex_version
     /**
      * Checks the version of the requirement.
      *
-     * @param string $version     Version
+     * @param string $version Version
      * @param string $constraints Constraint list, separated by comma
      *
      * @throws rex_exception
@@ -99,8 +99,8 @@ class rex_version
      *
      * @see https://www.php.net/manual/en/function.version-compare.php
      *
-     * @param string $version1   First version number
-     * @param string $version2   Second version number
+     * @param string $version1 First version number
+     * @param string $version2 Second version number
      * @param null|'='|'=='|'!='|'<>'|'<'|'<='|'>'|'>=' $comparator Optional comparator
      *
      * @return bool
@@ -126,7 +126,7 @@ class rex_version
     /**
      * Returns the current git version hash for the given path.
      *
-     * @param string      $path A local filesystem path
+     * @param string $path A local filesystem path
      * @param null|string $repo If given, the version hash is returned only if the remote repository matches the
      *                          given github repo (e.g. `redaxo/redaxo`)
      */

--- a/redaxo/src/core/lib/var/var.php
+++ b/redaxo/src/core/lib/var/var.php
@@ -37,10 +37,10 @@ abstract class rex_var
     /**
      * Parses all REX_VARs in the given content.
      *
-     * @param string $content     Content
-     * @param int    $env         Environment
-     * @param string $context     Context
-     * @param mixed  $contextData Context data
+     * @param string $content Content
+     * @param int $env Environment
+     * @param string $context Context
+     * @param mixed $contextData Context data
      *
      * @return string
      */
@@ -157,7 +157,7 @@ abstract class rex_var
      *
      * @param string $content
      * @param string $format
-     * @param bool   $useVariables
+     * @param bool $useVariables
      * @param string $stripslashes
      *
      * @return string
@@ -247,7 +247,7 @@ abstract class rex_var
      * Checks whether the given arguments exists.
      *
      * @param string $key
-     * @param bool   $defaultArg
+     * @param bool $defaultArg
      *
      * @return bool
      */

--- a/redaxo/src/core/lib/view.php
+++ b/redaxo/src/core/lib/view.php
@@ -95,7 +95,7 @@ class rex_view
      * Sets a JS property.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      * @return void
      */
     public static function setJsProperty($key, $value)
@@ -278,7 +278,7 @@ class rex_view
     /**
      * Returns the formatted title.
      *
-     * @param string            $head
+     * @param string $head
      * @param null|string|array $subtitle
      *
      * @throws InvalidArgumentException


### PR DESCRIPTION
Da die Typangaben inzwischen teils rech lang werden (callables, generics etc.), nutzen wir bereits seit einer Weile nicht mehr den Align-Fixer.
Dieser PR entfernt nun alle Alignments, damit es einheitlich ist.

Zunächst als Einmal-Aktion, da der Fixer zum Entfernen teils unerwünschte Effekte hat in speziellen Fällen. Schaue ich mir bei Gelegenheit nochmal weiter an.