### PR TITLE
rex_form_control_element: `data-confirm`-Attribut abfragen

### DIFF
--- a/redaxo/src/core/lib/form/elements/control.php
+++ b/redaxo/src/core/lib/form/elements/control.php
@@ -59,7 +59,7 @@ class rex_form_control_element extends rex_form_element
                 $this->deleteElement->setAttribute('class', 'btn btn-delete');
             }
 
-            if (!$this->deleteElement->hasAttribute('data-confirm')) {
+            if (!$this->deleteElement->hasAttribute('data-confirm') && !$this->deleteElement->hasAttribute('onclick')) {
                 $this->deleteElement->setAttribute('data-confirm', rex_i18n::msg('form_delete') . '?');
             }
 
@@ -73,7 +73,7 @@ class rex_form_control_element extends rex_form_element
                 $this->resetElement->setAttribute('class', 'btn btn-reset');
             }
 
-            if (!$this->resetElement->hasAttribute('data-confirm')) {
+            if (!$this->resetElement->hasAttribute('data-confirm') && !$this->resetElement->hasAttribute('onclick')) {
                 $this->resetElement->setAttribute('data-confirm', rex_i18n::msg('form_reset') . '?');
             }
 

--- a/redaxo/src/core/lib/form/elements/control.php
+++ b/redaxo/src/core/lib/form/elements/control.php
@@ -59,7 +59,7 @@ class rex_form_control_element extends rex_form_element
                 $this->deleteElement->setAttribute('class', 'btn btn-delete');
             }
 
-            if (!$this->deleteElement->hasAttribute('onclick')) {
+            if (!$this->deleteElement->hasAttribute('data-confirm')) {
                 $this->deleteElement->setAttribute('data-confirm', rex_i18n::msg('form_delete') . '?');
             }
 
@@ -73,7 +73,7 @@ class rex_form_control_element extends rex_form_element
                 $this->resetElement->setAttribute('class', 'btn btn-reset');
             }
 
-            if (!$this->resetElement->hasAttribute('onclick')) {
+            if (!$this->resetElement->hasAttribute('data-confirm')) {
                 $this->resetElement->setAttribute('data-confirm', rex_i18n::msg('form_reset') . '?');
             }
 


### PR DESCRIPTION
~statt~ zusätzlich zu `onclick`.

Ich denke, das war ein Versehen in https://github.com/redaxo/redaxo/commit/b4aaf11856f0e7de03feb31ea4590b4bd6cfd680#diff-f93fb0335861fa411ec71e47a184b19217f4462cdfb8fe13f656cf3be9807d1c, dass bei der Umstellung auf `data-confirm` nicht auch die Abfrage entsprechend angepasst wurde.