### PR TITLE
Vorschlag: Linkmap Language Switch

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2056,18 +2056,6 @@
       <code><![CDATA[rex_addon::get('structure')->getProperty('start_article_id', 1)]]></code>
     </MixedReturnStatement>
   </file>
-  <file src="redaxo/src/addons/structure/lib/linkmap/linkmap.php">
-    <MixedArgument>
-      <code><![CDATA[$liClasses]]></code>
-      <code><![CDATA[$linkClasses]]></code>
-    </MixedArgument>
-    <MixedOperand>
-      <code><![CDATA[$liClasses]]></code>
-      <code><![CDATA[$liIcon]]></code>
-      <code><![CDATA[$linkClasses]]></code>
-      <code><![CDATA[$subHtml]]></code>
-    </MixedOperand>
-  </file>
   <file src="redaxo/src/addons/structure/lib/linkmap/renderer.php">
     <MixedArgument>
       <code><![CDATA[$article]]></code>
@@ -2078,23 +2066,6 @@
       <code><![CDATA[$article]]></code>
       <code><![CDATA[$categoryId]]></code>
     </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$liAttr]]></code>
-      <code><![CDATA[$linkAttr]]></code>
-    </MixedOperand>
-    <PossiblyNullReference>
-      <code><![CDATA[getArticles]]></code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/linkmap/sitemap.php">
-    <MixedArgument>
-      <code><![CDATA[$liClasses]]></code>
-    </MixedArgument>
-    <MixedOperand>
-      <code><![CDATA[$liClasses]]></code>
-      <code><![CDATA[$linkClasses]]></code>
-      <code><![CDATA[$subHtml]]></code>
-    </MixedOperand>
   </file>
   <file src="redaxo/src/addons/structure/lib/linkmap/var_link.php">
     <MixedArgument>

--- a/redaxo/src/addons/structure/lib/linkmap/linkmap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/linkmap.php
@@ -23,7 +23,7 @@ class rex_linkmap_category_tree extends rex_linkmap_tree_renderer
     /**
      * @return string
      */
