### PR TITLE
rex_http_exception: Bei 4xx-Fehler nicht loggen im Frontend + an weiteren Stellen nutzen

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2746,16 +2746,10 @@
   </file>
   <file src="redaxo/src/core/backend.php">
     <MixedArgument>
-      <code><![CDATA[$assetFile]]></code>
-      <code><![CDATA[$assetFile]]></code>
-      <code><![CDATA[$assetFile]]></code>
-      <code><![CDATA[$assetFile]]></code>
-      <code><![CDATA[$assetFile]]></code>
       <code><![CDATA[$userAgent]]></code>
       <code><![CDATA[$userAgent]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code><![CDATA[$assetFile]]></code>
       <code><![CDATA[$userAgent]]></code>
     </MixedAssignment>
     <PossiblyNullArgument>

--- a/redaxo/src/addons/structure/plugins/history/boot.php
+++ b/redaxo/src/addons/structure/plugins/history/boot.php
@@ -41,7 +41,7 @@ if ('' != $historyDate) {
     }
 
     if (!$user->hasPerm('history[article_rollback]')) {
-        throw new rex_http_exception(throw new rex_exception('no permission for the slice version'), rex_response::HTTP_FORBIDDEN);
+        throw new rex_http_exception(new rex_exception('no permission for the slice version'), rex_response::HTTP_FORBIDDEN);
     }
 
     rex_extension::register('ART_INIT', static function (rex_extension_point $ep) {

--- a/redaxo/src/addons/structure/plugins/history/boot.php
+++ b/redaxo/src/addons/structure/plugins/history/boot.php
@@ -37,11 +37,11 @@ if ('' != $historyDate) {
     }
 
     if (!$user) {
-        throw new rex_exception('no permission');
+        throw new rex_http_exception(new rex_exception('no permission'), rex_response::HTTP_UNAUTHORIZED);
     }
 
     if (!$user->hasPerm('history[article_rollback]')) {
-        throw new rex_exception('no permission for the slice version');
+        throw new rex_http_exception(throw new rex_exception('no permission for the slice version'), rex_response::HTTP_FORBIDDEN);
     }
 
     rex_extension::register('ART_INIT', static function (rex_extension_point $ep) {

--- a/redaxo/src/core/lib/api_function.php
+++ b/redaxo/src/core/lib/api_function.php
@@ -90,9 +90,9 @@ abstract class rex_api_function
                     self::$instance = $apiImpl;
                     return $apiImpl;
                 }
-                throw new rex_exception('$apiClass is expected to define a subclass of rex_api_function, "' . $apiClass . '" given!');
+                throw new rex_http_exception(new rex_exception('$apiClass is expected to define a subclass of rex_api_function, "' . $apiClass . '" given!'), rex_response::HTTP_NOT_FOUND);
             }
-            throw new rex_exception('$apiClass "' . $apiClass . '" not found!');
+            throw new rex_http_exception(new rex_exception('$apiClass "' . $apiClass . '" not found!'), rex_response::HTTP_NOT_FOUND);
         }
 
         return null;

--- a/redaxo/src/core/lib/exception.php
+++ b/redaxo/src/core/lib/exception.php
@@ -91,6 +91,11 @@ class rex_http_exception extends rex_exception
     {
         return $this->httpCode;
     }
+
+    public function isClientError(): bool
+    {
+        return str_starts_with($this->httpCode, '4');
+    }
 }
 
 /**

--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -37,10 +37,20 @@ class rex_logger extends AbstractLogger
     {
         if ($exception instanceof ErrorException) {
             self::logError($exception->getSeverity(), $exception->getMessage(), $exception->getFile(), $exception->getLine(), $url);
-        } else {
-            $logger = self::factory();
-            $logger->log($exception::class, $exception->getMessage(), [], $exception->getFile(), $exception->getLine(), $url);
+
+            return;
         }
+
+        if ($exception instanceof rex_http_exception) {
+            if (!rex::isDebugMode() && $exception->isClientError() && (!($user = rex_backend_login::createUser()) || !$user->isAdmin())) {
+                return;
+            }
+
+            $exception = $exception->getPrevious(); // log original exception
+        }
+
+        $logger = self::factory();
+        $logger->log($exception::class, $exception->getMessage(), [], $exception->getFile(), $exception->getLine(), $url);
     }
 
     /**

--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -42,6 +42,8 @@ class rex_logger extends AbstractLogger
         }
 
         if ($exception instanceof rex_http_exception) {
+            // Client errors should not be logged to system error log (if not debug mode or backend admin).
+            // This prevents that external website visitors can fill up the log (and possibly trigger error emails etc.).
             if (!rex::isDebugMode() && $exception->isClientError() && (!($user = rex_backend_login::createUser()) || !$user->isAdmin())) {
                 return;
             }

--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -46,7 +46,7 @@ class rex_logger extends AbstractLogger
                 return;
             }
 
-            $exception = $exception->getPrevious(); // log original exception
+            $exception = $exception->getPrevious() ?? $exception; // log original exception
         }
 
         $logger = self::factory();


### PR DESCRIPTION
@dergel ist aufgefallen, was auch in #1950 beschrieben ist, dass man von außen das normale Fehlerlog zumüllen kann, indem man nicht existierende Api-Functions aufruft.

Dies wollen wir mit diesem PR verhindern (und auch noch weitere ähnliche Stellen).

Daher wird bei `rex_http_exception` bei Client-Errors (4xx Statuscode) nur noch ins Fehlerlog geschrieben, wenn Debug-Mode aktiv oder man als Backend-Admin eingeloggt ist.
Und es wird `rex_http_exception` an weiteren Stellen ergänzt mit 4xx-Statuscode.

closes #1950