### PR TITLE
Wasserzeichen Breite-%, Opacity

### DIFF
--- a/redaxo/src/addons/media_manager/lang/de_de.lang
+++ b/redaxo/src/addons/media_manager/lang/de_de.lang
@@ -178,3 +178,7 @@ media_manager_effect_greyscale = Bild: Graustufen
 
 media_manager_effect_image_format = Bild: In JPEG/PNG/GIF/WEBP/AVIF konvertieren
 media_manager_effect_image_format_convertto = Zielformat
+
+media_manager_effect_insert_image_percent = Bild: Bild platzieren / Wasserzeichen (Transparent)
+media_manager_effect_brand_width_percent_x = Breite in Prozent
+media_manager_effect_brand_opacity_percent = Deckkraft in Prozent

--- a/redaxo/src/addons/media_manager/lang/en_gb.lang
+++ b/redaxo/src/addons/media_manager/lang/en_gb.lang
@@ -175,3 +175,7 @@ media_manager_effect_greyscale = Image: greyscale
 
 media_manager_effect_image_format = Image: convert to JPEG/PNG/GIF/WEBP/AVIF
 media_manager_effect_image_format_convertto = Target format
+
+media_manager_effect_insert_image_percent = Image: place image/watermark (transparent)
+media_manager_effect_brand_width_percent_x = Width in percent
+media_manager_effect_brand_opacity_percent = Opacity in percent

--- a/redaxo/src/addons/media_manager/lang/es_es.lang
+++ b/redaxo/src/addons/media_manager/lang/es_es.lang
@@ -166,3 +166,7 @@ media_manager_effect_contrast_notice = [-100 a 100]. Dejar en blanco para el val
 media_manager_effect_sepia = Imagen: Sepia
 
 media_manager_effect_greyscale = Imagen: Escala de grises
+
+media_manager_effect_insert_image_percent = Imagen: colocar imagen / marca de agua (transparente)
+media_manager_effect_brand_width_percent_x = ancho en porcentaje
+media_manager_effect_brand_opacity_percent = Opacidad en porcentaje

--- a/redaxo/src/addons/media_manager/lang/it_it.lang
+++ b/redaxo/src/addons/media_manager/lang/it_it.lang
@@ -132,3 +132,7 @@ media_manager_effect_brightness_notice =
 
 media_manager_effect_contrast = 
 media_manager_effect_contrast_notice = 
+
+media_manager_effect_insert_image_percent = Image: place image/watermark (transparent)
+media_manager_effect_brand_width_percent_x = Larghezza in percentuale
+media_manager_effect_brand_opacity_percent = Opacità in percentuale

--- a/redaxo/src/addons/media_manager/lang/pt_br.lang
+++ b/redaxo/src/addons/media_manager/lang/pt_br.lang
@@ -132,3 +132,7 @@ media_manager_effect_brightness_notice = [-255 to 255]. Deixe em branco para o v
 
 media_manager_effect_contrast = Contraste
 media_manager_effect_contrast_notice = [-100 to 100]. Deixe em branco para o valor padrão (0).
+
+media_manager_effect_insert_image_percent = Image: place image/watermark (transparent)
+media_manager_effect_brand_width_percent_x = Width in percent
+media_manager_effect_brand_opacity_percent = Opacity in percent

--- a/redaxo/src/addons/media_manager/lang/ru_ru.lang
+++ b/redaxo/src/addons/media_manager/lang/ru_ru.lang
@@ -178,3 +178,7 @@ media_manager_effect_greyscale = Изображение: оттенки серо
 
 media_manager_effect_image_format = Изображение: конвертировать в JPEG/PNG/GIF/WEBP/AVIF
 media_manager_effect_image_format_convertto = Целевой формат
+
+media_manager_effect_insert_image_percent = Image: place image/watermark (transparent)
+media_manager_effect_brand_width_percent_x = Width in percent
+media_manager_effect_brand_opacity_percent = Opacity in percent

--- a/redaxo/src/addons/media_manager/lang/sv_se.lang
+++ b/redaxo/src/addons/media_manager/lang/sv_se.lang
@@ -169,3 +169,7 @@ media_manager_effect_greyscale = Bild: grånyanser
 
 media_manager_effect_image_format = Bild: konvertera till JPEG/PNG/GIF/WEBP/AVIF
 media_manager_effect_image_format_convertto = Målformat
+
+media_manager_effect_insert_image_percent = Image: place image/watermark (transparent)
+media_manager_effect_brand_width_percent_x = Width in percent
+media_manager_effect_brand_opacity_percent = Opacity in percent

