### PR TITLE
PHP 8.4: E_STRICT nicht mehr nutzen

### DIFF
--- a/redaxo/src/core/lib/error_handler.php
+++ b/redaxo/src/core/lib/error_handler.php
@@ -370,7 +370,6 @@ abstract class rex_error_handler
             E_USER_WARNING, E_WARNING, E_COMPILE_WARNING => 'Warning',
             E_USER_NOTICE, E_NOTICE => 'Notice',
             E_USER_DEPRECATED, E_DEPRECATED => 'Deprecated',
-            E_STRICT => 'Strict',
             default => 'Unknown',
         };
     }

--- a/redaxo/src/core/lib/util/logger.php
+++ b/redaxo/src/core/lib/util/logger.php
@@ -174,7 +174,7 @@ class rex_logger extends AbstractLogger
     public static function getLogLevel($errno)
     {
         return match ($errno) {
-            E_STRICT, E_USER_DEPRECATED, E_DEPRECATED, E_USER_WARNING, E_WARNING, E_COMPILE_WARNING => LogLevel::WARNING,
+            E_USER_DEPRECATED, E_DEPRECATED, E_USER_WARNING, E_WARNING, E_COMPILE_WARNING => LogLevel::WARNING,
             E_USER_NOTICE, E_NOTICE => LogLevel::NOTICE,
             default => LogLevel::ERROR,
         };


### PR DESCRIPTION
In allen unterstützten PHP-Versionen gibt es bereits keine `E_STRICT`-Meldungen mehr.
Bisher gab es die Konstante aber trotzdem noch, und wir hatten sie im Code noch beachtet.
Mit PHP 8.4 wird auch die Konstante auf deprecated gesetzt.

Da es sowieso keine Strict-Meldungen mehr gibt, brauchen wir keine Versionsweiche, sondern können die Zeilen ganz entfernen, denke ich.