### PR TITLE
API-Extensions unabhängig von Backend registrieren

### DIFF
--- a/redaxo/src/addons/media_manager/boot.php
+++ b/redaxo/src/addons/media_manager/boot.php
@@ -8,6 +8,7 @@
  */
 
 rex_extension::register('PACKAGES_INCLUDED', [rex_media_manager::class, 'init'], rex_extension::EARLY);
+
 // delete thumbnails on mediapool changes
 rex_extension::register('MEDIA_UPDATED', [rex_media_manager::class, 'mediaUpdated']);
 rex_extension::register('MEDIA_DELETED', [rex_media_manager::class, 'mediaUpdated']);

--- a/redaxo/src/addons/media_manager/boot.php
+++ b/redaxo/src/addons/media_manager/boot.php
@@ -8,10 +8,7 @@
  */
 
 rex_extension::register('PACKAGES_INCLUDED', [rex_media_manager::class, 'init'], rex_extension::EARLY);
-
-if (rex::isBackend()) {
-    // delete thumbnails on mediapool changes
-    rex_extension::register('MEDIA_UPDATED', [rex_media_manager::class, 'mediaUpdated']);
-    rex_extension::register('MEDIA_DELETED', [rex_media_manager::class, 'mediaUpdated']);
-    rex_extension::register('MEDIA_IS_IN_USE', [rex_media_manager::class, 'mediaIsInUse']);
-}
+// delete thumbnails on mediapool changes
+rex_extension::register('MEDIA_UPDATED', [rex_media_manager::class, 'mediaUpdated']);
+rex_extension::register('MEDIA_DELETED', [rex_media_manager::class, 'mediaUpdated']);
+rex_extension::register('MEDIA_IS_IN_USE', [rex_media_manager::class, 'mediaIsInUse']);

--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -9,6 +9,10 @@
 rex_perm::register('moveSlice[]', null, rex_perm::OPTIONS);
 rex_perm::register('publishSlice[]', null, rex_perm::OPTIONS);
 rex_complex_perm::register('modules', rex_module_perm::class);
