### PR TITLE
Console setup: possibility to keep existing db password

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -4028,7 +4028,6 @@
       <code><![CDATA[$config['db'][1]['host']]]></code>
       <code><![CDATA[$config['db'][1]['login']]]></code>
       <code><![CDATA[$config['db'][1]['name']]]></code>
-      <code><![CDATA[$config['db'][1]['password']]]></code>
       <code><![CDATA[$config['error_email']]]></code>
       <code><![CDATA[$config['lang']]]></code>
       <code><![CDATA[$config['server']]]></code>

--- a/redaxo/src/core/lib/console/setup/run.php
+++ b/redaxo/src/core/lib/console/setup/run.php
@@ -179,6 +179,10 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
 
         $io->section('Database information');
 
+        $previousHost = $config['db'][1]['host'] ?? null;
+        $previousLogin = $config['db'][1]['login'] ?? null;
+        $previousPassword = $config['db'][1]['password'] ?? null;
+
         do {
             $config['db'][1]['host'] = $this->getOptionOrAsk(
                 'MySQL Host',
@@ -195,16 +199,28 @@ class rex_command_setup_run extends rex_console_command implements rex_command_o
                 $requiredValue,
             );
 
-            $q = new Question('Password');
-            $q->setHidden(true);
+            $keepPassword = false;
+            if ($previousPassword
+                && $config['db'][1]['host'] === $previousHost
+                && $config['db'][1]['login'] === $previousLogin
+                && null === $input->getOption('db-password')
+                && $input->isInteractive()
+            ) {
+                $keepPassword = $io->confirm('Keep existing database password?', true);
+            }
 
-            $config['db'][1]['password'] = $this->getOptionOrAsk(
-                $q,
-                'db-password',
-                '',
-                'Using database password *secret*',
-                null,
-            );
+            if (!$keepPassword) {
+                $q = new Question('Password');
+                $q->setHidden(true);
+
+                $config['db'][1]['password'] = (string) $this->getOptionOrAsk(
+                    $q,
+                    'db-password',
+                    '',
+                    'Using database password *secret*',
+                    null,
+                );
+            }
 
             $config['db'][1]['name'] = $this->getOptionOrAsk(
                 'Database name',


### PR DESCRIPTION
closes #3745

Wenn man zuvor Host und Login bei den alten Werten belässt, dann wird vor der Passworteingabe gefragt, ob man auch das alte Passwort belassen möchte (falls denn schon eins vorhanden war).