### PR TITLE
Backup-Cronjob: Option zum endgültigen Löschen alter Backups

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -45,20 +45,12 @@
     <MixedArgument>
       <code><![CDATA[$excludedTables]]></code>
       <code><![CDATA[$filename]]></code>
-      <code><![CDATA[$sqlFile]]></code>
       <code><![CDATA[$this->getParam('delete_interval')]]></code>
       <code><![CDATA[$this->getParam('mailaddress')]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$backup]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayOffset>
-      <code><![CDATA[$backups[$sqlFile]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$excludedTables]]></code>
       <code><![CDATA[$filename]]></code>
-      <code><![CDATA[$sqlFile]]></code>
     </MixedAssignment>
     <PossiblyFalseArgument>
       <code><![CDATA[glob(rex_path::addonData('backup', '*' . $ext . '.gz'), GLOB_NOSORT)]]></code>

--- a/redaxo/src/addons/backup/lang/de_de.lang
+++ b/redaxo/src/addons/backup/lang/de_de.lang
@@ -64,6 +64,13 @@ backup_delete_interval_off = Aus
 backup_delete_interval_weekly = Ein Backup pro Woche behalten
 backup_delete_interval_monthly = Ein Backup pro Monat behalten
 backup_delete_interval_notice = Es werden nur Backups gelöscht, die älter als ein Monat sind und deren Dateinamen auf <code>.cronjob.sql</code> enden.
+backup_delete_max_age = Backups endgültig löschen nach
+backup_delete_max_age_off = Aus
+backup_delete_max_age_3months = 3 Monaten
+backup_delete_max_age_6months = 6 Monaten
+backup_delete_max_age_12months = 12 Monaten
+backup_delete_max_age_24months = 24 Monaten
+backup_delete_max_age_notice = Backups, die älter als der gewählte Zeitraum sind, werden vollständig gelöscht – auch die wöchentlich/monatlich aufbewahrten.
 
 backup_exclude_tables = Von Backup ausschließen
 backup_exclude_tables_notice = Wenn ausgewählt, werden diese Tabellen nicht gesichert. Tabellen mit dem Präfix <code>rex_tmp_*</code> werden automatisch ausgeschlossen.

--- a/redaxo/src/addons/backup/lang/en_gb.lang
+++ b/redaxo/src/addons/backup/lang/en_gb.lang
@@ -64,6 +64,13 @@ backup_delete_interval_off = Off
 backup_delete_interval_weekly = Keep one backup per week
 backup_delete_interval_monthly = Keep one backup per month
 backup_delete_interval_notice = Only backups older than one month will be deleted, and file name must end with <code>.cronjob.sql</code>.
+backup_delete_max_age = Delete backups permanently after
+backup_delete_max_age_off = Off
+backup_delete_max_age_3months = 3 months
+backup_delete_max_age_6months = 6 months
+backup_delete_max_age_12months = 12 months
+backup_delete_max_age_24months = 24 months
+backup_delete_max_age_notice = Backups older than the selected period will be permanently deleted – including those kept weekly/monthly.
 
 backup_exclude_tables = Exclude from backup
 backup_exclude_tables_notice = The selected tables will not be backed up. Tables with a prefix of <code>rex_tmp_*</code> will be excluded automatically.

--- a/redaxo/src/addons/backup/lib/cronjob.php
+++ b/redaxo/src/addons/backup/lib/cronjob.php
@@ -52,6 +52,7 @@ class rex_cronjob_export extends rex_cronjob
             }
 
             if ($this->getParam('delete_interval') || $this->getParam('delete_max_age')) {
+                /** @var list<string> $allSqlfiles */
                 $allSqlfiles = array_merge(
                     glob(rex_path::addonData('backup', '*' . $ext), GLOB_NOSORT),
                     glob(rex_path::addonData('backup', '*' . $ext . '.gz'), GLOB_NOSORT),

--- a/redaxo/src/addons/backup/lib/cronjob.php
+++ b/redaxo/src/addons/backup/lib/cronjob.php
@@ -51,42 +51,62 @@ class rex_cronjob_export extends rex_cronjob
                 }
             }
 
