### PR TITLE
config_form.php

### DIFF
--- a/redaxo/src/core/lib/form/config_form.php
+++ b/redaxo/src/core/lib/form/config_form.php
@@ -11,6 +11,9 @@ class rex_config_form extends rex_form_base
 
     /** @var string */
     private $namespace;
+    
+    /** @var array */
+    private $additionalButtons = [];
 
     /**
      * @param string $namespace `rex_config` namespace, usually the package key
@@ -46,11 +49,64 @@ class rex_config_form extends rex_form_base
     {
         parent::loadBackendConfig();
 
+        // Wir erzeugen die Buttons erst beim Anzeigen des Formulars,
+        // damit alle zusätzlichen Buttons erfasst werden können
+    }
+    
+    /**
+     * Adds a button to the form.
+     *
+     * @param string $name Name of the button (will be used as name attribute)
+     * @param string $label Label text of the button
+     * @param string $type Type of the button (submit, reset, button)
+     * @param array $attributes Additional HTML attributes for the button
+     * @return rex_form_element The created button element
+     */
+    public function addButton($name, $label, $type = 'submit', array $attributes = [])
+    {
+        $attr = array_merge(['type' => $type, 'internal::useArraySyntax' => false, 'internal::fieldSeparateEnding' => true], $attributes);
+        $button = $this->addField('button', $name, $label, $attr, false);
+        $this->additionalButtons[] = $button;
+        return $button;
+    }
+    
+    /**
+     * @return string
+     */
+    public function get()
+    {
+        // Wir erstellen das Kontrollfeld mit allen Buttons kurz vor der Ausgabe des Formulars
+        $this->createControlField();
+        
+        return parent::get();
+    }
+    
+    /**
+     * Creates the control field with the save button and any additional buttons
+     */
+    protected function createControlField()
+    {
+        // Standard-Speichern-Button
         $attr = ['type' => 'submit', 'internal::useArraySyntax' => false, 'internal::fieldSeparateEnding' => true];
-        $this->addControlField(
-            null,
-            $this->addField('button', 'save', rex_i18n::msg('form_save'), $attr, false),
-        );
+        $saveButton = $this->addField('button', 'save', rex_i18n::msg('form_save'), $attr, false);
+        
+        // Control-Element mit allen Buttons erstellen
+        if (empty($this->additionalButtons)) {
+            // Standardverhalten, wenn keine zusätzlichen Buttons vorhanden sind
+            $this->addControlField(null, $saveButton);
+        } else {
+            // Bei mindestens einem Button erstellen wir ein erweitertes Control-Element
+            $buttons = array_merge([$saveButton], $this->additionalButtons);
+            
+            // Die ersten fünf Buttons als Parameter übergeben
+            $saveElement = isset($buttons[0]) ? $buttons[0] : null;
+            $applyElement = isset($buttons[1]) ? $buttons[1] : null;
+            $deleteElement = isset($buttons[2]) ? $buttons[2] : null;
+            $resetElement = isset($buttons[3]) ? $buttons[3] : null;
+            $abortElement = isset($buttons[4]) ? $buttons[4] : null;
+            
+            $this->addControlField($saveElement, $applyElement, $deleteElement, $resetElement, $abortElement);
+        }
     }
 
     protected function getValue($name)


### PR DESCRIPTION

<img width="985" alt="Bildschirmfoto 2025-04-22 um 13 30 29" src="https://github.com/user-attachments/assets/0570be4f-909b-42e9-b397-02924a524a4b" />


fixed: https://github.com/redaxo/redaxo/issues/3666

## Beschreibung

Diese PR erweitert die `rex_config_form` Klasse, um das Hinzufügen zusätzlicher Buttons neben dem Standard-Speichern-Button zu ermöglichen. z.B.:  "Speichern und Testen", "Auf Standard zurücksetzen" oder andere funktionale Buttons 

## Motivation und Hintergrund

In der aktuellen Implementierung der `rex_config_form` bietet sie nur einen Standard-"Speichern"-Button. In vielen AddOns besteht jedoch der Bedarf, zusätzliche Aktionen anzubieten, wie beispielsweise:
- Speichern und eine Testfunktion ausführen
- Zurücksetzen auf Standardwerte
- Anwenden von Änderungen ohne Umleitung
- Zusätzliche benutzerdefinierte Aktionen


## Einschränkungen dieser Lösung

Maximal fünf Buttons insgesamt (der Standard-Speichern-Button plus bis zu vier zusätzliche Buttons), basierend auf:
https://github.com/redaxo/redaxo/blob/6cca7d44655e6deebce7eb8cfc83935838cb8173/redaxo/src/core/lib/form/form.php#L147


## Test-Code

Hier ist ein Beispielcode, um die neue Funktionalität zu testen:

```php
<?php
// Beispiel für die Verwendung der erweiterten rex_config_form mit zusätzlichen Buttons

// Formular erstellen
$form = rex_config_form::factory('test_addon');

// Formularfelder hinzufügen
$field = $form->addTextField('setting_1');
$field->setLabel('Einstellung 1');

$field = $form->addTextAreaField('setting_2');
$field->setLabel('Einstellung 2');

// Zusätzlichen "Speichern und Testen"-Button hinzufügen
// Wird als "apply" Button behandelt (speichern ohne Weiterleitung)
$form->addButton('apply', 'Speichern und Testen', 'submit');

// Zusätzlichen "Auf Standard zurücksetzen"-Button hinzufügen
$form->addButton('reset_defaults', 'Auf Standard zurücksetzen', 'button', [
    'class' => 'btn btn-danger',
    'onclick' => 'if(confirm("Wirklich auf Standardwerte zurücksetzen?")) { location.href="index.php?page=test_addon/settings&reset_defaults=1"; }'
]);

// Prüfen, ob Standardwerte zurückgesetzt werden sollen
if (rex_get('reset_defaults', 'bool')) {
    // Hier Standardwerte setzen
    rex_config::set('test_addon', 'setting_1', 'Standardwert 1');
    rex_config::set('test_addon', 'setting_2', 'Standardwert 2');
    
    // Erfolgsmeldung und Umleitung
    echo rex_view::success('Einstellungen wurden auf Standardwerte zurückgesetzt.');
}

// Formular ausgeben
$fragment = new rex_fragment();
$fragment->setVar('class', 'edit', false);
$fragment->setVar('title', 'Test-Addon Einstellungen');
$fragment->setVar('body', $form->get(), false);
echo $fragment->parse('core/page/section.php');
```


