### PR TITLE
Codemirror wurde in Moduleingabe nicht ausgelöst

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
@@ -244,7 +244,7 @@ if ('add' == $function || 'edit' == $function) {
 
         $n = [];
         $n['label'] = '<label for="minput">' . rex_i18n::msg('input') . '</label>';
-        $n['field'] = '<textarea class="form-control rex-code2 rex-js-code2" id="minput" name="eingabe" autocapitalize="off" autocorrect="off" spellcheck="false">' . rex_escape($eingabe) . '</textarea>';
+        $n['field'] = '<textarea class="form-control rex-code rex-js-code" id="minput" name="eingabe" autocapitalize="off" autocorrect="off" spellcheck="false">' . rex_escape($eingabe) . '</textarea>';
         $formElements[] = $n;
 
         $n = [];


### PR DESCRIPTION
fixes: https://github.com/redaxo/redaxo/issues/6035