### PR TITLE
Core-Klasse und Addon-Klassen optimiert bzgl. Typen etc.

### DIFF
--- a/.tools/bin/release
+++ b/.tools/bin/release
@@ -64,7 +64,7 @@ class rex_release
         };
 
         foreach (self::$addons as $addon) {
-            $addon = rex_addon::get($addon);
+            $addon = rex_addon::require($addon);
             $updateVersion($addon);
         }
     }

--- a/.tools/phpstan/baseline.neon
+++ b/.tools/phpstan/baseline.neon
@@ -151,16 +151,6 @@ parameters:
 			path: ../../redaxo/src/core/functions/function_structure_rex_url.php
 
 		-
-			message: "#^Method rex_be_controller\\:\\:includeCurrentPageSubPath\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/be/controller.php
-
-		-
-			message: "#^Method rex_be_controller\\:\\:includePath\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/be/controller.php
-
-		-
 			message: "#^Method rex_be_controller\\:\\:pageAddProperties\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/be/controller.php
@@ -846,29 +836,9 @@ parameters:
 			path: ../../redaxo/src/core/lib/metainfo/input/mediabutton.php
 
 		-
-			message: "#^Method rex_addon\\:\\:includeFile\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			message: "#^Call to static method Redaxo\\\\Core\\\\Util\\\\Type\\:\\:string\\(\\) on a separate line has no effect\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/lib/packages/addon.php
-
-		-
-			message: "#^Property rex_addon\\:\\:\\$properties type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/packages/addon.php
-
-		-
-			message: "#^Method rex_addon_interface\\:\\:includeFile\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/packages/interface.php
-
-		-
-			message: "#^Negated boolean expression is always true\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/packages/manager.php
-
-		-
-			message: "#^Method rex_null_addon\\:\\:includeFile\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../redaxo/src/core/lib/packages/null.php
 
 		-
 			message: "#^Property rex_mailer\\:\\:\\$xHeader type has no value type specified in iterable type array\\.$#"
@@ -1569,6 +1539,11 @@ parameters:
 			message: "#^Static property rex_test_instance_pool_base\\:\\:\\$instances \\(array\\<class\\-string, array\\<string, static\\(rex_test_instance_pool_base\\)\\|null\\>\\>\\) does not accept array\\<class\\-string, array\\<string, rex_test_instance_pool_base\\|null\\>\\>\\.$#"
 			count: 1
 			path: ../../redaxo/src/core/tests/base/instance_pool_trait_test.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with arguments 'rex_test_singleton', rex_test_singleton and 'instance of the…' will always evaluate to true\\.$#"
+			count: 1
+			path: ../../redaxo/src/core/tests/base/singleton_trait_test.php
 
 		-
 			message: "#^Parameter \\#1 \\$extensionPoint of static method rex_extension\\:\\:registerPoint\\(\\) expects rex_extension_point\\<string\\|null\\>, rex_extension_point\\<string\\|null\\> given\\.$#"

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -973,7 +973,6 @@
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$buttonTitle]]></code>
-      <code><![CDATA[$buttonTitle]]></code>
       <code><![CDATA[rex_escape($argValue)]]></code>
       <code><![CDATA[rex_escape($ftitle)]]></code>
     </MixedOperand>
@@ -1031,6 +1030,7 @@
   </file>
   <file src="redaxo/src/core/lib/base/singleton_trait.php">
     <PropertyTypeCoercion>
+      <code><![CDATA[self::$instances]]></code>
       <code><![CDATA[self::$instances]]></code>
     </PropertyTypeCoercion>
   </file>
@@ -2376,12 +2376,7 @@
     </PossiblyNullOperand>
   </file>
   <file src="redaxo/src/core/lib/packages/addon.php">
-    <InvalidScalarArgument>
-      <code><![CDATA[$args]]></code>
-    </InvalidScalarArgument>
     <MixedArgument>
-      <code><![CDATA[$args]]></code>
-      <code><![CDATA[$args]]></code>
       <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedAssignment>
@@ -2397,13 +2392,15 @@
       <code><![CDATA[$packages]]></code>
     </LessSpecificReturnStatement>
     <MixedArgument>
-      <code><![CDATA[$args]]></code>
       <code><![CDATA[$instmsg]]></code>
       <code><![CDATA[$instmsg]]></code>
       <code><![CDATA[$key]]></code>
       <code><![CDATA[$packageId]]></code>
       <code><![CDATA[$requirements['packages'][$packageId]]]></code>
+      <code><![CDATA[$requirements['packages'][$packageId]]]></code>
       <code><![CDATA[$requirements['php']['version']]]></code>
