### PR TITLE
rex_form: Shortcut um Spellcheck/Autocorrect abzuschalten

### DIFF
--- a/redaxo/src/addons/media_manager/pages/types.php
+++ b/redaxo/src/addons/media_manager/pages/types.php
@@ -194,6 +194,7 @@ if ('' == $func) {
 
     $field = $form->addTextField('name');
     $field->setLabel(rex_i18n::msg('media_manager_type_name'));
+    $field->disableSpellcheckAndAutoCorrect();
     $field->getValidator()
         ->add(rex_validation_rule::NOT_EMPTY, rex_i18n::msg('media_manager_error_name'))
         ->add(rex_validation_rule::NOT_MATCH, rex_i18n::msg('media_manager_error_type_name_invalid'), '{[/\\\\]}')

--- a/redaxo/src/addons/metainfo/lib/table_expander.php
+++ b/redaxo/src/addons/metainfo/lib/table_expander.php
@@ -41,6 +41,7 @@ class rex_metainfo_table_expander extends rex_form
 
         $field = $this->addTextField('name');
         $field->setLabel(rex_i18n::msg('minfo_field_label_name'));
+        $field->disableSpellcheckAndAutoCorrect();
 
         $field = $this->addSelectField('priority');
         $field->setLabel(rex_i18n::msg('minfo_field_label_priority'));
@@ -108,17 +109,20 @@ class rex_metainfo_table_expander extends rex_form
         $field = $this->addTextAreaField('params');
         $field->setLabel(rex_i18n::msg('minfo_field_label_params'));
         $field->setNotice($notices);
+        $field->disableSpellcheckAndAutoCorrect();
 
         $field = $this->addTextAreaField('attributes');
         $field->setLabel(rex_i18n::msg('minfo_field_label_attributes'));
         $notice = rex_i18n::msg('minfo_field_attributes_notice') . "\n";
         $field->setNotice($notice);
+        $field->disableSpellcheckAndAutoCorrect();
 
         $field = $this->addTextAreaField('callback');
         $field->setLabel(rex_i18n::msg('minfo_field_label_callback'));
         $field->setAttribute('class', 'form-control rex-code rex-js-code');
         $notice = rex_i18n::msg('minfo_field_label_notice') . "\n";
         $field->setNotice($notice);
+        $field->disableSpellcheckAndAutoCorrect();
 
         $field = $this->addTextField('default');
         $field->setLabel(rex_i18n::msg('minfo_field_label_default'));

--- a/redaxo/src/addons/metainfo/package.yml
+++ b/redaxo/src/addons/metainfo/package.yml
@@ -17,7 +17,7 @@ page:
 
 requires:
     php: '>=8.1'
-    redaxo: ^5.16.0
+    redaxo: ^5.17.0-dev
     packages:
         structure: '^2.12.1'
         mediapool: '^2.10.1'

--- a/redaxo/src/core/lib/form/elements/element.php
+++ b/redaxo/src/core/lib/form/elements/element.php
@@ -290,6 +290,13 @@ class rex_form_element
         return isset($this->attributes[$name]);
     }
 
+    public function disableSpellcheckAndAutoCorrect(): void
+    {
+        $this->setAttribute('autocapitalize', 'off');
+        $this->setAttribute('autocorrect', 'off');
+        $this->setAttribute('spellcheck', 'false');
+    }
+
     public function isReadOnly(): bool
     {
         return str_contains((string) $this->getAttribute('class', ''), 'form-control-static');


### PR DESCRIPTION
refs https://github.com/redaxo/redaxo/issues/604

Ich denke, dass man die drei Attribute oftmals zusammen setzen will. Daher die Idee, dafür eine Shortcut-Methode einzuführen.