### PR TITLE
media_service: Count-Query ohne Order-By

### DIFF
--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -343,10 +343,10 @@ final class rex_media_service
         }
 
         if ($pager) {
-            $query .= ' GROUP BY m.filename ORDER BY ' . implode(', ', $orderbys);
             $sql->setQuery(str_replace('SELECT m.filename', 'SELECT count(*)', $query), $queryParams);
             $pager->setRowCount((int) $sql->getValue('count(*)'));
 
+            $query .= '  ORDER BY ' . implode(', ', $orderbys);
             $query .= ' LIMIT ' . $pager->getCursor() . ',' . $pager->getRowsPerPage();
         }
 

--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -343,7 +343,7 @@ final class rex_media_service
         }
 
         if ($pager) {
-            $query .= ' ORDER BY ' . implode(', ', $orderbys);
+            $query .= ' GROUP BY m.filename ORDER BY ' . implode(', ', $orderbys);
             $sql->setQuery(str_replace('SELECT m.filename', 'SELECT count(*)', $query), $queryParams);
             $pager->setRowCount((int) $sql->getValue('count(*)'));
 

--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -346,7 +346,7 @@ final class rex_media_service
             $sql->setQuery(str_replace('SELECT m.filename', 'SELECT count(*)', $query), $queryParams);
             $pager->setRowCount((int) $sql->getValue('count(*)'));
 
-            $query .= '  ORDER BY ' . implode(', ', $orderbys);
+            $query .= ' ORDER BY ' . implode(', ', $orderbys);
             $query .= ' LIMIT ' . $pager->getCursor() . ',' . $pager->getRowsPerPage();
         }
 


### PR DESCRIPTION
Erhielt unter 6.x diesen Fehler:

```
rex_sql_exception | Error while executing statement "SELECT count(*) FROM rex_media AS m  WHERE (m.category_id = :search_1) ORDER BY m.updatedate DESC" using params {"search_1":0}! SQLSTATE[42000]: Syntax error or access violation: 1140 Mixing of GROUP columns (MIN(),MAX(),COUNT(),...) with no GROUP columns is illegal if there is no GROUP BY clause | src/Database/Sql.php | 444 | https://redaxo.localhost/redaxo/index.php?page=mediapool/media&opener_input_field=
```
