### PR TITLE
Pagination for Redaxo Mediapool

### DIFF
--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -2,6 +2,7 @@ package: mediapool
 version: '2.15.1'
 author: 'Jan Kristinus'
 supportpage: https://github.com/redaxo/redaxo
+rows_per_page: 100
 
 page:
     title: translate:mediapool

--- a/redaxo/src/addons/mediapool/pages/media.list.php
+++ b/redaxo/src/addons/mediapool/pages/media.list.php
@@ -152,7 +152,7 @@ if (!rex_addon::get('media_manager')->isAvailable()) {
 }
 
 // Pagination
-if(empty($filter['term'] ))
+if(empty($mediaName))
 {
     $pagination = '';
     $context = new rex_context([


### PR DESCRIPTION
I added pagination to the Redaxo Mediapool using the rex_pager class.
Each page now displays a maximum of 100 entries.

Problem Statement:
1. When a large number of images are stored in the Mediapool, the overview becomes cluttered and difficult to navigate.
2. During testing, I found that the Browser crashes when more than 1000 images are loaded at once. This causes the Mediapool tab to close unexpectedly.

Solution:
To address these issues, I implemented pagination to:
1. Enhance performance by reducing the number of loaded images per page.
2.  Improve usability by making the Mediapool easier to navigate.

**Note:** Pagination is disabled when performing a media search to ensure the search function continues to work as expected.