### PR TITLE
add setCompressionLevel method

### DIFF
--- a/redaxo/src/addons/backup/lib/tar.php
+++ b/redaxo/src/addons/backup/lib/tar.php
@@ -74,6 +74,16 @@ class rex_backup_tar
     }
 
     /**
+     * Sets compression Level
+     * 
+     * @param int $level
+     */
+    public function setCompressionLevel(int $level)
+    {
+        $this->tar->setCompression($level, Archive::COMPRESS_GZIP);
+    }
+
+    /**
      * Saves tar archive to a different file than the current file.
      *
      * @return bool|string


### PR DESCRIPTION
closes #5721

Beispiel via EP

```php
rex_extension::register('BACKUP_BEFORE_FILE_EXPORT', function (rex_extension_point $ep) {
    $tar = $ep->getSubject();
    $tar->setCompressionLevel(2);
    return $tar;
});
``` 

Ich kann jedoch keinen Unterschied in der Dateigröße feststellen, obwohl das Kompressionslevel korrekt gesetzt wird.