### PR TITLE
BUGFIX: return types in doRun & doRunCommand methode ergänzt

### DIFF
--- a/redaxo/src/core/lib/console/application.php
+++ b/redaxo/src/core/lib/console/application.php
@@ -16,7 +16,7 @@ class rex_console_application extends Application
         parent::__construct('REDAXO', rex::getVersion());
     }
 
-    public function doRun(InputInterface $input, OutputInterface $output)
+    public function doRun(InputInterface $input, OutputInterface $output): int
     {
         try {
             $this->checkConsoleUser($input, $output);
@@ -42,7 +42,7 @@ class rex_console_application extends Application
         }
     }
 
-    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
+    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output): int
     {
         if ($command instanceof rex_console_command) {
             $this->loadPackages($command);


### PR DESCRIPTION
**Description / Beschreibung**

GitHub Issue: #6244

Ergänzt die Rückgabe werte aus denn original Methoden aus dem Symfony core. Ansonsten läuft man in eine exception rein:

![image](https://github.com/user-attachments/assets/6756323f-4287-4c49-982b-5fb06103ca07)