### PR TITLE
rex_type::cast: Explizite Angabe der möglichen Werte möglich

### DIFF
--- a/redaxo/src/core/lib/request.php
+++ b/redaxo/src/core/lib/request.php
@@ -211,6 +211,10 @@ class rex_request
         }
 
         if (array_key_exists($needle, $haystack)) {
+            if (is_array($vartype) && '' !== $default && is_scalar($vartype[0] ?? null) && $vartype[0] !== $default) {
+                array_unshift($vartype, $default);
+            }
+
             return rex_type::cast($haystack[$needle], $vartype);
         }
 

--- a/redaxo/src/core/lib/util/type.php
+++ b/redaxo/src/core/lib/util/type.php
@@ -24,14 +24,15 @@ class rex_type
      *  - 'array[<type>]', e.g. 'array[int]'
      *  - '' (don't cast)
      *  - a callable
-     *  - array(
-     *      array(<key>, <vartype>, <default>),
-     *      array(<key>, <vartype>, <default>),
+     *  - ['foo', 'bar', 'baz'] (cast to ony of the given values)
+     *  - [
+     *      [<key>, <vartype>, <default>],
+     *      [<key>, <vartype>, <default>],
      *      ...
-     *    )
+     *    ]
      *
      * @param mixed $var Variable to cast
-     * @param string|callable(mixed):mixed|list<array{0: string, 1: string|callable(mixed):mixed|list<mixed>, 2?: mixed}> $vartype Variable type
+     * @param string|callable(mixed):mixed|list<int|string|null>|list<array{0: string, 1: string|callable(mixed):mixed|list<mixed>, 2?: mixed}> $vartype Variable type
      *
      * @throws InvalidArgumentException
      *
@@ -112,8 +113,33 @@ class rex_type
         if (is_string($vartype)) {
             throw new InvalidArgumentException('Unexpected vartype "' . $vartype . '" in cast()!');
         }
-        if (!is_array($vartype)) {
+        if (!is_array($vartype) || [] === $vartype) {
             throw new InvalidArgumentException('Unexpected vartype in cast()!');
+        }
+
+        $oneOf = false;
+        $shape = false;
+        foreach ($vartype as $cast) {
+            if (is_array($cast)) {
+                $shape = true;
+            } elseif (is_scalar($cast) || null === $cast) {
+                $oneOf = true;
+            } else {
+                throw new InvalidArgumentException('Unexpected vartype in cast()!');
+            }
+        }
+        if ($oneOf && $shape) {
+            throw new InvalidArgumentException('Unexpected vartype in cast()!');
+        }
+
+        if ($oneOf) {
+            foreach ($vartype as $cast) {
+                $castedVar = null === $cast ? $var : self::cast($var, gettype($cast));
+                if ($castedVar === $cast) {
+                    return $cast;
+                }
+            }
+            return $vartype[array_key_first($vartype)];
         }
 
         $var = self::cast($var, 'array');
@@ -125,9 +151,14 @@ class rex_type
 
             $key = $cast[0];
             $innerVartype = $cast[1] ?? '';
+            $default = array_key_exists(2, $cast) ? $cast[2] : '';
             if (array_key_exists($key, $var)) {
+                if (is_array($innerVartype) && '' !== $default && is_scalar($innerVartype[0] ?? null) && $innerVartype[0] !== $default) {
+                    array_unshift($innerVartype, $default);
+                }
+
                 $newVar[$key] = self::cast($var[$key], $innerVartype);
-            } elseif (!isset($cast[2])) {
+            } elseif ('' === $default) {
                 $newVar[$key] = self::cast('', $innerVartype);
             } else {
                 $newVar[$key] = $cast[2];

--- a/redaxo/src/core/tests/request_test.php
+++ b/redaxo/src/core/tests/request_test.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class rex_request_test extends TestCase
+{
+    #[DataProvider('dataArrayKeyCast')]
+    public function testArrayKeyCast(mixed $expected, mixed $value, mixed $vartype, mixed $default = ''): void
+    {
+        $method = new ReflectionMethod(rex_request::class, 'arrayKeyCast');
+
+        $haystack = null === $value ? [] : ['varname' => $value];
+
+        self::assertSame($expected, $method->invoke(null, $haystack, 'varname', $vartype, $default));
+    }
+
+    /** @return list<array{0: mixed, 1: mixed, 2: mixed, 3?: mixed}> */
+    public static function dataArrayKeyCast(): array
+    {
+        return [
+            [0, null, 'int'],
+            [null, null, 'int', null],
+            ['foo', null, 'int', 'foo'],
+            ['foo', 'foo', 'string', 'bar'],
+            ['', ['foo', 'bar'], 'string', 'qux'], // https://github.com/redaxo/redaxo/issues/2900
+            ['foo', 'x', ['foo', 'bar']],
+            ['baz', 'x', ['foo', 'bar'], 'baz'],
+            [null, 'x', ['foo', 'bar'], null],
+        ];
+    }
+}

--- a/redaxo/src/core/tests/util/type_test.php
+++ b/redaxo/src/core/tests/util/type_test.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
  */
 class rex_type_test extends TestCase
 {
-    /** @return list<array{mixed, string|callable(mixed):mixed|list<array{0: string, 1: string|callable(mixed):mixed|list<mixed>, 2?: mixed}>, mixed}> */
+    /** @return list<array{mixed, string|callable(mixed):mixed|list<int|string>|list<array{0: string, 1: string|callable(mixed):mixed|list<mixed>, 2?: mixed}>, mixed}> */
     public static function castProvider(): array
     {
         $callback = static function ($var) {
@@ -35,16 +35,29 @@ class rex_type_test extends TestCase
             [1, 'array', [1]],
             [[1, '2'], 'array[int]', [1, 2]],
             ['a', $callback, 'ab'],
+            ['bar', ['foo', 'bar', 'baz'], 'bar'],
+            ['qux', ['foo', 'bar', 'baz'], 'foo'],
+            [2, [1, 2, 4], 2],
+            [3, [1, 2, 4], 1],
             [$arrayVar, $arrayCasts, $arrayExpected],
             [
                 ['k' => $arrayVar],
                 [['k', $arrayCasts]],
                 ['k' => $arrayExpected],
             ],
+            [
+                ['key1' => 'bar', 'key3' => 'qux'],
+                [
+                    ['key1', ['foo', 'bar', 'baz']],
+                    ['key2', ['foo', 'bar', 'baz']],
+                    ['key3', ['foo', 'bar'], 'baz'],
+                ],
+                ['key1' => 'bar', 'key2' => 'foo', 'key3' => 'baz'],
+            ],
         ];
     }
 
-    /** @param string|callable(mixed):mixed|list<array{0: string, 1: string|callable(mixed):mixed|list<mixed>, 2?: mixed}> $vartype */
+    /** @param string|callable(mixed):mixed|list<int|string>|list<array{0: string, 1: string|callable(mixed):mixed|list<mixed>, 2?: mixed}> $vartype */
     #[DataProvider('castProvider')]
     public function testCast(mixed $var, string|callable|array $vartype, mixed $expectedResult): void
     {
@@ -60,7 +73,8 @@ class rex_type_test extends TestCase
             [false],
             ['array['],
             ['array[abc]'],
-            [[1]],
+            [[]],
+            [[1, ['foo', 'bool']]],
             [new stdClass()],
         ];
     }


### PR DESCRIPTION
closes #5848

Bei `rex_get()`, `rex_post()` etc. ist es neu möglich, explizit die möglichen Werte anzugeben:

```php
$value = rex_get('mykey', ['foo', 'bar', 'baz']);
```

- `$value` ist danach definitiv einer der drei Werte. 
- Wenn mykey nicht gesetzt ist, oder einen anderen Wert enthält, dann wird `$value` den ersten Wert aus dem Array erhalten (also `'foo'`). Das ist konsistent zu dem Verhalten bei anderen Cast-Typen.
- Optional kann aber auch ein anderer Default-Wert angegeben werden (der nicht im Array sein muss), z.b. `null`:
  ```php
  $value = rex_get('mykey', ['foo', 'bar', 'baz'], null);
  ```
- Es können auch Int-Werte im Array sein:
  ```php
  $value = rex_get('mykey', [10, 20, 50, 100]);
  ```