### PR TITLE
refactor: remove unnecessary `imagedestroy()` calls

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -855,8 +855,6 @@
       <code><![CDATA[$imgBlur]]></code>
       <code><![CDATA[$imgBlur]]></code>
       <code><![CDATA[$imgBlur]]></code>
-      <code><![CDATA[$imgBlur]]></code>
-      <code><![CDATA[$imgCanvas]]></code>
       <code><![CDATA[$imgCanvas]]></code>
       <code><![CDATA[$imgCanvas]]></code>
       <code><![CDATA[$imgCanvas]]></code>

--- a/redaxo/src/addons/media_manager/lib/effects/effect_filter_sharpen.php
+++ b/redaxo/src/addons/media_manager/lib/effects/effect_filter_sharpen.php
@@ -159,8 +159,7 @@ class rex_effect_filter_sharpen extends rex_effect_abstract
                 }
             }
         }
-        imagedestroy($imgCanvas);
-        imagedestroy($imgBlur);
+
         $this->media->setImage($gdimage);
     }
 


### PR DESCRIPTION
Since PHP 8.0, GD images are `GdImage` objects that are automatically freed by the garbage collector, making `imagedestroy()` a no-op.