### PR TITLE
Mediapool: Alternativer Suchmodus entfernt

### DIFF
--- a/redaxo/src/addons/mediapool/pages/media.list.php
+++ b/redaxo/src/addons/mediapool/pages/media.list.php
@@ -228,7 +228,7 @@ $mediaName = rex_request('media_name', 'string');
 if ('' != $mediaName) {
     $filter['term'] = $mediaName;
 
-    if ('global' != rex_addon::get('mediapool')->getConfig('searchmode', 'local') && 0 != $rexFileCategory) {
+    if (0 != $rexFileCategory) {
         $filter['category_id_path'] = $rexFileCategory;
     }
 } else {


### PR DESCRIPTION
Im Mediapool gibt es eine versteckte Config für einen alternativen Suchmodus. Dazu musste man selbst den Configwert in rex_config eintragen.

Dieser PR entfernt den alternativen Modus für 6.x