### PR TITLE
Register LINKMAP_ARTICLE_LIST extension point

### DIFF
--- a/redaxo/src/addons/structure/lib/linkmap/renderer.php
+++ b/redaxo/src/addons/structure/lib/linkmap/renderer.php
@@ -169,7 +169,6 @@ abstract class rex_linkmap_article_list_renderer
                     ['articles' => $articles, 'category_id' => $categoryId],
                 ),
             );
-            
             if ('' != $list) {
                 $list = '<ul class="list-group rex-linkmap-list-group">' . $list . '</ul>';
             }

--- a/redaxo/src/addons/structure/lib/linkmap/renderer.php
+++ b/redaxo/src/addons/structure/lib/linkmap/renderer.php
@@ -162,6 +162,14 @@ abstract class rex_linkmap_article_list_renderer
                 $list .= $this->listItem($article, $categoryId);
             }
 
+            $list = rex_extension::registerPoint(
+                new rex_extension_point(
+                    'LINKMAP_ARTICLE_LIST',
+                    $list,
+                    ['articles' => $articles, 'category_id' => $categoryId],
+                ),
+            );
+            
             if ('' != $list) {
                 $list = '<ul class="list-group rex-linkmap-list-group">' . $list . '</ul>';
             }


### PR DESCRIPTION
Allows extending the list of links under articles in the Linkmap dialog.
See also:
https://github.com/redaxo/redaxo/pull/6361