### PR TITLE
Live-Mode einführen

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -3508,7 +3508,6 @@
       <code><![CDATA[$pageArray['title']]]></code>
       <code><![CDATA[$pageArray['title']]]></code>
       <code><![CDATA[$plugin->getProperty('page')]]></code>
-      <code>$subProperties</code>
       <code><![CDATA[$subProperties['title']]]></code>
       <code>$value</code>
       <code>$value</code>
@@ -3524,9 +3523,6 @@
       <code>$key</code>
       <code>$pageKey</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$subProperties['title']]]></code>
-    </MixedArrayAccess>
     <MixedAssignment>
       <code>$k</code>
       <code>$page</code>
@@ -3539,6 +3535,9 @@
       <code>$v</code>
       <code>$value</code>
     </MixedAssignment>
+    <PossiblyInvalidArgument>
+      <code>$subProperties</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="redaxo/src/core/lib/be/navigation.php">
     <MixedArgumentTypeCoercion>

--- a/redaxo/src/addons/backup/package.yml
+++ b/redaxo/src/addons/backup/package.yml
@@ -13,6 +13,7 @@ page:
         import:
             title: 'translate:backup_import'
             perm: 'admin[]'
+            live_mode: false
             subpages:
                 upload: { title: 'translate:backup_upload' }
                 server: { title: 'translate:backup_load_from_server' }
@@ -21,4 +22,4 @@ requires:
     php:
         version: '>=8.1'
         extensions: [ctype]
-    redaxo: ^5.15.0
+    redaxo: ^5.16.0-beta1

--- a/redaxo/src/addons/cronjob/lib/cronjob.php
+++ b/redaxo/src/addons/cronjob/lib/cronjob.php
@@ -26,6 +26,10 @@ abstract class rex_cronjob
             return $class;
         }
 
+        if (!in_array($class, rex_cronjob_manager::getTypes())) {
+            return $class;
+        }
+
         return rex_type::instanceOf(new $class(), self::class);
     }
 

