### PR TITLE
Templates/Module/Actions: virtuelle Konstanten ("common vars") entfernt

### DIFF
--- a/.tools/phpstan/baseline/_loader.php
+++ b/.tools/phpstan/baseline/_loader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// total 357 errors
+// total 356 errors
 
 return ['includes' => [
     __DIR__ . '/argument.templateType.php',

--- a/.tools/phpstan/baseline/_loader.php
+++ b/.tools/phpstan/baseline/_loader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// total 358 errors
+// total 357 errors
 
 return ['includes' => [
     __DIR__ . '/argument.templateType.php',

--- a/.tools/phpstan/baseline/argument.type.php
+++ b/.tools/phpstan/baseline/argument.type.php
@@ -2,14 +2,9 @@
 
 declare(strict_types=1);
 
-// total 3 errors
+// total 2 errors
 
 $ignoreErrors = [];
-$ignoreErrors[] = [
-    'rawMessage' => 'Parameter #2 $replace of function str_replace expects array<string>|string, list<int> given.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/ArticleAction.php',
-];
 $ignoreErrors[] = [
     'rawMessage' => 'Parameter #3 $priority of static method Redaxo\\Core\\MetaInfo\\MetaInfo::addField() expects int, string given.',
     'count' => 1,

--- a/.tools/phpstan/baseline/argument.type.php
+++ b/.tools/phpstan/baseline/argument.type.php
@@ -2,18 +2,13 @@
 
 declare(strict_types=1);
 
-// total 4 errors
+// total 3 errors
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
     'rawMessage' => 'Parameter #2 $replace of function str_replace expects array<string>|string, list<int> given.',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Content/ArticleAction.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Parameter #2 $replace of function str_replace expects array<string>|string, array<int, int|string> given.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/ArticleContentBase.php',
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Parameter #3 $priority of static method Redaxo\\Core\\MetaInfo\\MetaInfo::addField() expects int, string given.',

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2373,7 +2373,6 @@
     </PossiblyFalseArgument>
     <PossiblyNullArgument>
       <code><![CDATA[$TEMPLATE->getTemplate()]]></code>
-      <code><![CDATA[$template->getKey()]]></code>
     </PossiblyNullArgument>
   </file>
   <file src="src/Content/ArticleContentEditor.php">
@@ -4502,15 +4501,10 @@
   </file>
   <file src="src/RexVar/TemplateVar.php">
     <PossiblyFalseArgument>
-      <code><![CDATA[$tmpl]]></code>
-      <code><![CDATA[$tmpl]]></code>
+      <code><![CDATA[new Template($id)->getTemplate()]]></code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$id]]></code>
-    </PossiblyInvalidArgument>
     <PossiblyNullArgument>
-      <code><![CDATA[$tmpl]]></code>
-      <code><![CDATA[$tmpl]]></code>
+      <code><![CDATA[new Template($id)->getTemplate()]]></code>
     </PossiblyNullArgument>
   </file>
   <file src="src/RexVar/ValueVar.php">

--- a/src/Content/ArticleAction.php
+++ b/src/Content/ArticleAction.php
@@ -18,8 +18,12 @@ class ArticleAction
     public const PRESAVE = 'presave';
     public const POSTSAVE = 'postsave';
 
-    /** @var int */
-    private $moduleId;
+    protected readonly int $moduleId;
+    protected readonly int $articleId;
+    protected readonly int $clangId;
+    protected readonly int $ctypeId;
+    protected readonly int $sliceId;
+
     /** @var string */
     private $event;
     /** @var int */
@@ -30,8 +34,6 @@ class ArticleAction
     private $messages = [];
     /** @var Sql */
     private $sql;
-    /** @var array{search: list<string>, replace: list<int>} */
-    private $vars;
 
     public function __construct($moduleId, $function, Sql $sql)
     {
@@ -45,14 +47,11 @@ class ArticleAction
             $this->mode = 1;
         }
         $this->sql = $sql;
-        $this->vars['search'] = ['REX_ARTICLE_ID', 'REX_CLANG_ID', 'REX_CTYPE_ID', 'REX_MODULE_ID', 'REX_SLICE_ID'];
-        $this->vars['replace'] = [
-            Request::request('article_id', 'int'),
-            Request::request('clang', 'int'),
-            Request::request('ctype', 'int'),
-            Request::request('module_id', 'int'),
-            1 == $this->mode ? 0 : Request::request('slice_id', 'int'),
-        ];
+
+        $this->articleId = Request::request('article_id', 'int');
+        $this->clangId = Request::request('clang', 'int');
+        $this->ctypeId = Request::request('ctype', 'int');
+        $this->sliceId = 1 == $this->mode ? 0 : Request::request('slice_id', 'int');
     }
 
     /** @return void */
@@ -93,7 +92,6 @@ class ArticleAction
 
         foreach ($ga as $row) {
             $action = (string) $row->getValue('code');
-            $action = str_replace($this->vars['search'], $this->vars['replace'], $action);
             $action = RexVar::parse($action, RexVar::ENV_BACKEND | RexVar::ENV_INPUT, 'action', $this->sql);
 
             $articleId = (int) $row->getValue('id');

--- a/src/Content/ArticleContentBase.php
+++ b/src/Content/ArticleContentBase.php
@@ -442,9 +442,7 @@ class ArticleContentBase
                 $TEMPLATE = new Template($this->template_id);
 
                 Timer::measure('Template: ' . ($TEMPLATE->getKey() ?? $TEMPLATE->getId()), function () use ($TEMPLATE) {
-                    $tplContent = $this->replaceCommonVars($TEMPLATE->getTemplate());
-
-                    require Stream::factory('template/' . $this->template_id, $tplContent);
+                    require Stream::factory('template/' . $this->template_id, $TEMPLATE->getTemplate());
                 });
             } finally {
                 $CONTENT = ob_get_clean();
@@ -493,36 +491,6 @@ class ArticleContentBase
      */
     protected function replaceVars(Sql $sql, $content)
     {
-        $content = $this->replaceCommonVars($content);
-        $content = str_replace(
-            [
-                'REX_MODULE_ID',
-                'REX_MODULE_KEY',
-                'REX_SLICE_ID',
-                'REX_CTYPE_ID',
-            ],
-            [
-                (string) $sql->getValue('module_id'),
-                (string) $sql->getValue(Core::getTable('module') . '.key'),
-                (string) $sql->getValue(Core::getTable('article_slice') . '.id'),
-                (string) $sql->getValue('ctype_id'),
-            ],
-            $content,
-        );
-
-        $content = $this->replaceObjectVars($sql, $content);
-
-        return $content;
-    }
-
-    // ----- REX_VAR Ersetzungen
-
-    /**
-     * @param string $content
-     * @return string
-     */
-    protected function replaceObjectVars(Sql $sql, $content)
-    {
         $sliceId = $sql->getValue(Core::getTablePrefix() . 'article_slice.id');
 
         if ('edit' == $this->mode) {
@@ -535,58 +503,6 @@ class ArticleContentBase
         }
 
         return RexVar::parse($content, $env, 'module', $sql);
-    }
-
-    // ---- Artikelweite globale variablen werden ersetzt
-
-    /**
-     * @param string $content
-     * @param int|null $templateId
-     * @return string
-     */
-    public function replaceCommonVars($content, $templateId = null)
-    {
-        /** @var int|string|null $userId */
-        static $userId = null;
-        /** @var string|null $userLogin */
-        static $userLogin = null;
-
-        // UserId gibts nur im Backend
-        if (null === $userId || null === $userLogin) {
-            if ($user = Core::getUser()) {
-                $userId = $user->getId();
-                $userLogin = $user->getLogin();
-            } else {
-                $userId = '';
-                $userLogin = '';
-            }
-        }
-
-        if (!$templateId) {
-            $templateId = $this->getTemplateId();
-        }
-
-        // calculating the key takes an additional sql query... execute the query only when we are sure the var is used
-        if (str_contains($content, 'REX_TEMPLATE_KEY')) {
-            $template = new Template($templateId);
-            $content = str_replace('REX_TEMPLATE_KEY', $template->getKey(), $content);
-        }
-
-        return str_replace([
-            'REX_ARTICLE_ID',
-            'REX_CATEGORY_ID',
-            'REX_CLANG_ID',
-            'REX_TEMPLATE_ID',
-            'REX_USER_ID',
-            'REX_USER_LOGIN',
-        ], [
-            $this->article_id,
-            $this->category_id,
-            $this->clang,
-            $templateId,
-            $userId,
-            $userLogin,
-        ], $content);
     }
 
     /**

--- a/src/RexVar/TemplateVar.php
+++ b/src/RexVar/TemplateVar.php
@@ -45,13 +45,7 @@ class TemplateVar extends RexVar
     {
         ob_start(); // will be closed in getTemplateOutput()
 
-        $tmpl = new Template($id);
-        $tmpl = $tmpl->getTemplate();
-        if ($article) {
-            $tmpl = $article->replaceCommonVars($tmpl, $id);
-        }
-
-        return Stream::factory('template/' . $id, $tmpl);
+        return Stream::factory('template/' . $id, new Template($id)->getTemplate());
     }
 
     /**


### PR DESCRIPTION
Der PR entfernt die einfachen Vars ohne eckige Klammern, also `REX_ARTICLE_ID` etc.
Diese wurden auch vor PHP-Ausführung ersetzt.

refs #5420