--- a/redaxo/src/addons/media_manager/lib/effects/effect_insert_image_percent.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_insert_image_percent.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Branded ein Bild mit einem Wasserzeichen.
+ *
+ * @package redaxo\media-manager
+ */
+class rex_effect_insert_image_percent extends rex_effect_abstract
+{
+    public function execute()
+    {
+        $this->media->asImage();
+
+        // -------------------------------------- CONFIG
+        $brandimage = rex_path::media($this->params['brandimage']);
+        if (!is_file($brandimage)) {
+            return;
+        }
+
+        // Deckkraft in Prozent
+        $opacityPercent = 50;
+        if (isset($this->params['opacity_percent'])) {
+            $opacityPercent = (int) $this->params['opacity_percent'];
+        }
+        $opacity = intval(127 * (100 - $opacityPercent) / 100);
+
+        // Breite in Prozent des Bildes
+        $widthPercentX = 30;
+        if (isset($this->params['width_percent_x'])) {
+            $widthPercentX = (int) $this->params['width_percent_x'];
+        }
+
+        // Abstand vom Rand
+        $paddingX = -10;
+        if (isset($this->params['padding_x'])) {
+            $paddingX = (int) $this->params['padding_x'];
+        }
+        
+
+        $paddingY = -10;
+        if (isset($this->params['padding_y'])) {
+            $paddingY = (int) $this->params['padding_y'];
+        }
+
+        // horizontale ausrichtung: left/center/right
+        $hpos = 'right';
+        if (isset($this->params['hpos'])) {
+            $hpos = (string) $this->params['hpos'];
+        }
+
+        // vertikale ausrichtung:   top/center/bottom
+        $vpos = 'bottom';
+        if (isset($this->params['vpos'])) {
+            $vpos = (string) $this->params['vpos'];
+        }
+
+        // -------------------------------------- /CONFIG
+        $brand = new rex_managed_media($brandimage);
+        $brand->asImage();
+        $gdbrand = $brand->getImage();
+        $gdimage = $this->media->getImage();
+
+        $imageWidth = (int) $this->media->getWidth();
+        $imageHeight = (int) $this->media->getHeight();
+        $brandWidth = (int) $brand->getWidth();
+        $brandHeight = (int) $brand->getHeight();
+        var_dump($imageWidth, $brandWidth, $widthPercentX);
+        
+        $brandInsertedWidth = (int) ($imageWidth * $widthPercentX / 100);
+        $brandInsertedHeight = (int) ($brandHeight * ($brandInsertedWidth / $brandWidth));
+
+        $des = @imagecreatetruecolor($brandInsertedWidth, $brandInsertedHeight);
+        if (!$des) {
+            return;
+        }
+        $this->keepTransparent($des);
+        imagealphablending($des, false);
+        imagecopyresampled($des, $gdbrand, 0, 0, 0, 0, $brandInsertedWidth, $brandInsertedHeight, $brandWidth, $brandHeight);
+        imagefilter($des, IMG_FILTER_COLORIZE, 0, 0, 0, $opacity);
+
+        $dstX = match ($hpos) {
+            'left' =>  $paddingX,
+            'right' => $imageWidth - $brandInsertedWidth + $paddingX,
+            'center' => (int) (($imageWidth - $brandInsertedWidth) / 2),
+            default => $paddingX,
+        };
+
+        $dstY = match ($vpos) {
+            'top' => 0 - $paddingY,
+            'middle' => (int) (($imageHeight - $brandInsertedHeight) / 2) + $paddingY,
+            default => $imageHeight - $brandInsertedHeight + $paddingY,
+        };
+
+        imagealphablending($gdimage, true);
+        imagecopy($gdimage, $des, $dstX, $dstY, 0, 0, $brandInsertedWidth, $brandInsertedHeight);
+
+        $this->media->setImage($gdimage);
+    }
+
+    public function getName()
+    {
+        return rex_i18n::msg('media_manager_effect_insert_image_percent');
+    }
+
+    public function getParams()
+    {
+        return [
+            [
+                'label' => rex_i18n::msg('media_manager_effect_brand_image'),
+                'name' => 'brandimage',
+                'type' => 'media',
+                'default' => '',
+            ],
+            [
+                'label' => rex_i18n::msg('media_manager_effect_brand_hpos'),
+                'name' => 'hpos',
+                'type' => 'select',
+                'options' => ['left', 'center', 'right'],
+                'default' => 'left',
+            ],
+            [
+                'label' => rex_i18n::msg('media_manager_effect_brand_vpos'),
+                'name' => 'vpos',
+                'type' => 'select',
+                'options' => ['top', 'middle', 'bottom'],
+                'default' => 'top',
+            ],
+            [
+                'label' => rex_i18n::msg('media_manager_effect_brand_opacity_percent'),
+                'name' => 'opacity_percent',
+                'type' => 'int',
+                'default' => '50',
+            ],
+            [
+                'label' => rex_i18n::msg('media_manager_effect_brand_width_percent_x'),
+                'name' => 'width_percent_x',
+                'type' => 'int',
+                'default' => '30',
+            ],
+            [
+                'label' => rex_i18n::msg('media_manager_effect_brand_padding_x'),
+                'name' => 'padding_x',
+                'type' => 'int',
+                'default' => '-10',
+            ],
+            [
+                'label' => rex_i18n::msg('media_manager_effect_brand_padding_y'),
+                'name' => 'padding_y',
+                'type' => 'int',
+                'default' => '-10',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Kopie und Erweiterung des Effekts 'effect_insert_image'

- Wasserzeichen-Breite in Prozent des Originalbildes
- Deckkraft in Prozent als Parameter