### PR TITLE
chore: remove obsolete `Pdo\Mysql` class.notFound ignore from phpstan config

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -42,8 +42,5 @@ parameters:
         - '#^Offset .* on .* always exists#'
         -   identifiers: [possiblyImpure.functionCall, possiblyImpure.methodCall]
         -
-            message: '#\bPdo\\Mysql\b#'
-            identifier: class.notFound
-        -
             message: '#.*deprecated.*#'
             path: '*/update.php'


### PR DESCRIPTION
The `Pdo\Mysql` class is now recognized by PHPStan's PHP stubs, so the ignore rule is no longer matched and causes an error.