### PR TITLE
Angabe der Datenbank-ID im REX-Log für SQL-Exceptions ergänzt

### DIFF
--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -146,7 +146,7 @@ class rex_sql implements Iterator
             }
         } catch (PDOException $e) {
             if ('cli' === PHP_SAPI) {
-                throw new rex_sql_could_not_connect_exception("Could not connect to database.\n\nConsider starting either the web-based or console-based REDAXO setup to configure the database connection settings.", $e, $this);
+                throw new rex_sql_could_not_connect_exception("Could not connect to database (DB: ' . $db . ')'.\n\nConsider starting either the web-based or console-based REDAXO setup to configure the database connection settings.", $e, $this);
             }
             throw new rex_sql_could_not_connect_exception('Could not connect to database (DB: ' . $db . ')', $e, $this);
         }

--- a/redaxo/src/core/lib/sql/sql.php
+++ b/redaxo/src/core/lib/sql/sql.php
@@ -148,7 +148,7 @@ class rex_sql implements Iterator
             if ('cli' === PHP_SAPI) {
                 throw new rex_sql_could_not_connect_exception("Could not connect to database.\n\nConsider starting either the web-based or console-based REDAXO setup to configure the database connection settings.", $e, $this);
             }
-            throw new rex_sql_could_not_connect_exception('Could not connect to database', $e, $this);
+            throw new rex_sql_could_not_connect_exception('Could not connect to database (DB: ' . $db . ')', $e, $this);
         }
     }
 


### PR DESCRIPTION
Bei einer rex_sql_could_not_connect_exception im REX-Log war bisher nicht sichtbar um welche Datenbank-Verbindung es sich handelt. Wenn man in der config.yml des Cores mehrere DBs eingetragen hat, war im Log nicht nachzuvollziehen, welche Connection den Fehler verursacht hat.

Dieser PR ergänzt die DB-ID im REX-Log und in der Whoops-Meldung.

**REX-Log:**

![Bildschirmfoto 2025-02-07 um 12 28 50](https://github.com/user-attachments/assets/14cb9594-09e9-48c7-ba8f-9da28a11fd14)

**Whoops:**
<img width="529" alt="Bildschirmfoto 2025-02-07 um 12 29 32" src="https://github.com/user-attachments/assets/9029efac-cef1-482d-9234-02e6fc5a787b" />


Closes https://github.com/redaxo/redaxo/issues/6221