### PR TITLE
Feature/linkmap language selection

### DIFF
--- a/redaxo/src/addons/structure/lib/linkmap/clang_aware_trait.php
+++ b/redaxo/src/addons/structure/lib/linkmap/clang_aware_trait.php
@@ -8,9 +8,7 @@
 trait rex_linkmap_clang_aware_trait
 {
     /**
-     * Get the language ID for this renderer
-     * 
-     * @return int
+     * Get the language ID for this renderer.
      */
     protected function getClangId(): int
     {
@@ -27,18 +25,13 @@ trait rex_linkmap_context_aware_trait
 {
     private rex_context $context;
 
-    /**
-     * @return rex_context
-     */
     public function getContext(): rex_context
     {
         return $this->context;
     }
 
     /**
-     * Get the language ID from context
-     * 
-     * @return int
+     * Get the language ID from context.
      */
     protected function getClangId(): int
     {

--- a/redaxo/src/addons/structure/lib/linkmap/clang_aware_trait.php
+++ b/redaxo/src/addons/structure/lib/linkmap/clang_aware_trait.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @package redaxo\structure
+ *
+ * @internal
+ */
+trait rex_linkmap_clang_aware_trait
+{
+    /**
+     * Get the language ID for this renderer
+     * 
+     * @return int
+     */
+    protected function getClangId(): int
+    {
+        return rex_clang::getStartId();
+    }
+}
+
+/**
+ * @package redaxo\structure
+ *
+ * @internal
+ */
+trait rex_linkmap_context_aware_trait
+{
+    private rex_context $context;
+
+    /**
+     * @return rex_context
+     */
+    public function getContext(): rex_context
+    {
+        return $this->context;
+    }
+
+    /**
+     * Get the language ID from context
+     * 
+     * @return int
+     */
+    protected function getClangId(): int
+    {
+        return (int) $this->context->getParam('clang', rex_clang::getStartId());
+    }
+}

--- a/redaxo/src/addons/structure/lib/linkmap/linkmap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/linkmap.php
@@ -12,6 +12,24 @@ class rex_linkmap_category_tree extends rex_linkmap_tree_renderer
     ) {}
 
     /**
+     * @return rex_context
+     */
+    public function getContext(): rex_context
+    {
+        return $this->context;
+    }
+
+    /**
+     * Get the language ID from context
+     * 
+     * @return int
+     */
+    protected function getClangId(): int
+    {
+        return (int) $this->context->getParam('clang', rex_clang::getStartId());
+    }
+
+    /**
      * @return string
      */
     protected function treeItem(rex_category $cat, $liClasses, $linkClasses, $subHtml, $liIcon)
@@ -49,6 +67,24 @@ class rex_linkmap_article_list extends rex_linkmap_article_list_renderer
     public function __construct(
         private rex_context $context,
     ) {}
+
+    /**
+     * @return rex_context
+     */
+    public function getContext(): rex_context
+    {
+        return $this->context;
+    }
+
+    /**
+     * Get the language ID from context
+     * 
+     * @return int
+     */
+    protected function getClangId(): int
+    {
+        return (int) $this->context->getParam('clang', rex_clang::getStartId());
+    }
 
     /**
      * @return string

--- a/redaxo/src/addons/structure/lib/linkmap/linkmap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/linkmap.php
@@ -7,22 +7,11 @@
  */
 class rex_linkmap_category_tree extends rex_linkmap_tree_renderer
 {
+    use rex_linkmap_context_aware_trait;
+
     public function __construct(
         private rex_context $context,
     ) {}
-
-    public function getContext(): rex_context
-    {
-        return $this->context;
-    }
-
-    /**
-     * Get the language ID from context.
-     */
-    protected function getClangId(): int
-    {
-        return (int) $this->context->getParam('clang', rex_clang::getStartId());
-    }
 
     /**
      * @return string
@@ -59,22 +48,11 @@ class rex_linkmap_category_tree extends rex_linkmap_tree_renderer
  */
 class rex_linkmap_article_list extends rex_linkmap_article_list_renderer
 {
+    use rex_linkmap_context_aware_trait;
+
     public function __construct(
         private rex_context $context,
     ) {}
-
-    public function getContext(): rex_context
-    {
-        return $this->context;
-    }
-
-    /**
-     * Get the language ID from context.
-     */
-    protected function getClangId(): int
-    {
-        return (int) $this->context->getParam('clang', rex_clang::getStartId());
-    }
 
     /**
      * @return string

--- a/redaxo/src/addons/structure/lib/linkmap/linkmap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/linkmap.php
@@ -11,18 +11,13 @@ class rex_linkmap_category_tree extends rex_linkmap_tree_renderer
         private rex_context $context,
     ) {}
 
-    /**
-     * @return rex_context
-     */
     public function getContext(): rex_context
     {
         return $this->context;
     }
 
     /**
-     * Get the language ID from context
-     * 
-     * @return int
+     * Get the language ID from context.
      */
     protected function getClangId(): int
     {
@@ -68,18 +63,13 @@ class rex_linkmap_article_list extends rex_linkmap_article_list_renderer
         private rex_context $context,
     ) {}
 
-    /**
-     * @return rex_context
-     */
     public function getContext(): rex_context
     {
         return $this->context;
     }
 
     /**
-     * Get the language ID from context
-     * 
-     * @return int
+     * Get the language ID from context.
      */
     protected function getClangId(): int
     {

--- a/redaxo/src/addons/structure/lib/linkmap/renderer.php
+++ b/redaxo/src/addons/structure/lib/linkmap/renderer.php
@@ -12,7 +12,9 @@ abstract class rex_linkmap_tree_renderer
      */
     public function getTree($categoryId)
     {
-        $category = rex_category::get($categoryId);
+        $clang = $this->getClangId();
+            
+        $category = rex_category::get($categoryId, $clang);
 
         $mountpoints = rex::requireUser()->getComplexPerm('structure')->getMountpointCategories();
         if (count($mountpoints) > 0) {
@@ -21,7 +23,7 @@ abstract class rex_linkmap_tree_renderer
                 $category = $roots[0];
             }
         } else {
-            $roots = rex_category::getRootCategories();
+            $roots = rex_category::getRootCategories($clang);
         }
 
         $tree = [];
@@ -34,6 +36,16 @@ abstract class rex_linkmap_tree_renderer
         $rendered = $this->renderTree($roots, $tree);
         // add css class to root node
         return '<ul class="list-group rex-linkmap-list-group"' . substr($rendered, 3);
+    }
+
+    /**
+     * Get the language ID for this renderer
+     * 
+     * @return int
+     */
+    protected function getClangId(): int
+    {
+        return rex_clang::getStartId();
     }
 
     /**
@@ -127,6 +139,8 @@ abstract class rex_linkmap_article_list_renderer
      */
     public function getList($categoryId)
     {
+        $clang = $this->getClangId();
+            
         $isRoot = 0 === $categoryId;
         $mountpoints = rex::requireUser()->getComplexPerm('structure')->getMountpoints();
 
@@ -136,13 +150,24 @@ abstract class rex_linkmap_article_list_renderer
         }
 
         if ($isRoot && 0 == count($mountpoints)) {
-            $articles = rex_article::getRootArticles();
+            $articles = rex_article::getRootArticles($clang);
         } elseif ($isRoot) {
             $articles = [];
         } else {
-            $articles = rex_category::get($categoryId)->getArticles();
+            $category = rex_category::get($categoryId, $clang);
+            $articles = $category ? $category->getArticles() : [];
         }
         return self::renderList($articles, $categoryId);
+    }
+
+    /**
+     * Get the language ID for this renderer
+     * 
+     * @return int
+     */
+    protected function getClangId(): int
+    {
+        return rex_clang::getStartId();
     }
 
     /**

--- a/redaxo/src/addons/structure/lib/linkmap/renderer.php
+++ b/redaxo/src/addons/structure/lib/linkmap/renderer.php
@@ -13,7 +13,7 @@ abstract class rex_linkmap_tree_renderer
     public function getTree($categoryId)
     {
         $clang = $this->getClangId();
-            
+
         $category = rex_category::get($categoryId, $clang);
 
         $mountpoints = rex::requireUser()->getComplexPerm('structure')->getMountpointCategories();
@@ -39,9 +39,7 @@ abstract class rex_linkmap_tree_renderer
     }
 
     /**
-     * Get the language ID for this renderer
-     * 
-     * @return int
+     * Get the language ID for this renderer.
      */
     protected function getClangId(): int
     {
@@ -140,7 +138,7 @@ abstract class rex_linkmap_article_list_renderer
     public function getList($categoryId)
     {
         $clang = $this->getClangId();
-            
+
         $isRoot = 0 === $categoryId;
         $mountpoints = rex::requireUser()->getComplexPerm('structure')->getMountpoints();
 
@@ -161,9 +159,7 @@ abstract class rex_linkmap_article_list_renderer
     }
 
     /**
-     * Get the language ID for this renderer
-     * 
-     * @return int
+     * Get the language ID for this renderer.
      */
     protected function getClangId(): int
     {

--- a/redaxo/src/addons/structure/lib/linkmap/renderer.php
+++ b/redaxo/src/addons/structure/lib/linkmap/renderer.php
@@ -7,6 +7,8 @@
  */
 abstract class rex_linkmap_tree_renderer
 {
+    use rex_linkmap_clang_aware_trait;
+
     /**
      * @return string
      */
@@ -36,14 +38,6 @@ abstract class rex_linkmap_tree_renderer
         $rendered = $this->renderTree($roots, $tree);
         // add css class to root node
         return '<ul class="list-group rex-linkmap-list-group"' . substr($rendered, 3);
-    }
-
-    /**
-     * Get the language ID for this renderer.
-     */
-    protected function getClangId(): int
-    {
-        return rex_clang::getStartId();
     }
 
     /**
@@ -132,6 +126,8 @@ abstract class rex_linkmap_tree_renderer
  */
 abstract class rex_linkmap_article_list_renderer
 {
+    use rex_linkmap_clang_aware_trait;
+
     /**
      * @return string
      */
@@ -156,14 +152,6 @@ abstract class rex_linkmap_article_list_renderer
             $articles = $category ? $category->getArticles() : [];
         }
         return self::renderList($articles, $categoryId);
-    }
-
-    /**
-     * Get the language ID for this renderer.
-     */
-    protected function getClangId(): int
-    {
-        return rex_clang::getStartId();
     }
 
     /**

--- a/redaxo/src/addons/structure/pages/linkmap.php
+++ b/redaxo/src/addons/structure/pages/linkmap.php
@@ -79,7 +79,7 @@ if (!rex_request::isXmlHttpRequest()) {
 <?php
 
 $isRoot = 0 === $categoryId;
-$category = rex_category::get($categoryId);
+$category = rex_category::get($categoryId, $clang);
 
 $navigation = [];
 if ($category) {
@@ -92,6 +92,14 @@ if ($category) {
 }
 
 echo rex_view::title('<i class="rex-icon rex-icon-linkmap"></i> Linkmap');
+
+// Language switcher for multi-language setups - displayed above breadcrumb, right aligned
+if (rex_clang::count() > 1) {
+    $langSwitcher = rex_view::clangSwitchAsDropdown($context, false);
+    if ($langSwitcher) {
+        echo '<div class="text-right">' . $langSwitcher . '</div>';
+    }
+}
 
 $title = '<a href="' . $context->getUrl(['category_id' => 0]) . '"><i class="rex-icon rex-icon-structure-root-level"></i> ' . rex_i18n::msg('root_level') . '</a>';
 

--- a/redaxo/src/addons/structure/pages/linkmap.php
+++ b/redaxo/src/addons/structure/pages/linkmap.php
@@ -97,7 +97,7 @@ echo rex_view::title('<i class="rex-icon rex-icon-linkmap"></i> Linkmap');
 if (rex_clang::count() > 1) {
     $langSwitcher = rex_view::clangSwitchAsDropdown($context, false);
     if ($langSwitcher) {
-        echo '<div class="text-right">' . $langSwitcher . '</div>';
+        echo '<div class="clearfix"><div class="pull-right">' . $langSwitcher . '</div></div>';
     }
 }
 

--- a/redaxo/src/core/lib/view.php
+++ b/redaxo/src/core/lib/view.php
@@ -409,9 +409,11 @@ class rex_view
     /**
      * Returns a clang switch.
      *
+     * @param rex_context $context
+     * @param bool $showEditLink Whether to show the "edit languages" link (default: true)
      * @return string
      */
-    public static function clangSwitchAsDropdown(rex_context $context)
+    public static function clangSwitchAsDropdown(rex_context $context, $showEditLink = true)
     {
         if (1 == rex_clang::count()) {
             return '';
@@ -441,7 +443,7 @@ class rex_view
         $fragment->setVar('header', rex_i18n::msg('clang_select'));
         $fragment->setVar('items', $items, false);
 
-        if ($user->isAdmin()) {
+        if ($showEditLink && $user->isAdmin()) {
             $fragment->setVar('footer', '<a href="' . rex_url::backendPage('system/lang') . '"><i class="fa fa-flag"></i> ' . rex_i18n::msg('languages_edit') . '</a>', false);
         }
 

--- a/redaxo/src/core/lib/view.php
+++ b/redaxo/src/core/lib/view.php
@@ -409,7 +409,6 @@ class rex_view
     /**
      * Returns a clang switch.
      *
-     * @param rex_context $context
      * @param bool $showEditLink Whether to show the "edit languages" link (default: true)
      * @return string
      */

--- a/redaxo/src/core/lib/view.php
+++ b/redaxo/src/core/lib/view.php
@@ -441,6 +441,7 @@ class rex_view
         $fragment->setVar('button_label', $buttonLabel);
         $fragment->setVar('header', rex_i18n::msg('clang_select'));
         $fragment->setVar('items', $items, false);
+        $fragment->setVar('right', true);
 
         if ($showEditLink && $user->isAdmin()) {
             $fragment->setVar('footer', '<a href="' . rex_url::backendPage('system/lang') . '"><i class="fa fa-flag"></i> ' . rex_i18n::msg('languages_edit') . '</a>', false);


### PR DESCRIPTION
- Hinzufügen eines Sprach-Dropdowns zur Linkmap-Oberfläche (oberhalb der Brotkrümel, rechtsbündig)
- Implementierung einer sprachabhängigen Darstellung im Linkmap-Baum und in der Artikelliste
- Erweiterung von rex_view::clangSwitchAsDropdown() um den optionalen Parameter showEditLink
- Aktualisierung der Linkmap-Renderer zur Unterstützung der Abfrage mehrsprachiger Inhalte
- Sicherstellung der korrekten Handhabung von Kontextparametern für die Clang-Umschaltung

Fixes #4016
<img width="824" height="358" alt="Bildschirmfoto 2025-07-16 um 22 47 02" src="https://github.com/user-attachments/assets/5e8d2276-65a9-4127-aa8c-bfbb13ba14c2" />
