### PR TITLE
refactor: make Addon::$path externally read-only and fix getInstallPath argument

### DIFF
--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -50,14 +50,14 @@ final class Addon implements AddonInterface
     private static array $addons = [];
 
     /** @var non-empty-string */
-    public string $path {
+    public private(set) string $path {
         get {
             if (isset($this->path)) {
                 return $this->path;
             }
 
             try {
-                return $this->path = realpath(InstalledVersions::getInstallPath($this->name));
+                return $this->path = realpath(InstalledVersions::getInstallPath($this->package));
             } catch (OutOfBoundsException) {
                 return $this->path = realpath(InstalledVersions::getRootPackage()['install_path']) . '/vendor/' . $this->package;
             }


### PR DESCRIPTION
## Summary
- Make `Addon::$path` externally read-only via asymmetric visibility (`public private(set)`); the property hook keeps lazy-init internally.
- Use `$this->package` instead of `$this->name` when resolving the install path through `InstalledVersions::getInstallPath()` — that API expects the Composer package name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)