### PR TITLE
feat: auto-discover API functions via attributes and ClassDiscovery

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1819,6 +1819,12 @@
       <code><![CDATA[gzgets($fpIn, 1024 * 512)]]></code>
     </PossiblyFalseOperand>
   </file>
+  <file src="src/ClassDiscovery.php">
+    <MixedReturnStatement>
+      <code><![CDATA[array_first(ClassLoader::getRegisteredLoaders())
+            ?? throw new RuntimeException('Composer ClassLoader not found.')]]></code>
+    </MixedReturnStatement>
+  </file>
   <file src="src/Config.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$cfg->getValue('value')]]></code>

--- a/addons/debug/boot.php
+++ b/addons/debug/boot.php
@@ -19,8 +19,6 @@ use Redaxo\Core\Util\Timer;
 
 use function Redaxo\Core\View\escape;
 
-ApiFunction::register('debug', rex_api_debug::class);
-
 if (!rex_debug_clockwork::isRexDebugEnabled() || 'debug' === Request::get(ApiFunction::REQ_CALL_PARAM)) {
     return;
 }

--- a/addons/debug/lib/api_debug.php
+++ b/addons/debug/lib/api_debug.php
@@ -1,6 +1,7 @@
 <?php
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Core;
 use Redaxo\Core\Http\Response;
@@ -8,6 +9,7 @@ use Redaxo\Core\Http\Response;
 /**
  * @internal
  */
