### PR TITLE
feat!: enable CSRF protection for ApiFunctions by default

### DIFF
--- a/addons/debug/lib/api_debug.php
+++ b/addons/debug/lib/api_debug.php
@@ -24,7 +24,7 @@ class rex_api_debug extends ApiFunction
         exit;
     }
 
-    protected function requiresCsrfProtection()
+    protected function requiresCsrfProtection(): bool
     {
         return false;
     }

--- a/src/Addon/ApiFunction/AddonOperation.php
+++ b/src/Addon/ApiFunction/AddonOperation.php
@@ -55,10 +55,4 @@ final class AddonOperation extends ApiFunction
         }
         return $result;
     }
-
-    #[Override]
-    protected function requiresCsrfProtection(): true
-    {
-        return true;
-    }
 }

--- a/src/ApiFunction/ApiFunction.php
+++ b/src/ApiFunction/ApiFunction.php
@@ -279,14 +279,12 @@ abstract class ApiFunction
     }
 
     /**
-     * Csrf validation is disabled by default for backwards compatiblity reasons. This default will change in a future version.
-     * Prepare all your api functions to work with csrf token by using your-api-class::getUrlParams()/getHiddenFields(), otherwise they will stop work.
-     *
-     * @return bool
+     * Csrf validation is enabled by default. Override this method and return `false` to disable it
+     * (e.g. for read-only endpoints or actions that must be callable by 3rd-party apps which can't know the csrf token).
      */
-    protected function requiresCsrfProtection()
+    protected function requiresCsrfProtection(): bool
     {
-        return false;
+        return true;
     }
 
     /** @return array<string, class-string<ApiFunction>> */

--- a/src/Content/ApiFunction/ArticleAdd.php
+++ b/src/Content/ApiFunction/ArticleAdd.php
@@ -36,9 +36,4 @@ class ArticleAdd extends ApiFunction
         $data['category_id'] = $categoryId;
         return new Result(true, ArticleHandler::addArticle($data));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ArticleCopy.php
+++ b/src/Content/ApiFunction/ArticleCopy.php
@@ -49,9 +49,4 @@ class ArticleCopy extends ApiFunction
 
         throw new ApiFunctionException(I18n::msg('no_rights_to_this_function'));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ArticleDelete.php
+++ b/src/Content/ApiFunction/ArticleDelete.php
@@ -31,9 +31,4 @@ class ArticleDelete extends ApiFunction
         }
         return new Result(true, ArticleHandler::deleteArticle($articleId));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ArticleEdit.php
+++ b/src/Content/ApiFunction/ArticleEdit.php
@@ -38,9 +38,4 @@ class ArticleEdit extends ApiFunction
         $data['template_id'] = Request::post('template_id', 'int');
         return new Result(true, ArticleHandler::editArticle($articleId, $clang, $data));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ArticleMove.php
+++ b/src/Content/ApiFunction/ArticleMove.php
@@ -44,9 +44,4 @@ class ArticleMove extends ApiFunction
 
         throw new ApiFunctionException(I18n::msg('no_rights_to_this_function'));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ArticleSliceMove.php
+++ b/src/Content/ApiFunction/ArticleSliceMove.php
@@ -59,9 +59,4 @@ class ArticleSliceMove extends ApiFunction
         }
         return new Result(true, $message);
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ArticleSliceStatusChange.php
+++ b/src/Content/ApiFunction/ArticleSliceStatusChange.php
@@ -42,9 +42,4 @@ class ArticleSliceStatusChange extends ApiFunction
 
         return new Result(true);
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ArticleStatusChange.php
+++ b/src/Content/ApiFunction/ArticleStatusChange.php
@@ -34,9 +34,4 @@ class ArticleStatusChange extends ApiFunction
 
         throw new ApiFunctionException('user has no permission for this article!');
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ArticleToCategory.php
+++ b/src/Content/ApiFunction/ArticleToCategory.php
@@ -34,9 +34,4 @@ class ArticleToCategory extends ApiFunction
         }
         throw new ApiFunctionException('User has no permission for this article!');
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ArticleToStartArticle.php
+++ b/src/Content/ApiFunction/ArticleToStartArticle.php
@@ -35,9 +35,4 @@ class ArticleToStartArticle extends ApiFunction
 
         throw new ApiFunctionException('user has no permission for this article!');
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/CategoryAdd.php
+++ b/src/Content/ApiFunction/CategoryAdd.php
@@ -35,9 +35,4 @@ class CategoryAdd extends ApiFunction
         $data['catname'] = Request::post('category-name', 'string');
         return new Result(true, CategoryHandler::addCategory($parentId, $data));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/CategoryDelete.php
