### PR TITLE
Debug-Addon: Bei Update die install.php ausführen

### DIFF
--- a/redaxo/src/addons/debug/update.php
+++ b/redaxo/src/addons/debug/update.php
@@ -1,0 +1,6 @@
+<?php
+
+$addon = rex_addon::get('debug');
+
+// use path relative to __DIR__ to get correct path in update temp dir
+$addon->includeFile(__DIR__ . '/install.php');


### PR DESCRIPTION
Hier haben wir versehentlich vergessen, eine `update.php` anzulegen. Die `install.php` wird ja beim Update nicht automatisch ausgeführt.
Somit wurde das frontend.zip beim Update nicht aktualisiert.