### PR TITLE
EP REX_MARKDOWN_PAGE

### DIFF
--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -462,7 +462,14 @@ class rex_be_controller
             $path = $languagePath;
         }
 
-        [$toc, $content] = rex_markdown::factory()->parseWithToc(rex_file::require($path), 2, 3, [
+        // ----- EXTENSION POINT
+        $document = rex_extension::registerPoint(new rex_extension_point('REX_MARKDOWN_PAGE', rex_file::require($path), [
+            'page' => self::requireCurrentPageObject(),
+            'lang' => rex_i18n::getLanguage(),
+            'path' => $path,
+        ]));
+        
+        [$toc, $content] = rex_markdown::factory()->parseWithToc($document, 2, 3, [
             rex_markdown::SOFT_LINE_BREAKS => false,
             rex_markdown::HIGHLIGHT_PHP => true,
         ]);


### PR DESCRIPTION
Hallöle! 

Ich hätte gerne einen neuen EP eingeführt, der die Nutzung von Markdown-Dateien für Dokumentationen erweitert.

Dieser EP schafft die Möglichkeit, BE-Seiten aus Markdown-Dateien vor der Ausgabe noch zu überarbeiten. Z.B. Links/Verweise oder auch Inhalte überarbeiten und an die lokale Installation anpassen.

Ich denke an z.B. an Grafik-Links. Hier mal ein Beispiel:

- Dokument: `./docs/doku.md`
- Grafik: `./docs/screenshot.jpg`
- Eingebunden mit `![Beispiel](screenshot.jpg)`

Auf Github würde bei Anzeige des Dokumentes die Grafik korrekt eingebunden. Doku also gut lesbar. Interessant für die, die sich schon mal vorab informieren wollen, ohne das Addon zu installieren

Lokal in der Redaxo-Instanz klappt das nicht, weil die Grafiken ja nicht von extern her zugänglich sind. Aber .... wenn man den Grafik-Link ändern könnte und einen durchleitenden MM-Type vorschaltet, wäre die Grafik wieder eingebunden.

- aus `[screenshot.jpg]` wird `[index.php?rex_media_type=passthrue&rex_media_file=screenshot.jpg]`

Das fände ich eine smartere Lösung als die Grafiken im asset-Verzeichnis zu lagern, denn dann wäre ja der Doppelnutzen - lesbar auf GitHUB _und_ in der Instanz - nicht mehr gegeben (unterschiedliche Links).

Verlinkungen zwischen den Seiten kann man ähnlich auflösen.