### PR TITLE
Media Manager: neuer EP MEDIA_MANAGER_INIT

### DIFF
--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -89,6 +89,11 @@ class rex_media_manager
     {
         $this->type = $type;
 
+        rex_extension::registerPoint(new rex_extension_point('MEDIA_MANAGER_INIT', $this, [
+            'type' => $type,
+            'file' => $this->originalFilename,
+        ], true));
+
         if (!$this->isCached()) {
             $set = $this->effectsFromType($type);
             $set = rex_extension::registerPoint(new rex_extension_point('MEDIA_MANAGER_FILTERSET', $set, ['rex_media_type' => $type]));


### PR DESCRIPTION
replaces #6135

@AndiLeni kannst du es mit diesem EP mal testen. Ich stelle mir den Code dann so in der Art vor:

```php
rex_extension::register('MEDIA_MANAGER_INIT', function (rex_extension_point $ep) {
    $mediaManager = $ep->getSubject();
    $type = $ep->getParam('type');

    $effects = $mediaManager->effectsFromType($type);

    foreach ($effects as $effect) {
        if ($effect['effect'] === 'negotiator') {
            // change cache path for negotiator
            $possible_types = rex_server('HTTP_ACCEPT', 'string', '');
            $types = explode(',', $possible_types);
            $possibleFormat = media_negotiator\Helper::getOutputFormat($types);

            $mediaManager->setCachePath($mediaManager->getCachePath() . $possibleFormat . '/');

            return;
        }
    }
});
```

Gut fände ich an dem EP, dass er allgemeiner gefasst ist und einfach dann die vorhandenen getCachePath/setCachePath-Methoden verwendet werden. 
Wobei man wissen muss, dass setCachePath nur den Basis-Pfad setzt. type und filename werden da dann noch angehangen.
Daher mein Vorschlag mit einem Unterordner für `$possibleFormat`.