### PR TITLE
.htaccess-Check entfernt

### DIFF
--- a/.github/tests-visual/visual-record.js
+++ b/.github/tests-visual/visual-record.js
@@ -37,17 +37,6 @@ if (myArgs.includes('setup')) {
 }
 const MIN_DIFF_PIXELS = minDiffPixels;
 
-// htaccess ajax checks are subject to race conditions and therefore generated 'random' markup.
-// disable the check to get less visual noise.
-const noHtaccessCheckCookie = {
-    name: 'rex_htaccess_check',
-    value: '1',
-    domain: 'localhost',
-    path: '/',
-    httpOnly: false,
-    secure: false
-};
-
 // all pages
 const allPages = {
     'structure_category_edit.png': START_URL + '?page=structure&category_id=0&article_id=0&clang=1&edit_id=1&function=edit_cat&catstart=0',
@@ -241,7 +230,6 @@ async function main() {
 
     const browser = await playwright.chromium.launch();
     const context = await browser.newContext();
-    await context.addCookies([noHtaccessCheckCookie]);
     let page = await context.newPage();
     // log browser errors into the console
     page.on('console', function(msg) {

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -448,52 +448,6 @@ jQuery(function($){
             rex.accesskeys = laststate;
         });
     $("[autofocus]").trigger("focus");
-
-    if ($('#rex-page-setup, #rex-page-login').length == 0 && getCookie('rex_htaccess_check') == '')
-    {
-        time = new Date();
-        time.setTime(time.getTime() + 1000 * 60 * 60 * 24);
-
-        setCookie(
-            'rex_htaccess_check',
-            '1',
-            time.toGMTString(),
-            rex.cookie_params.path,
-            rex.cookie_params.domain,
-            rex.cookie_params.secure,
-            rex.cookie_params.samesite.toLowerCase()
-        );
-
-        var allowedUrl = 'index.php';
-
-        // test urls, which is not expected to be accessible
-        // after each expected error, run a request which is expected to succeed.
-        // that way we try to make sure tools like fail2ban dont block the client
-        var urls = [
-            'bin/console',
-            allowedUrl,
-            'data/.redaxo',
-            allowedUrl,
-            'src/core/boot.php',
-            allowedUrl,
-            'cache/.redaxo'
-        ];
-
-        // NOTE: we have essentially a copy of this code in the setup process.
-        $.each(urls, function (i, url) {
-            $.ajax({
-                // add a human readable suffix so people get an idea what we are doing here
-                url: url + '?redaxo-security-self-test',
-                cache: false,
-                success: function (data) {
-                    if (i % 2 == 0) {
-                        $('#rex-js-page-main').prepend('<div class="alert alert-danger" style="margin-top: 20px;">The folder <code>redaxo/' + url + '</code> is insecure. Make sure this folder is not publicly accessible.</div>');
-                        setCookie('rex_htaccess_check', '');
-                    }
-                }
-            });
-        });
-    }
 });
 
 

--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -450,38 +450,6 @@ jQuery(function($){
     $("[autofocus]").trigger("focus");
 });
 
-
-// cookie functions
-
-function setCookie(name, value, expires, path, domain, secure, samesite) {
-    if (typeof expires != undefined && expires == "never") {
-        // never expire means expires in 3000 days
-        expires = new Date();
-        expires.setTime(expires.getTime() + (1000 * 60 * 60 * 24 * 3000));
-        expires = expires.toGMTString();
-    }
-
-    document.cookie = name + "=" + escape(value)
-        + ((expires) ? "; expires=" + expires : "")
-        + ((path) ? "; path=" + path : "")
-        + ((domain) ? "; domain=" + domain : "")
-        + ((secure) ? "; secure" : "")
-        + ((samesite) ? "; samesite=" + samesite : "");
-}
-
-function getCookie(cookieName) {
-    var theCookie = "" + document.cookie;
-    var ind = theCookie.indexOf(cookieName);
-    if (ind == -1 || cookieName == "")
-        return "";
-
-    var ind1 = theCookie.indexOf(';', ind);
-    if (ind1 == -1)
-        ind1 = theCookie.length;
-
-    return unescape(theCookie.substring(ind + cookieName.length + 1, ind1));
-}
-
 // scroll to anchor element + adjust scroll-padding-top
 function scrollToAnchor() {
     if (window.location.hash) {

--- a/redaxo/src/core/lang/de_de.lang
+++ b/redaxo/src/core/lang/de_de.lang
@@ -268,8 +268,6 @@ setup_605 = Viel Spaß und Erfolg!<br />Das REDAXO-Team
 setup_606 = zum Login
 setup_699 = 6 / Heureka
 
-setup_security_msg = Mindestens einer der Ordner <code>redaxo/bin</code>, <code>redaxo/cache</code>, <code>redaxo/data</code>, <code>redaxo/src</code> ist unsicher. Gründe hierfür sind häufig, dass die <code>.htaccess</code>-Dateien innerhalb der Ordner nicht übertragen wurden oder der Schutz z.B. für nginx-Server nicht erstellt wurde.
-setup_no_js_security_msg = Prüfe, ob Dateien aus den Ordnern <code>redaxo/bin</code>, <code>redaxo/cache</code>, <code>redaxo/data</code> und <code>redaxo/src</code> direkt aufrufbar sind. Dies darf aus Sicherheitsgründen nicht möglich sein!
 setup_security_no_https = Das Setup wird unverschlüsselt durchgeführt. Frontend und Backend sollten grundsätzlich durch HTTPS verschlüsselt aufgerufen werden, um die Privatsphäre zu schützen und den Datenschutz zu gewährleisten.
 setup_security_warn_mod_security = Das Apache Modul "mod_security" ist geladen. Dies kann bei falscher Konfiguration zu Problemen führen.
 setup_security_deprecated_php = Die verwendete PHP-Version {0} wird nicht mehr vom Hersteller gepflegt und sollte aktualisiert werden.

--- a/redaxo/src/core/lang/en_gb.lang
+++ b/redaxo/src/core/lang/en_gb.lang
@@ -267,8 +267,6 @@ setup_605 = Have fun and good luck!<br />The REDAXO team
 setup_606 = Sign in
 setup_699 = 6 / Hooray
 
-setup_security_msg =
-setup_no_js_security_msg =
 setup_security_no_https = The setup will continue without SSL encryption. It is recommended to use SSL encryption for each call to the front- and backend in order to ensure privacy and data protection.
 setup_security_warn_mod_security = The Apache module "mod_security" is loaded. This can cause problems if not configured correctly.
 setup_security_deprecated_php = The used PHP Version {0} version will no longer receive updates. You should consider upgrading to a newer version.

--- a/redaxo/src/core/pages/setup.step2.php
+++ b/redaxo/src/core/pages/setup.step2.php
@@ -32,45 +32,7 @@ if (count($errorArray) > 0) {
     $buttons = '<a class="btn btn-setup" href="' . $context->getUrl(['step' => 3]) . '">' . I18n::msg('setup_210') . '</a>';
 }
 
-$security = '<div class="rex-js-setup-security-message" style="display:none">' . Message::error(I18n::msg('setup_security_msg') . '<br />' . I18n::msg('setup_no_js_security_msg')) . '</div>';
-$security .= '<noscript>' . Message::error(I18n::msg('setup_no_js_security_msg')) . '</noscript>';
-
-$security .= '<script nonce="' . Response::getNonce() . '">
-
-    jQuery(function($){
-        var allowedUrl = "' . Url::backend('index.php') . '";
-
-        // test url, which is not expected to be accessible
-        // after each expected error, run a request which is expected to succeed.
-        // that way we try to make sure tools like fail2ban dont block the client
-        var urls = [
-            "' . Url::backend('bin/console') . '",
-            allowedUrl,
-            "' . Url::backend('data/.redaxo') . '",
-            allowedUrl,
-            "' . Url::backend('src/core/boot.php') . '",
-            allowedUrl,
-            "' . Url::backend('cache/.redaxo') . '"
-        ];
-
-        // NOTE: we have essentially a copy of this code in checkHtaccess() - see standard.js
-        $.each(urls, function (i, url) {
-            $.ajax({
-                url: url,
-                cache: false,
-                success: function(data) {
-                    if (i % 2 == 0) {
-                        $(".rex-js-setup-security-message").show();
-                        $(".rex-js-setup-section").hide();
-                    }
-                }
-            });
-        });
-
-    })
-
-</script>';
-
+$security = '';
 foreach (Setup::checkPhpSecurity() as $warning) {
     $security .= Message::warning($warning);
 }

--- a/redaxo/src/core/pages/setup.step2.php
+++ b/redaxo/src/core/pages/setup.step2.php
@@ -1,8 +1,6 @@
 <?php
 
-use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\Http\Context;
-use Redaxo\Core\Http\Response;
 use Redaxo\Core\Setup\Setup;
 use Redaxo\Core\Translation\I18n;
 use Redaxo\Core\View\Fragment;

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -29,7 +29,6 @@ final class Cache
         $finder = Finder::factory(Path::cache())
             ->recursive()
             ->childFirst()
-            ->ignoreFiles(['.htaccess', '.redaxo'], false)
             ->ignoreSystemStuff(false);
         Dir::deleteIterator($finder);
 


### PR DESCRIPTION
Da R6 Standardmäßig einen public-Ordner nutzt und die src-Dateien etc. außerhalb liegen, ist der Check in der Form nicht mehr notwendig.
(Man muss natürlich trotzdem den Server korrekt konfigurieren, sodass nur der public-Ordner erreichbar ist.)