### PR TITLE
PHPMailer Auto-Purge Cronjob: 90 Tage erlauben

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/cronjob.php
+++ b/redaxo/src/addons/phpmailer/lib/cronjob.php
@@ -59,6 +59,7 @@ class rex_cronjob_mailer_purge extends rex_cronjob
                     7 => '7 ' . rex_i18n::msg('phpmailer_archivecron_days'),
                     14 => '14 ' . rex_i18n::msg('phpmailer_archivecron_days'),
                     30 => '30 ' . rex_i18n::msg('phpmailer_archivecron_days'),
+                    90 => '90 ' . rex_i18n::msg('phpmailer_archivecron_days')
                 ],
                 'default' => 7,
             ],


### PR DESCRIPTION
In Projekten, in denen sehr spät erst Probleme auffallen, wäre es mir wichtig, das auf 90 setzen zu können.

Nach wie vor finde ich es aber gut, dass es ein Select-Feld ist und nicht beliebige Werte wie "ein ganzes Jahr" erlaubt sind.