+      <code><![CDATA[$requirements['php']['version']]]></code>
+      <code><![CDATA[$requirements['redaxo']]]></code>
       <code><![CDATA[$requirements['redaxo']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
@@ -2412,6 +2409,7 @@
       <code><![CDATA[$packageId]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
+      <code><![CDATA[$conflicts['packages']]]></code>
       <code><![CDATA[$conflicts['packages']]]></code>
       <code><![CDATA[$conflicts['packages'][$packageId]]]></code>
       <code><![CDATA[$conflicts['packages'][$this->package->getPackageId()]]]></code>
@@ -2431,6 +2429,7 @@
     <MixedAssignment>
       <code><![CDATA[$conflicts]]></code>
       <code><![CDATA[$conflicts]]></code>
+      <code><![CDATA[$conflicts]]></code>
       <code><![CDATA[$constraints]]></code>
       <code><![CDATA[$key]]></code>
       <code><![CDATA[$load]]></code>
@@ -2447,20 +2446,19 @@
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedOperand>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
       <code><![CDATA[$requirements['packages'][$packageId]]]></code>
       <code><![CDATA[$successMessage]]></code>
     </MixedOperand>
     <MoreSpecificReturnType>
       <code><![CDATA[list<non-empty-string>]]></code>
     </MoreSpecificReturnType>
+    <PossiblyNullArgument>
+      <code><![CDATA[$package->getPackageId()]]></code>
+      <code><![CDATA[$package->getPackageId()]]></code>
+      <code><![CDATA[$package->getPackageId()]]></code>
+    </PossiblyNullArgument>
   </file>
   <file src="redaxo/src/core/lib/packages/null.php">
-    <MixedArgument>
-      <code><![CDATA[$args]]></code>
-      <code><![CDATA[$args]]></code>
-    </MixedArgument>
     <MixedReturnStatement>
       <code><![CDATA[$default]]></code>
     </MixedReturnStatement>
@@ -3652,16 +3650,6 @@
       <code><![CDATA[!is_string($metaTable)]]></code>
     </TypeDoesNotContainType>
   </file>
-  <file src="redaxo/src/core/pages/packages.details.php">
-    <PossiblyNullOperand>
-      <code><![CDATA[$packageId]]></code>
-    </PossiblyNullOperand>
-  </file>
-  <file src="redaxo/src/core/pages/packages.help.php">
-    <NullOperand>
-      <code><![CDATA[rex_escape($name)]]></code>
-    </NullOperand>
-  </file>
   <file src="redaxo/src/core/pages/packages.list.php">
     <MixedOperand>
       <code><![CDATA[$function]]></code>
@@ -4252,12 +4240,12 @@
       <code><![CDATA[$item]]></code>
       <code><![CDATA[$login]]></code>
       <code><![CDATA[$request]]></code>
-      <code><![CDATA[$value['throw_always_exception']]]></code>
       <code><![CDATA[self::$properties[$key]]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
+      <code><![CDATA[?rex_user]]></code>
       <code><![CDATA[Request]]></code>
-      <code><![CDATA[rex_user|null]]></code>
+      <code><![CDATA[int]]></code>
     </MixedInferredReturnType>
     <MixedMethodCall>
       <code><![CDATA[getImpersonator]]></code>
@@ -4269,6 +4257,7 @@
       <code><![CDATA[$login ? $login->getImpersonator() : null]]></code>
       <code><![CDATA[$login ? $login->getImpersonator() : null]]></code>
       <code><![CDATA[$request]]></code>
+      <code><![CDATA[$result | $item]]></code>
     </MixedReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[list<non-empty-string>]]></code>

--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -13,7 +13,7 @@ if (!rex_debug_clockwork::isRexDebugEnabled() || 'debug' === rex_get(rex_api_fun
 }
 
 if (Core::isBackend() && 'debug' === rex_request::get('page') && Core::getUser()?->isAdmin()) {
-    $index = file_get_contents(rex_addon::get('debug')->getAssetsPath('clockwork/index.html'));
+    $index = file_get_contents(rex_addon::require('debug')->getAssetsPath('clockwork/index.html'));
 
     $editor = Editor::factory();
     $curEditor = $editor->getName();
@@ -95,7 +95,7 @@ $shutdownFn = static function () {
 
     if (Core::isBackend()) {
         $req->controller = 'page: ' . rex_be_controller::getCurrentPage();
-    } elseif (rex_addon::get('structure')->isAvailable()) {
+    } else {
         $req->controller = 'article: ' . rex_article::getCurrentId() . '; clang: ' . rex_clang::getCurrent()->getCode();
     }
 

--- a/redaxo/src/addons/debug/install.php
+++ b/redaxo/src/addons/debug/install.php
@@ -3,7 +3,7 @@
 use Redaxo\Core\Filesystem\Dir;
 use Redaxo\Core\Translation\I18n;
 
-$addon = rex_addon::get('debug');
+$addon = rex_addon::require('debug');
 
 // the filenames contain rev hashes and the old ones would never be cleaned up
 Dir::delete($addon->getAssetsPath());

--- a/redaxo/src/addons/debug/lib/debug_clockwork.php
+++ b/redaxo/src/addons/debug/lib/debug_clockwork.php
@@ -83,7 +83,7 @@ class rex_debug_clockwork
      */
     public static function getStoragePath()
     {
-        return rex_addon::get('debug')->getCachePath('clockwork.db');
+        return rex_addon::require('debug')->getCachePath('clockwork.db');
     }
 
     /**

--- a/redaxo/src/addons/debug/update.php
+++ b/redaxo/src/addons/debug/update.php
@@ -1,6 +1,6 @@
 <?php
 
-$addon = rex_addon::get('debug');
+$addon = rex_addon::require('debug');
 
 // use path relative to __DIR__ to get correct path in update temp dir
 $addon->includeFile(__DIR__ . '/install.php');

--- a/redaxo/src/addons/install/lib/api/api_core_update.php
+++ b/redaxo/src/addons/install/lib/api/api_core_update.php
@@ -300,6 +300,6 @@ class rex_api_install_core_update extends rex_api_function
 
     private function messageFromPackage(rex_addon $package, rex_addon_manager $manager): string
     {
-        return I18n::msg('install_warning_message_from_' . $package->getType(), $package->getPackageId()) . ' ' . $manager->getMessage();
+        return I18n::msg('install_warning_message_from_addon', $package->getPackageId()) . ' ' . $manager->getMessage();
     }
 }

--- a/redaxo/src/addons/install/lib/package/package_update.php
+++ b/redaxo/src/addons/install/lib/package/package_update.php
@@ -184,7 +184,7 @@ class rex_install_package_update extends rex_install_package_download
 
         if (empty($messages)) {
             foreach (rex_addon::getAvailableAddons() as $package) {
-                if ($package->getAddon() === $this->addon) {
+                if ($package === $this->addon) {
                     continue;
                 }
                 $manager = rex_addon_manager::factory($package);
@@ -210,6 +210,6 @@ class rex_install_package_update extends rex_install_package_download
 
     private function messageFromPackage(rex_addon $package, rex_addon_manager $manager): string
     {
-        return I18n::msg('install_warning_message_from_' . $package->getType(), $package->getPackageId()) . ' ' . $manager->getMessage();
+        return I18n::msg('install_warning_message_from_addon', $package->getPackageId()) . ' ' . $manager->getMessage();
     }
 }

--- a/redaxo/src/addons/install/lib/packages.php
+++ b/redaxo/src/addons/install/lib/packages.php
@@ -29,7 +29,7 @@ class rex_install_packages
 
         foreach (self::$updatePackages as $key => $addon) {
             if (rex_addon::exists($key) && isset($addon['files'])) {
-                self::unsetOlderVersions($key, rex_addon::get($key)->getVersion());
+                self::unsetOlderVersions($key, rex_addon::require($key)->getVersion());
             } else {
                 unset(self::$updatePackages[$key]);
             }

--- a/redaxo/src/addons/project/boot.php
+++ b/redaxo/src/addons/project/boot.php
@@ -1,6 +1,6 @@
 <?php
 
-$addon = rex_addon::get('project');
+$addon = rex_addon::require('project');
 
 // register a custom yrewrite scheme
 // rex_yrewrite::setScheme(new rex_project_rewrite_scheme());

--- a/redaxo/src/core/lib/base/singleton_trait.php
+++ b/redaxo/src/core/lib/base/singleton_trait.php
@@ -11,10 +11,8 @@ trait rex_singleton_trait
 
     /**
      * Returns the singleton instance.
-     *
-     * @return static
      */
-    public static function getInstance()
+    public static function getInstance(): static
     {
         $class = static::class;
         if (!isset(self::$instances[$class])) {

--- a/redaxo/src/core/lib/be/controller.php
+++ b/redaxo/src/core/lib/be/controller.php
@@ -611,6 +611,7 @@ class rex_be_controller
     /**
      * Includes the sub-path of current page.
      *
+     * @param array<string, mixed> $context
      * @return mixed
      */
     public static function includeCurrentPageSubPath(array $context = [])
@@ -646,11 +647,9 @@ class rex_be_controller
     /**
      * Includes a path in correct package context.
      *
-     * @param string $path
-     *
-     * @return mixed
+     * @param array<string, mixed> $context
      */
-    private static function includePath($path, array $context = [])
+    private static function includePath(string $path, array $context = []): mixed
     {
         return Timer::measure('Page: ' . Path::relative($path, Path::src()), function () use ($path, $context) {
             $pattern = '@' . preg_quote(Path::src('addons/'), '@') . '([^/\\\]+)@';

--- a/redaxo/src/core/lib/packages/api_package.php
+++ b/redaxo/src/core/lib/packages/api_package.php
@@ -6,9 +6,10 @@ use Redaxo\Core\Util\Type;
 /**
  * @internal
  */
-class rex_api_package extends rex_api_function
+final class rex_api_package extends rex_api_function
 {
-    public function execute()
+    #[Override]
+    public function execute(): rex_api_result
     {
         if (Core::isLiveMode()) {
             throw new rex_api_exception('Package management is not available in live mode!');
@@ -42,7 +43,8 @@ class rex_api_package extends rex_api_function
         return $result;
     }
 
-    protected function requiresCsrfProtection()
+    #[Override]
+    protected function requiresCsrfProtection(): true
     {
         return true;
     }

--- a/redaxo/src/core/lib/packages/ep_package_cache_deleted.php
+++ b/redaxo/src/core/lib/packages/ep_package_cache_deleted.php
@@ -5,7 +5,7 @@
  */
 final class rex_extension_point_package_cache_deleted extends rex_extension_point
 {
-    public const NAME = 'PACKAGE_CACHE_DELETED';
+    public const string NAME = 'PACKAGE_CACHE_DELETED';
 
     public function __construct(rex_addon $package)
     {

--- a/redaxo/src/core/lib/packages/interface.php
+++ b/redaxo/src/core/lib/packages/interface.php
@@ -7,68 +7,49 @@ interface rex_addon_interface
      *
      * @return non-empty-string Name
      */
-    public function getName();
-
-    /**
-     * Returns the related Addon.
-     *
-     * @return rex_addon_interface
-     */
-    public function getAddon();
+    public function getName(): string;
 
     /**
      * Returns the package ID.
      *
      * @return non-empty-string|null
      */
-    public function getPackageId();
-
-    /**
-     * Returns the package type as string.
-     *
-     * @return 'addon'
-     */
-    public function getType();
+    public function getPackageId(): ?string;
 
     /**
      * Returns the base path.
      *
-     * @param string $file File
      * @return non-empty-string
      */
-    public function getPath($file = '');
+    public function getPath(string $file = ''): string;
 
     /**
      * Returns the assets path.
      *
-     * @param string $file File
      * @return non-empty-string
      */
-    public function getAssetsPath($file = '');
+    public function getAssetsPath(string $file = ''): string;
 
     /**
      * Returns the assets url.
      *
-     * @param string $file File
      * @return non-empty-string
      */
-    public function getAssetsUrl($file = '');
+    public function getAssetsUrl(string $file = ''): string;
 
     /**
      * Returns the data path.
      *
-     * @param string $file File
      * @return non-empty-string
      */
-    public function getDataPath($file = '');
+    public function getDataPath(string $file = ''): string;
 
     /**
      * Returns the cache path.
      *
-     * @param string $file File
      * @return non-empty-string
      */
-    public function getCachePath($file = '');
+    public function getCachePath(string $file = ''): string;
 
     /**
      * @see rex_config::set()
@@ -134,59 +115,52 @@ interface rex_addon_interface
     /**
      * Returns if the package is available (activated and installed).
      *
-     * @return bool
+     * @psalm-assert-if-true =rex_addon $this
      */
-    public function isAvailable();
+    public function isAvailable(): bool;
 
     /**
      * Returns if the package is installed.
      *
-     * @return bool
+     * @psalm-assert-if-true =rex_addon $this
      */
-    public function isInstalled();
+    public function isInstalled(): bool;
 
     /**
      * Returns if it is a system package.
      *
-     * @return bool
+     * @psalm-assert-if-true =rex_addon $this
      */
-    public function isSystemPackage();
+    public function isSystemPackage(): bool;
 
     /**
      * Returns the author.
      *
      * @param string|null $default Default value, will be returned if the property isn't set
-     *
-     * @return string|null
      */
-    public function getAuthor($default = null);
+    public function getAuthor(?string $default = null): ?string;
 
     /**
      * Returns the version.
      *
-     * @param string $format See {@link rex_formatter::version()}
-     *
-     * @return string
+     * @param string|null $format See {@link rex_formatter::version()}
      */
-    public function getVersion($format = null);
+    public function getVersion(?string $format = null): string;
 
     /**
      * Returns the supportpage.
      *
      * @param string|null $default Default value, will be returned if the property isn't set
-     *
-     * @return string|null
      */
-    public function getSupportPage($default = null);
+    public function getSupportPage(?string $default = null): ?string;
 
     /**
      * Includes a file in the package context.
      *
      * @param non-empty-string $file Filename
-     * @param array $context Context values, available as variables in given file
-     * @return mixed
+     * @param array<string, mixed> $context Context values, available as variables in given file
      */
-    public function includeFile($file, array $context = []);
+    public function includeFile(string $file, array $context = []): mixed;
 
     /**
      * Adds the package prefix to the given key and returns the translation for it.
@@ -196,5 +170,5 @@ interface rex_addon_interface
      *
      * @return non-empty-string Translation for the key
      */
-    public function i18n($key, ...$replacements);
+    public function i18n(string $key, string|int ...$replacements): string;
 }

--- a/redaxo/src/core/lib/packages/null.php
+++ b/redaxo/src/core/lib/packages/null.php
@@ -10,130 +10,139 @@ use Redaxo\Core\Translation\I18n;
  * Other methods should not be called on null-addons since they do not return useful values.
  * Some methods like `getPath()` throw exceptions.
  */
-class rex_null_addon implements rex_addon_interface
+final class rex_null_addon implements rex_addon_interface
 {
     use rex_singleton_trait;
 
-    public function getName()
+    #[Override]
+    public function getName(): string
     {
-        return static::class;
+        return self::class;
     }
 
-    /**
-     * @return rex_null_addon
-     */
-    public function getAddon()
-    {
-        return self::getInstance();
-    }
-
-    public function getPackageId()
+    #[Override]
+    public function getPackageId(): null
     {
         return null;
     }
 
-    public function getType()
-    {
-        return 'addon';
-    }
-
-    public function getPath($file = '')
+    #[Override]
+    public function getPath(string $file = ''): never
     {
         throw new rex_exception(sprintf('Calling %s on %s is not allowed', __FUNCTION__, self::class));
     }
 
-    public function getAssetsPath($file = '')
+    #[Override]
+    public function getAssetsPath(string $file = ''): never
     {
         throw new rex_exception(sprintf('Calling %s on %s is not allowed', __FUNCTION__, self::class));
     }
 
-    public function getAssetsUrl($file = '')
+    #[Override]
+    public function getAssetsUrl(string $file = ''): never
     {
         throw new rex_exception(sprintf('Calling %s on %s is not allowed', __FUNCTION__, self::class));
     }
 
-    public function getDataPath($file = '')
+    #[Override]
+    public function getDataPath(string $file = ''): never
     {
         throw new rex_exception(sprintf('Calling %s on %s is not allowed', __FUNCTION__, self::class));
     }
 
-    public function getCachePath($file = '')
+    #[Override]
+    public function getCachePath(string $file = ''): never
     {
         throw new rex_exception(sprintf('Calling %s on %s is not allowed', __FUNCTION__, self::class));
     }
 
-    public function setConfig(string|array $key, mixed $value = null): bool
+    #[Override]
+    public function setConfig(string|array $key, mixed $value = null): false
     {
         return false;
     }
 
+    #[Override]
     public function getConfig(?string $key = null, mixed $default = null): mixed
     {
         return $default;
     }
 
-    public function hasConfig(?string $key = null): bool
+    #[Override]
+    public function hasConfig(?string $key = null): false
     {
         return false;
     }
 
-    public function removeConfig(string $key): bool
+    #[Override]
+    public function removeConfig(string $key): false
     {
         return false;
     }
 
+    #[Override]
     public function setProperty(string $key, mixed $value): void {}
 
+    #[Override]
     public function getProperty(string $key, mixed $default = null): mixed
     {
         return $default;
     }
 
-    public function hasProperty(string $key): bool
+    #[Override]
+    public function hasProperty(string $key): false
     {
         return false;
     }
 
+    #[Override]
     public function removeProperty(string $key): void {}
 
-    public function isAvailable()
+    #[Override]
+    public function isAvailable(): false
     {
         return false;
     }
 
-    public function isInstalled()
+    #[Override]
+    public function isInstalled(): false
     {
         return false;
     }
 
-    public function isSystemPackage()
+    #[Override]
+    public function isSystemPackage(): false
     {
         return false;
     }
 
-    public function getAuthor($default = null)
+    #[Override]
+    public function getAuthor(?string $default = null): ?string
     {
         return $default;
     }
 
-    public function getVersion($format = null)
+    #[Override]
+    public function getVersion(?string $format = null): string
     {
         return '';
     }
 
-    public function getSupportPage($default = null)
+    #[Override]
+    public function getSupportPage(?string $default = null): ?string
     {
         return $default;
     }
 
-    public function includeFile($file, array $context = [])
+    #[Override]
+    public function includeFile(string $file, array $context = []): null
     {
         return null;
     }
 
-    public function i18n($key, ...$replacements)
+    #[Override]
+    public function i18n(string $key, string|int ...$replacements): string
     {
-        $args = func_get_args();
-        return call_user_func_array(I18n::msg(...), $args);
+        return I18n::msg($key, ...$replacements);
     }
 }

--- a/redaxo/src/core/pages/credits.php
+++ b/redaxo/src/core/pages/credits.php
@@ -109,8 +109,8 @@ foreach (rex_addon::getAvailableAddons() as $package) {
     }
 
     $content .= '
-            <tr class="rex-package-is-' . $package->getType() . '">
-                <td class="rex-table-icon"><i class="rex-icon rex-icon-package-' . $package->getType() . '"></i></td>
+            <tr class="rex-package-is-addon">
+                <td class="rex-table-icon"><i class="rex-icon rex-icon-package-addon"></i></td>
                 <td data-title="' . I18n::msg('credits_name') . '">' . $package->getName() . ' </td>
                 <td data-title="' . I18n::msg('credits_version') . '">' . $packageVersion . '</td>
                 <td class="rex-table-slimmer" data-title="' . I18n::msg('credits_help') . '">

--- a/redaxo/src/core/pages/packages.changelog.php
+++ b/redaxo/src/core/pages/packages.changelog.php
@@ -7,7 +7,7 @@ use Redaxo\Core\Util\Markdown;
 
 $content = '';
 
-$package = rex_addon::get(rex_request('package', 'string'));
+$package = rex_addon::require(rex_request('package', 'string'));
 
 if (is_readable($package->getPath('CHANGELOG.md'))) {
     [$readmeToc, $readmeContent] = Markdown::factory()->parseWithToc(File::require($package->getPath('CHANGELOG.md')), 1, 2, [

--- a/redaxo/src/core/pages/packages.details.php
+++ b/redaxo/src/core/pages/packages.details.php
@@ -3,7 +3,7 @@
 use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\Translation\I18n;
 
-$package = rex_addon::get(rex_request('package', 'string'));
+$package = rex_addon::require(rex_request('package', 'string'));
 $subPage = rex_request('subpage', 'string');
 $packageId = $package->getPackageId();
 

--- a/redaxo/src/core/pages/packages.help.php
+++ b/redaxo/src/core/pages/packages.help.php
@@ -7,7 +7,7 @@ use Redaxo\Core\Util\Markdown;
 
 $content = '';
 
-$package = rex_addon::get(rex_request('package', 'string'));
+$package = rex_addon::require(rex_request('package', 'string'));
 $name = $package->getPackageId();
 $version = $package->getVersion();
 $author = $package->getAuthor();

--- a/redaxo/src/core/pages/packages.license.php
+++ b/redaxo/src/core/pages/packages.license.php
@@ -4,7 +4,7 @@ use Redaxo\Core\Filesystem\File;
 use Redaxo\Core\Translation\I18n;
 use Redaxo\Core\Util\Markdown;
 
-$package = rex_addon::get(rex_request('package', 'string'));
+$package = rex_addon::require(rex_request('package', 'string'));
 
 $license = null;
 if (is_readable($package->getPath('LICENSE.md'))) {

--- a/redaxo/src/core/pages/packages.list.php
+++ b/redaxo/src/core/pages/packages.list.php
@@ -34,7 +34,7 @@ $content = '
 $getLink = static function (rex_addon $package, $function, $icon = '', $confirm = false, $key = null) {
     $onclick = '';
     if ($confirm) {
-        $onclick = ' data-confirm="' . I18n::msg($package->getType() . '_' . $function . '_question', $package->getName()) . '"';
+        $onclick = ' data-confirm="' . I18n::msg('addon_' . $function . '_question', $package->getName()) . '"';
     }
     $text = I18n::msg('package_' . ($key ?: $function));
     $url = Url::currentBackendPage([
@@ -48,9 +48,8 @@ $getLink = static function (rex_addon $package, $function, $icon = '', $confirm 
 
 $getTableRow = static function (rex_addon $package) use ($getLink) {
     $packageId = $package->getPackageId();
-    $type = $package->getType();
 
-    $delete = $package->isSystemPackage() ? '<small class="text-muted">' . I18n::msg($type . '_system' . $type) . '</small>' : $getLink($package, 'delete', 'rex-icon-package-delete', true);
+    $delete = $package->isSystemPackage() ? '<small class="text-muted">' . I18n::msg('addon_systemaddon') . '</small>' : $getLink($package, 'delete', 'rex-icon-package-delete', true);
 
     $uninstall = '&nbsp;';
     if ($package->isInstalled()) {
@@ -72,9 +71,9 @@ $getTableRow = static function (rex_addon $package) use ($getLink) {
     } else {
         $class .= ' rex-package-not-installed';
     }
-    $name = '<span class="rex-' . $type . '-name">' . rex_escape($package->getName()) . '</span>';
+    $name = '<span class="rex-addon-name">' . rex_escape($package->getName()) . '</span>';
 
-    $class .= $package->isSystemPackage() ? ' rex-system-' . $type : '';
+    $class .= $package->isSystemPackage() ? ' rex-system-addon' : '';
 
     // --------------------------------------------- API MESSAGES
     if (($package->getPackageId() == rex_get('package', 'string') && rex_api_function::hasMessage()) || ($package->getPackageId() == rex_get('mark', 'string'))) {
@@ -83,7 +82,7 @@ $getTableRow = static function (rex_addon $package) use ($getLink) {
 
     $version = '';
     if ('' !== trim($package->getVersion())) {
-        $version = ' <span class="rex-' . $type . '-version">' . trim($package->getVersion()) . '</span>';
+        $version = ' <span class="rex-addon-version">' . trim($package->getVersion()) . '</span>';
 
         if (Version::isUnstable($package->getVersion())) {
             $version = '<i class="rex-icon rex-icon-unstable-version" title="' . I18n::msg('unstable_version') . '"></i> ' . $version;
@@ -104,8 +103,8 @@ $getTableRow = static function (rex_addon $package) use ($getLink) {
     }
 
     return '
-                <tr id="package-' . rex_escape(Str::normalize($packageId, '-', '_')) . '" class="rex-package-is-' . $type . $class . '">
-                    <td class="rex-table-icon"><i class="rex-icon rex-icon-package-' . $type . '"></i></td>
+                <tr id="package-' . rex_escape(Str::normalize($packageId, '-', '_')) . '" class="rex-package-is-addon' . $class . '">
+                    <td class="rex-table-icon"><i class="rex-icon rex-icon-package-addon"></i></td>
                     <td data-title="' . I18n::msg('package_hname') . '">' . $name . '</td>
                     <td data-title="' . I18n::msg('package_hversion') . '">' . $version . '</td>
                     <td class="rex-table-slim" data-title="' . I18n::msg('package_hhelp') . '">

--- a/src/Core.php
+++ b/src/Core.php
@@ -27,16 +27,18 @@ use const PHP_SESSION_ACTIVE;
 /**
  * REX base class for core properties etc.
  */
-class Core
+final class Core
 {
-    public const CONFIG_NAMESPACE = 'core';
+    public const string CONFIG_NAMESPACE = 'core';
 
     /**
      * Array of properties.
      *
      * @var array<string, mixed>
      */
-    protected static $properties = [];
+    private static array $properties = [];
+
+    private function __construct() {}
 
     /**
      * @see rex_config::set()
@@ -110,7 +112,7 @@ class Core
                 if (!isset($value['throw_always_exception']) || !$value['throw_always_exception']) {
                     $value['throw_always_exception'] = false;
                 } elseif (is_array($value['throw_always_exception'])) {
-                    $value['throw_always_exception'] = array_reduce($value['throw_always_exception'], static function ($result, $item) {
+                    $value['throw_always_exception'] = array_reduce($value['throw_always_exception'], static function ($result, $item): int {
                         if (is_string($item)) {
                             // $item is string, e.g. "E_WARNING"
                             $item = constant($item);
@@ -220,30 +222,24 @@ class Core
 
     /**
      * Returns if the setup is active.
-     *
-     * @return bool
      */
-    public static function isSetup()
+    public static function isSetup(): bool
     {
         return rex_setup::isEnabled();
     }
 
     /**
      * Returns if the environment is the backend.
-     *
-     * @return bool
      */
-    public static function isBackend()
+    public static function isBackend(): bool
     {
         return (bool) self::getProperty('redaxo', false);
     }
 
     /**
      * Returns if the environment is the frontend.
-     *
-     * @return bool
      */
-    public static function isFrontend()
+    public static function isFrontend(): bool
     {
         if (self::getConsole()) {
             return false;
@@ -254,10 +250,9 @@ class Core
     /**
      * Returns the environment.
      *
-     * @return string
-     * @psalm-return 'console'|'backend'|'frontend'
+     * @return 'console'|'backend'|'frontend'
      */
-    public static function getEnvironment()
+    public static function getEnvironment(): string
     {
         if (self::getConsole()) {
             return 'console';
@@ -268,10 +263,8 @@ class Core
 
     /**
      * Returns if the debug mode is active.
-     *
-     * @return bool
      */
-    public static function isDebugMode()
+    public static function isDebugMode(): bool
     {
         if (self::isLiveMode()) {
             return false;
@@ -287,7 +280,7 @@ class Core
      *
      * @return array{enabled: bool, throw_always_exception: bool|int}
      */
-    public static function getDebugFlags()
+    public static function getDebugFlags(): array
     {
         $flags = self::getProperty('debug', []);
 
@@ -299,10 +292,8 @@ class Core
 
     /**
      * Returns if the safe mode is active.
-     *
-     * @return bool
      */
-    public static function isSafeMode()
+    public static function isSafeMode(): bool
     {
         if (!self::isBackend() || self::isLiveMode()) {
             return false;
@@ -331,7 +322,7 @@ class Core
      * @phpstandba-inference-placeholder 'rex_'
      * @psalm-taint-escape sql
      */
-    public static function getTablePrefix()
+    public static function getTablePrefix(): string
     {
         return self::getProperty('table_prefix');
     }
@@ -343,7 +334,7 @@ class Core
      *
      * @return non-empty-string
      */
-    public static function getTable($table)
+    public static function getTable(string $table): string
     {
         return self::getTablePrefix() . $table;
     }
@@ -356,17 +347,15 @@ class Core
      * @phpstandba-inference-placeholder 'tmp_'
      * @psalm-taint-escape sql
      */
-    public static function getTempPrefix()
+    public static function getTempPrefix(): string
     {
         return self::getProperty('temp_prefix');
     }
 
     /**
      * Returns the current user.
-     *
-     * @return rex_user|null
      */
-    public static function getUser()
+    public static function getUser(): ?rex_user
     {
         return self::getProperty('user');
     }
@@ -389,10 +378,8 @@ class Core
 
     /**
      * Returns the current impersonator user.
-     *
-     * @return rex_user|null
      */
-    public static function getImpersonator()
+    public static function getImpersonator(): ?rex_user
     {
         $login = self::$properties['login'] ?? null;
 
@@ -401,10 +388,8 @@ class Core
 
     /**
      * Returns the console application.
-     *
-     * @return rex_console_application|null
      */
-    public static function getConsole()
+    public static function getConsole(): ?rex_console_application
     {
         return self::getProperty('console', null);
     }
@@ -440,12 +425,8 @@ class Core
 
     /**
      * Returns the server URL.
-     *
-     * @param string|null $protocol
-     *
-     * @return string
      */
-    public static function getServer($protocol = null)
+    public static function getServer(?string $protocol = null): string
     {
         if (null === $protocol) {
             return self::getProperty('server');
@@ -456,20 +437,16 @@ class Core
 
     /**
      * Returns the server name.
-     *
-     * @return string
      */
-    public static function getServerName()
+    public static function getServerName(): string
     {
         return self::getProperty('servername');
     }
 
     /**
      * Returns the error email.
-     *
-     * @return string
      */
-    public static function getErrorEmail()
+    public static function getErrorEmail(): string
     {
         return self::getProperty('error_email');
     }
@@ -478,10 +455,8 @@ class Core
      * Returns the redaxo version.
      *
      * @param string $format See {@link rex_formatter::version()}
-     *
-     * @return string
      */
-    public static function getVersion($format = null)
+    public static function getVersion(?string $format = null): string
     {
         /** @psalm-taint-escape file */
         $version = self::getProperty('version');
@@ -514,10 +489,9 @@ class Core
      *
      * @param string $title Title
      * @param string $key Key for the accesskey
-     *
-     * @return string
+     * @return non-empty-string
      */
-    public static function getAccesskey($title, $key)
+    public static function getAccesskey(string $title, string $key): string
     {
         if (self::getProperty('use_accesskeys')) {
             $accesskeys = (array) self::getProperty('accesskeys', []);
@@ -531,20 +505,16 @@ class Core
 
     /**
      * Returns the file perm.
-     *
-     * @return int
      */
-    public static function getFilePerm()
+    public static function getFilePerm(): int
     {
         return (int) self::getProperty('fileperm', 0o664);
     }
 
     /**
      * Returns the dir perm.
-     *
-     * @return int
      */
-    public static function getDirPerm()
+    public static function getDirPerm(): int
     {
         return (int) self::getProperty('dirperm', 0o775);
     }


### PR DESCRIPTION
plus Entfernung der Methode `getAddon` und `getType`, die überflüssig sind aufgrund der Plugin-Abschaffung.