### PR TITLE
Session overlay: Fix für "eingeloggt bleiben"

### DIFF
--- a/redaxo/src/core/assets/session-timeout.js
+++ b/redaxo/src/core/assets/session-timeout.js
@@ -59,7 +59,7 @@
                     }
                     clearInterval(sessionCheckInterval);
                     performKeepAlive();
-                } else if (currentSessionWarningTime < currentTime) {
+                } else if (!rex.session_stay_logged_in && currentSessionWarningTime < currentTime) {
                     clearInterval(sessionCheckInterval);
                     viewSessionExpandDialog();
                 }


### PR DESCRIPTION
In meinem Commit [`97295b0` (#6282)](https://github.com/redaxo/redaxo/pull/6282/commits/97295b043f8845719f48a1b9ca5f4ea7586d57b9) im Ursprungs-PR hatte ich versehentlich die zugehörige Änderung in der JS-Datei vergessen.