### PR TITLE
be_style/redaxo: Bei update/reinstall alte Login-Bilder löschen

### DIFF
--- a/redaxo/src/addons/be_style/plugins/redaxo/install.php
+++ b/redaxo/src/addons/be_style/plugins/redaxo/install.php
@@ -1,0 +1,9 @@
+<?php
+
+// remove old login background images
+$files = glob(rex_path::pluginAssets('be_style', 'redaxo', 'images/*-unsplash*')) ?: [];
+foreach ($files as $file) {
+    if (!is_file(rex_path::plugin('be_style', 'redaxo', 'assets/images/' . rex_path::basename($file)))) {
+        rex_file::delete($file);
+    }
+}


### PR DESCRIPTION
Bei Core-Update verschwanden die alten Bilder zwar aus dem Plugin-Ordner, aber im Root-assets-Ordner blieben sie erhalten.
Beim Assets-Kopieren werden keine Dateien gelöscht. Nur ergänzt oder überschrieben.

Daher nun explizit im Plugin gelöst, sodass sich im Assets-Ordner nicht immer mehr Bilder ansammeln von Update zu Update.