### PR TITLE
Block hinzufügen: `$this->getCurrentSlice()` korrigiert

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
@@ -13,6 +13,8 @@ class rex_article_content_editor extends rex_article_content
     /** @var int */
     private $sliceAddPosition = 0;
 
+    private ?rex_article_slice $currentSlice = null;
+
     /**
      * @param int|null $articleId
      * @param int|null $clang
@@ -377,6 +379,7 @@ class rex_article_content_editor extends rex_article_content
         // ----- add module im edit mode
         if ('edit' == $this->mode) {
             if ('add' == $this->function && $this->slice_id == $behindlastSliceId) {
+                ++$this->sliceAddPosition;
                 $sliceContent = $this->addSlice($behindlastSliceId, $moduleId);
             } else {
                 // ----- BLOCKAUSWAHL - SELECT
@@ -418,8 +421,12 @@ class rex_article_content_editor extends rex_article_content
         $action->exec(rex_article_action::PREVIEW);
         // ----- / PRE VIEW ACTION
 
+        $this->currentSlice = rex_article_slice::forNewSlice($this->article_id, $this->clang, $this->ctype, $moduleId, $this->sliceAddPosition, $this->slice_revision);
+
         $moduleInput = $this->replaceVars($initDataSql, (string) $MOD->getValue('input'));
         $moduleInput = $this->getStreamOutput('module/' . $moduleId . '/input', $moduleInput);
+
+        $this->currentSlice = null;
 
         $msg = '';
         if ('' != $this->warning) {
@@ -536,5 +543,10 @@ class rex_article_content_editor extends rex_article_content
         $fragment->setVar('formAction', rex_url::currentBackendPage(['article_id' => $this->article_id, 'slice_id' => $sliceId, 'ctype' => $ctypeId, 'clang' => $this->clang, 'function' => 'edit']) . '#slice' . $sliceId, false);
         $fragment->setVar('content', $sliceContent, false);
         return $fragment->parse('slice_list_item.php');
+    }
+
+    public function getCurrentSlice(): rex_article_slice
+    {
+        return $this->currentSlice ?? parent::getCurrentSlice();
     }
 }

--- a/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_slice.php
@@ -53,6 +53,36 @@ class rex_article_slice
     ) {}
 
     /** @internal  */
+    public static function forNewSlice(
+        int $articleId,
+        int $clang,
+        int $ctype,
+        int $moduleId,
+        int $priority,
+        int $revision,
+    ): self {
+        return new self(
+            0,
+            $articleId,
+            $clang,
+            $ctype,
+            $moduleId,
+            $priority,
+            1,
+            $time = time(),
+            $time,
+            $user = rex::requireUser()->getLogin(),
+            $user,
+            $revision,
+            array_fill(0, 20, null),
+            array_fill(0, 10, null),
+            array_fill(0, 10, null),
+            array_fill(0, 10, null),
+            array_fill(0, 10, null),
+        );
+    }
+
+    /** @internal  */
     public static function fromSql(rex_sql $sql): self
     {
         $table = rex::getTable('article_slice');


### PR DESCRIPTION
Zurzeit liefert `$this->getCurrentSlice()` in der Moduleingabe beim Hinzufügen eines Blocks jeweils den vorherigen Slice, bzw. an letzter Stelle dann eine Exception.

Neu wird ein `rex_article_slice`-Objekt geliefert mit leeren Values etc.