### PR TITLE
`rex_sql_table`: Bei `TEXT`-Columns Default normalisieren

### DIFF
--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -87,11 +87,16 @@ class rex_sql_table
                 $type = 'int(10) unsigned';
             }
 
+            $default = $column['default'];
+            if ("''" === $default && in_array($type, ['tinytext', 'text', 'mediumtext', 'longtext', 'tinyblob', 'blob', 'mediumblob', 'longblob'], true)) {
+                $default = '';
+            }
+
             $this->columns[$column['name']] = new rex_sql_column(
                 $column['name'],
                 $type,
                 'YES' === $column['null'],
-                $column['default'],
+                $default,
                 $column['extra'] ?: null,
                 $column['comment'] ?: null,
             );


### PR DESCRIPTION
closes #6426, wobei es das Problem wahrscheinlich nicht gänzlich löst. Aber zumindest sollte das Problem damit abgemildert werden. Das Problem tritt ja sowieso nur auf, wenn man MariaDB und MySQL gemischt nutzt. Bei Mischung mit älteren MySQL-Datenbanken (5.x) könnte es ggf. trotzdem noch zu Problemen führen (wenn vorher mit MariaDB eine Migration erstellt wurde).

Muss man mal beobachten, wie sich die Änderung bewährt.