### PR TITLE
Remove old update scripts

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -862,14 +862,6 @@
       <code>$allowedMimeTypes</code>
     </MixedAssignment>
   </file>
-  <file src="redaxo/src/addons/mediapool/update.php">
-    <MixedAssignment>
-      <code><![CDATA[$perms['general']]]></code>
-    </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$perms['general']]]></code>
-    </MixedOperand>
-  </file>
   <file src="redaxo/src/addons/metainfo/boot.php">
     <MixedArgument>
       <code><![CDATA[$ep->getParam('file')]]></code>
@@ -2113,16 +2105,6 @@
     <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-  </file>
-  <file src="redaxo/src/addons/structure/update.php">
-    <MixedAssignment>
-      <code><![CDATA[$perms['options']]]></code>
-      <code><![CDATA[$perms['options']]]></code>
-    </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$perms['options']]]></code>
-      <code><![CDATA[$perms['options']]]></code>
-    </MixedOperand>
   </file>
   <file src="redaxo/src/core/backend.php">
     <MixedArgument>
@@ -5242,16 +5224,5 @@
       <code><![CDATA[$params['suffix']]]></code>
       <code><![CDATA[$params['var']]]></code>
     </MixedArgument>
-  </file>
-  <file src="redaxo/src/core/update.php">
-    <MixedArrayAccess>
-      <code><![CDATA[$_SESSION[rex::getProperty('instname')]['backend_login']]]></code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$config['setup_addons'][]]]></code>
-    </MixedArrayAssignment>
-    <MixedAssignment>
-      <code><![CDATA[$_SESSION[$sessionKey]['backend_login']]]></code>
-    </MixedAssignment>
   </file>
 </files>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,6 +35,3 @@ parameters:
         - '#Unsafe usage of new static\(\)\.#'
         - '#Constructor of class rex_form_.*_element has an unused parameter \$tag.#'
         - '#^Offset .* on .* always exists#'
-        -
-            message: '#.*deprecated.*#'
-            path: '*/update.php'

--- a/psalm.xml
+++ b/psalm.xml
@@ -54,11 +54,6 @@
             </errorLevel>
         </InvalidGlobal>
 <!-- level 2 issues - slightly lazy code writing, but provably low false-negatives -->
-        <DeprecatedMethod>
-            <errorLevel type="info">
-                <referencedMethod name="rex_string::versionCompare"/>
-            </errorLevel>
-        </DeprecatedMethod>
         <DocblockTypeContradiction errorLevel="info" />
         <InternalClass errorLevel="info" />
         <InternalMethod errorLevel="info" />

--- a/redaxo/src/addons/install/update.php
+++ b/redaxo/src/addons/install/update.php
@@ -1,8 +1,0 @@
-<?php
-
-$addon = rex_addon::get('install');
-
-if (rex_string::versionCompare($addon->getVersion(), '2.0.1', '<') && rex_config::has('install')) {
-    rex_file::putCache($addon->getDataPath('config.json'), rex_config::get('install'));
-    rex_config::removeNamespace('install');
-}

--- a/redaxo/src/addons/media_manager/update.php
+++ b/redaxo/src/addons/media_manager/update.php
@@ -2,20 +2,5 @@
 
 $addon = rex_addon::get('media_manager');
 
