### PR TITLE
MetaInfo: Escaping für Meta-Präfix korrigiert

### DIFF
--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -639,7 +639,7 @@ abstract class rex_metainfo_handler
     protected static function getSqlFields($prefix, $filterCondition = '')
     {
         $sqlFields = rex_sql::factory();
-        $prefix = $sqlFields->escapeLikeWildcards($prefix);
+        $prefix = $sqlFields->escape($sqlFields->escapeLikeWildcards($prefix) . '%');
 
         $qry = 'SELECT
                             *
@@ -648,7 +648,7 @@ abstract class rex_metainfo_handler
                             ' . rex::getTablePrefix() . 'metainfo_type t
                         WHERE
                             `p`.`type_id` = `t`.`id` AND
-                            `p`.`name` LIKE "' . $prefix . '%"
+                            `p`.`name` LIKE ' . $prefix . '
                             ' . $filterCondition . '
                             ORDER BY
                             priority';

--- a/redaxo/src/addons/metainfo/lib/table_expander.php
+++ b/redaxo/src/addons/metainfo/lib/table_expander.php
@@ -318,12 +318,12 @@ class rex_metainfo_table_expander extends rex_form
         }
 
         $sql = rex_sql::factory();
-        $metaPrefix = $sql->escapeLikeWildcards($this->metaPrefix);
+        $metaPrefix = $sql->escape($sql->escapeLikeWildcards($this->metaPrefix) . '%');
 
         rex_sql_util::organizePriorities(
             $this->tableName,
             'priority',
-            'name LIKE "' . $metaPrefix . '%"',
+            'name LIKE ' . $metaPrefix,
             'priority, updatedate desc',
         );
     }

--- a/redaxo/src/addons/metainfo/pages/field.php
+++ b/redaxo/src/addons/metainfo/pages/field.php
@@ -41,9 +41,9 @@ if ('' == $func) {
     $title = rex_i18n::msg('minfo_field_list_caption');
 
     $sql = rex_sql::factory();
-    $likePrefix = $sql->escapeLikeWildcards($prefix);
+    $likePrefix = $sql->escape($sql->escapeLikeWildcards($prefix) . '%');
 
-    $list = rex_list::factory('SELECT id, name FROM ' . rex::getTablePrefix() . 'metainfo_field WHERE `name` LIKE "' . $likePrefix . '%" ORDER BY priority');
+    $list = rex_list::factory('SELECT id, name FROM ' . rex::getTablePrefix() . 'metainfo_field WHERE `name` LIKE ' . $likePrefix . ' ORDER BY priority');
     $list->addTableAttribute('class', 'table-striped table-hover');
 
     $tdIcon = '<i class="rex-icon rex-icon-metainfo"></i>';


### PR DESCRIPTION
Die Werte wurden nicht korrekt escaped. War hier nicht so schlimm, da der Präfix immer validiert wird und nur feste Werte einnimmt. Trotzdem ist es so besser.