### PR TITLE
Passwort nur rehashen, wenn sich User gerade mit Passwort neu einloggt

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -4484,7 +4484,6 @@
       <code><![CDATA[$_SESSION[static::getSessionNamespace()]]]></code>
     </PossiblyInvalidArrayOffset>
     <PossiblyNullArgument>
-      <code><![CDATA[$this->userPassword]]></code>
       <code><![CDATA[rex::getProperty('session_duration')]]></code>
     </PossiblyNullArgument>
   </file>

--- a/redaxo/src/core/lib/login/backend_login.php
+++ b/redaxo/src/core/lib/login/backend_login.php
@@ -126,7 +126,8 @@ class rex_backend_login extends rex_login
                 self::regenerateSessionId();
                 $params = [];
                 $add = '';
-                if (($password = $this->user->getValue('password')) && self::passwordNeedsRehash($password)) {
+                $password = $this->user->getValue('password');
+                if ($password && $this->userLogin && $this->userPassword && self::passwordNeedsRehash($password)) {
                     $add .= 'password = ?, ';
                     $params[] = $password = self::passwordHash($this->userPassword, true);
                 }


### PR DESCRIPTION
Bei PHP-Umstellung auf 8.4 werden die Passwörter zum ersten Mal neu gehasht, da sich der Default-Kostenfaktor für bcrypt geändert hat.

Dabei gibt es aber einen Fehler in REDAXO, und die Passwörter werden auch neu gehasht, wenn man über den "Eingeloggt bleiben"-Cookie automatisch wieder eingeloggt wird, oder wenn man sich über einen Passkey einloggt.
In den Situationen liegt das Passwort aber im Klartext ja gar nicht vor, somit kann es auch nicht rehasht werden. Es wird dann ein falscher Hash in die DB geschrieben und der User kann sich nicht mehr neu mit Passwort einloggen.

Das Rehashen darf nur passieren, wenn sich der User gerade frisch mit Passwort einloggt, weil man nur dann das Passwort als Klartext zur Verfügung hat für das Rehashen.