### PR TITLE
Session-Overlay: Warning-Time nach Keep-Alive anpassen

### DIFF
--- a/redaxo/src/core/assets/session-timeout.js
+++ b/redaxo/src/core/assets/session-timeout.js
@@ -75,6 +75,7 @@
                 if (xhr.status === 200) {
                     let response = JSON.parse(xhr.responseText);
                     overallSessionWarningTime = new Date().getTime() + ((response.rest_overall_time - warningTime) * 1000);
+                    setCurrentSessionWarningTime();
                     startSessionInterval();
                 } else {
                     viewSessionFailedDialog();


### PR DESCRIPTION
Default-Werte sind ja 2h Session-Dauer und 6h Keep-Alive-Ajax-Aufrufe.
Nach den Keep-Alive-Aufrufen soll die Session-Dauer also wieder 2h sein, dafür sind ja die Keep-Alive-Aufrufe, um die Session zu verlängern, solange man einen Tab offen hat.

Zurzeit hat das JS-Skript die Warning-Time aber nach den Keep-Alive-Aufrufen nicht angepasst.

ref #6311
