### PR TITLE
chore: add Rector rules for setter refactorings

### DIFF
--- a/.tools/rector/Rule/MethodCallToPropertyAssignRector.php
+++ b/.tools/rector/Rule/MethodCallToPropertyAssignRector.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redaxo\Rector\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Expression;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use Redaxo\Rector\ValueObject\MethodCallToPropertyAssign;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+use function count;
+
+/**
+ * Turns a setter call used as a stand-alone statement into a property
+ * assignment. Only `$obj->setX($value);` statements are touched — calls
+ * embedded in other expressions are skipped to avoid changing the result
+ * type (e.g. fluent setters returning `$this`).
+ */
+final class MethodCallToPropertyAssignRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /** @var list<MethodCallToPropertyAssign> */
+    private array $configuration = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Turn setter method calls into property assignments', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+                    $action->setSave(true);
+                    CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+                    $action->save = true;
+                    CODE_SAMPLE,
+                [new MethodCallToPropertyAssign('Some\Action', 'setSave', 'save')],
+            ),
+        ]);
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [Expression::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node->expr instanceof MethodCall) {
+            return null;
+        }
+
+        $methodCall = $node->expr;
+        if ($methodCall->isFirstClassCallable()) {
+            return null;
+        }
+
+        $args = $methodCall->getArgs();
+        if (1 !== count($args)) {
+            return null;
+        }
+
+        $arg = $args[0];
+        if (null !== $arg->name || $arg->byRef || $arg->unpack) {
+            return null;
+        }
+
+        $methodName = $this->getName($methodCall->name);
+        if (null === $methodName) {
+            return null;
+        }
+
+        foreach ($this->configuration as $config) {
+            if ($methodName !== $config->method) {
+                continue;
+            }
+            if (!$this->isObjectType($methodCall->var, $config->getObjectType())) {
+                continue;
+            }
+
+            $node->expr = new Assign(
+                new PropertyFetch($methodCall->var, new Identifier($config->property)),
+                $arg->value,
+            );
+            return $node;
+        }
+
+        return null;
+    }
+
+    /** @param array<mixed> $configuration */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsInstanceOf($configuration, MethodCallToPropertyAssign::class);
+        $this->configuration = $configuration;
+    }
+}

--- a/.tools/rector/Rule/SetterCallToConstructorArgumentRector.php
+++ b/.tools/rector/Rule/SetterCallToConstructorArgumentRector.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redaxo\Rector\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Expression;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\PhpParser\Enum\NodeGroup;
+use Rector\Rector\AbstractRector;
+use Redaxo\Rector\ValueObject\SetterCallToConstructorArgument;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+use function count;
+
+/**
+ * Merges a setter call directly following a `new` assignment into a named
+ * constructor argument. Only adjacent statements operating on the same local
+ * variable are touched — anything more complex (conditionals, loops,
+ * intermediate calls) is left for manual cleanup.
+ */
+final class SetterCallToConstructorArgumentRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /** @var list<SetterCallToConstructorArgument> */
+    private array $configuration = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Merge setter calls following `new` into a named constructor argument', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+                    $result = new Result(true);
+                    $result->setRequiresReboot(true);
+                    CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+                    $result = new Result(true, requiresReboot: true);
+                    CODE_SAMPLE,
+                [new SetterCallToConstructorArgument('Some\Result', 'setRequiresReboot', 'requiresReboot')],
+            ),
+        ]);
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return NodeGroup::STMTS_AWARE;
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (null === $node->stmts) {
+            return null;
+        }
+
+        $stmts = array_values($node->stmts);
+        $count = count($stmts);
+        $skip = [];
+        $changed = false;
+
+        for ($i = 0; $i < $count; ++$i) {
+            $assignNew = $this->matchAssignNew($stmts[$i]);
+            if (null === $assignNew) {
+                continue;
+            }
+
+            [$variableName, $new] = $assignNew;
+
+            for ($j = $i + 1; $j < $count; ++$j) {
+                $config = $this->matchSetterCall($stmts[$j], $variableName);
+                if (null === $config) {
+                    break;
+                }
+
+                /** @var MethodCall $methodCall */
+                $methodCall = $stmts[$j]->expr;
+
+                if ($this->hasNamedArgument($new, $config->argumentName)) {
+                    break;
+                }
+
+                $new->args[] = new Arg(
+                    $methodCall->getArgs()[0]->value,
+                    name: new Identifier($config->argumentName),
+                );
+
+                $skip[$j] = true;
+                $changed = true;
+            }
+        }
+
+        if (!$changed) {
+            return null;
+        }
+
+        $newStmts = [];
+        foreach ($stmts as $key => $stmt) {
+            if (!isset($skip[$key])) {
+                $newStmts[] = $stmt;
+            }
+        }
+        $node->stmts = $newStmts;
+        return $node;
+    }
+
+    /** @param array<mixed> $configuration */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsInstanceOf($configuration, SetterCallToConstructorArgument::class);
+        $this->configuration = $configuration;
+    }
+
+    /** @return array{string, New_}|null */
+    private function matchAssignNew(Node $stmt): ?array
+    {
+        if (!$stmt instanceof Expression || !$stmt->expr instanceof Assign) {
+            return null;
+        }
+
+        $assign = $stmt->expr;
+        if (!$assign->var instanceof Variable || !$assign->expr instanceof New_) {
+            return null;
+        }
+
+        $variableName = $this->getName($assign->var);
+        if (null === $variableName) {
+            return null;
+        }
+
+        return [$variableName, $assign->expr];
+    }
+
+    private function matchSetterCall(Node $stmt, string $variableName): ?SetterCallToConstructorArgument
+    {
+        if (!$stmt instanceof Expression || !$stmt->expr instanceof MethodCall) {
+            return null;
+        }
+
+        $methodCall = $stmt->expr;
+        if (!$methodCall->var instanceof Variable
+            || $this->getName($methodCall->var) !== $variableName
+            || $methodCall->isFirstClassCallable()
+        ) {
+            return null;
+        }
+
+        $args = $methodCall->getArgs();
+        if (1 !== count($args)) {
+            return null;
+        }
+
+        $arg = $args[0];
+        if (null !== $arg->name || $arg->byRef || $arg->unpack) {
+            return null;
+        }
+
+        $methodName = $this->getName($methodCall->name);
+        if (null === $methodName) {
+            return null;
+        }
+
+        foreach ($this->configuration as $config) {
+            if ($methodName !== $config->method) {
+                continue;
+            }
+            if (!$this->isObjectType($methodCall->var, $config->getObjectType())) {
+                continue;
+            }
+            return $config;
+        }
+
+        return null;
+    }
+
+    private function hasNamedArgument(New_ $new, string $name): bool
+    {
+        foreach ($new->args as $arg) {
+            if ($arg instanceof Arg && null !== $arg->name && $arg->name->toString() === $name) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/.tools/rector/ValueObject/MethodCallToPropertyAssign.php
+++ b/.tools/rector/ValueObject/MethodCallToPropertyAssign.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redaxo\Rector\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+final readonly class MethodCallToPropertyAssign
+{
+    public function __construct(
+        private string $class,
+        public string $method,
+        public string $property,
+    ) {}
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->class);
+    }
+}

