### PR TITLE
Rector-Ruleset beginnen für Upgrade zu R6

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -26,6 +26,8 @@ use Rector\Removing\Rector\ClassMethod\ArgumentRemoverRector;
 use Rector\Removing\Rector\FuncCall\RemoveFuncCallArgRector;
 use Rector\Removing\ValueObject\ArgumentRemover;
 use Rector\Removing\ValueObject\RemoveFuncCallArg;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\ValueObject\PhpVersion;
 use Redaxo\Rector\Rule\UnderscoreToCamelCasePropertyNameRector;
 use Redaxo\Rector\Rule\UnderscoreToCamelCaseVariableNameRector;
@@ -90,6 +92,10 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(UnnecessaryTernaryExpressionRector::class);
 
     // Upgrade REDAXO 5 to 6
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        new MethodCallRename(rex_managed_media::class, 'getImageWidth', 'getWidth'),
+        new MethodCallRename(rex_managed_media::class, 'getImageHeight', 'getHeight'),
+    ]);
     $rectorConfig->ruleWithConfiguration(RemoveFuncCallArgRector::class, [
         new RemoveFuncCallArg('rex_getUrl', 3),
     ]);

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Rector\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector;
+use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\CodeQuality\Rector\Assign\CombinedAssignRector;
 use Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
@@ -28,6 +30,8 @@ use Rector\Removing\ValueObject\ArgumentRemover;
 use Rector\Removing\ValueObject\RemoveFuncCallArg;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Transform\Rector\ConstFetch\ConstFetchToClassConstFetchRector;
+use Rector\Transform\ValueObject\ConstFetchToClassConstFetch;
 use Rector\ValueObject\PhpVersion;
 use Redaxo\Rector\Rule\UnderscoreToCamelCasePropertyNameRector;
 use Redaxo\Rector\Rule\UnderscoreToCamelCaseVariableNameRector;
