### PR TITLE
Create/Update-Felder korrekt setzen

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
@@ -94,6 +94,7 @@ if ('add' == $function || 'edit' == $function) {
         $faction->setValue('previewmode', $previewmode);
         $faction->setValue('presavemode', $presavemode);
         $faction->setValue('postsavemode', $postsavemode);
+        $faction->addGlobalUpdateFields();
 
         try {
             if ('add' == $function) {
@@ -102,7 +103,6 @@ if ('add' == $function || 'edit' == $function) {
                 $faction->insert();
                 $success = rex_i18n::msg('action_added');
             } else {
-                $faction->addGlobalUpdateFields();
                 $faction->setWhere(['id' => $actionId]);
 
                 $faction->update();

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
@@ -123,6 +123,7 @@ if ('add' == $function || 'edit' == $function) {
                 $IMOD->setValue('input', $eingabe);
                 $IMOD->setValue('output', $ausgabe);
                 $IMOD->addGlobalCreateFields();
+                $IMOD->addGlobalUpdateFields();
 
                 $IMOD->insert();
                 $moduleId = (int) $IMOD->getLastId();

--- a/redaxo/src/addons/structure/plugins/content/pages/templates.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/templates.php
@@ -117,7 +117,7 @@ if ('add' == $function || 'edit' == $function) {
         $TPL->setValue('name', $templatename);
         $TPL->setValue('active', $active);
         $TPL->setValue('content', $template);
-        $TPL->addGlobalCreateFields();
+        $TPL->addGlobalUpdateFields();
 
         $TPL->setArrayValue('attributes', $attributes);
 
@@ -161,7 +161,6 @@ if ('add' == $function || 'edit' == $function) {
 
             if ('' == $error) {
                 $TPL->setWhere(['id' => $templateId]);
-                $TPL->addGlobalUpdateFields();
 
                 try {
                     $TPL->update();


### PR DESCRIPTION
Beim Erstellen von Datensätzen sollten sowohl createdate/createuser, als auch updatedate/updateuser gesetzt werden. Beim Update natürlich nur die Update-Felder.

Letztes Jahr war bereits eine Stelle aufgefallen, wo es falsch gemacht wurde: https://github.com/redaxo/redaxo/pull/5710

Habe nun noch weitere Stellen gefunden:

- Templates: Beim Aktualisieren wurden auch die Create-Felder aktualisiert
- Module und Actions: Beim Erstellen wurden die Update-Felder nicht gesetzt