### PR TITLE
MediaPool: Mime-Type-Check default aktiviert

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1276,14 +1276,9 @@
   </file>
   <file src="redaxo/src/addons/mediapool/lib/mediapool.php">
     <MixedArgument>
-      <code><![CDATA[$allowedMimetypes[$extension]]]></code>
       <code><![CDATA[$args['types']]]></code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$allowedMimetypes[$extension]]]></code>
-    </MixedArrayAccess>
     <MixedAssignment>
-      <code><![CDATA[$allowedMimetypes]]></code>
       <code><![CDATA[$blockedExtension]]></code>
     </MixedAssignment>
     <MixedOperand>
@@ -1291,6 +1286,7 @@
       <code><![CDATA[$blockedExtension]]></code>
     </MixedOperand>
     <MixedReturnStatement>
+      <code><![CDATA[rex_addon::get('mediapool')->getProperty('allowed_mime_types', [])]]></code>
       <code><![CDATA[rex_addon::get('mediapool')->getProperty('blocked_extensions')]]></code>
     </MixedReturnStatement>
   </file>
@@ -1515,11 +1511,6 @@
       <code><![CDATA[$data['filename']]]></code>
       <code><![CDATA[$data['filename']]]></code>
     </MixedOperand>
-  </file>
-  <file src="redaxo/src/addons/mediapool/tests/mediapool_test.php">
-    <MixedAssignment>
-      <code><![CDATA[$allowedMimeTypes]]></code>
-    </MixedAssignment>
   </file>
   <file src="redaxo/src/addons/mediapool/update.php">
     <InvalidArgument>

