### PR TITLE
Clockwork: manifest.json-Request ignorieren

### DIFF
--- a/redaxo/src/addons/debug/boot.php
+++ b/redaxo/src/addons/debug/boot.php
@@ -145,7 +145,7 @@ if ('cli' === PHP_SAPI) {
 } else {
     register_shutdown_function(static function () use ($shutdownFn) {
         // don't track preflight requests
-        if ('/__clockwork/latest' === $_SERVER['REQUEST_URI']) {
+        if (in_array($_SERVER['REQUEST_URI'], ['/__clockwork/latest', '/assets/addons/debug/clockwork/manifest.json'], true)) {
             return;
         }
 


### PR DESCRIPTION
fixes #6073

Noch besser fände ich, wenn der Request gar nicht gemacht werden würde. Aber blicke beim Frontend zu wenig durch, weiß daher nicht, ob man den Manifest-Meta-Tag irgendwie sinnvoll entfernt bekommt.