### PR TITLE
rex_article_not_found_exception erweitert um sie auch im Artikel-Template nutzen zu können

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -60,6 +60,7 @@ if (rex::isBackend()) {
             $article = new rex_article_content();
             $article->setCLang(rex_clang::getCurrentId());
             $article->setArticleId(rex_article::getNotfoundArticleId());
+            rex_addon::get('structure')->setProperty('article_id', rex_article::getNotfoundArticleId());
 
             $content .= $article->getArticleTemplate();
         }


### PR DESCRIPTION
ich benutze die  rex_article_not_found_exception in meinem Template, um offline Artikel als 404 Fehlerartikel auszugeben.

Der bisherige Code holt sich den Inhalt des 404-Artikels und jagt ihn durch das Template.
Bei mir wurde dabei der SEO Title nicht auf "not found" gesetzt, meine Navigationen zeigten noch den ursprünglichen Artikel an.
Außerdem bekam ich zunächst einen 500er Fehler, weil die exception immer wieder ausgelöst wird, wenn ich versuche sie nur bei rex_article::getCurrentId() != rex_article::getNotFoundArticleId() auszuführen.
Denn viele Methoden, die dabei zum Einsatz kommen wie z.B. `rex_article::getCurrentId()`, basieren alle auf der Property "article_id" (https://github.com/redaxo/redaxo/blob/main/redaxo/src/addons/structure/lib/article.php#L17). 

Mit dieser einen zusätzlichen Zeile, die die Property setzt, funktioniert alles wie gewünscht
![Zwischenablage-1](https://github.com/redaxo/redaxo/assets/1277494/75befdf1-387a-44c4-a4f7-73cdc74a8585)
