### PR TITLE
Fix for code scanning alert no. 1124: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -8,6 +8,10 @@ jobs:
     slash-command-dispatch:
         runs-on: ubuntu-slim
         timeout-minutes: 30
+        permissions:
+            contents: read
+            issues: read
+            pull-requests: read
         if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/')
 
         steps:

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -4,14 +4,15 @@ on:
     issue_comment:
         types: [created]
 
+permissions:
+    contents: read
+    issues: read
+    pull-requests: read
+
 jobs:
     slash-command-dispatch:
         runs-on: ubuntu-slim
         timeout-minutes: 30
-        permissions:
-            contents: read
-            issues: read
-            pull-requests: read
         if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/')
 
         steps:


### PR DESCRIPTION
Potential fix for <a href="https://github.com/redaxo/redaxo/security/code-scanning/1124">https://github.com/redaxo/redaxo/security/code-scanning/1124</a>

In general, the fix is to add an explicit `permissions` block to the workflow so that the `GITHUB_TOKEN` only has the minimal scopes required. For a chatops workflow that reacts to `issue_comment` and dispatches slash commands via an external token (`secrets.BOT_TOKEN`), the `GITHUB_TOKEN` usually only needs read access to repository contents and issues, and possibly pull requests, but not write access.

The fix adds a workflow-level `permissions` block in `.github/workflows/chatops.yml`, above `jobs`, so it applies globally to the entire workflow:

```yaml
permissions:
  contents: read
  issues: read
  pull-requests: read
```

These permissions allow the workflow (and any actions it calls that use `GITHUB_TOKEN`) to read repository contents, issues, and pull requests, which is typically sufficient for reacting to comments and evaluating conditions. The `peter-evans/slash-command-dispatch` action is configured to use `secrets.BOT_TOKEN` for write operations (dispatching commands, adding reactions), so the `GITHUB_TOKEN` can remain read-only.

No additional imports or external methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._