### PR TITLE
MetaInfo uninstall: Functions auch einbinden, da benötigt

### DIFF
--- a/redaxo/src/addons/metainfo/uninstall.php
+++ b/redaxo/src/addons/metainfo/uninstall.php
@@ -7,6 +7,7 @@
  */
 
 $curDir = __DIR__;
+require_once $curDir . '/functions/function_metainfo.php';
 require_once $curDir . '/extensions/extension_cleanup.php';
 
 rex_metainfo_cleanup(['force' => true]);

--- a/redaxo/src/addons/metainfo/uninstall.php
+++ b/redaxo/src/addons/metainfo/uninstall.php
@@ -7,7 +7,7 @@
  */
 
 $curDir = __DIR__;
-require_once $curDir . '/functions/function_metainfo.php';
+require_once $curDir . '/boot.php';
 require_once $curDir . '/extensions/extension_cleanup.php';
 
 rex_metainfo_cleanup(['force' => true]);


### PR DESCRIPTION
Einerseits um die Functions zur Verfügung zu stellen, andererseits um die Meta-Tables zu registrieren.

fixes #6253