-if (rex_string::versionCompare($addon->getVersion(), '2.4.1-dev', '<')) {
-    rex_media_manager::deleteCache();
-}
-
-if (rex_string::versionCompare($addon->getVersion(), '2.12.0-dev', '<')) {
-    rex_sql::factory()->setQuery('
-        DELETE t, te
-        FROM ' . rex::getTable('media_manager_type') . ' t
-        LEFT JOIN ' . rex::getTable('media_manager_type_effect') . ' te ON te.type_id = t.id
-        WHERE t.id < 6
-    ');
-
-    rex_media_manager::deleteCache();
-}
-
 // use path relative to __DIR__ to get correct path in update temp dir
 $addon->includeFile(__DIR__ . '/install.php');

--- a/redaxo/src/addons/mediapool/update.php
+++ b/redaxo/src/addons/mediapool/update.php
@@ -2,25 +2,4 @@
 
 $addon = rex_addon::get('mediapool');
 
-if (rex_string::versionCompare($addon->getVersion(), '2.9.0-beta1', '<')) {
-    $sql = rex_sql::factory();
-    $sql->transactional(static function () use ($sql) {
-        $roles = rex_sql::factory()->setQuery('SELECT * FROM ' . rex::getTable('user_role'));
-        foreach ($roles as $role) {
-            $perms = $role->getArrayValue('perms');
-            if (rex_complex_perm::ALL !== $perms['media']) {
-                continue;
-            }
-
-            $perms['general'] ??= '|';
-            $perms['general'] .= 'media[sync]|';
-            $sql
-                ->setTable(rex::getTable('user_role'))
-                ->setWhere(['id' => $role->getValue('id')])
-                ->setArrayValue('perms', $perms)
-                ->update();
-        }
-    });
-}
-
 $addon->includeFile(__DIR__ . '/install.php');

--- a/redaxo/src/addons/structure/update.php
+++ b/redaxo/src/addons/structure/update.php
@@ -2,41 +2,5 @@
 
 $addon = rex_addon::get('structure');
 
-if (rex_string::versionCompare($addon->getVersion(), '2.9.0-beta1', '<')) {
-    $sql = rex_sql::factory();
-    $sql->transactional(static function () use ($sql) {
-        $roles = rex_sql::factory()->setQuery('SELECT * FROM ' . rex::getTable('user_role'));
-        foreach ($roles as $role) {
-            $perms = $role->getArrayValue('perms');
-            $perms['options'] ??= '|';
-            $perms['options'] .= 'addArticle[]|addCategory[]|editArticle[]|editCategory[]|deleteArticle[]|deleteCategory[]|';
-
-            $sql
-                ->setTable(rex::getTable('user_role'))
-                ->setWhere(['id' => $role->getValue('id')])
-                ->setArrayValue('perms', $perms)
-                ->update();
-        }
-    });
-}
-
-if (rex_string::versionCompare($addon->getVersion(), '2.11.0-beta1', '<')) {
-    $sql = rex_sql::factory();
-    $sql->transactional(static function () use ($sql) {
-        $roles = rex_sql::factory()->setQuery('SELECT * FROM ' . rex::getTable('user_role'));
-        foreach ($roles as $role) {
-            $perms = $role->getArrayValue('perms');
-            $perms['options'] ??= '|';
-            $perms['options'] .= 'publishSlice[]|';
-
-            $sql
-                ->setTable(rex::getTable('user_role'))
-                ->setWhere(['id' => $role->getValue('id')])
-                ->setArrayValue('perms', $perms)
-                ->update();
-        }
-    });
-}
-
 // use path relative to __DIR__ to get correct path in update temp dir
 $addon->includeFile(__DIR__ . '/install.php');

--- a/redaxo/src/core/install.php
+++ b/redaxo/src/core/install.php
@@ -39,9 +39,7 @@ rex_sql_table::get(rex::getTable('cronjob'))
     ->ensureGlobalColumns()
     ->ensure();
 
-$table = rex_sql_table::get(rex::getTable('user'));
-$hasPasswordChanged = $table->hasColumn('password_changed');
-$table
+rex_sql_table::get(rex::getTable('user'))
     ->ensurePrimaryIdColumn()
     ->ensureColumn(new rex_sql_column('name', 'varchar(255)', true))
     ->ensureColumn(new rex_sql_column('description', 'text', true))
@@ -66,13 +64,6 @@ $table
     ->ensureIndex(new rex_sql_index('login', ['login'], rex_sql_index::UNIQUE))
     ->removeColumn('cookiekey')
     ->ensure();
-
-if (!$hasPasswordChanged) {
-    rex_sql::factory()
-        ->setTable(rex::getTable('user'))
-        ->setRawValue('password_changed', 'updatedate')
-        ->update();
-}
 
 rex_sql_table::get(rex::getTable('user_passkey'))
     ->ensureColumn(new rex_sql_column('id', 'varchar(255)'))

--- a/redaxo/src/core/update.php
+++ b/redaxo/src/core/update.php
@@ -3,8 +3,13 @@
 // don't use REX_MIN_PHP_VERSION or rex_setup::MIN_* constants here!
 // while updating the core, the constants contain the old min versions from previous core version
 
+// Since R6 we require at least R5.16 because of some `rex_sql_table` and `rex_sql::addRecord` usages in core addons
+if (version_compare(rex::getVersion(), '5.16', '<')) {
+    throw new rex_functional_exception(sprintf('The REDAXO version "%s" is too old for this update, please update to 5.16 before.', rex::getVersion()));
+}
+
 if (PHP_VERSION_ID < 80100) {
-    throw new rex_functional_exception(rex_i18n::msg(rex_string::versionCompare(rex::getVersion(), '5.14.0-dev', '<') ? 'setup_301' : 'setup_201', PHP_VERSION, '8.1'));
+    throw new rex_functional_exception(rex_i18n::msg('setup_201', PHP_VERSION, '8.1'));
 }
 
 $minExtensions = ['ctype', 'fileinfo', 'filter', 'iconv', 'intl', 'mbstring', 'pcre', 'pdo', 'pdo_mysql', 'session', 'tokenizer'];
@@ -26,7 +31,7 @@ if (preg_match('/^(?:\d+\.\d+\.\d+-)?(\d+\.\d+\.\d+)-mariadb/i', $dbVersion, $ma
     $dbType = 'MariaDB';
     $dbVersion = $match[1];
 }
-if (rex_string::versionCompare($dbVersion, $minVersion, '<')) {
+if (rex_version::compare($dbVersion, $minVersion, '<')) {
     // The message was added in REDAXO 5.11.1, so it does not exist while updating from previous versions
     $message = rex_i18n::hasMsg('sql_database_required_version')
         ? rex_i18n::msg('sql_database_required_version', $dbType, $dbVersion, $minMysqlVersion, $minMariaDbVersion)
@@ -35,70 +40,12 @@ if (rex_string::versionCompare($dbVersion, $minVersion, '<')) {
     throw new rex_functional_exception($message);
 }
 
-// Since R5.7 we require at least R5.4 because of some `rex_sql_table` and `rex_sql::addRecord` usages in core addons
-if (rex_string::versionCompare(rex::getVersion(), '5.6', '<')) {
-    throw new rex_functional_exception(sprintf('The REDAXO version "%s" is too old for this update, please update to 5.6.5 before.', rex::getVersion()));
-}
-
-// Installer >= 2.9.2 required because of https://github.com/redaxo/redaxo/pull/4922
-// (Installer < 2.9.0 also works, because it does not contain the bug)
-$installerVersion = rex_addon::get('install')->getVersion();
-if (rex_string::versionCompare($installerVersion, '2.9.2', '<') && rex_string::versionCompare($installerVersion, '2.9.0', '>=')) {
-    throw new rex_functional_exception('This update requires at least version <b>2.9.2</b> of the <b>install</b> addon!');
-}
-
-$sessionKey = (string) rex::getProperty('instname') . '_backend';
-
-if (rex_string::versionCompare(rex::getVersion(), '5.7.0-beta3', '<')) {
-    /** @psalm-suppress MixedArrayAssignment */
-    $_SESSION[$sessionKey]['backend_login'] = $_SESSION[rex::getProperty('instname')]['backend_login'];
-}
-
-if (rex_string::versionCompare(rex::getVersion(), '5.9.0-beta1', '<')) {
-    // do not use `rex_path::log()` because it does not exist while updating from rex < 5.9
-    rex_dir::create(rex_path::data('log'));
-    @rename(rex_path::coreData('system.log'), rex_path::data('log/system.log'));
-    @rename(rex_path::coreData('system.log.2'), rex_path::data('log/system.log.2'));
-}
-
-if (rex_string::versionCompare(rex::getVersion(), '5.13.1', '<') && ($user = rex::getUser())) {
-    /** @psalm-suppress MixedArrayAssignment */
-    $_SESSION[$sessionKey]['backend_login']['password'] = $user->getValue('password');
-}
-
 $path = rex_path::coreData('config.yml');
 $config = array_merge(
     rex_file::getConfig(__DIR__ . '/default.config.yml'),
     rex_file::getConfig($path),
 );
 
-if (rex_string::versionCompare(rex::getVersion(), '5.12.0-dev', '<')) {
-    $config['setup_addons'][] = 'install';
-}
-
 rex_file::putConfig($path, $config);
 
 require __DIR__ . '/install.php';
-
-if (rex_version::compare(rex::getVersion(), '5.15.0-dev', '<') && $user = rex::getUser()) {
-    // prevent admin logout during update
-    try {
-        rex_sql::factory()
-            ->setTable(rex::getTable('user_session'))
-            ->setValue('session_id', session_id())
-            ->setValue('user_id', $user->getId())
-            ->setValue('ip', rex_request::server('REMOTE_ADDR', 'string'))
-            ->setValue('useragent', rex_request::server('HTTP_USER_AGENT', 'string'))
-            ->setValue('starttime', rex_sql::datetime())
-            ->setValue('last_activity', rex_sql::datetime())
-            ->insert();
-    } catch (rex_sql_exception $exception) {
-        if (rex_sql::ERROR_VIOLATE_UNIQUE_KEY !== $exception->getErrorCode()) {
-            throw $exception;
-        }
-    }
-}
-
-if (rex_version::compare(rex::getVersion(), '5.16.0', '<')) {
-    class_exists(Psr\Log\LogLevel::class);
-}


### PR DESCRIPTION
Wie man zu R6 updaten können wird, steht noch nicht fest.
Aber in jedem Fall sollte man zunächst zur neusten R5-Version updaten. Somit werden die alten Update-Skripte nicht mehr benötigt.