### PR TITLE
ci: avoid unnecessary label removal/re-adding on PR edits

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -13,7 +13,8 @@ jobs:
         timeout-minutes: 5
 
         steps:
-            -   uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+            -   name: Lint PR title
+                uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
                 env:
                     GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
                 with:
@@ -32,7 +33,9 @@ jobs:
                     requireScope: false
                     subjectPattern: ^.+$
 
-            -   uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # v1.3.1
+            -   name: Add release labels
+                uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # v1.3.1
+                if: github.event.action == 'opened' || github.event.changes.title
                 with:
                     token: ${{ secrets.BOT_TOKEN }}
                     type_labels: |


### PR DESCRIPTION
Only run the release labels step when the PR is opened or the title changes, not on every description edit or branch synchronize.