### PR TITLE
config.yml: safe_mode statt safemode

### DIFF
--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -162,13 +162,13 @@ if (rex::isSetup()) {
                 rex_set_session('safemode', true);
             } else {
                 rex_unset_session('safemode');
-                if (rex::getProperty('safemode')) {
+                if (rex::getProperty('safe_mode')) {
                     $configFile = rex_path::coreData('config.yml');
                     $config = array_merge(
                         rex_file::getConfig(rex_path::core('default.config.yml')),
                         rex_file::getConfig($configFile),
                     );
-                    $config['safemode'] = false;
+                    $config['safe_mode'] = false;
                     rex_file::putConfig($configFile, $config);
                 }
             }

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -2,7 +2,7 @@ setup: true
 debug:
     enabled: false
     throw_always_exception: false # `true` for all error levels, `[E_WARNING, E_NOTICE]` for subset
-safemode: false
+safe_mode: false
 instname: null
 server: https://www.redaxo.org/
 servername: REDAXO

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -292,7 +292,7 @@ class rex
             return false;
         }
 
-        if (self::getProperty('safemode')) {
+        if (self::getProperty('safe_mode')) {
             return true;
         }
 

--- a/redaxo/src/core/schemas/config.json
+++ b/redaxo/src/core/schemas/config.json
@@ -58,7 +58,7 @@
                 }
             ]
         },
-        "safemode": {
+        "safe_mode": {
             "description": "Safe mode",
             "type": "boolean"
         },


### PR DESCRIPTION
In https://github.com/redaxo/redaxo/pull/5881 wurde für 5.16 ein neuer `safemode`-Schalter für die config.yml eingeführt.

Dieser PR nennt ihn (noch vor Release) doch nochmal um in `safe_mode`. 
Passt besser zum neuen `live_mode` (#5909) und auch besser zu `rex::isSafeMode()`.

(Nur eine kleine Unstimmigkeit gibt es: der schon vorher existierende URL-Parameter bleibt bei `safemode`, und auch der Session-Key.)