### PR TITLE
Category in Service Article Add, wurde nicht genullt wenn nicht vorhanden

### DIFF
--- a/redaxo/src/addons/structure/lib/service_article.php
+++ b/redaxo/src/addons/structure/lib/service_article.php
@@ -35,6 +35,7 @@ class rex_article_service
             $path .= $parent->getId() . '|';
         } else {
             $path = '|';
+            $data['category_id'] = 0; // Bugfix: Wenn kein Parent, dann in Root
         }
 
         if (rex_plugin::get('structure', 'content')->isAvailable()) {


### PR DESCRIPTION
führte dazu, dann man die Klasse falsch nutzen konnte und article im "leeren" Raum sind