+++ b/src/Content/ApiFunction/CategoryDelete.php
@@ -31,9 +31,4 @@ class CategoryDelete extends ApiFunction
 
         return new Result(true, CategoryHandler::deleteCategory($catId));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/CategoryEdit.php
+++ b/src/Content/ApiFunction/CategoryEdit.php
@@ -38,9 +38,4 @@ class CategoryEdit extends ApiFunction
         $data['catname'] = Request::post('category-name', 'string');
         return new Result(true, CategoryHandler::editCategory($catId, $clangId, $data));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/CategoryMove.php
+++ b/src/Content/ApiFunction/CategoryMove.php
@@ -43,9 +43,4 @@ class CategoryMove extends ApiFunction
 
         throw new ApiFunctionException('user has no permission for this category!');
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/CategoryStatusChange.php
+++ b/src/Content/ApiFunction/CategoryStatusChange.php
@@ -32,9 +32,4 @@ class CategoryStatusChange extends ApiFunction
 
         throw new ApiFunctionException('User has no permission for this category!');
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/CategoryToArticle.php
+++ b/src/Content/ApiFunction/CategoryToArticle.php
@@ -34,9 +34,4 @@ class CategoryToArticle extends ApiFunction
         }
         throw new ApiFunctionException('User has no permission for this article!');
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Content/ApiFunction/ContentCopy.php
+++ b/src/Content/ApiFunction/ContentCopy.php
@@ -46,9 +46,4 @@ class ContentCopy extends ApiFunction
 
         throw new ApiFunctionException(I18n::msg('no_rights_to_this_function'));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/MetaInfo/ApiFunction/DefaultFieldsCreate.php
+++ b/src/MetaInfo/ApiFunction/DefaultFieldsCreate.php
@@ -64,9 +64,4 @@ class DefaultFieldsCreate extends ApiFunction
 
         return new Result(true, I18n::msg('minfo_default_fields_created'));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Security/ApiFunction/UserHasSession.php
+++ b/src/Security/ApiFunction/UserHasSession.php
@@ -38,7 +38,7 @@ class UserHasSession extends ApiFunction
         exit;
     }
 
-    protected function requiresCsrfProtection()
+    protected function requiresCsrfProtection(): bool
     {
         // this action supports to be callable by 3rd party apps, which can't know our valid csrf token
         return false;

--- a/src/Security/ApiFunction/UserImpersonate.php
+++ b/src/Security/ApiFunction/UserImpersonate.php
@@ -39,9 +39,4 @@ class UserImpersonate extends ApiFunction
 
         Response::sendRedirect(Url::backendController());
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Security/ApiFunction/UserRemoveAuthMethod.php
+++ b/src/Security/ApiFunction/UserRemoveAuthMethod.php
@@ -34,11 +34,6 @@ class UserRemoveAuthMethod extends ApiFunction
         return $this->removePasskey($userId);
     }
 
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
-
     private function removePassword(int $userId): Result
     {
         $sql = Sql::factory()

--- a/src/Security/ApiFunction/UserRemoveSession.php
+++ b/src/Security/ApiFunction/UserRemoveSession.php
@@ -35,9 +35,4 @@ class UserRemoveSession extends ApiFunction
 
         return new Result(false, I18n::msg('session_remove_error'));
     }
-
-    protected function requiresCsrfProtection()
-    {
-        return true;
-    }
 }

--- a/src/Security/ApiFunction/UserSessionStatus.php
+++ b/src/Security/ApiFunction/UserSessionStatus.php
@@ -33,7 +33,7 @@ class UserSessionStatus extends ApiFunction
         exit;
     }
 
-    protected function requiresCsrfProtection()
+    protected function requiresCsrfProtection(): bool
     {
         // this action supports to be callable by 3rd party apps, which can't know our valid csrf token
         return false;


### PR DESCRIPTION
## Summary

- Flips `ApiFunction::requiresCsrfProtection()` default from `false` → `true` and removes the now-redundant `return true` overrides in 22 core ApiFunctions.
- The three endpoints that intentionally stay CSRF-free (`UserSessionStatus`, `UserHasSession`, debug API) keep their override and only get a `: bool` return type.
- Resolves the long-standing BC shim noted in the docblock: _"Csrf validation is disabled by default for backwards compatibility reasons. This default will change in a future version."_

## Breaking change

ApiFunctions in addons and projects that don't already override `requiresCsrfProtection()` will now require a valid CSRF token. Callers must send the token via `YourApiClass::getUrlParams()` / `getHiddenFields()`, or override the method to return `false` for endpoints that must remain CSRF-free (e.g. read-only or 3rd-party-callable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)