--- a/redaxo/src/addons/cronjob/lib/manager.php
+++ b/redaxo/src/addons/cronjob/lib/manager.php
@@ -9,12 +9,8 @@
  */
 class rex_cronjob_manager
 {
-    /** @var list<class-string<rex_cronjob>> */
-    private static $types = [
-        rex_cronjob_phpcode::class,
-        rex_cronjob_phpcallback::class,
-        rex_cronjob_urlrequest::class,
-    ];
+    /** @var list<class-string<rex_cronjob>>|null */
+    private static $types;
 
     /** @var string */
     private $message = '';
@@ -158,6 +154,16 @@ class rex_cronjob_manager
      */
     public static function getTypes()
     {
+        if (null === self::$types) {
+            self::$types = [];
+
+            if (!rex::isLiveMode()) {
+                self::$types[] = rex_cronjob_phpcode::class;
+                self::$types[] = rex_cronjob_phpcallback::class;
+            }
+            self::$types[] = rex_cronjob_urlrequest::class;
+        }
+
         return self::$types;
     }
 
@@ -167,7 +173,9 @@ class rex_cronjob_manager
      */
     public static function registerType($class)
     {
-        self::$types[] = $class;
+        $types = self::getTypes();
+        $types[] = $class;
+        self::$types = $types;
     }
 
     /**

--- a/redaxo/src/addons/cronjob/package.yml
+++ b/redaxo/src/addons/cronjob/package.yml
@@ -19,7 +19,7 @@ pages:
 
 requires:
     php: '>=8.1'
-    redaxo: ^5.15.0
+    redaxo: ^5.16.0-beta1
 
 console_commands:
     cronjob:run: rex_command_cronjob_run

--- a/redaxo/src/addons/cronjob/pages/cronjobs.php
+++ b/redaxo/src/addons/cronjob/pages/cronjobs.php
@@ -102,7 +102,7 @@ if ('' == $func) {
     $list->setColumnParams('status', ['func' => 'setstatus', 'oldstatus' => '###status###', 'oid' => '###id###'] + $csrfToken->getUrlParams());
     $list->setColumnLayout('status', ['<th class="rex-table-action" colspan="4">###VALUE###</th>', '<td class="rex-table-action">###VALUE###</td>']);
     $list->setColumnFormat('status', 'custom', static function () use ($list) {
-        if (!class_exists($list->getValue('type'))) {
+        if (!class_exists($list->getValue('type')) || !in_array($list->getValue('type'), rex_cronjob_manager::getTypes())) {
             $str = rex_i18n::msg('cronjob_status_invalid');
         } elseif (1 == $list->getValue('status')) {
             $str = $list->getColumnLink('status', '<span class="rex-online"><i class="rex-icon rex-icon-active-true"></i> ' . rex_i18n::msg('cronjob_status_activated') . '</span>');

--- a/redaxo/src/addons/debug/package.yml
+++ b/redaxo/src/addons/debug/package.yml
@@ -8,6 +8,7 @@ load: early
 page:
     title: translate:debug
     perm: admin
+    live_mode: false
     block: system
     pjax: false
     icon: rex-icon rex-icon-heartbeat

--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -17,6 +17,9 @@ class rex_api_install_core_update extends rex_api_function
 
     public function execute()
     {
+        if (rex::isLiveMode()) {
+            throw new rex_api_exception('Core update is not available in live mode!');
+        }
         if (!rex::getUser()?->isAdmin()) {
             throw new rex_api_exception('You do not have the permission!');
         }

--- a/redaxo/src/addons/install/lib/api/api_package_add.php
+++ b/redaxo/src/addons/install/lib/api/api_package_add.php
@@ -9,6 +9,9 @@ class rex_api_install_package_add extends rex_api_function
 {
     public function execute()
     {
+        if (rex::isLiveMode()) {
+            throw new rex_api_exception('Package management is not available in live mode!');
+        }
         if (!rex::getUser()?->isAdmin()) {
             throw new rex_api_exception('You do not have the permission!');
         }

--- a/redaxo/src/addons/install/lib/api/api_package_delete.php
+++ b/redaxo/src/addons/install/lib/api/api_package_delete.php
@@ -9,6 +9,9 @@ class rex_api_install_package_delete extends rex_api_function
 {
     public function execute()
     {
+        if (rex::isLiveMode()) {
+            throw new rex_api_exception('Package management is not available in live mode!');
+        }
         if (!rex::getUser()?->isAdmin()) {
             throw new rex_api_exception('You do not have the permission!');
         }

--- a/redaxo/src/addons/install/lib/api/api_package_update.php
+++ b/redaxo/src/addons/install/lib/api/api_package_update.php
@@ -9,6 +9,9 @@ class rex_api_install_package_update extends rex_api_function
 {
     public function execute()
     {
+        if (rex::isLiveMode()) {
+            throw new rex_api_exception('Package management is not available in live mode!');
+        }
         if (!rex::getUser()?->isAdmin()) {
             throw new rex_api_exception('You do not have the permission!');
         }

--- a/redaxo/src/addons/install/lib/api/api_package_upload.php
+++ b/redaxo/src/addons/install/lib/api/api_package_upload.php
@@ -9,6 +9,9 @@ class rex_api_install_package_upload extends rex_api_function
 {
     public function execute()
     {
+        if (rex::isLiveMode()) {
+            throw new rex_api_exception('Package management is not available in live mode!');
+        }
         if (!rex::getUser()?->isAdmin()) {
             throw new rex_api_exception('You do not have the permission!');
         }

--- a/redaxo/src/addons/install/package.yml
+++ b/redaxo/src/addons/install/package.yml
@@ -6,6 +6,7 @@ supportpage: https://github.com/redaxo/redaxo
 page:
     title: 'translate:title'
     perm: admin[]
+    live_mode: false
     block: system
     prio: 70
     pjax: true
@@ -23,7 +24,7 @@ requires:
     php:
         version: '>=8.1'
         extensions: [zlib]
-    redaxo: ^5.15.0
+    redaxo: ^5.16.0-beta1
 
 
 console_commands:

--- a/redaxo/src/addons/media_manager/package.yml
+++ b/redaxo/src/addons/media_manager/package.yml
@@ -6,6 +6,7 @@ supportpage: https://github.com/redaxo/redaxo
 page:
     title: 'Media Manager'
     perm: admin
+    live_mode: false
     pjax: true
     icon: rex-icon rex-icon-media
     subpages:
@@ -18,7 +19,7 @@ requires:
     php:
         version: '>=8.1'
         extensions: [gd]
-    redaxo: ^5.15.0
+    redaxo: ^5.16.0-beta1
 
 default_config:
     jpg_quality: 80

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -689,6 +689,11 @@ abstract class rex_metainfo_handler
      */
     protected function fireCallbacks(rex_sql $sqlFields)
     {
+        if (rex::isLiveMode()) {
+            // Metainfo callbacks are not supported in live mode
+            return;
+        }
+
         foreach ($sqlFields as $row) {
             if ('' != $row->getValue('callback')) {
                 // use a small sandbox, so the callback cannot affect our local variables

--- a/redaxo/src/addons/metainfo/package.yml
+++ b/redaxo/src/addons/metainfo/package.yml
@@ -6,6 +6,7 @@ supportpage: https://github.com/redaxo/redaxo
 page:
     title: Meta Infos
     perm: admin[]
+    live_mode: false
     pjax: true
     icon: rex-icon rex-icon-metainfo
     subpages:
@@ -16,7 +17,7 @@ page:
 
 requires:
     php: '>=8.1'
-    redaxo: ^5.15.0
+    redaxo: ^5.16.0-beta1
     packages:
         structure: '^2.12.1'
         mediapool: '^2.10.1'

--- a/redaxo/src/addons/structure/plugins/content/lib/var_value.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/var_value.php
@@ -28,6 +28,11 @@ class rex_var_value extends rex_var
         if ('php' == $output) {
             if ($this->environmentIs(self::ENV_BACKEND)) {
                 $value = rex_string::highlight($value);
+                if (rex::isLiveMode()) {
+                    $value = rex_view::error('Modules with dynamic PHP code are not supported in live mode.') . $value;
+                }
+            } elseif (rex::isLiveMode()) {
+                return 'null';
             } else {
                 return 'rex_var::nothing(require rex_stream::factory(substr(__FILE__, 6) . \'/REX_VALUE/' . $id . '\', ' . self::quote($value) . '))';
             }

--- a/redaxo/src/addons/structure/plugins/content/package.yml
+++ b/redaxo/src/addons/structure/plugins/content/package.yml
@@ -20,6 +20,7 @@ pages:
         block: system
         prio: 30
         perm: admin
+        live_mode: false
         pjax: true
         icon: rex-icon rex-icon-template
     modules:
@@ -28,6 +29,7 @@ pages:
         block: system
         prio: 40
         perm: admin
+        live_mode: false
         pjax: true
         icon: rex-icon rex-icon-module
         subpages:

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -157,7 +157,7 @@ if (rex::isSetup()) {
         rex::setProperty('user', $user);
 
         // Safe Mode
-        if ($user->isAdmin() && null !== ($safeMode = rex_get('safemode', 'boolean', null))) {
+        if (!rex::isLiveMode() && $user->isAdmin() && null !== ($safeMode = rex_get('safemode', 'boolean', null))) {
             if ($safeMode) {
                 rex_set_session('safemode', true);
             } else {

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -1,9 +1,9 @@
 setup: true
+live_mode: false
+safe_mode: false
 debug:
     enabled: false
     throw_always_exception: false # `true` for all error levels, `[E_WARNING, E_NOTICE]` for subset
-safe_mode: false
-live_mode: false
 instname: null
 server: https://www.redaxo.org/
 servername: REDAXO

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -3,6 +3,7 @@ debug:
     enabled: false
     throw_always_exception: false # `true` for all error levels, `[E_WARNING, E_NOTICE]` for subset
 safemode: false
+live_mode: false
 instname: null
 server: https://www.redaxo.org/
 servername: REDAXO

--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -267,7 +267,7 @@ class rex_be_controller
      */
     private static function pageCreate($page, rex_package $package, $createMainPage, ?rex_be_page $parentPage = null, $pageKey = null, $prefix = false)
     {
-        if (is_array($page) && isset($page['title']) && false !== ($page['live_mode'] ?? null)) {
+        if (is_array($page) && isset($page['title']) && (false !== ($page['live_mode'] ?? null) || !rex::isLiveMode())) {
             $pageArray = $page;
             $pageKey = $pageKey ?: $package->getName();
             if ($createMainPage || isset($pageArray['main']) && $pageArray['main']) {
@@ -325,7 +325,7 @@ class rex_be_controller
                 case 'subpages':
                     if (is_array($value)) {
                         foreach ($value as $pageKey => $subProperties) {
-                            if (isset($subProperties['title']) && false !== ($subProperties['live_mode'] ?? null)) {
+                            if (isset($subProperties['title']) && (false !== ($subProperties['live_mode'] ?? null) || !rex::isLiveMode())) {
                                 $subpage = new rex_be_page($pageKey, $subProperties['title']);
                                 $page->addSubpage($subpage);
                                 self::pageAddProperties($subpage, $subProperties, $package);

--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -161,13 +161,6 @@ class rex_be_controller
         self::$pages['credits'] = (new rex_be_page('credits', rex_i18n::msg('credits')))
             ->setPath(rex_path::core('pages/credits.php'));
 
-        self::$pages['packages'] = (new rex_be_page_main('system', 'packages', rex_i18n::msg('addons')))
-            ->setPath(rex_path::core('pages/packages.php'))
-            ->setRequiredPermissions('isAdmin')
-            ->setPrio(60)
-            ->setPjax()
-            ->setIcon('rex-icon rex-icon-package-addon');
-
         $logsPage = (new rex_be_page('log', rex_i18n::msg('logfiles')))->setSubPath(rex_path::core('pages/system.log.php'));
         $logsPage->addSubpage((new rex_be_page('redaxo', rex_i18n::msg('syslog_redaxo')))->setSubPath(rex_path::core('pages/system.log.redaxo.php')));
         if ('' != ini_get('error_log') && @is_readable(ini_get('error_log'))) {
@@ -199,6 +192,17 @@ class rex_be_controller
                 ->setHasLayout(false)
                 ->setPath(rex_path::core('pages/system.phpinfo.php')),
             );
+
+        if (rex::isLiveMode()) {
+            return;
+        }
+
+        self::$pages['packages'] = (new rex_be_page_main('system', 'packages', rex_i18n::msg('addons')))
+            ->setPath(rex_path::core('pages/packages.php'))
+            ->setRequiredPermissions('isAdmin')
+            ->setPrio(60)
+            ->setPjax()
+            ->setIcon('rex-icon rex-icon-package-addon');
     }
 
     /**
@@ -263,7 +267,7 @@ class rex_be_controller
      */
     private static function pageCreate($page, rex_package $package, $createMainPage, ?rex_be_page $parentPage = null, $pageKey = null, $prefix = false)
     {
-        if (is_array($page) && isset($page['title'])) {
+        if (is_array($page) && isset($page['title']) && false !== ($page['live_mode'] ?? null)) {
             $pageArray = $page;
             $pageKey = $pageKey ?: $package->getName();
             if ($createMainPage || isset($pageArray['main']) && $pageArray['main']) {
@@ -321,7 +325,7 @@ class rex_be_controller
                 case 'subpages':
                     if (is_array($value)) {
                         foreach ($value as $pageKey => $subProperties) {
-                            if (isset($subProperties['title'])) {
+                            if (isset($subProperties['title']) && false !== ($subProperties['live_mode'] ?? null)) {
                                 $subpage = new rex_be_page($pageKey, $subProperties['title']);
                                 $page->addSubpage($subpage);
                                 self::pageAddProperties($subpage, $subProperties, $package);

--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -85,7 +85,7 @@ abstract class rex_error_handler
             }
             rex_response::setStatus($status);
 
-            if (rex::isSetup() || rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin()) {
+            if (rex::isSetup() || rex::isDebugMode() || !rex::isLiveMode() && rex_backend_login::createUser()?->isAdmin()) {
                 [$errPage, $contentType] = self::renderWhoops($exception);
                 rex_response::sendContent($errPage, $contentType);
                 exit(1);
@@ -316,7 +316,7 @@ abstract class rex_error_handler
             throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
         }
 
-        if (ini_get('display_errors') && (rex::isSetup() || rex::isDebugMode() || ($user = rex_backend_login::createUser()) && $user->isAdmin())) {
+        if (ini_get('display_errors') && (rex::isSetup() || rex::isDebugMode() || !rex::isLiveMode() && rex_backend_login::createUser()?->isAdmin())) {
             $file = rex_path::relative($errfile);
             if ('cli' === PHP_SAPI) {
                 echo self::getErrorType($errno) . ": $errstr in $file on line $errline";

--- a/redaxo/src/core/lib/packages/api_package.php
+++ b/redaxo/src/core/lib/packages/api_package.php
@@ -9,6 +9,10 @@ class rex_api_package extends rex_api_function
 {
     public function execute()
     {
+        if (rex::isLiveMode()) {
+            throw new rex_api_exception('Package management is not available in live mode!');
+        }
+
         $function = rex_request('function', 'string');
         if (!in_array($function, ['install', 'uninstall', 'activate', 'deactivate', 'delete'])) {
             throw new rex_api_exception('Unknown package function "' . $function . '"!');

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -136,6 +136,8 @@ class rex
      * @return mixed The value for $key or $default if $key cannot be found
      * @psalm-return (
      *     $key is 'login' ? rex_backend_login|null :
+     *     ($key is 'live_mode' ? bool :
+     *     ($key is 'safe_mode' ? bool :
      *     ($key is 'debug' ? array{enabled: bool, throw_always_exception: bool|int} :
      *     ($key is 'lang_fallback' ? string[] :
      *     ($key is 'use_accesskeys' ? bool :
@@ -162,7 +164,7 @@ class rex
      *     ($key is 'system_addons' ? non-empty-string[] :
      *     ($key is 'setup_addons' ? non-empty-string[] :
      *     mixed|null
-     *     )))))))))))))))))))))))))
+     *     )))))))))))))))))))))))))))
      * )
      */
     public static function getProperty($key, $default = null)
