### PR TITLE
rex_formatter: Missing "t" in "dateime"

### DIFF
--- a/redaxo/src/core/lib/util/formatter.php
+++ b/redaxo/src/core/lib/util/formatter.php
@@ -521,7 +521,7 @@ abstract class rex_formatter
         }
 
         if (str_starts_with($value, '0000-00-00')) {
-            trigger_error(sprintf('%s: "%s" is not a valid dateime string.', __METHOD__, $value), E_USER_WARNING);
+            trigger_error(sprintf('%s: "%s" is not a valid datetime string.', __METHOD__, $value), E_USER_WARNING);
 
             return null;
         }


### PR DESCRIPTION
Missing "t" in "dateime"