+rex_extension::register('CLANG_DELETED', static function (rex_extension_point $ep) {
+    $del = rex_sql::factory();
+    $del->setQuery('delete from ' . rex::getTablePrefix() . 'article_slice where clang_id=?', [$ep->getParam('clang')->getId()]);
+});
 
 if (rex::isBackend()) {
     rex_extension::register('PAGE_CHECKED', static function () {
@@ -25,10 +29,6 @@ if (rex::isBackend()) {
         rex_view::addJsFile(rex_url::pluginAssets('structure', 'content', 'content.js'), [rex_view::JS_IMMUTABLE => true]);
     }
 
-    rex_extension::register('CLANG_DELETED', static function (rex_extension_point $ep) {
-        $del = rex_sql::factory();
-        $del->setQuery('delete from ' . rex::getTablePrefix() . 'article_slice where clang_id=?', [$ep->getParam('clang')->getId()]);
-    });
 } else {
     rex_extension::register('FE_OUTPUT', static function (rex_extension_point $ep) {
         $clangId = rex_get('clang', 'int');

--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -28,7 +28,6 @@ if (rex::isBackend()) {
     if ('content' == rex_be_controller::getCurrentPagePart(1)) {
         rex_view::addJsFile(rex_url::pluginAssets('structure', 'content', 'content.js'), [rex_view::JS_IMMUTABLE => true]);
     }
-
 } else {
     rex_extension::register('FE_OUTPUT', static function (rex_extension_point $ep) {
         $clangId = rex_get('clang', 'int');

--- a/redaxo/src/addons/structure/plugins/content/boot.php
+++ b/redaxo/src/addons/structure/plugins/content/boot.php
@@ -9,6 +9,7 @@
 rex_perm::register('moveSlice[]', null, rex_perm::OPTIONS);
 rex_perm::register('publishSlice[]', null, rex_perm::OPTIONS);
 rex_complex_perm::register('modules', rex_module_perm::class);
+
 rex_extension::register('CLANG_DELETED', static function (rex_extension_point $ep) {
     $del = rex_sql::factory();
     $del->setQuery('delete from ' . rex::getTablePrefix() . 'article_slice where clang_id=?', [$ep->getParam('clang')->getId()]);

--- a/redaxo/src/addons/structure/plugins/history/boot.php
+++ b/redaxo/src/addons/structure/plugins/history/boot.php
@@ -86,7 +86,7 @@ if ('' != $historyDate) {
     });
 }
 
-if (rex::isBackend() && rex::getUser()?->hasPerm('history[article_rollback]')) {
+if (rex::getUser()?->hasPerm('history[article_rollback]')) {
     rex_extension::register(
         ['ART_SLICES_COPY', 'SLICE_ADD', 'SLICE_UPDATE', 'SLICE_MOVE', 'SLICE_DELETE'],
         static function (rex_extension_point $ep) {
@@ -105,7 +105,9 @@ if (rex::isBackend() && rex::getUser()?->hasPerm('history[article_rollback]')) {
             }
         },
     );
+}
 
+if (rex::isBackend() && rex::getUser()?->hasPerm('history[article_rollback]')) {
     rex_view::addCssFile($plugin->getAssetsUrl('noUiSlider/nouislider.css'));
     rex_view::addJsFile($plugin->getAssetsUrl('noUiSlider/nouislider.js'), [rex_view::JS_IMMUTABLE => true]);
     rex_view::addCssFile($plugin->getAssetsUrl('history.css'));

--- a/redaxo/src/addons/structure/plugins/history/boot.php
+++ b/redaxo/src/addons/structure/plugins/history/boot.php
@@ -86,26 +86,24 @@ if ('' != $historyDate) {
     });
 }
 
-if (rex::getUser()?->hasPerm('history[article_rollback]')) {
-    rex_extension::register(
-        ['ART_SLICES_COPY', 'SLICE_ADD', 'SLICE_UPDATE', 'SLICE_MOVE', 'SLICE_DELETE'],
-        static function (rex_extension_point $ep) {
-            $type = match ($ep->getName()) {
-                'ART_SLICES_COPY' => 'slices_copy',
-                'SLICE_MOVE' => 'slice_' . $ep->getParam('direction'),
-                default => strtolower($ep->getName()),
-            };
+rex_extension::register(
+    ['ART_SLICES_COPY', 'SLICE_ADD', 'SLICE_UPDATE', 'SLICE_MOVE', 'SLICE_DELETE'],
+    static function (rex_extension_point $ep) {
+        $type = match ($ep->getName()) {
+            'ART_SLICES_COPY' => 'slices_copy',
+            'SLICE_MOVE' => 'slice_' . $ep->getParam('direction'),
+            default => strtolower($ep->getName()),
+        };
 
-            $articleId = $ep->getParam('article_id');
-            $clangId = $ep->getParam('clang_id');
-            $sliceRevision = $ep->getParam('slice_revision');
+        $articleId = $ep->getParam('article_id');
+        $clangId = $ep->getParam('clang_id');
+        $sliceRevision = $ep->getParam('slice_revision');
 
-            if (0 == $sliceRevision) {
-                rex_article_slice_history::makeSnapshot($articleId, $clangId, $type);
-            }
-        },
-    );
-}
+        if (0 == $sliceRevision) {
+            rex_article_slice_history::makeSnapshot($articleId, $clangId, $type);
+        }
+    },
+);
 
 if (rex::isBackend() && rex::getUser()?->hasPerm('history[article_rollback]')) {
     rex_view::addCssFile($plugin->getAssetsUrl('noUiSlider/nouislider.css'));


### PR DESCRIPTION
Hier noch ein paar Stellen an denen die EPs im Backend aufgerufen werden. Soweit ich das sehe können die aber so bleiben.

# metainfo/boot
```
rex_extension::register('PAGE_CHECKED', 'rex_metainfo_extensions_handler');
rex_extension::register('STRUCTURE_CONTENT_SIDEBAR', function ($ep) {
```

# phpmailer/boot
```
rex_extension::register('RESPONSE_SHUTDOWN', static function () {
```

# structure/content/boot
```
rex_extension::register('PAGE_CHECKED', static function () {
```

# structure/history/boot
```
rex_extension::register('STRUCTURE_CONTENT_HEADER', static function (rex_extension_point $ep) {
```