--- a/.tools/rector/ValueObject/SetterCallToConstructorArgument.php
+++ b/.tools/rector/ValueObject/SetterCallToConstructorArgument.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redaxo\Rector\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+final readonly class SetterCallToConstructorArgument
+{
+    public function __construct(
+        private string $class,
+        public string $method,
+        public string $argumentName,
+    ) {}
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->class);
+    }
+}

--- a/rector.php
+++ b/rector.php
@@ -74,6 +74,7 @@ use Redaxo\Core\Util;
 use Redaxo\Core\Validator;
 use Redaxo\Core\View;
 use Redaxo\Rector\Rule as RedaxoRule;
+use Redaxo\Rector\ValueObject\MethodCallToPropertyAssign;
 use Redaxo\Rector\ValueObject\MethodCallToPropertyFetch;
 
 return RectorConfig::configure()
@@ -520,11 +521,14 @@ return RectorConfig::configure()
         new MethodCallToPropertyFetch(Content\ArticleSlice::class, 'getPriority', 'priority'),
 
         new MethodCallToPropertyFetch(Content\ArticleSliceAction::class, 'getEvent', 'event'),
-        new MethodCallToPropertyFetch(Content\ArticleSliceAction::class, 'getSave', 'save'), // todo setter
+        new MethodCallToPropertyFetch(Content\ArticleSliceAction::class, 'getSave', 'save'),
         new MethodCallToPropertyFetch(Content\ArticleSliceAction::class, 'getMessages', 'messages'),
 
         new MethodCallToPropertyFetch(Content\ContentSection::class, 'getId', 'id'),
         new MethodCallToPropertyFetch(Content\ContentSection::class, 'getName', 'name'),
+    ])
+    ->withConfiguredRule(RedaxoRule\MethodCallToPropertyAssignRector::class, [
+        new MethodCallToPropertyAssign(Content\ArticleSliceAction::class, 'setSave', 'save'),
     ])
     ->withConfiguredRule(ArgumentRemoverRector::class, [
         new ArgumentRemover(Util\Str::class, 'buildQuery', 1, null),


### PR DESCRIPTION
## Summary

Adds two custom Rector rules that are useful for the in-progress 5→6 upgrade set and for future refactorings:

- **`MethodCallToPropertyAssignRector`** — turns stand-alone setter statements `$obj->setX($v);` into `$obj->x = $v;`. Only statement-form calls are touched, so fluent setters returning `$this` and setter calls embedded in other expressions stay intact.
- **`SetterCallToConstructorArgumentRector`** — merges a setter call directly following a `new` assignment into a named constructor argument (`new Foo(...); $foo->setX($v);` → `new Foo(..., x: $v);`). Conditional or non-adjacent setters are left for manual cleanup.

Configures `MethodCallToPropertyAssignRector` for the existing `ArticleSliceAction::setSave` conversion (resolving the `// todo setter` marker in `rector.php`). `SetterCallToConstructorArgumentRector` ships unconfigured here — it will be wired up in the follow-up API-functions PR.