### PR TITLE
Add sticky positioning to panel footer

### DIFF
--- a/redaxo/src/addons/be_style/vendor/bootstrap/assets/stylesheets/bootstrap/_panels.scss
+++ b/redaxo/src/addons/be_style/vendor/bootstrap/assets/stylesheets/bootstrap/_panels.scss
@@ -53,6 +53,12 @@
   @include border-bottom-radius(($panel-border-radius - 1));
 }
 
+.rex-slice .panel-footer {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  z-index: 100;
+}
 
 // List groups in panels
 //


### PR DESCRIPTION
Makes modul input panel footers sticky, which is super useful in longer module input forms