--- a/redaxo/src/addons/mediapool/lib/mediapool.php
+++ b/redaxo/src/addons/mediapool/lib/mediapool.php
@@ -142,7 +142,7 @@ final class rex_mediapool
      */
     public static function isAllowedMimeType(string $path, ?string $filename = null): bool
     {
-        $allowedMimetypes = rex_addon::get('mediapool')->getProperty('allowed_mime_types');
+        $allowedMimetypes = self::getAllowedMimeTypes();
 
         if (!$allowedMimetypes) {
             return true;
@@ -191,5 +191,25 @@ final class rex_mediapool
     public static function getBlockedExtensions(): array
     {
         return rex_addon::get('mediapool')->getProperty('blocked_extensions');
+    }
+
+    /**
+     * Get global list of allowed mime types.
+     *
+     * @return array<string, list<string>> Mapping of file extensions to corresponding list of allowed mime types
+     */
+    public static function getAllowedMimeTypes(): array
+    {
+        return rex_addon::get('mediapool')->getProperty('allowed_mime_types', []);
+    }
+
+    /**
+     * Set global list of allowed mime types.
+     *
+     * @param array<string, list<string>> $mimeTypes Mapping of file extensions to corresponding list of allowed mime types
+     */
+    public static function setAllowedMimeTypes(array $mimeTypes): void
+    {
+        rex_addon::get('mediapool')->setProperty('allowed_mime_types', $mimeTypes);
     }
 }

--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -201,6 +201,10 @@ final class rex_media_service
                 $extensionNew == $extensionOld
                 || in_array($extensionNew, ['jpg', 'jpeg']) && in_array($extensionOld, ['jpg', 'jpeg'])
             ) {
+                if (!rex_mediapool::isAllowedMimeType($srcFile, $dstFile)) {
+                    $warning = rex_i18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . $extensionNew . '</code> (<code>' . $filetype . '</code>)';
+                    throw new rex_api_exception($warning);
+                }
                 if (!rex_file::move($srcFile, $dstFile)) {
                     throw new rex_api_exception(rex_i18n::msg('pool_file_movefailed'));
                 }

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -21,12 +21,12 @@ blocked_extensions: [asp, aspx, bat, cfm, cgi, flv, hh, html, htaccess, htpasswd
 
 # mime type allowlist. the list is checked after the blocked_extensions check from above has passed.
 allowed_mime_types:
+    avif: [image/avif]
     gif: [image/gif]
     jpg: [image/jpeg, image/pjpeg]
     jpeg: [image/jpeg, image/pjpeg]
     png: [image/png]
     webp: [image/webp]
-    avif: [image/avif]
     eps: [application/postscript]
     tif: [image/tiff]
     tiff: [image/tiff]

--- a/redaxo/src/addons/mediapool/package.yml
+++ b/redaxo/src/addons/mediapool/package.yml
@@ -19,12 +19,44 @@ page:
 
 blocked_extensions: [asp, aspx, bat, cfm, cgi, flv, hh, html, htaccess, htpasswd, ini, jsp, jsf, js, jsphp, log, mjs, pht, php, php3, php4, php5, php6, php7, php8, phar, pl, ps1, phtml, py, rb, rm, sh, shmtl, shtml, swf, wasm, wmv, wma, xhtml, xht, xml]
 
-# optional mime type allowlist. the list is checked after the blocked_extensions check from above has passed.
-# exmaple:
-#   allowed_mime_types:
-#       gif: [image/gif]
-#       jpg: [image/jpeg, image/pjpeg]
-allowed_mime_types: ~
+# mime type allowlist. the list is checked after the blocked_extensions check from above has passed.
+allowed_mime_types:
+    gif: [image/gif]
+    jpg: [image/jpeg, image/pjpeg]
+    jpeg: [image/jpeg, image/pjpeg]
+    png: [image/png]
+    webp: [image/webp]
+    avif: [image/avif]
+    eps: [application/postscript]
+    tif: [image/tiff]
+    tiff: [image/tiff]
+    svg: [image/svg+xml]
+    pdf: [application/pdf]
+    xls: [application/vnd.ms-excel]
+    xlsx: [application/vnd.openxmlformats-officedocument.spreadsheetml.sheet]
+    doc: [application/msword]
+    docx: [application/vnd.openxmlformats-officedocument.wordprocessingml.document]
+    dot: [application/msword]
+    dotx: [application/vnd.openxmlformats-officedocument.wordprocessingml.template]
+    ppt: [application/vnd.ms-powerpoint]
+    pptx: [application/vnd.openxmlformats-officedocument.presentationml.presentation]
+    pot: [application/vnd.ms-powerpoint]
+    potx: [application/vnd.openxmlformats-officedocument.presentationml.template]
+    pps: [application/vnd.ms-powerpoint]
+    ppsx: [application/vnd.openxmlformats-officedocument.presentationml.slideshow]
+    rtf: [application/rtf]
+    txt: [text/plain, application/octet-stream]
+    csv: [text/plain, application/octet-stream]
+    zip: [application/x-zip-compressed, application/zip]
+    gz: [application/x-gzip]
+    tar: [application/x-tar]
+    mov: [video/quicktime]
+    movie: [video/quicktime]
+    mp3: [audio/mpeg]
+    mpe: [video/mpeg]
+    mpeg: [video/mpeg]
+    mpg: [video/mpeg]
+    mp4: [video/mp4]
 
 allowed_doctypes: [avif, bmp, css, doc, docx, eps, gif, gz, jpg, jpeg, mov, mp3, mp4, ogg, pdf, png, ppt, pptx, pps, ppsx, rar, rtf, svg, swf, tar, tif, tiff, txt, webp, wma, xls, xlsx, zip]
 image_extensions: [avif, bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]

--- a/redaxo/src/addons/mediapool/tests/mediapool_test.php
+++ b/redaxo/src/addons/mediapool/tests/mediapool_test.php
@@ -36,17 +36,15 @@ final class rex_mediapool_test extends TestCase
     #[DataProvider('provideIsAllowedMimeType')]
     public function testIsAllowedMimeType(bool $expected, string $path, ?string $filename = null): void
     {
-        $addon = rex_addon::get('mediapool');
+        $allowedMimeTypes = rex_mediapool::getAllowedMimeTypes();
 
-        $allowedMimeTypes = $addon->getProperty('allowed_mime_types');
-
-        $addon->setProperty('allowed_mime_types', [
+        rex_mediapool::setAllowedMimeTypes([
             'md' => ['text/plain'],
         ]);
 
         self::assertSame($expected, rex_mediapool::isAllowedMimeType($path, $filename));
 
-        $addon->setProperty('allowed_mime_types', $allowedMimeTypes);
+        rex_mediapool::setAllowedMimeTypes($allowedMimeTypes);
     }
 
     /** @return list<array{0: bool, 1: string, 2?: string}> */

--- a/redaxo/src/addons/project/boot.php
+++ b/redaxo/src/addons/project/boot.php
@@ -11,47 +11,8 @@ $addon = rex_addon::get('project');
 // register yorm class
 // rex_yform_manager_dataset::setModelClass('rex_my_table', my_classname::class);
 
-// Example list of allowed mime types for mediapool
-/*
-rex_addon::get('mediapool')->setProperty('allowed_mime_types', [
-    'gif'   => ['image/gif'],
-    'jpg'   => ['image/jpeg', 'image/pjpeg'],
-    'jpeg'  => ['image/jpeg', 'image/pjpeg'],
-    'png'   => ['image/png'],
-    'eps'   => ['application/postscript'],
-    'tif'   => ['image/tiff'],
-    'tiff'  => ['image/tiff'],
-    'svg'   => ['image/svg+xml'],
-    'pdf'   => ['application/pdf'],
-    'xls'   => ['application/vnd.ms-excel'],
-    'xlsx'  => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
-    'xlsm'  => ['application/vnd.ms-excel.sheet.macroEnabled.12'],
-    'doc'   => ['application/msword'],
-    'docx'  => ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
-    'docm'  => ['application/vnd.ms-word.document.macroEnabled.12'],
-    'dot'   => ['application/msword'],
-    'dotx'  => ['application/vnd.openxmlformats-officedocument.wordprocessingml.template'],
-    'dotm'  => ['application/vnd.ms-word.template.macroEnabled.12'],
-    'ppt'   => ['application/vnd.ms-powerpoint'],
-    'pptx'  => ['application/vnd.openxmlformats-officedocument.presentationml.presentation'],
-    'pptm'  => ['application/vnd.ms-powerpoint.presentation.macroEnabled.12'],
-    'pot'   => ['application/vnd.ms-powerpoint'],
-    'potx'  => ['application/vnd.openxmlformats-officedocument.presentationml.template'],
-    'potm'  => ['application/vnd.ms-powerpoint.template.macroEnabled.12'],
-    'pps'   => ['application/vnd.ms-powerpoint'],
-    'ppsx'  => ['application/vnd.openxmlformats-officedocument.presentationml.slideshow'],
-    'ppsm'  => ['application/vnd.ms-powerpoint.slideshow.macroEnabled.12'],
-    'rtf'   => ['application/rtf'],
-    'txt'   => ['text/plain', 'application/octet-stream'],
-    'csv'   => ['text/plain', 'application/octet-stream'],
-    'zip'   => ['application/x-zip-compressed','application/zip'],
-    'gz'    => ['application/x-gzip'],
-    'tar'   => ['application/x-tar'],
-    'mov'   => ['video/quicktime'],
-    'movie' => ['video/quicktime'],
-    'mp3'   => ['audio/mpeg'],
-    'mpe'   => ['video/mpeg'],
-    'mpeg'  => ['video/mpeg'],
-    'mpg'   => ['video/mpeg'],
-]);
-*/
+// change list of allowed mime types for mediapool
+// rex_mediapool::setAllowedMimeTypes([
+//     ...rex_mediapool::getAllowedMimeTypes(),
+//     'json' => ['application/json'],
+// ]);


### PR DESCRIPTION
Aus Sicherheitsgründen werden wir im MP default eine Liste mit erlaubten Extensions/MimeTypes aktivieren, auch wenn es ein BC-Break ist.

In der Projekt-boot liegt der Code bereit, wie man die Liste ergänzen/ändern kann.

Zusätzlich werden die Mime-Types nun auch beim Dateiaustausch geprüft. Vorher konnte man da eine invalide Datei hochladen (gleiche Extension wie existierende Datei, aber Inhalt der nicht zum Dateityp passt).