@@ -261,6 +263,10 @@ class rex
      */
     public static function isDebugMode()
     {
+        if (self::isLiveMode()) {
+            return false;
+        }
+
         $debug = self::getDebugFlags();
 
         return $debug['enabled'];
@@ -288,7 +294,7 @@ class rex
      */
     public static function isSafeMode()
     {
-        if (!self::isBackend()) {
+        if (!self::isBackend() || self::isLiveMode()) {
             return false;
         }
 

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -300,6 +300,14 @@ class rex
     }
 
     /**
+     * Returns if the live mode is active.
+     */
+    public static function isLiveMode(): bool
+    {
+        return (bool) self::getProperty('live_mode');
+    }
+
+    /**
      * Returns the table prefix.
      *
      * @return non-empty-string

--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -169,7 +169,7 @@ $content = '
     <p><a class="btn btn-delete" href="' . rex_url::currentBackendPage(['func' => 'generate'] + $csrfToken->getUrlParams()) . '">' . rex_i18n::msg('delete_cache') . '</a></p>';
 
 if (!rex::isLiveMode()) {
-    $content = '
+    $content .= '
         <h3>' . rex_i18n::msg('debug_mode') . '</h3>
         <p>' . rex_i18n::msg('debug_mode_note') . '</p>
         <p><a class="btn btn-debug-mode" href="' . rex_url::currentBackendPage(['func' => 'debugmode'] + $csrfToken->getUrlParams()) . '" data-pjax="false"' . $debugConfirm . '><i class="rex-icon rex-icon-heartbeat"></i> ' . (rex::isDebugMode() ? rex_i18n::msg('debug_mode_off') : rex_i18n::msg('debug_mode_on')) . '</a></p>

--- a/redaxo/src/core/pages/system.settings.php
+++ b/redaxo/src/core/pages/system.settings.php
@@ -13,7 +13,7 @@ if (rex_request('rex_debug_updated', 'bool', false)) {
 
 if ($func && !$csrfToken->isValid()) {
     $error[] = rex_i18n::msg('csrf_token_invalid');
-} elseif ('setup' == $func) {
+} elseif ('setup' == $func && !rex::isLiveMode()) {
     // REACTIVATE SETUP
     if (false !== $url = rex_setup::startWithToken()) {
         header('Location:' . $url);
@@ -23,10 +23,10 @@ if ($func && !$csrfToken->isValid()) {
 } elseif ('generate' == $func) {
     // generate all articles,cats,templates,caches
     $success = rex_delete_cache();
-} elseif ('updateassets' == $func) {
+} elseif ('updateassets' == $func && !rex::isLiveMode()) {
     rex_dir::copy(rex_path::core('assets'), rex_path::coreAssets());
     $success = 'Updated assets';
-} elseif ('debugmode' == $func) {
+} elseif ('debugmode' == $func && !rex::isLiveMode()) {
     $configFile = rex_path::coreData('config.yml');
     $config = array_merge(
         rex_file::getConfig(rex_path::core('default.config.yml')),
@@ -166,28 +166,30 @@ if (!rex::isDebugMode()) {
 $content = '
     <h3>' . rex_i18n::msg('delete_cache') . '</h3>
     <p>' . rex_i18n::msg('delete_cache_description') . '</p>
-    <p><a class="btn btn-delete" href="' . rex_url::currentBackendPage(['func' => 'generate'] + $csrfToken->getUrlParams()) . '">' . rex_i18n::msg('delete_cache') . '</a></p>
+    <p><a class="btn btn-delete" href="' . rex_url::currentBackendPage(['func' => 'generate'] + $csrfToken->getUrlParams()) . '">' . rex_i18n::msg('delete_cache') . '</a></p>';
 
-    <h3>' . rex_i18n::msg('debug_mode') . '</h3>
-    <p>' . rex_i18n::msg('debug_mode_note') . '</p>
-    <p><a class="btn btn-debug-mode" href="' . rex_url::currentBackendPage(['func' => 'debugmode'] + $csrfToken->getUrlParams()) . '" data-pjax="false"' . $debugConfirm . '><i class="rex-icon rex-icon-heartbeat"></i> ' . (rex::isDebugMode() ? rex_i18n::msg('debug_mode_off') : rex_i18n::msg('debug_mode_on')) . '</a></p>
+if (!rex::isLiveMode()) {
+    $content = '
+        <h3>' . rex_i18n::msg('debug_mode') . '</h3>
+        <p>' . rex_i18n::msg('debug_mode_note') . '</p>
+        <p><a class="btn btn-debug-mode" href="' . rex_url::currentBackendPage(['func' => 'debugmode'] + $csrfToken->getUrlParams()) . '" data-pjax="false"' . $debugConfirm . '><i class="rex-icon rex-icon-heartbeat"></i> ' . (rex::isDebugMode() ? rex_i18n::msg('debug_mode_off') : rex_i18n::msg('debug_mode_on')) . '</a></p>
 
-    <h3>' . rex_i18n::msg('safemode') . '</h3>
-    <p>' . rex_i18n::msg('safemode_text') . '</p>';
+        <h3>' . rex_i18n::msg('safemode') . '</h3>
+        <p>' . rex_i18n::msg('safemode_text') . '</p>';
 
-$safemodeUrl = rex_url::currentBackendPage(['safemode' => '1'] + $csrfToken->getUrlParams());
-if (rex::isSafeMode()) {
-    $safemodeUrl = rex_url::currentBackendPage(['safemode' => '0'] + $csrfToken->getUrlParams());
+    $safemodeUrl = rex_url::currentBackendPage(['safemode' => '1'] + $csrfToken->getUrlParams());
+    if (rex::isSafeMode()) {
+        $safemodeUrl = rex_url::currentBackendPage(['safemode' => '0'] + $csrfToken->getUrlParams());
+    }
+
+    $content .= '
+        <p><a class="btn btn-safemode-activate" href="' . $safemodeUrl . '" data-pjax="false">' . (rex::isSafeMode() ? rex_i18n::msg('safemode_deactivate') : rex_i18n::msg('safemode_activate')) . '</a></p>
+
+
+        <h3>' . rex_i18n::msg('setup') . '</h3>
+        <p>' . rex_i18n::msg('setup_text') . '</p>
+        <p><a class="btn btn-setup" href="' . rex_url::currentBackendPage(['func' => 'setup'] + $csrfToken->getUrlParams()) . '" data-confirm="' . rex_i18n::msg('setup_restart') . '?" data-pjax="false">' . rex_i18n::msg('setup') . '</a></p>';
 }
-
-$content .= '
-    <p><a class="btn btn-safemode-activate" href="' . $safemodeUrl . '" data-pjax="false">' . (rex::isSafeMode() ? rex_i18n::msg('safemode_deactivate') : rex_i18n::msg('safemode_activate')) . '</a></p>
-
-
-    <h3>' . rex_i18n::msg('setup') . '</h3>
-    <p>' . rex_i18n::msg('setup_text') . '</p>
-    <p><a class="btn btn-setup" href="' . rex_url::currentBackendPage(['func' => 'setup'] + $csrfToken->getUrlParams()) . '" data-confirm="' . rex_i18n::msg('setup_restart') . '?" data-pjax="false">' . rex_i18n::msg('setup') . '</a></p>';
-
 $fragment = new rex_fragment();
 $fragment->setVar('title', rex_i18n::msg('system_features'));
 $fragment->setVar('body', $content, false);

--- a/redaxo/src/core/schemas/config.json
+++ b/redaxo/src/core/schemas/config.json
@@ -62,6 +62,10 @@
             "description": "Safe mode",
             "type": "boolean"
         },
+        "live_mode": {
+            "description": "Safe mode",
+            "type": "boolean"
+        },
         "instname": {
             "description": "Unique instance name",
             "type": ["null", "string"]

--- a/redaxo/src/core/schemas/config.json
+++ b/redaxo/src/core/schemas/config.json
@@ -28,6 +28,14 @@
                 }
             ]
         },
+        "live_mode": {
+            "description": "Live mode",
+            "type": "boolean"
+        },
+        "safe_mode": {
+            "description": "Safe mode",
+            "type": "boolean"
+        },
         "debug": {
             "description": "Debug mode",
             "oneOf": [
@@ -57,14 +65,6 @@
                     "additionalProperties": false
                 }
             ]
-        },
-        "safe_mode": {
-            "description": "Safe mode",
-            "type": "boolean"
-        },
-        "live_mode": {
-            "description": "Safe mode",
-            "type": "boolean"
         },
         "instname": {
             "description": "Unique instance name",

--- a/redaxo/src/core/schemas/package.json
+++ b/redaxo/src/core/schemas/package.json
@@ -190,6 +190,11 @@
                     "type": "string",
                     "default": "admin"
                 },
+                "live_mode": {
+                    "description": "Live mode",
+                    "type": "boolean",
+                    "default": true
+                },
                 "icon": {
                     "description": "Icon class name(s)",
                     "type": "string"

--- a/redaxo/src/core/tests/rex_test.php
+++ b/redaxo/src/core/tests/rex_test.php
@@ -118,6 +118,31 @@ class rex_rex_test extends TestCase
         }
     }
 
+    public function testLiveModeFlag(): void
+    {
+        $origLiveMode = rex::getProperty('live_mode');
+        $origSafeMode = rex::getProperty('safe_mode');
+        $origDebug = rex::getProperty('debug');
+
+        try {
+            rex::setProperty('live_mode', false);
+            rex::setProperty('safe_mode', true);
+            rex::setProperty('debug', true);
+            self::assertFalse(rex::isLiveMode());
+            self::assertTrue(rex::isSafeMode());
+            self::assertTrue(rex::isDebugMode());
+
+            rex::setProperty('live_mode', true);
+            self::assertTrue(rex::isLiveMode());
+            self::assertFalse(rex::isSafeMode());
+            self::assertFalse(rex::isDebugMode());
+        } finally {
+            rex::setProperty('live_mode', $origLiveMode);
+            rex::setProperty('safe_mode', $origSafeMode);
+            rex::setProperty('debug', $origDebug);
+        }
+    }
+
     public function testGetTablePrefix(): void
     {
         self::assertEquals(rex::getTablePrefix(), 'rex_', 'table prefix defauts to rex_');


### PR DESCRIPTION
Der PR führt einen neuen Live-Mode ein, den man über die `config.yml` aktivieren kann.
Im Live-Mode wird das System gehärtet, sodass ein gekaperter Backend-Admin-Account weniger Schaden anrichten kann.
Insbesondere soll in dem Modus über das Backend kein PHP-Code eingegeben werden können (bzw. der soll zumindest dann nicht ausgeführt werden).

Im Einzelnen hat der Live-Modus diese Folgen:
- Safe-Mode und Debug-Mode sind immer deaktiviert
- System-Page: Buttons für Debug-Modus, Safe-Mode und Setup verschwinden
- Auch als Admin bekommt man kein Whoops, sondern die Ooops-Seite
- Backup-Import-Page verschwindet
- Addonverwaltung verschwindet
- Installer verschwindet
- Metainfoverwaltung verschwindet
- MediaManager-Verwaltung verschwindet
- Debug-Page verschwindet
- Module- und Template-Verwaltung verschwindet
- Bei `REX_VALUE[id=X output=php]` wird der PHP-Code nicht ausgeführt und im Backend wird eine Meldung ausgegeben (PHP-Code-Values können gleichzeitig als deprecated angesehen werden)
- Cronjob-Typen PHP-Code und PHP-Callback stehen nicht zur Verfügung und ggf. schon vorhandene Jobs mit den Typen werden auch nicht ausgeführt (die beiden Typen können auch als deprecated angesehen werden, stattdessen sollten eigene Cronjob-Typen erstellt werden)
- Metainfo-Callbacks werden nicht mehr ausgeführt werden (sind auch deprecated)