### PR TITLE
rex_list: `ORDER BY` nicht mehr per Regex ersetzen

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -4153,7 +4153,6 @@
     </PossiblyNullArgument>
     <PossiblyNullOperand>
       <code>$sortType</code>
-      <code>$sortType</code>
     </PossiblyNullOperand>
     <PropertyTypeCoercion>
       <code><![CDATA[$this->columnLayouts]]></code>

--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -567,8 +567,7 @@ if ($SHOW) {
             status,
             lastlogin
         FROM ' . rex::getTable('user') . ' u
-        ORDER BY name
-    ');
+    ', defaultSort: ['name' => 'asc']);
     $list->addTableAttribute('class', 'table-striped table-hover');
 
     $tdIcon = '<i class="rex-icon rex-icon-user" title="' . rex_i18n::msg('user_status_active') . '"></i>';

--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -125,8 +125,9 @@ class rex_list implements rex_url_provider_interface
      * @param string|null $listName Name der Liste
      * @param bool $debug
      * @param positive-int $db
+     * @param array<string, 'asc'|'desc'> $defaultSort
      */
-    protected function __construct($query, $rowsPerPage = 30, $listName = null, $debug = false, $db = 1)
+    protected function __construct($query, $rowsPerPage = 30, $listName = null, $debug = false, $db = 1, array $defaultSort = [])
     {
         // --------- Validation
         if (!$listName) {
@@ -187,7 +188,7 @@ class rex_list implements rex_url_provider_interface
         }
 
         // --------- Load Data
-        $this->sql->setQuery($this->prepareQuery($query));
+        $this->sql->setQuery($this->prepareQuery($query, $defaultSort));
         if (self::DISABLE_PAGINATION === $rowsPerPage) {
             $this->rows = (int) $this->sql->getRows();
         }
@@ -210,13 +211,14 @@ class rex_list implements rex_url_provider_interface
      * @param string|null $listName
      * @param bool $debug
      * @param positive-int $db DB connection ID
+     * @param array<string, 'asc'|'desc'> $defaultSort
      *
      * @return static
      */
-    public static function factory($query, $rowsPerPage = 30, $listName = null, $debug = false, $db = 1)
+    public static function factory($query, $rowsPerPage = 30, $listName = null, $debug = false, $db = 1, array $defaultSort = [])
     {
         $class = static::getFactoryClass();
-        return new $class($query, $rowsPerPage, $listName, $debug, $db);
+        return new $class($query, $rowsPerPage, $listName, $debug, $db, $defaultSort);
     }
 
     /**
@@ -894,10 +896,11 @@ class rex_list implements rex_url_provider_interface
      * Prepariert das SQL Statement vorm anzeigen der Liste.
      *
      * @param string $query SQL Statement
+     * @param array<string, 'asc'|'desc'> $defaultSort
      *
      * @return string
      */
-    protected function prepareQuery($query)
+    protected function prepareQuery($query, array $defaultSort = [])
     {
         $sortColumn = $this->getSortColumn();
         if ('' != $sortColumn) {
@@ -906,11 +909,22 @@ class rex_list implements rex_url_provider_interface
             $sql = rex_sql::factory($this->db);
             $sortColumn = $sql->escapeIdentifier($sortColumn);
 
-            if (false === stripos($query, ' ORDER BY ')) {
+            if ($defaultSort || false === stripos($query, ' ORDER BY ')) {
                 $query .= ' ORDER BY ' . $sortColumn . ' ' . $sortType;
-            } else {
-                $query = preg_replace('/ORDER\sBY\s[^ ]*(\sasc|\sdesc)?/i', 'ORDER BY ' . $sortColumn . ' ' . $sortType, $query);
             }
+        } elseif ($defaultSort) {
+            $sort = [];
+
+            $sql = rex_sql::factory($this->db);
+            foreach ($defaultSort as $column => $type) {
+                $type = strtolower($type);
+                if (!in_array($type, ['asc', 'desc'], true)) {
+                    throw new InvalidArgumentException('Default sort type must be "asc" or "desc", but "' . $type . '" given');
+                }
+                $sort[] = $sql->escapeIdentifier($column) . ' ' . $type;
+            }
+
+            $query .= ' ORDER BY ' . implode(', ', $sort);
         }
 
         if ($this->pager && false === stripos($query, ' LIMIT ')) {


### PR DESCRIPTION
Aktuell übergibt man die Default-Sortierung direkt mit der Query.
Wenn dann per Klick auf Spalte eine andere Sortierung gesetzt wird, wird die Query per Regex angepasst.
Die Regex-Stelle ist uns nicht mehr geheuer und wurde in einem externen Scan auch bemängelt. Daher möchten wir sie gerne loswerden.

Neu sollte die Default-Sortierung als zusätzlicher Param übergeben werden:
```php
$list = rex_list::factory($queryWithoutOrderBy, 30, defaultSort: ['name' => 'asc']);
```

Addons, die eine Default-Sortierung übergeben und die Spaltensortierung aktivieren, müssen nun leider angepasst werden. Ohne Anpassung funktioniert die Per-Spaltenklick-Sortierung nicht mehr (es kommt aber auch kein Fehler).

Addons, die selbst ein `ORDER BY` übergeben und nicht die Per-Spaltenklick-Sortierung nutzen, müssen nicht angepasst werden.
Addons, die default keine Sortierung übergeben, und nur Per-Spaltenklick-Sortierung anbieten, müssen auch nicht angepasst werden.