### PR TITLE
 updateMedia  erlaubt jetzt die Aktualisierung beliebiger Metas

### DIFF
--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -146,10 +146,10 @@ final class rex_media_service
     /**
      * Aktualisiert eine Mediendatei im Medienpool, einschließlich dynamischer Metadaten wie 'med_description'.
      *
-     * @param string $filename Der Name der zu aktualisierenden Datei.
+     * @param string $filename der Name der zu aktualisierenden Datei
      * @param array $data Die zu aktualisierenden Daten (z.B. 'title', 'category_id', 'med_description').
-     * @return array Die aktualisierten Daten, zusammen mit einer Erfolgs- oder Fehlermeldung.
-     * @throws rex_api_exception Wenn die Datei nicht gefunden wird oder ein anderes Problem auftritt.
+     * @throws rex_api_exception wenn die Datei nicht gefunden wird oder ein anderes Problem auftritt
+     * @return array die aktualisierten Daten, zusammen mit einer Erfolgs- oder Fehlermeldung
      */
     public static function updateMedia(string $filename, array $data): array
     {
@@ -207,8 +207,8 @@ final class rex_media_service
             static $jpgExtensions = ['jpg', 'jpeg'];
 
             if (
-                $extensionNew == $extensionOld ||
-                in_array($extensionNew, $jpgExtensions) && in_array($extensionOld, $jpgExtensions)
+                $extensionNew == $extensionOld
+                || in_array($extensionNew, $jpgExtensions) && in_array($extensionOld, $jpgExtensions)
             ) {
                 if (!rex_file::move($srcFile, $dstFile)) {
                     throw new rex_api_exception(rex_i18n::msg('pool_file_movefailed'));
@@ -238,7 +238,7 @@ final class rex_media_service
                     $message = sprintf(
                         "Field '%s' does not exist in the database table and was skipped during the update for media '%s'.",
                         $key,
-                        $filename
+                        $filename,
                     );
                     rex_logger::logException(new Exception($message));
                 }
@@ -268,8 +268,6 @@ final class rex_media_service
 
         return $return;
     }
-
-
 
     public static function deleteMedia(string $filename): void
     {

--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -204,8 +204,8 @@ final class rex_media_service
             static $jpgExtensions = ['jpg', 'jpeg'];
 
             if (
-                $extensionNew == $extensionOld ||
-                in_array($extensionNew, $jpgExtensions) && in_array($extensionOld, $jpgExtensions)
+                $extensionNew == $extensionOld
+                || in_array($extensionNew, $jpgExtensions) && in_array($extensionOld, $jpgExtensions)
             ) {
                 if (!rex_file::move($srcFile, $dstFile)) {
                     throw new rex_api_exception(rex_i18n::msg('pool_file_movefailed'));
@@ -231,13 +231,13 @@ final class rex_media_service
         foreach ($data as $key => $value) {
             if (!in_array($key, ['file', 'category_id', 'title'])) {
                 // Check if the value is scalar or null
-                if (is_scalar($value) || is_null($value)) {
+                if (is_scalar($value) || null === $value) {
                     if (!$saveObject->setValue($key, $value)) {
                         // Write error message to Redaxo log
                         $message = sprintf(
                             "Field '%s' does not exist in the database table and was skipped during the update for media '%s'.",
                             $key,
-                            $filename
+                            $filename,
                         );
                         rex_logger::logException(new Exception($message));
                     }
@@ -246,7 +246,7 @@ final class rex_media_service
                     $message = sprintf(
                         "Field '%s' has an unsupported value type during the update for media '%s'.",
                         $key,
-                        $filename
+                        $filename,
                     );
                     rex_logger::logException(new Exception($message));
                 }


### PR DESCRIPTION
fixes: https://github.com/redaxo/redaxo/issues/5468

Erlaubt das Aktualisieren oder Hinzufügen von Metadaten. 
Existiert das Feld nicht, wird es ins Log geschrieben

```php
<?php 
$filename = 'img_2652.jpeg'; // Der Name der Datei, die du aktualisieren möchtest
$data = [
    'title' => 'Very', 
    'category_id' => 1, 
    'med_description' => foo',
    'med_author' => 'ba',

 // Weitere Metadaten können hier hinzugefügt werden
];

$result = rex_media_service::updateMedia($filename, $data);

if ($result['ok']) {
    echo "Description updated successfully!";
} else {
    echo "Failed to update the description.";
}
```