+#[AsApiFunction('debug')]
 class rex_api_debug extends ApiFunction
 {
     public function execute()

--- a/src/Addon/ApiFunction/AddonOperation.php
+++ b/src/Addon/ApiFunction/AddonOperation.php
@@ -6,6 +6,7 @@ use Override;
 use Redaxo\Core\Addon\Addon as BaseAddon;
 use Redaxo\Core\Addon\AddonManager;
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Core;
@@ -18,6 +19,7 @@ use function Redaxo\Core\View\escape;
 /**
  * @internal
  */
+#[AsApiFunction('addon_operation')]
 final class AddonOperation extends ApiFunction
 {
     #[Override]

--- a/src/ApiFunction/ApiFunction.php
+++ b/src/ApiFunction/ApiFunction.php
@@ -3,10 +3,9 @@
 namespace Redaxo\Core\ApiFunction;
 
 use BadMethodCallException;
-use Redaxo\Core\Addon\ApiFunction\AddonOperation;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\Base\FactoryTrait;
-use Redaxo\Core\Content\ApiFunction as ContentApiFunction;
+use Redaxo\Core\ClassDiscovery;
 use Redaxo\Core\Core;
 use Redaxo\Core\Exception\LogicException;
 use Redaxo\Core\Http\Context;
@@ -14,8 +13,6 @@ use Redaxo\Core\Http\Exception\HttpException;
 use Redaxo\Core\Http\Exception\NotFoundHttpException;
 use Redaxo\Core\Http\Request;
 use Redaxo\Core\Http\Response;
-use Redaxo\Core\MetaInfo\ApiFunction\DefaultFieldsCreate;
-use Redaxo\Core\Security\ApiFunction as SecurityApiFunction;
 use Redaxo\Core\Security\CsrfToken;
 use Redaxo\Core\Security\Login;
 use Redaxo\Core\Translation\I18n;
@@ -65,36 +62,11 @@ abstract class ApiFunction
     protected $result;
 
     /**
-     * Explicitly registered api functions.
+     * Discovered and registered api functions.
      *
-     * @var array<string, class-string<ApiFunction>>
+     * @var array<string, class-string<self>>|null
      */
-    private static $functions = [
-        'addon_operation' => AddonOperation::class,
-        'article_add' => ContentApiFunction\ArticleAdd::class,
-        'article_copy' => ContentApiFunction\ArticleCopy::class,
-        'article_delete' => ContentApiFunction\ArticleDelete::class,
-        'article_edit' => ContentApiFunction\ArticleEdit::class,
-        'article_move' => ContentApiFunction\ArticleMove::class,
-        'article_slice_move' => ContentApiFunction\ArticleSliceMove::class,
-        'article_slice_status_change' => ContentApiFunction\ArticleSliceStatusChange::class,
-        'article_status_change' => ContentApiFunction\ArticleStatusChange::class,
-        'article_to_category' => ContentApiFunction\ArticleToCategory::class,
-        'article_to_startarticle' => ContentApiFunction\ArticleToStartArticle::class,
-        'category_add' => ContentApiFunction\CategoryAdd::class,
-        'category_delete' => ContentApiFunction\CategoryDelete::class,
-        'category_edit' => ContentApiFunction\CategoryEdit::class,
-        'category_move' => ContentApiFunction\CategoryMove::class,
-        'category_status_change' => ContentApiFunction\CategoryStatusChange::class,
-        'category_to_article' => ContentApiFunction\CategoryToArticle::class,
-        'content_copy' => ContentApiFunction\ContentCopy::class,
-        'metainfo_default_fields_create' => DefaultFieldsCreate::class,
-        'user_has_session' => SecurityApiFunction\UserHasSession::class,
-        'user_impersonate' => SecurityApiFunction\UserImpersonate::class,
-        'user_remove_auth_method' => SecurityApiFunction\UserRemoveAuthMethod::class,
-        'user_remove_session' => SecurityApiFunction\UserRemoveSession::class,
-        'user_session_status' => SecurityApiFunction\UserSessionStatus::class,
-    ];
+    private static ?array $functions = null;
 
     /**
      * The api function which is bound to the current request.
@@ -127,7 +99,11 @@ abstract class ApiFunction
         $api = Request::request(self::REQ_CALL_PARAM, 'string');
 
         if ($api) {
-            $apiClass = self::$functions[$api];
+            $apiClass = self::loadFunctions()[$api] ?? null;
+
+            if (null === $apiClass) {
+                throw new NotFoundHttpException('API function "' . $api . '" is not registered.');
+            }
 
             if (class_exists($apiClass)) {
                 $apiImpl = new $apiClass();
@@ -146,6 +122,7 @@ abstract class ApiFunction
     /** @param class-string<ApiFunction> $class */
     public static function register(string $name, string $class): void
     {
+        self::loadFunctions();
         self::$functions[$name] = $class;
     }
 
@@ -312,9 +289,24 @@ abstract class ApiFunction
         return false;
     }
 
+    /** @return array<string, class-string<ApiFunction>> */
+    private static function loadFunctions(): array
+    {
+        if (null !== self::$functions) {
+            return self::$functions;
+        }
+
+        $functions = [];
+        foreach (ClassDiscovery::getInstance()->discoverByAttribute(AsApiFunction::class, self::class) as $class => $attribute) {
+            $functions[$attribute->name] = $class;
+        }
+
+        return self::$functions = $functions;
+    }
+
     private static function getName(string $class): string
     {
-        $name = array_search($class, self::$functions, true);
+        $name = array_search($class, self::loadFunctions(), true);
         if (false !== $name) {
             return $name;
         }

--- a/src/ApiFunction/AsApiFunction.php
+++ b/src/ApiFunction/AsApiFunction.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Redaxo\Core\ApiFunction;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class AsApiFunction
+{
+    public function __construct(
+        public string $name,
+    ) {}
+}

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace Redaxo\Core;
+
+use Composer\Autoload\ClassLoader;
+use Composer\InstalledVersions;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Redaxo\Core\Addon\Addon;
+use Redaxo\Core\Filesystem\File;
+use Redaxo\Core\Filesystem\Path;
+use ReflectionClass;
+use RuntimeException;
+
+use function array_key_exists;
+use function class_exists;
+use function implode;
+use function is_array;
+use function is_dir;
+use function realpath;
+use function sort;
+use function str_replace;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+use const DIRECTORY_SEPARATOR;
+use const SORT_STRING;
+use const T_CLASS;
+use const T_ENUM;
+use const T_INTERFACE;
+use const T_TRAIT;
+use const TOKEN_PARSE;
+
+final class ClassDiscovery
+{
+    private static ?self $instance = null;
+
+    /** @var list<string>|null */
+    private ?array $relevantPaths = null;
+
+    /** @var array<string, array<class-string, array<string, mixed>|object>>|null */
+    private ?array $cacheData = null;
+
+    private function __construct(
+        private readonly ClassLoader $classLoader,
+    ) {}
+
+    public static function getInstance(): self
+    {
+        return self::$instance ??= new self(self::findClassLoader());
+    }
+
+    /**
+     * Discovers all non-abstract classes that carry the given attribute.
+     *
+     * @template TAttribute of object
+     * @template TParent of object
+     * @param class-string<TAttribute> $attributeClass
+     * @param class-string<TParent>|null $parentClass Only include classes extending/implementing this type
+     * @return array<class-string<TParent>, TAttribute> Map of class name to attribute instance
+     */
+    public function discoverByAttribute(string $attributeClass, ?string $parentClass = null): array
+    {
+        $cacheKey = $attributeClass . ($parentClass ? '|' . $parentClass : '');
+        $cacheData = $this->loadCacheData();
+
+        if (isset($cacheData[$cacheKey])) {
+            // Reconstruct attribute instances from cached arrays (JSON roundtrip converts objects to arrays)
+            $result = [];
+            foreach ($cacheData[$cacheKey] as $class => $entry) {
+                /**
+                 * @var TAttribute $attribute
+                 * @psalm-suppress MixedMethodCall
+                 */
+                $attribute = is_array($entry) ? new $attributeClass(...$entry) : $entry;
+                $result[$class] = $attribute;
+            }
+            /** @var array<class-string<TParent>, TAttribute> */
+            return $result;
+        }
+
+        $result = [];
+
+        foreach ($this->getRelevantClasses() as $class) {
+            if (!class_exists($class)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($class);
+
+            if ($reflection->isAbstract()) {
+                continue;
+            }
+
+            $attributes = $reflection->getAttributes($attributeClass);
+
+            if ([] === $attributes) {
+                continue;
+            }
+
+            if (null !== $parentClass && !$reflection->isSubclassOf($parentClass)) {
+                continue;
+            }
+
+            /** @var class-string<TParent> $class */
+            $result[$class] = $attributes[0]->newInstance();
+        }
+
+        $this->saveCacheData($cacheKey, $result);
+
+        return $result;
+    }
+
+    public static function clearCache(): void
+    {
+        File::delete(self::getCacheFile());
+    }
+
+    /** @return list<string> */
+    private function getRelevantClasses(): array
+    {
+        $relevantPaths = $this->getRelevantPaths();
+        $classes = [];
+
+        // 1. Classes from Composer's classmap (available for all autoload types when optimized)
+        foreach ($this->classLoader->getClassMap() as $class => $file) {
+            $realFile = (string) realpath($file);
+            if ($this->isRelevantPath($realFile, $relevantPaths)) {
+                $classes[] = $class;
+            }
+        }
+
+        // 2. For PSR-4 prefixes, scan directories not yet covered by the classmap.
+        //    With an optimized/authoritative classmap, all classes are already in the classmap above.
+        if ($this->classLoader->isClassMapAuthoritative()) {
+            return $classes;
+        }
+
+        foreach ($this->classLoader->getPrefixesPsr4() as $namespace => $dirs) {
+            foreach ($dirs as $dir) {
+                $realDir = (string) realpath($dir);
+                if (!is_dir($realDir) || !$this->isRelevantPath($realDir . DIRECTORY_SEPARATOR, $relevantPaths)) {
+                    continue;
+                }
+
+                foreach ($this->scanDirectory($realDir, $namespace) as $class) {
+                    if (!array_key_exists($class, $this->classLoader->getClassMap())) {
+                        $classes[] = $class;
+                    }
+                }
+            }
+        }
+
+        return $classes;
+    }
+
+    /** @param list<string> $relevantPaths */
+    private function isRelevantPath(string $path, array $relevantPaths): bool
+    {
+        foreach ($relevantPaths as $relevantPath) {
+            if (str_starts_with($path, $relevantPath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return list<string> */
+    private function getRelevantPaths(): array
+    {
+        if (null !== $this->relevantPaths) {
+            return $this->relevantPaths;
+        }
+
+        $paths = [];
+
+        // PSR-4 directories of the root composer package (project-level code)
+        $rootPath = realpath(InstalledVersions::getRootPackage()['install_path']);
+        if (false !== $rootPath) {
+            $vendorPrefix = $rootPath . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR;
+            foreach ($this->classLoader->getPrefixesPsr4() as $dirs) {
+                foreach ($dirs as $dir) {
+                    $realDir = (string) realpath($dir);
+                    if ('' !== $realDir && !str_starts_with($realDir, $vendorPrefix)) {
+                        $paths[] = $realDir . DIRECTORY_SEPARATOR;
+                    }
+                }
+            }
+        }
+
+        // Core source directory (dirname of this file's parent = src/)
+        $paths[] = __DIR__ . DIRECTORY_SEPARATOR;
+
+        // Active addon paths
+        foreach (Addon::getAvailableAddons() as $addon) {
+            $paths[] = $addon->path . DIRECTORY_SEPARATOR;
+        }
+
+        return $this->relevantPaths = $paths;
+    }
+
+    /** @return list<string> */
+    private function scanDirectory(string $dir, string $namespace): array
+    {
+        $classes = [];
+
+        /** @var RecursiveDirectoryIterator $file */
+        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)) as $file) {
+            if (!$file->isFile() || 'php' !== $file->getExtension()) {
+                continue;
+            }
+
+            if (!$this->fileDefinesClass($file->getPathname())) {
+                continue;
+            }
+
+            $relativePath = substr($file->getPathname(), strlen($dir) + 1);
+            $class = $namespace . str_replace(['/', '.php'], ['\\', ''], $relativePath);
+
+            $classes[] = $class;
+        }
+
+        return $classes;
+    }
+
+    /** Checks whether a PHP file defines a class, interface, enum, or trait. */
+    private function fileDefinesClass(string $filePath): bool
+    {
+        $content = file_get_contents($filePath);
+
+        if (false === $content) {
+            return false;
+        }
+
+        $tokens = token_get_all($content, TOKEN_PARSE);
+
+        foreach ($tokens as $token) {
+            if (!is_array($token)) {
+                continue;
+            }
+
+            if (T_CLASS === $token[0] || T_INTERFACE === $token[0] || T_TRAIT === $token[0] || T_ENUM === $token[0]) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return array<string, array<class-string, array<string, mixed>|object>> */
+    private function loadCacheData(): array
+    {
+        if (null !== $this->cacheData) {
+            return $this->cacheData;
+        }
+
+        /** @var array{addons_hash?: string, files_hash?: string, data?: array<string, array<class-string, array<string, mixed>>>} $cache */
+        $cache = File::getCache(self::getCacheFile());
+
+        if (!isset($cache['addons_hash']) || $cache['addons_hash'] !== $this->getAddonHash()) {
+            return $this->cacheData = [];
+        }
+
+        // In debug mode, check if PHP files were added/removed since cache was built
+        if (Core::isDebugMode()) {
+            if (!isset($cache['files_hash']) || $cache['files_hash'] !== $this->getPhpFilesHash()) {
+                return $this->cacheData = [];
+            }
+        }
+
+        return $this->cacheData = $cache['data'] ?? [];
+    }
+
+    /** @param array<class-string, array<string, mixed>|object> $data */
+    private function saveCacheData(string $cacheKey, array $data): void
+    {
+        $this->cacheData = $this->loadCacheData();
+        $this->cacheData[$cacheKey] = $data;
+
+        File::putCache(self::getCacheFile(), [
+            'addons_hash' => $this->getAddonHash(),
+            'files_hash' => $this->getPhpFilesHash(),
+            'data' => $this->cacheData,
+        ]);
+    }
+
+    private function getAddonHash(): string
+    {
+        $parts = [];
+        foreach (Addon::getAvailableAddons() as $addon) {
+            $parts[] = $addon->name . ':' . $addon->getVersion();
+        }
+
+        return hash('xxh128', implode(',', $parts));
+    }
+
+    /**
+     * Builds a hash of all PHP file paths in the relevant directories.
+     * This is cheap (just directory listing, no file reading) and detects
+     * added/removed files so the cache is invalidated automatically in debug mode.
+     */
+    private function getPhpFilesHash(): string
+    {
+        $files = [];
+
+        foreach ($this->getRelevantPaths() as $path) {
+            if (!is_dir($path)) {
+                continue;
+            }
+
+            /** @var RecursiveDirectoryIterator $file */
+            foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)) as $file) {
+                if ($file->isFile() && 'php' === $file->getExtension()) {
+                    $files[] = $file->getPathname();
+                }
+            }
+        }
+
+        sort($files, SORT_STRING);
+
+        return hash('xxh128', implode("\n", $files));
+    }
+
+    private static function getCacheFile(): string
+    {
+        return Path::coreCache('class_discovery.cache');
+    }
+
+    private static function findClassLoader(): ClassLoader
+    {
+        return array_first(ClassLoader::getRegisteredLoaders())
+            ?? throw new RuntimeException('Composer ClassLoader not found.');
+    }
+}

--- a/src/Content/ApiFunction/ArticleAdd.php
+++ b/src/Content/ApiFunction/ArticleAdd.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\ArticleHandler;
@@ -12,6 +13,7 @@ use Redaxo\Core\Http\Request;
 /**
  * @internal
  */
+#[AsApiFunction('article_add')]
 class ArticleAdd extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/ArticleCopy.php
+++ b/src/Content/ApiFunction/ArticleCopy.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Backend\Controller;
@@ -16,6 +17,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('article_copy')]
 class ArticleCopy extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/ArticleDelete.php
+++ b/src/Content/ApiFunction/ArticleDelete.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\ArticleHandler;
@@ -12,6 +13,7 @@ use Redaxo\Core\Http\Request;
 /**
  * @internal
  */
+#[AsApiFunction('article_delete')]
 class ArticleDelete extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/ArticleEdit.php
+++ b/src/Content/ApiFunction/ArticleEdit.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\ArticleHandler;
@@ -12,6 +13,7 @@ use Redaxo\Core\Http\Request;
 /**
  * @internal
  */
+#[AsApiFunction('article_edit')]
 class ArticleEdit extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/ArticleMove.php
+++ b/src/Content/ApiFunction/ArticleMove.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\Article;
@@ -14,6 +15,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('article_move')]
 class ArticleMove extends ApiFunction
 {
     /**

--- a/src/Content/ApiFunction/ArticleSliceMove.php
+++ b/src/Content/ApiFunction/ArticleSliceMove.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\Article;
@@ -15,6 +16,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('article_slice_move')]
 class ArticleSliceMove extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/ArticleSliceStatusChange.php
+++ b/src/Content/ApiFunction/ArticleSliceStatusChange.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\Article;
@@ -14,6 +15,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('article_slice_status_change')]
 class ArticleSliceStatusChange extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/ArticleStatusChange.php
+++ b/src/Content/ApiFunction/ArticleStatusChange.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\ArticleHandler;
@@ -13,6 +14,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('article_status_change')]
 class ArticleStatusChange extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/ArticleToCategory.php
+++ b/src/Content/ApiFunction/ArticleToCategory.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\Article;
@@ -14,6 +15,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('article_to_category')]
 class ArticleToCategory extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/ArticleToStartArticle.php
+++ b/src/Content/ApiFunction/ArticleToStartArticle.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\Article;
@@ -14,6 +15,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('article_to_startarticle')]
 class ArticleToStartArticle extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/CategoryAdd.php
+++ b/src/Content/ApiFunction/CategoryAdd.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\CategoryHandler;
@@ -12,6 +13,7 @@ use Redaxo\Core\Http\Request;
 /**
  * @internal
  */
+#[AsApiFunction('category_add')]
 class CategoryAdd extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/CategoryDelete.php
+++ b/src/Content/ApiFunction/CategoryDelete.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\CategoryHandler;
@@ -12,6 +13,7 @@ use Redaxo\Core\Http\Request;
 /**
  * @internal
  */
+#[AsApiFunction('category_delete')]
 class CategoryDelete extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/CategoryEdit.php
+++ b/src/Content/ApiFunction/CategoryEdit.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\CategoryHandler;
@@ -12,6 +13,7 @@ use Redaxo\Core\Http\Request;
 /**
  * @internal
  */
+#[AsApiFunction('category_edit')]
 class CategoryEdit extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/CategoryMove.php
+++ b/src/Content/ApiFunction/CategoryMove.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\Article;
@@ -14,6 +15,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('category_move')]
 class CategoryMove extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/CategoryStatusChange.php
+++ b/src/Content/ApiFunction/CategoryStatusChange.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\CategoryHandler;
@@ -13,6 +14,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('category_status_change')]
 class CategoryStatusChange extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/CategoryToArticle.php