@@ -85,8 +89,13 @@ return RectorConfig::configure()
 
     // Upgrade REDAXO 5 to 6
     ->withConfiguredRule(RenameMethodRector::class, [
+        new MethodCallRename(rex_password_policy::class, 'getRule', 'getDescription'),
+        new MethodCallRename(rex_article_content_base::class, 'getClang', 'getClangId'),
+        new MethodCallRename(rex_article_slice::class, 'getClang', 'getClangId'),
+        new MethodCallRename(rex_structure_element::class, 'getClang', 'getClangId'),
         new MethodCallRename(rex_managed_media::class, 'getImageWidth', 'getWidth'),
         new MethodCallRename(rex_managed_media::class, 'getImageHeight', 'getHeight'),
+        new MethodCallRename(rex_mailer::class, 'setLog', 'setArchive'),
     ])
     ->withConfiguredRule(RemoveFuncCallArgRector::class, [
         new RemoveFuncCallArg('rex_getUrl', 3),
@@ -103,5 +112,27 @@ return RectorConfig::configure()
         new ArgumentRemover(rex_list::class, 'getParsedUrl', 1, null),
         new ArgumentRemover(rex_structure_element::class, 'getUrl', 1, null),
         new ArgumentRemover(rex_media_manager::class, 'getUrl', 3, null),
+    ])
+    ->withConfiguredRule(ReplaceArgumentDefaultValueRector::class, [
+        new ReplaceArgumentDefaultValue(rex_extension::class, 'register', 0, 'STRUCTURE_CONTENT_SLICE_ADDED', 'SLICE_ADDED'),
+        new ReplaceArgumentDefaultValue(rex_extension::class, 'register', 0, 'STRUCTURE_CONTENT_SLICE_UPDATED', 'SLICE_UPDATED'),
+        new ReplaceArgumentDefaultValue(rex_extension::class, 'register', 0, 'STRUCTURE_CONTENT_SLICE_DELETED', 'SLICE_DELETED'),
+    ])
+    ->withConfiguredRule(ConstFetchToClassConstFetchRector::class, [
+        new ConstFetchToClassConstFetch('REX_FORM_ERROR_VIOLATE_UNIQUE_KEY', rex_form::class, 'ERROR_VIOLATE_UNIQUE_KEY'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_TEXT', rex_metainfo_table_manager::class, 'FIELD_TEXT'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_TEXTAREA', rex_metainfo_table_manager::class, 'FIELD_TEXTAREA'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_SELECT', rex_metainfo_table_manager::class, 'FIELD_SELECT'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_RADIO', rex_metainfo_table_manager::class, 'FIELD_RADIO'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_CHECKBOX', rex_metainfo_table_manager::class, 'FIELD_CHECKBOX'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_REX_MEDIA_WIDGET', rex_metainfo_table_manager::class, 'FIELD_REX_MEDIA_WIDGET'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_REX_MEDIALIST_WIDGET', rex_metainfo_table_manager::class, 'FIELD_REX_MEDIALIST_WIDGET'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_REX_LINK_WIDGET', rex_metainfo_table_manager::class, 'FIELD_REX_LINK_WIDGET'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_REX_LINKLIST_WIDGET', rex_metainfo_table_manager::class, 'FIELD_REX_LINKLIST_WIDGET'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_DATE', rex_metainfo_table_manager::class, 'FIELD_DATE'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_DATETIME', rex_metainfo_table_manager::class, 'FIELD_DATETIME'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_LEGEND', rex_metainfo_table_manager::class, 'FIELD_LEGEND'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_TIME', rex_metainfo_table_manager::class, 'FIELD_TIME'),
+        new ConstFetchToClassConstFetch('REX_METAINFO_FIELD_COUNT', rex_metainfo_table_manager::class, 'FIELD_COUNT'),
     ])
 ;

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Rector\Arguments\Rector\MethodCall\RemoveMethodCallParamRector;
 use Rector\CodeQuality\Rector\Assign\CombinedAssignRector;
 use Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
@@ -27,7 +26,6 @@ use Rector\Removing\Rector\ClassMethod\ArgumentRemoverRector;
 use Rector\Removing\Rector\FuncCall\RemoveFuncCallArgRector;
 use Rector\Removing\ValueObject\ArgumentRemover;
 use Rector\Removing\ValueObject\RemoveFuncCallArg;
-use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersion;
 use Redaxo\Rector\Rule\UnderscoreToCamelCasePropertyNameRector;
 use Redaxo\Rector\Rule\UnderscoreToCamelCaseVariableNameRector;

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\Arguments\Rector\MethodCall\RemoveMethodCallParamRector;
 use Rector\CodeQuality\Rector\Assign\CombinedAssignRector;
 use Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
@@ -22,6 +23,11 @@ use Rector\Php80\Rector\Identical\StrStartsWithRector;
 use Rector\Php80\Rector\NotIdentical\StrContainsRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Removing\Rector\ClassMethod\ArgumentRemoverRector;
+use Rector\Removing\Rector\FuncCall\RemoveFuncCallArgRector;
+use Rector\Removing\ValueObject\ArgumentRemover;
+use Rector\Removing\ValueObject\RemoveFuncCallArg;
+use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersion;
 use Redaxo\Rector\Rule\UnderscoreToCamelCasePropertyNameRector;
 use Redaxo\Rector\Rule\UnderscoreToCamelCaseVariableNameRector;
@@ -84,4 +90,22 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(UnderscoreToCamelCasePropertyNameRector::class);
     $rectorConfig->rule(UnderscoreToCamelCaseVariableNameRector::class);
     $rectorConfig->rule(UnnecessaryTernaryExpressionRector::class);
+
+    // Upgrade REDAXO 5 to 6
+    $rectorConfig->ruleWithConfiguration(RemoveFuncCallArgRector::class, [
+        new RemoveFuncCallArg('rex_getUrl', 3),
+    ]);
+    $rectorConfig->ruleWithConfiguration(ArgumentRemoverRector::class, [
+        new ArgumentRemover(rex_string::class, 'buildQuery', 1, null),
+        new ArgumentRemover(rex_url_provider_interface::class, 'getUrl', 1, null),
+        new ArgumentRemover(rex_url::class, 'frontendController', 1, null),
+        new ArgumentRemover(rex_url::class, 'backendController', 1, null),
+        new ArgumentRemover(rex_url::class, 'backendPage', 2, null),
+        new ArgumentRemover(rex_url::class, 'currentBackendPage', 1, null),
+        new ArgumentRemover(rex_form_base::class, 'getUrl', 1, null),
+        new ArgumentRemover(rex_list::class, 'getUrl', 1, null),
+        new ArgumentRemover(rex_list::class, 'getParsedUrl', 1, null),
+        new ArgumentRemover(rex_structure_element::class, 'getUrl', 1, null),
+        new ArgumentRemover(rex_media_manager::class, 'getUrl', 3, null),
+    ]);
 };


### PR DESCRIPTION
Idee ist, während der Entwicklung von R6 direkt ein Rector-Ruleset mit zu entwickeln und es auch direkt zu nutzen für das Refactoring hier im Repo. So sieht man dann direkt, ob es funktioniert.

Es kann dann später auch für andere Addons und Projekte verwendet werden.

Würde die Rules erstmal direkt in unserer normalen `rector.php` aufnehmen. Später kann man es dann auslagern, sodass es leichter von anderen verwendet werden kann.