-    protected function treeItem(rex_category $cat, $liClasses, $linkClasses, $subHtml, $liIcon)
+    protected function treeItem(rex_category $cat, string $liClasses, string $linkClasses, string $subHtml, string $liIcon)
     {
         if ('' != $liClasses) {
             $liClasses = ' class="' . rtrim($liClasses) . '"';
@@ -71,7 +71,7 @@ class rex_linkmap_article_list extends rex_linkmap_article_list_renderer
     /**
      * @return string
      */
-    protected function listItem(rex_article $article, $categoryId)
+    protected function listItem(rex_article $article, int $categoryId)
     {
         $liAttr = ' class="list-group-item"';
         $url = 'javascript:insertLink(\'redaxo://' . $article->getId() . '\',\'' . rex_escape(trim(sprintf('%s [%s]', $article->getName(), $article->getId())), 'js') . '\');';

--- a/redaxo/src/addons/structure/lib/linkmap/linkmap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/linkmap.php
@@ -9,7 +9,16 @@ class rex_linkmap_category_tree extends rex_linkmap_tree_renderer
 {
     public function __construct(
         private rex_context $context,
+        private int $clang,
     ) {}
+
+    /**
+     * @return string
+     */
+    public function getTree(int $categoryId, ?int $clang = null)
+    {
+        return parent::getTree($categoryId, $this->clang);
+    }
 
     /**
      * @return string
@@ -48,7 +57,16 @@ class rex_linkmap_article_list extends rex_linkmap_article_list_renderer
 {
     public function __construct(
         private rex_context $context,
+        private int $clang,
     ) {}
+
+    /**
+     * @return string
+     */
+    public function getList(int $categoryId, ?int $clang = null)
+    {
+        return parent::getList($categoryId, $this->clang);
+    }
 
     /**
      * @return string

--- a/redaxo/src/addons/structure/lib/linkmap/renderer.php
+++ b/redaxo/src/addons/structure/lib/linkmap/renderer.php
@@ -87,7 +87,7 @@ abstract class rex_linkmap_tree_renderer
     /**
      * @return string
      */
-    abstract protected function treeItem(rex_category $cat, $liClasses, $linkClasses, $subHtml, $liIcon);
+    abstract protected function treeItem(rex_category $cat, string $liClasses, string $linkClasses, string $subHtml, string $liIcon);
 
     /**
      * @return string
@@ -110,7 +110,7 @@ abstract class rex_linkmap_tree_renderer
     /**
      * @return string
      */
-    public static function formatLi(rex_structure_element $OOobject, $currentCategoryId, rex_context $context, $liAttr = '', $linkAttr = '')
+    public static function formatLi(rex_structure_element $OOobject, int $currentCategoryId, rex_context $context, string $liAttr = '', string $linkAttr = '')
     {
         $linkAttr .= ' class="' . ($OOobject->isOnline() ? 'rex-online' : 'rex-offline') . '"';
 
@@ -165,7 +165,7 @@ abstract class rex_linkmap_article_list_renderer
     /**
      * @return string
      */
-    public function renderList(array $articles, $categoryId)
+    public function renderList(array $articles, int $categoryId)
     {
         $list = '';
         if ($articles) {
@@ -183,5 +183,5 @@ abstract class rex_linkmap_article_list_renderer
     /**
      * @return string
      */
-    abstract protected function listItem(rex_article $article, $categoryId);
+    abstract protected function listItem(rex_article $article, int $categoryId);
 }

--- a/redaxo/src/addons/structure/lib/linkmap/sitemap.php
+++ b/redaxo/src/addons/structure/lib/linkmap/sitemap.php
@@ -11,7 +11,7 @@ class rex_sitemap_category_tree extends rex_linkmap_tree_renderer
         private rex_context $context,
     ) {}
 
-    public function getTree($categoryId)
+    public function getTree(int $categoryId, ?int $clang = null)
     {
         // if not, let the structure as is, by providing a remembered id
         if ($categoryId <= 0) {
@@ -19,13 +19,13 @@ class rex_sitemap_category_tree extends rex_linkmap_tree_renderer
         } else {
             rex_request::setSession('tree_category_id', $categoryId);
         }
-        return parent::getTree($categoryId);
+        return parent::getTree($categoryId, $clang);
     }
 
     /**
      * @return string
      */
-    protected function treeItem(rex_category $cat, $liClasses, $linkClasses, $subHtml, $liIcon)
+    protected function treeItem(rex_category $cat, string $liClasses, string $linkClasses, string $subHtml, string $liIcon)
     {
         $linkClasses .= '';
 

--- a/redaxo/src/addons/structure/pages/linkmap.php
+++ b/redaxo/src/addons/structure/pages/linkmap.php
@@ -79,7 +79,7 @@ if (!rex_request::isXmlHttpRequest()) {
 <?php
 
 $isRoot = 0 === $categoryId;
-$category = rex_category::get($categoryId);
+$category = rex_category::get($categoryId, $clang);
 
 $navigation = [];
 if ($category) {
@@ -93,6 +93,9 @@ if ($category) {
 
 echo rex_view::title('<i class="rex-icon rex-icon-linkmap"></i> Linkmap');
 
+// Language switcher for multi-language setups - same as in structure addon
+echo rex_view::clangSwitchAsButtons($context);
+
 $title = '<a href="' . $context->getUrl(['category_id' => 0]) . '"><i class="rex-icon rex-icon-structure-root-level"></i> ' . rex_i18n::msg('root_level') . '</a>';
 
 $fragment = new rex_fragment();
@@ -102,7 +105,7 @@ echo $fragment->parse('core/navigations/breadcrumb.php');
 
 $content = [];
 
-$categoryTree = new rex_linkmap_category_tree($context);
+$categoryTree = new rex_linkmap_category_tree($context, $clang);
 $panel = $categoryTree->getTree($categoryId);
 
 $fragment = new rex_fragment();
@@ -110,7 +113,7 @@ $fragment->setVar('title', rex_i18n::msg('linkmap_categories'), false);
 $fragment->setVar('content', $panel, false);
 $content[] = $fragment->parse('core/page/section.php');
 
-$articleList = new rex_linkmap_article_list($context);
+$articleList = new rex_linkmap_article_list($context, $clang);
 $panel = $articleList->getList($categoryId);
 
 $fragment = new rex_fragment();

--- a/redaxo/src/addons/structure/pages/linkmap.php
+++ b/redaxo/src/addons/structure/pages/linkmap.php
@@ -93,8 +93,8 @@ if ($category) {
 
 echo rex_view::title('<i class="rex-icon rex-icon-linkmap"></i> Linkmap');
 
-// Language switcher for multi-language setups - same as in structure addon
-echo rex_view::clangSwitchAsButtons($context);
+// Language switcher - same as structure but without edit link
+echo rex_view::clangSwitchAsButtons($context, true, false);
 
 $title = '<a href="' . $context->getUrl(['category_id' => 0]) . '"><i class="rex-icon rex-icon-structure-root-level"></i> ' . rex_i18n::msg('root_level') . '</a>';
 

--- a/redaxo/src/core/lib/view.php
+++ b/redaxo/src/core/lib/view.php
@@ -372,17 +372,18 @@ class rex_view
      * Returns a clang switch.
      *
      * @param bool $asDropDown
+     * @param bool $showEditLink Whether to show the "edit languages" link for admins in dropdown mode
      *
      * @return string
      */
-    public static function clangSwitchAsButtons(rex_context $context, $asDropDown = true)
+    public static function clangSwitchAsButtons(rex_context $context, $asDropDown = true, bool $showEditLink = true)
     {
         if (1 == rex_clang::count()) {
             return '';
         }
 
         if ($asDropDown && rex_clang::count() >= 4) {
-            return self::clangSwitchAsDropdown($context);
+            return self::clangSwitchAsDropdown($context, $showEditLink);
         }
 
         $items = [];
@@ -409,9 +410,10 @@ class rex_view
     /**
      * Returns a clang switch.
      *
+     * @param bool $showEditLink Whether to show the "edit languages" link for admins
      * @return string
      */
-    public static function clangSwitchAsDropdown(rex_context $context)
+    public static function clangSwitchAsDropdown(rex_context $context, bool $showEditLink = true)
     {
         if (1 == rex_clang::count()) {
             return '';
@@ -441,7 +443,7 @@ class rex_view
         $fragment->setVar('header', rex_i18n::msg('clang_select'));
         $fragment->setVar('items', $items, false);
 
-        if ($user->isAdmin()) {
+        if ($showEditLink && $user->isAdmin()) {
             $fragment->setVar('footer', '<a href="' . rex_url::backendPage('system/lang') . '"><i class="fa fa-flag"></i> ' . rex_i18n::msg('languages_edit') . '</a>', false);
         }
 


### PR DESCRIPTION
Erlaubt die Umschaltung der Sprache in der Linkmap, z.B. bei Verlinkungen aus YForm und co. 
Es ist sonst nicht möglich zu sehen ob ein Artikel in der gewünschten Sprache offline ist. 

<img width="1316" height="863" alt="Bildschirmfoto 2025-09-02 um 15 41 50" src="https://github.com/user-attachments/assets/735f7ea8-d85b-4490-ba7b-c76d6974dfc2" />

<img width="1029" height="655" alt="Bildschirmfoto 2025-09-02 um 15 41 15" src="https://github.com/user-attachments/assets/2641ba30-7957-48db-af38-154f1f80232e" />

fixed: https://github.com/redaxo/redaxo/issues/4016 