### PR TITLE
Exception-Messages nicht an User ausgeben

### DIFF
--- a/redaxo/src/addons/mediapool/pages/structure.php
+++ b/redaxo/src/addons/mediapool/pages/structure.php
@@ -20,36 +20,32 @@ $csrf = rex_csrf_token::factory('mediapool_structure');
 if ($PERMALL) {
     $editId = rex_request('edit_id', 'int');
 
-    try {
-        if (in_array($mediaMethod, ['edit_file_cat', 'delete_file_cat', 'add_file_cat'])) {
-            if (!$csrf->isValid()) {
-                $error = rex_i18n::msg('csrf_token_invalid');
-            } else {
-                if ('edit_file_cat' == $mediaMethod) {
-                    $catName = rex_request('cat_name', 'string');
-                    $data = ['name' => $catName];
-                    $success = rex_media_category_service::editCategory($editId, $data);
-                } elseif ('delete_file_cat' == $mediaMethod) {
-                    try {
-                        $success = rex_media_category_service::deleteCategory($editId);
-                    } catch (rex_functional_exception $e) {
-                        $error = $e->getMessage();
-                    }
-                } elseif ('add_file_cat' == $mediaMethod) {
-                    $parent = null;
-                    $parentId = rex_request('cat_id', 'int');
-                    if ($parentId) {
-                        $parent = rex_media_category::get($parentId);
-                    }
-                    $success = rex_media_category_service::addCategory(
-                        rex_request('catname', 'string'),
-                        $parent,
-                    );
+    if (in_array($mediaMethod, ['edit_file_cat', 'delete_file_cat', 'add_file_cat'])) {
+        if (!$csrf->isValid()) {
+            $error = rex_i18n::msg('csrf_token_invalid');
+        } else {
+            if ('edit_file_cat' == $mediaMethod) {
+                $catName = rex_request('cat_name', 'string');
+                $data = ['name' => $catName];
+                $success = rex_media_category_service::editCategory($editId, $data);
+            } elseif ('delete_file_cat' == $mediaMethod) {
+                try {
+                    $success = rex_media_category_service::deleteCategory($editId);
+                } catch (rex_functional_exception $e) {
+                    $error = $e->getMessage();
                 }
+            } elseif ('add_file_cat' == $mediaMethod) {
+                $parent = null;
+                $parentId = rex_request('cat_id', 'int');
+                if ($parentId) {
+                    $parent = rex_media_category::get($parentId);
+                }
+                $success = rex_media_category_service::addCategory(
+                    rex_request('catname', 'string'),
+                    $parent,
+                );
             }
         }
-    } catch (rex_sql_exception $e) {
-        $error = $e->getMessage();
     }
 
     $link = rex_url::currentBackendPage(array_merge($argUrl, ['cat_id' => '']));

--- a/redaxo/src/addons/structure/lib/service_article.php
+++ b/redaxo/src/addons/structure/lib/service_article.php
@@ -82,13 +82,9 @@ class rex_article_service
             $AART->addGlobalCreateFields($user);
             $AART->addGlobalUpdateFields($user);
 
-            try {
-                $AART->insert();
-                // ----- PRIOR
-                self::newArtPrio($data['category_id'], $key, 0, $data['priority']);
-            } catch (rex_sql_exception $e) {
-                throw new rex_api_exception($e->getMessage(), $e);
-            }
+            $AART->insert();
+            // ----- PRIOR
+            self::newArtPrio($data['category_id'], $key, 0, $data['priority']);
 
             rex_article_cache::delete($id, $key);
 
@@ -170,45 +166,41 @@ class rex_article_service
         $EA->setValue('priority', $data['priority']);
         $EA->addGlobalUpdateFields(self::getUser());
 
-        try {
-            $EA->update();
-            $message = rex_i18n::msg('article_updated');
+        $EA->update();
+        $message = rex_i18n::msg('article_updated');
 
-            // ----- PRIOR
-            $oldPrio = (int) $thisArt->getValue('priority');
+        // ----- PRIOR
+        $oldPrio = (int) $thisArt->getValue('priority');
 
-            if ($oldPrio != $data['priority']) {
-                rex_sql::factory()
-                    ->setTable(rex::getTable('article'))
-                    ->setWhere('id = :id AND clang_id != :clang', ['id' => $articleId, 'clang' => $clang])
-                    ->setValue('priority', $data['priority'])
-                    ->addGlobalUpdateFields(self::getUser())
-                    ->update();
+        if ($oldPrio != $data['priority']) {
+            rex_sql::factory()
+                ->setTable(rex::getTable('article'))
+                ->setWhere('id = :id AND clang_id != :clang', ['id' => $articleId, 'clang' => $clang])
+                ->setValue('priority', $data['priority'])
+                ->addGlobalUpdateFields(self::getUser())
+                ->update();
 
-                foreach (rex_clang::getAllIds() as $clangId) {
-                    self::newArtPrio($data['category_id'], $clangId, $data['priority'], $oldPrio);
-                }
+            foreach (rex_clang::getAllIds() as $clangId) {
+                self::newArtPrio($data['category_id'], $clangId, $data['priority'], $oldPrio);
             }
-
-            rex_article_cache::delete($articleId);
-
-            // ----- EXTENSION POINT
-            $message = rex_extension::registerPoint(new rex_extension_point('ART_UPDATED', $message, [
-                'id' => $articleId,
-                'article' => clone $EA,
-                'article_old' => clone $thisArt,
-                'status' => $thisArt->getValue('status'),
-                'name' => $data['name'],
-                'clang' => $clang,
-                'parent_id' => $data['category_id'],
-                'priority' => $data['priority'],
-                'path' => $data['path'],
-                'template_id' => $data['template_id'],
-                'data' => $data,
-            ]));
-        } catch (rex_sql_exception $e) {
-            throw new rex_api_exception($e->getMessage(), $e);
         }
+
+        rex_article_cache::delete($articleId);
+
+        // ----- EXTENSION POINT
+        $message = rex_extension::registerPoint(new rex_extension_point('ART_UPDATED', $message, [
+            'id' => $articleId,
+            'article' => clone $EA,
+            'article_old' => clone $thisArt,
+            'status' => $thisArt->getValue('status'),
+            'name' => $data['name'],
+            'clang' => $clang,
+            'parent_id' => $data['category_id'],
+            'priority' => $data['priority'],
+            'path' => $data['path'],
+            'template_id' => $data['template_id'],
+            'data' => $data,
+        ]));
 
         return $message;
     }
@@ -357,20 +349,16 @@ class rex_article_service
             $EA->setValue('status', $newstatus);
             $EA->addGlobalUpdateFields(self::getUser());
 
-            try {
-                $EA->update();
+            $EA->update();
 
-                rex_article_cache::delete($articleId, $clang);
+            rex_article_cache::delete($articleId, $clang);
 
-                // ----- EXTENSION POINT
-                rex_extension::registerPoint(new rex_extension_point('ART_STATUS', null, [
-                    'id' => $articleId,
-                    'clang' => $clang,
-                    'status' => $newstatus,
-                ]));
-            } catch (rex_sql_exception $e) {
-                throw new rex_api_exception($e->getMessage(), $e);
-            }
+            // ----- EXTENSION POINT
+            rex_extension::registerPoint(new rex_extension_point('ART_STATUS', null, [
+                'id' => $articleId,
+                'clang' => $clang,
+                'status' => $newstatus,
+            ]));
         } else {
             throw new rex_api_exception(rex_i18n::msg('no_such_category'));
         }

--- a/redaxo/src/addons/structure/lib/service_category.php
+++ b/redaxo/src/addons/structure/lib/service_category.php
@@ -108,35 +108,31 @@ class rex_category_service
             $AART->addGlobalUpdateFields($user);
             $AART->addGlobalCreateFields($user);
 
-            try {
-                $AART->insert();
+            $AART->insert();
 
-                // ----- PRIOR
-                if (isset($data['catpriority'])) {
-                    self::newCatPrio($categoryId, $key, 0, $data['catpriority']);
-                }
-
-                $message = rex_i18n::msg('category_added_and_startarticle_created');
-
-                rex_article_cache::delete($id, $key);
-
-                // ----- EXTENSION POINT
-                // Objekte clonen, damit diese nicht von der extension veraendert werden koennen
-                $message = rex_extension::registerPoint(new rex_extension_point('CAT_ADDED', $message, [
-                    'category' => clone $AART,
-                    'id' => $id,
-                    'parent_id' => $categoryId,
-                    'clang' => $key,
-                    'name' => $data['catname'],
-                    'priority' => $data['catpriority'],
-                    'path' => $path,
-                    'status' => $data['status'],
-                    'article' => clone $AART,
-                    'data' => $data,
-                ]));
-            } catch (rex_sql_exception $e) {
-                throw new rex_api_exception($e->getMessage(), $e);
+            // ----- PRIOR
+            if (isset($data['catpriority'])) {
+                self::newCatPrio($categoryId, $key, 0, $data['catpriority']);
             }
+
+            $message = rex_i18n::msg('category_added_and_startarticle_created');
+
+            rex_article_cache::delete($id, $key);
+
+            // ----- EXTENSION POINT
+            // Objekte clonen, damit diese nicht von der extension veraendert werden koennen
+            $message = rex_extension::registerPoint(new rex_extension_point('CAT_ADDED', $message, [
+                'category' => clone $AART,
+                'id' => $id,
+                'parent_id' => $categoryId,
+                'clang' => $key,
+                'name' => $data['catname'],
+                'priority' => $data['catpriority'],
+                'path' => $path,
+                'status' => $data['status'],
+                'article' => clone $AART,
+                'data' => $data,
+            ]));
         }
 
         return $message;
@@ -175,76 +171,72 @@ class rex_category_service
 
         $EKAT->addGlobalUpdateFields($user);
 
-        try {
-            $EKAT->update();
+        $EKAT->update();
 
-            // --- Kategorie Kindelemente updaten
-            if (isset($data['catname'])) {
-                $ArtSql = rex_sql::factory();
-                $ArtSql->setQuery('SELECT id FROM ' . rex::getTablePrefix() . 'article WHERE parent_id=? AND startarticle=0 AND clang_id=?', [$categoryId, $clang]);
+        // --- Kategorie Kindelemente updaten
+        if (isset($data['catname'])) {
+            $ArtSql = rex_sql::factory();
+            $ArtSql->setQuery('SELECT id FROM ' . rex::getTablePrefix() . 'article WHERE parent_id=? AND startarticle=0 AND clang_id=?', [$categoryId, $clang]);
 
-                $EART = rex_sql::factory();
-                for ($i = 0; $i < $ArtSql->getRows(); ++$i) {
-                    $EART->setTable(rex::getTablePrefix() . 'article');
-                    $EART->setWhere(['id' => $ArtSql->getValue('id'), 'startarticle' => '0', 'clang_id' => $clang]);
-                    $EART->setValue('catname', $data['catname']);
-                    $EART->addGlobalUpdateFields($user);
+            $EART = rex_sql::factory();
+            for ($i = 0; $i < $ArtSql->getRows(); ++$i) {
+                $EART->setTable(rex::getTablePrefix() . 'article');
+                $EART->setWhere(['id' => $ArtSql->getValue('id'), 'startarticle' => '0', 'clang_id' => $clang]);
+                $EART->setValue('catname', $data['catname']);
+                $EART->addGlobalUpdateFields($user);
 
-                    $EART->update();
-                    rex_article_cache::delete((int) $ArtSql->getValue('id'), $clang);
+                $EART->update();
+                rex_article_cache::delete((int) $ArtSql->getValue('id'), $clang);
 
-                    $ArtSql->next();
-                }
+                $ArtSql->next();
             }
-
-            // ----- PRIOR
-            if (isset($data['catpriority'])) {
-                $parentId = (int) $thisCat->getValue('parent_id');
-                $oldPrio = (int) $thisCat->getValue('catpriority');
-
-                if ($data['catpriority'] <= 0) {
-                    $data['catpriority'] = 1;
-                }
-
-                if ($oldPrio != $data['catpriority']) {
-                    rex_sql::factory()
-                        ->setTable(rex::getTable('article'))
-                        ->setWhere('id = :id AND clang_id != :clang', ['id' => $categoryId, 'clang' => $clang])
-                        ->setValue('catpriority', $data['catpriority'])
-                        ->addGlobalUpdateFields($user)
-                        ->update();
-
-                    foreach (rex_clang::getAllIds() as $clangId) {
-                        self::newCatPrio($parentId, $clangId, $data['catpriority'], $oldPrio);
-                    }
-                }
-            }
-
-            $message = rex_i18n::msg('category_updated');
-
-            rex_article_cache::delete($categoryId);
-
-            // ----- EXTENSION POINT
-            // Objekte clonen, damit diese nicht von der extension veraendert werden koennen
-            $message = rex_extension::registerPoint(new rex_extension_point('CAT_UPDATED', $message, [
-                'id' => $categoryId,
-
-                'category' => clone $EKAT,
-                'category_old' => clone $thisCat,
-                'article' => clone $EKAT,
-
-                'parent_id' => $thisCat->getValue('parent_id'),
-                'clang' => $clang,
-                'name' => $data['catname'] ?? $thisCat->getValue('catname'),
-                'priority' => $data['catpriority'] ?? $thisCat->getValue('catpriority'),
-                'path' => $thisCat->getValue('path'),
-                'status' => $thisCat->getValue('status'),
-
-                'data' => $data,
-            ]));
-        } catch (rex_sql_exception $e) {
-            throw new rex_api_exception($e->getMessage(), $e);
         }
+
+        // ----- PRIOR
+        if (isset($data['catpriority'])) {
+            $parentId = (int) $thisCat->getValue('parent_id');
+            $oldPrio = (int) $thisCat->getValue('catpriority');
+
+            if ($data['catpriority'] <= 0) {
+                $data['catpriority'] = 1;
+            }
+
+            if ($oldPrio != $data['catpriority']) {
+                rex_sql::factory()
+                    ->setTable(rex::getTable('article'))
+                    ->setWhere('id = :id AND clang_id != :clang', ['id' => $categoryId, 'clang' => $clang])
+                    ->setValue('catpriority', $data['catpriority'])
+                    ->addGlobalUpdateFields($user)
+                    ->update();
+
+                foreach (rex_clang::getAllIds() as $clangId) {
+                    self::newCatPrio($parentId, $clangId, $data['catpriority'], $oldPrio);
+                }
+            }
+        }
+
+        $message = rex_i18n::msg('category_updated');
+
+        rex_article_cache::delete($categoryId);
+
+        // ----- EXTENSION POINT
+        // Objekte clonen, damit diese nicht von der extension veraendert werden koennen
+        $message = rex_extension::registerPoint(new rex_extension_point('CAT_UPDATED', $message, [
+            'id' => $categoryId,
+
+            'category' => clone $EKAT,
+            'category_old' => clone $thisCat,
+            'article' => clone $EKAT,
+
+            'parent_id' => $thisCat->getValue('parent_id'),
+            'clang' => $clang,
+            'name' => $data['catname'] ?? $thisCat->getValue('catname'),
+            'priority' => $data['catpriority'] ?? $thisCat->getValue('catpriority'),
+            'path' => $thisCat->getValue('path'),
+            'status' => $thisCat->getValue('status'),
+
+            'data' => $data,
+        ]));
 
         return $message;
     }
@@ -342,20 +334,16 @@ class rex_category_service
             $EKAT->setValue('status', $newstatus);
             $EKAT->addGlobalUpdateFields(self::getUser());
 
-            try {
-                $EKAT->update();
+            $EKAT->update();
 
-                rex_article_cache::delete($categoryId, $clang);
+            rex_article_cache::delete($categoryId, $clang);
 
-                // ----- EXTENSION POINT
-                rex_extension::registerPoint(new rex_extension_point('CAT_STATUS', null, [
-                    'id' => $categoryId,
-                    'clang' => $clang,
-                    'status' => $newstatus,
-                ]));
-            } catch (rex_sql_exception $e) {
-                throw new rex_api_exception($e->getMessage(), $e);
-            }
+            // ----- EXTENSION POINT
+            rex_extension::registerPoint(new rex_extension_point('CAT_STATUS', null, [
+                'id' => $categoryId,
+                'clang' => $clang,
+                'status' => $newstatus,
+            ]));
         } else {
             throw new rex_api_exception(rex_i18n::msg('no_such_category'));
         }

--- a/redaxo/src/addons/structure/plugins/content/lib/content_service.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/content_service.php
@@ -37,19 +37,15 @@ class rex_content_service
         $sql->addGlobalCreateFields();
         $sql->addGlobalUpdateFields();
 
-        try {
-            $sql->insert();
-            $sliceId = $sql->getLastId();
+        $sql->insert();
+        $sliceId = $sql->getLastId();
 
-            rex_sql_util::organizePriorities(
-                rex::getTable('article_slice'),
-                'priority',
-                $where,
-                'priority, updatedate DESC',
-            );
-        } catch (rex_sql_exception $e) {
-            throw new rex_api_exception($e->getMessage(), $e);
-        }
+        rex_sql_util::organizePriorities(
+            rex::getTable('article_slice'),
+            'priority',
+            $where,
+            'priority, updatedate DESC',
+        );
 
         rex_article_cache::delete($articleId, $clangId);
 

--- a/redaxo/src/addons/structure/plugins/content/pages/content.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.php
@@ -201,79 +201,72 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
 
                         if ('edit' == $function) {
                             $newsql->addGlobalUpdateFields();
-                            try {
-                                rex_extension::registerPoint(new rex_extension_point('SLICE_UPDATE', '', [
-                                    'slice_id' => $sliceId,
-                                    'article_id' => $articleId,
-                                    'clang_id' => $clang,
-                                    'slice_revision' => $sliceRevision,
-                                ]));
 
-                                $newsql->update();
-                                $info = $actionMessage . rex_i18n::msg('block_updated');
-                                $epParams = [
-                                    'article_id' => $articleId,
-                                    'clang' => $clang,
-                                    'function' => $function,
-                                    'slice_id' => $sliceId,
-                                    'page' => rex_be_controller::getCurrentPage(),
-                                    'ctype' => $ctype,
-                                    'category_id' => $categoryId,
-                                    'module_id' => $moduleId,
-                                    'article_revision' => &$articleRevision,
-                                    'slice_revision' => &$sliceRevision,
-                                ];
+                            rex_extension::registerPoint(new rex_extension_point('SLICE_UPDATE', '', [
+                                'slice_id' => $sliceId,
+                                'article_id' => $articleId,
+                                'clang_id' => $clang,
+                                'slice_revision' => $sliceRevision,
+                            ]));
 
-                                // ----- EXTENSION POINT
-                                $info = rex_extension::registerPoint(new rex_extension_point('SLICE_UPDATED', $info, $epParams));
-                                /* deprecated */ $info = rex_extension::registerPoint(new rex_extension_point('STRUCTURE_CONTENT_SLICE_UPDATED', $info, $epParams));
-                                $info = rex_extension::registerPoint(new rex_extension_point_art_content_updated($OOArt, 'slice_updated', $info));
-                            } catch (rex_sql_exception $e) {
-                                $warning = $actionMessage . $e->getMessage();
-                            }
+                            $newsql->update();
+                            $info = $actionMessage . rex_i18n::msg('block_updated');
+                            $epParams = [
+                                'article_id' => $articleId,
+                                'clang' => $clang,
+                                'function' => $function,
+                                'slice_id' => $sliceId,
+                                'page' => rex_be_controller::getCurrentPage(),
+                                'ctype' => $ctype,
+                                'category_id' => $categoryId,
+                                'module_id' => $moduleId,
+                                'article_revision' => &$articleRevision,
+                                'slice_revision' => &$sliceRevision,
+                            ];
+
+                            // ----- EXTENSION POINT
+                            $info = rex_extension::registerPoint(new rex_extension_point('SLICE_UPDATED', $info, $epParams));
+                            /* deprecated */ $info = rex_extension::registerPoint(new rex_extension_point('STRUCTURE_CONTENT_SLICE_UPDATED', $info, $epParams));
+                            $info = rex_extension::registerPoint(new rex_extension_point_art_content_updated($OOArt, 'slice_updated', $info));
                         } else {
                             $newsql->addGlobalUpdateFields();
                             $newsql->addGlobalCreateFields();
 
-                            try {
-                                rex_extension::registerPoint(new rex_extension_point('SLICE_ADD', '', [
-                                    'article_id' => $articleId,
-                                    'clang_id' => $clang,
-                                    'slice_revision' => $sliceRevision,
-                                ]));
+                            rex_extension::registerPoint(new rex_extension_point('SLICE_ADD', '', [
+                                'article_id' => $articleId,
+                                'clang_id' => $clang,
+                                'slice_revision' => $sliceRevision,
+                            ]));
 
-                                $newsql->insert();
-                                $sliceId = (int) $newsql->getLastId();
+                            $newsql->insert();
+                            $sliceId = (int) $newsql->getLastId();
 
-                                rex_sql_util::organizePriorities(
-                                    rex::getTable('article_slice'),
-                                    'priority',
-                                    'article_id=' . $articleId . ' AND clang_id=' . $clang . ' AND ctype_id=' . $ctype . ' AND revision=' . (int) $sliceRevision,
-                                    'priority, updatedate DESC',
-                                );
+                            rex_sql_util::organizePriorities(
+                                rex::getTable('article_slice'),
+                                'priority',
+                                'article_id=' . $articleId . ' AND clang_id=' . $clang . ' AND ctype_id=' . $ctype . ' AND revision=' . (int) $sliceRevision,
+                                'priority, updatedate DESC',
+                            );
 
-                                $info = $actionMessage . rex_i18n::msg('block_added');
-                                $function = '';
-                                $epParams = [
-                                    'article_id' => $articleId,
-                                    'clang' => $clang,
-                                    'function' => $function,
-                                    'slice_id' => $sliceId,
-                                    'page' => rex_be_controller::getCurrentPage(),
-                                    'ctype' => $ctype,
-                                    'category_id' => $categoryId,
-                                    'module_id' => $moduleId,
-                                    'article_revision' => &$articleRevision,
-                                    'slice_revision' => &$sliceRevision,
-                                ];
+                            $info = $actionMessage . rex_i18n::msg('block_added');
+                            $function = '';
+                            $epParams = [
+                                'article_id' => $articleId,
+                                'clang' => $clang,
+                                'function' => $function,
+                                'slice_id' => $sliceId,
+                                'page' => rex_be_controller::getCurrentPage(),
+                                'ctype' => $ctype,
+                                'category_id' => $categoryId,
+                                'module_id' => $moduleId,
+                                'article_revision' => &$articleRevision,
+                                'slice_revision' => &$sliceRevision,
+                            ];
 
-                                // ----- EXTENSION POINT
-                                $info = rex_extension::registerPoint(new rex_extension_point('SLICE_ADDED', $info, $epParams));
-                                /* deprecated */ $info = rex_extension::registerPoint(new rex_extension_point('STRUCTURE_CONTENT_SLICE_ADDED', $info, $epParams));
-                                $info = rex_extension::registerPoint(new rex_extension_point_art_content_updated($OOArt, 'slice_added', $info));
-                            } catch (rex_sql_exception $e) {
-                                $warning = $actionMessage . $e->getMessage();
-                            }
+                            // ----- EXTENSION POINT
+                            $info = rex_extension::registerPoint(new rex_extension_point('SLICE_ADDED', $info, $epParams));
+                            /* deprecated */ $info = rex_extension::registerPoint(new rex_extension_point('STRUCTURE_CONTENT_SLICE_ADDED', $info, $epParams));
+                            $info = rex_extension::registerPoint(new rex_extension_point_art_content_updated($OOArt, 'slice_added', $info));
                         }
                     } else {
                         // make delete

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.actions.php
@@ -96,20 +96,16 @@ if ('add' == $function || 'edit' == $function) {
         $faction->setValue('postsavemode', $postsavemode);
         $faction->addGlobalUpdateFields();
 
-        try {
-            if ('add' == $function) {
-                $faction->addGlobalCreateFields();
+        if ('add' == $function) {
+            $faction->addGlobalCreateFields();
 
-                $faction->insert();
-                $success = rex_i18n::msg('action_added');
-            } else {
-                $faction->setWhere(['id' => $actionId]);
+            $faction->insert();
+            $success = rex_i18n::msg('action_added');
+        } else {
+            $faction->setWhere(['id' => $actionId]);
 
-                $faction->update();
-                $success = rex_i18n::msg('action_updated');
-            }
-        } catch (rex_sql_exception $e) {
-            $error = $e->getMessage();
+            $faction->update();
+            $success = rex_i18n::msg('action_updated');
         }
 
         if ('' != $goon) {

--- a/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/modules.modules.php
@@ -33,13 +33,9 @@ if (('' != $addAction || 'delete' == $functionAction) && !$csrfToken->isValid())
     $action->setValue('module_id', $moduleId);
     $action->setValue('action_id', $actionId);
 
-    try {
-        $action->insert();
-        $success = rex_i18n::msg('action_taken');
-        $goon = '1';
-    } catch (rex_sql_exception) {
-        $error = $action->getError();
-    }
+    $action->insert();
+    $success = rex_i18n::msg('action_taken');
+    $goon = '1';
 } elseif ('delete' == $functionAction) {
     $action = rex_sql::factory();
     $action->setTable(rex::getTablePrefix() . 'module_action');

--- a/redaxo/src/core/pages/profile.php
+++ b/redaxo/src/core/pages/profile.php
@@ -88,20 +88,16 @@ if ($update && !$error) {
 
     $updateuser->addGlobalUpdateFields();
 
-    try {
-        $updateuser->update();
-        rex_user::clearInstance($userId);
+    $updateuser->update();
+    rex_user::clearInstance($userId);
 
-        rex_extension::registerPoint(new rex_extension_point('PROFILE_UPDATED', '', [
-            'user_id' => $userId,
-            'user' => rex_user::require($userId),
-        ], true));
+    rex_extension::registerPoint(new rex_extension_point('PROFILE_UPDATED', '', [
+        'user_id' => $userId,
+        'user' => rex_user::require($userId),
+    ], true));
 
-        // trigger a fullpage-reload which immediately reflects a possible changed language
-        rex_response::sendRedirect(rex_url::currentBackendPage(['rex_user_updated' => true], false));
-    } catch (rex_sql_exception $e) {
-        $error = $e->getMessage();
-    }
+    // trigger a fullpage-reload which immediately reflects a possible changed language
+    rex_response::sendRedirect(rex_url::currentBackendPage(['rex_user_updated' => true], false));
 }
 
 $verifyLogin = static function () use ($user, $login, $userpsw, $webauthn): bool|string {
@@ -148,25 +144,21 @@ if (rex_post('upd_psw_button', 'bool')) {
         $updateuser->setDateTimeValue('password_changed', time());
         $updateuser->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords($user, $userpswNew1));
 
-        try {
-            $updateuser->update();
-            rex_user::clearInstance($userId);
+        $updateuser->update();
+        rex_user::clearInstance($userId);
 
-            $success = rex_i18n::msg('user_psw_updated');
+        $success = rex_i18n::msg('user_psw_updated');
 
-            if ($passwordChangeRequired) {
-                $passwordChangeRequired = false;
-            }
-            $login->changedPassword($userpswNew1);
-
-            rex_extension::registerPoint(new rex_extension_point('PASSWORD_UPDATED', '', [
-                'user_id' => $userId,
-                'user' => rex_user::require($userId),
-                'password' => $userpswNew2,
-            ], true));
-        } catch (rex_sql_exception $e) {
-            $error = $e->getMessage();
+        if ($passwordChangeRequired) {
+            $passwordChangeRequired = false;
         }
+        $login->changedPassword($userpswNew1);
+
+        rex_extension::registerPoint(new rex_extension_point('PASSWORD_UPDATED', '', [
+            'user_id' => $userId,
+            'user' => rex_user::require($userId),
+            'password' => $userpswNew2,
+        ], true));
     }
 }
 


### PR DESCRIPTION
Wir haben mehrere Stellen im Code, wo wir Exception abfangen und die Message an den User ausgeben. 
Dabei geht es nicht um Stellen mit `rex_functional_exception`/`rex_api_exception`, die extra dafür gedacht sind.

Sondern insbesondere `rex_sql_exception` fangen wir öfters ab und geben die Message aus. An Redakteure, also Nicht-Admins. Das finde ich problematisch, sollte man nicht tun, denke ich.