-            if ($this->getParam('delete_interval')) {
+            if ($this->getParam('delete_interval') || $this->getParam('delete_max_age')) {
                 $allSqlfiles = array_merge(
                     glob(rex_path::addonData('backup', '*' . $ext), GLOB_NOSORT),
                     glob(rex_path::addonData('backup', '*' . $ext . '.gz'), GLOB_NOSORT),
                 );
-                $backups = [];
-                $limit = strtotime('-1 month'); // Generelle Vorhaltezeit: 1 Monat
-
-                foreach ($allSqlfiles as $sqlFile) {
-                    $timestamp = filectime($sqlFile);
-
-                    if ($timestamp > $limit) {
-                        // wenn es die generelle Vorhaltezeit unterschreitet
-                        continue;
-                    }
-
-                    $backups[$sqlFile] = $timestamp;
-                }
-
-                asort($backups, SORT_NUMERIC);
-
-                $step = '';
                 $countDeleted = 0;
 
-                foreach ($backups as $backup => $timestamp) {
-                    $stepLast = $step;
-                    $step = date($this->getParam('delete_interval'), (int) $timestamp);
+                if ($this->getParam('delete_interval')) {
+                    $backups = [];
+                    $limit = strtotime('-1 month'); // Generelle Vorhaltezeit: 1 Monat
 
-                    if ($stepLast !== $step) {
-                        // wenn es zu diesem Interval schon ein Backup gibt
-                        continue;
+                    foreach ($allSqlfiles as $sqlFile) {
+                        $timestamp = filectime($sqlFile);
+
+                        if ($timestamp > $limit) {
+                            // wenn es die generelle Vorhaltezeit unterschreitet
+                            continue;
+                        }
+
+                        $backups[$sqlFile] = $timestamp;
                     }
 
-                    // dann löschen
-                    rex_file::delete($backup);
-                    ++$countDeleted;
+                    asort($backups, SORT_NUMERIC);
+
+                    $step = '';
+
+                    foreach ($backups as $backup => $timestamp) {
+                        $stepLast = $step;
+                        $step = date($this->getParam('delete_interval'), (int) $timestamp);
+
+                        if ($stepLast !== $step) {
+                            // wenn es zu diesem Interval schon ein Backup gibt
+                            continue;
+                        }
+
+                        // dann löschen
+                        rex_file::delete($backup);
+                        ++$countDeleted;
+                    }
+                }
+
+                if ($this->getParam('delete_max_age')) {
+                    $maxAgeLimit = strtotime('-' . (int) $this->getParam('delete_max_age') . ' months');
+
+                    foreach ($allSqlfiles as $sqlFile) {
+                        if (!is_file($sqlFile)) {
+                            continue;
+                        }
+
+                        $timestamp = filectime($sqlFile);
+
+                        if ($timestamp < $maxAgeLimit) {
+                            rex_file::delete($sqlFile);
+                            ++$countDeleted;
+                        }
+                    }
                 }
 
                 if ($countDeleted) {
@@ -184,6 +204,21 @@ class rex_cronjob_export extends rex_cronjob
                 'YM' => rex_i18n::msg('backup_delete_interval_monthly'), ],
             'default' => 'YW',
             'notice' => rex_i18n::msg('backup_delete_interval_notice'),
+        ];
+
+        $fields[] = [
+            'label' => rex_i18n::msg('backup_delete_max_age'),
+            'name' => 'delete_max_age',
+            'type' => 'select',
+            'options' => [
+                '0' => rex_i18n::msg('backup_delete_max_age_off'),
+                '3' => rex_i18n::msg('backup_delete_max_age_3months'),
+                '6' => rex_i18n::msg('backup_delete_max_age_6months'),
+                '12' => rex_i18n::msg('backup_delete_max_age_12months'),
+                '24' => rex_i18n::msg('backup_delete_max_age_24months'),
+            ],
+            'default' => '0',
+            'notice' => rex_i18n::msg('backup_delete_max_age_notice'),
         ];
 
         return $fields;


### PR DESCRIPTION
Neue Option "delete_max_age" im Backup-Cronjob, mit der Backups nach einem konfigurierbaren Zeitraum (3/6/12/24 Monate) vollständig gelöscht werden – unabhängig von der bestehenden Intervall-Ausdünnung.

closes #5706