+++ b/src/Content/ApiFunction/CategoryToArticle.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\Article;
@@ -14,6 +15,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('category_to_article')]
 class CategoryToArticle extends ApiFunction
 {
     public function execute()

--- a/src/Content/ApiFunction/ContentCopy.php
+++ b/src/Content/ApiFunction/ContentCopy.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Content\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Content\ContentHandler;
@@ -13,6 +14,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('content_copy')]
 class ContentCopy extends ApiFunction
 {
     /**

--- a/src/MetaInfo/ApiFunction/DefaultFieldsCreate.php
+++ b/src/MetaInfo/ApiFunction/DefaultFieldsCreate.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\MetaInfo\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Core;
@@ -18,6 +19,7 @@ use function sprintf;
 /**
  * @internal
  */
+#[AsApiFunction('metainfo_default_fields_create')]
 class DefaultFieldsCreate extends ApiFunction
 {
     public function execute()

--- a/src/Security/ApiFunction/UserHasSession.php
+++ b/src/Security/ApiFunction/UserHasSession.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Security\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\Core;
 use Redaxo\Core\Http\Request;
@@ -11,6 +12,7 @@ use Redaxo\Core\Http\Response;
 /**
  * @internal
  */
+#[AsApiFunction('user_has_session')]
 class UserHasSession extends ApiFunction
 {
     /** @return never */

--- a/src/Security/ApiFunction/UserImpersonate.php
+++ b/src/Security/ApiFunction/UserImpersonate.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Security\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\Core;
 use Redaxo\Core\Filesystem\Url;
@@ -15,6 +16,7 @@ use function sprintf;
 /**
  * @internal
  */
+#[AsApiFunction('user_impersonate')]
 class UserImpersonate extends ApiFunction
 {
     /** @return never */

--- a/src/Security/ApiFunction/UserRemoveAuthMethod.php
+++ b/src/Security/ApiFunction/UserRemoveAuthMethod.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Security\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Core;
@@ -14,6 +15,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('user_remove_auth_method')]
 class UserRemoveAuthMethod extends ApiFunction
 {
     public function execute()

--- a/src/Security/ApiFunction/UserRemoveSession.php
+++ b/src/Security/ApiFunction/UserRemoveSession.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Security\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\ApiFunction\Result;
 use Redaxo\Core\Core;
@@ -14,6 +15,7 @@ use Redaxo\Core\Translation\I18n;
 /**
  * @internal
  */
+#[AsApiFunction('user_remove_session')]
 class UserRemoveSession extends ApiFunction
 {
     public function execute()

--- a/src/Security/ApiFunction/UserSessionStatus.php
+++ b/src/Security/ApiFunction/UserSessionStatus.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\Security\ApiFunction;
 
 use Redaxo\Core\ApiFunction\ApiFunction;
+use Redaxo\Core\ApiFunction\AsApiFunction;
 use Redaxo\Core\Core;
 use Redaxo\Core\Http\Response;
 use Redaxo\Core\Security\BackendLogin;
@@ -10,6 +11,7 @@ use Redaxo\Core\Security\BackendLogin;
 /**
  * @internal
  */
+#[AsApiFunction('user_session_status')]
 class UserSessionStatus extends ApiFunction
 {
     /** @return never */


### PR DESCRIPTION
## Summary

- Neuer `ClassDiscovery`-Service, der Klassen über Composers ClassLoader (Classmap + PSR-4-Fallback) in Core, aktiven Addons und Projekt-Code findet
- Neues PHP-Attribut `#[AsApiFunction('name')]` zur deklarativen Registrierung von API-Funktionen
- Alle 23 Core-API-Funktionen und die Debug-Addon-API-Funktion mit dem Attribut annotiert
- `ApiFunction::register()` bleibt als alternativer Weg bestehen
- Cache mit xxh128-Hash-Invalidierung basierend auf aktiven Addons; im Debug-Modus zusätzlich ein Dateilisten-Hash, damit neue Klassen sofort ohne manuelles Cache-Löschen gefunden werden
- Perspektivisch kann `ClassDiscovery` auch für Media-Effekte, Cronjob-Types etc. genutzt werden

🤖 Generated with [Claude Code](https://claude.com/claude-code)