### PR TITLE
refactor!: modernize ApiFunction and Result with public properties

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1738,14 +1738,6 @@
       <code><![CDATA[$default]]></code>
     </MixedReturnStatement>
   </file>
-  <file src="src/ApiFunction/ApiFunction.php">
-    <MixedOperand>
-      <code><![CDATA[Request::get(self::REQ_CALL_PARAM)]]></code>
-    </MixedOperand>
-    <PossiblyNullOperand>
-      <code><![CDATA[$message]]></code>
-    </PossiblyNullOperand>
-  </file>
   <file src="src/ApiFunction/Result.php">
     <MixedAssignment>
       <code><![CDATA[$json]]></code>

--- a/addons/debug/lib/api_debug.php
+++ b/addons/debug/lib/api_debug.php
@@ -12,7 +12,9 @@ use Redaxo\Core\Http\Response;
 #[AsApiFunction('debug')]
 class rex_api_debug extends ApiFunction
 {
-    public function execute()
+    protected bool $requiresCsrfProtection = false;
+
+    public function execute(): Result
     {
         if (!Core::isDebugMode() || !Core::getUser()?->isAdmin()) {
             return new Result(false);
@@ -24,12 +26,7 @@ class rex_api_debug extends ApiFunction
         exit;
     }
 
-    protected function requiresCsrfProtection(): bool
-    {
-        return false;
-    }
-
-    public static function getUrlParams()
+    public static function getUrlParams(): array
     {
         return [
             self::REQ_CALL_PARAM => 'debug',

--- a/addons/debug/lib/extensions/api_function_debug.php
+++ b/addons/debug/lib/extensions/api_function_debug.php
@@ -7,7 +7,7 @@ use Redaxo\Core\ApiFunction\ApiFunction;
  */
 abstract class rex_api_function_debug extends ApiFunction
 {
-    public static function handleCall()
+    public static function handleCall(): void
     {
         $apiFunc = self::factory();
 

--- a/pages/structure/content.edit.php
+++ b/pages/structure/content.edit.php
@@ -14,12 +14,11 @@ assert(isset($function) && is_string($function));
 assert(isset($info) && is_string($info));
 assert(isset($warning) && is_string($warning));
 
-$apiFunc = ApiFunction::factory();
-if ($apiFunc && $result = $apiFunc->getResult()) {
-    if ($result->isSuccessfull()) {
-        $info = $result->getMessage();
+if ($result = ApiFunction::factory()?->result) {
+    if ($result->succeeded) {
+        $info = $result->message;
     } else {
-        $warning = $result->getMessage();
+        $warning = $result->message;
     }
 }
 

--- a/rector.php
+++ b/rector.php
@@ -76,6 +76,7 @@ use Redaxo\Core\View;
 use Redaxo\Rector\Rule as RedaxoRule;
 use Redaxo\Rector\ValueObject\MethodCallToPropertyAssign;
 use Redaxo\Rector\ValueObject\MethodCallToPropertyFetch;
+use Redaxo\Rector\ValueObject\SetterCallToConstructorArgument;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -422,6 +423,9 @@ return RectorConfig::configure()
         new MethodCallRename(Console\Command\AbstractCommand::class, 'getPackage', 'getAddon'),
         new MethodCallRename(Console\Command\AbstractCommand::class, 'setPackage', 'setAddon'),
 
+        new MethodCallRename(ApiFunction\Result::class, 'toJSON', 'toJson'),
+        new MethodCallRename(ApiFunction\Result::class, 'fromJSON', 'fromJson'),
+
         new MethodCallRename(Security\PasswordPolicy::class, 'getRule', 'getDescription'),
 
         new MethodCallRename(Content\ArticleContentBase::class, 'getClang', 'getClangId'),
@@ -512,6 +516,13 @@ return RectorConfig::configure()
         new MethodCallToPropertyFetch(Addon\Addon::class, 'getName', 'name'),
         new MethodCallToPropertyFetch(Addon\Addon::class, 'getPackageId', 'name'),
 
+        new MethodCallToPropertyFetch(ApiFunction\ApiFunction::class, 'getResult', 'result'),
+        new MethodCallToPropertyFetch(ApiFunction\ApiFunction::class, 'requiresCsrfProtection', 'requiresCsrfProtection'),
+
+        new MethodCallToPropertyFetch(ApiFunction\Result::class, 'isSuccessfull', 'succeeded'),
+        new MethodCallToPropertyFetch(ApiFunction\Result::class, 'getMessage', 'message'),
+        new MethodCallToPropertyFetch(ApiFunction\Result::class, 'requiresReboot', 'requiresReboot'),
+
         new MethodCallToPropertyFetch(Content\ArticleSlice::class, 'getId', 'id'),
         new MethodCallToPropertyFetch(Content\ArticleSlice::class, 'getArticleId', 'articleId'),
         new MethodCallToPropertyFetch(Content\ArticleSlice::class, 'getClang', 'clangId'),
@@ -529,6 +540,9 @@ return RectorConfig::configure()
     ])
     ->withConfiguredRule(RedaxoRule\MethodCallToPropertyAssignRector::class, [
         new MethodCallToPropertyAssign(Content\ArticleSliceAction::class, 'setSave', 'save'),
+    ])
+    ->withConfiguredRule(RedaxoRule\SetterCallToConstructorArgumentRector::class, [
+        new SetterCallToConstructorArgument(ApiFunction\Result::class, 'setRequiresReboot', 'requiresReboot'),
     ])
     ->withConfiguredRule(ArgumentRemoverRector::class, [
         new ArgumentRemover(Util\Str::class, 'buildQuery', 1, null),

--- a/src/Addon/ApiFunction/AddonOperation.php
+++ b/src/Addon/ApiFunction/AddonOperation.php
@@ -49,10 +49,7 @@ final class AddonOperation extends ApiFunction
         $manager = AddonManager::factory($package);
         $success = Type::bool($manager->$function());
         $message = $manager->getMessage();
-        $result = new Result($success, $message);
-        if ($success && !$reinstall) {
-            $result->setRequiresReboot(true);
-        }
-        return $result;
+
+        return new Result($success, $message, requiresReboot: $success && !$reinstall);
     }
 }

--- a/src/ApiFunction/ApiFunction.php
+++ b/src/ApiFunction/ApiFunction.php
@@ -23,7 +23,7 @@ use function sprintf;
 
 /**
  * This is a base class for all functions which a component may provide for public use.
- * Those function will be called automatically by the core.
+ * Those functions will be called automatically by the core.
  * Inside an api function you might check the preconditions which have to be met (permissions, etc.)
  * and forward the call to an underlying service which does the actual job.
  *
@@ -31,12 +31,12 @@ use function sprintf;
  *
  * The ApiFunction classes must be registered explicitly via `ApiFunction::register()`.
  *
- * A api function may also be called by an ajax-request.
+ * An api function may also be called by an ajax-request.
  * In fact there might be ajax-requests which do nothing more than triggering an api function.
  *
- * The api functions return meaningfull error messages which the caller may display to the end-user.
+ * The api functions return meaningful error messages which the caller may display to the end-user.
  *
- * Calling a api function with the backend-frontcontroller (index.php) requires a valid page parameter and the current user needs permissions to access the given page.
+ * Calling an api function with the backend-frontcontroller (index.php) requires a valid page parameter and the current user needs permissions to access the given page.
  *
  * @psalm-consistent-constructor
  */
@@ -44,22 +44,20 @@ abstract class ApiFunction
 {
     use FactoryTrait;
 
-    public const REQ_CALL_PARAM = 'rex-api-call';
-    public const REQ_RESULT_PARAM = 'rex-api-result';
+    final public const string REQ_CALL_PARAM = 'rex-api-call';
+    final public const string REQ_RESULT_PARAM = 'rex-api-result';
+
+    /** Flag, indicating if this api function may be called from the frontend. False by default. */
+    protected bool $published = false;
 
     /**
-     * Flag, indicating if this api function may be called from the frontend. False by default.
-     *
-     * @var bool
+     * Whether this api function requires CSRF protection. Enabled by default; override with `false`
+     * (e.g. for read-only endpoints or actions that must be callable by 3rd-party apps which can't know the csrf token).
      */
-    protected $published = false;
+    protected bool $requiresCsrfProtection = true;
 
-    /**
-     * The result of the function call.
-     *
-     * @var Result|null
-     */
-    protected $result;
+    /** The result of the function call. */
+    public private(set) ?Result $result = null;
 
     /**
      * Discovered and registered api functions.
@@ -68,29 +66,26 @@ abstract class ApiFunction
      */
     private static ?array $functions = null;
 
-    /**
-     * The api function which is bound to the current request.
-     *
-     * @var ApiFunction|null
-     */
-    private static $instance;
+    /** The api function which is bound to the current request. */
+    private static ?ApiFunction $instance = null;
 
     protected function __construct() {}
 
     /**
-     * This method have to be overriden by a subclass and does all logic which the api function represents.
+     * This method has to be overridden by a subclass and does all logic which the api function represents.
      *
      * In the first place this method may retrieve and validate parameters from the request.
      * Afterwards the actual logic should be executed.
      *
      * This function may also throw exceptions e.g. in case when permissions are missing or the provided parameters are invalid.
      *
+     * @throws ApiFunctionException
      * @return Result The result of the api-function
      */
-    abstract public function execute();
+    abstract public function execute(): Result;
 
     /** Returns the api function instance which is bound to the current request, or null if no api function was bound. */
-    public static function factory(): ?self
+    final public static function factory(): ?self
     {
         if (self::$instance) {
             return self::$instance;
@@ -119,8 +114,8 @@ abstract class ApiFunction
         return null;
     }
 
-    /** @param class-string<ApiFunction> $class */
-    public static function register(string $name, string $class): void
+    /** @param class-string<self> $class */
+    final public static function register(string $name, string $class): void
     {
         self::loadFunctions();
         self::$functions[$name] = $class;
@@ -133,7 +128,7 @@ abstract class ApiFunction
      *
      * @return array<string, string>
      */
-    public static function getUrlParams()
+    public static function getUrlParams(): array
     {
         $class = static::class;
 
@@ -148,10 +143,8 @@ abstract class ApiFunction
      * Returns the hidden fields for `rex-api-call` and `_csrf_token`.
      *
      * The method must be called on sub classes.
-     *
-     * @return string
      */
-    public static function getHiddenFields()
+    public static function getHiddenFields(): string
     {
         $class = static::class;
 
@@ -163,12 +156,8 @@ abstract class ApiFunction
             . CsrfToken::factory($class)->getHiddenField();
     }
 
-    /**
-     * checks whether an api function is bound to the current requests. If so, so the api function will be executed.
-     *
-     * @return void
-     */
-    public static function handleCall()
+    /** checks whether an api function is bound to the current requests. If so, so the api function will be executed. */
+    public static function handleCall(): void
     {
         if ($factoryClass = static::getExplicitFactoryClass()) {
             $factoryClass::handleCall();
@@ -197,9 +186,9 @@ abstract class ApiFunction
                     throw new NotFoundHttpException(new ApiFunctionException('The result of the api function is not available in the session.'));
                 }
 
-                $apiFunc->result = Result::fromJSON($result);
+                $apiFunc->result = Result::fromJson($result);
             } else {
-                if ($apiFunc->requiresCsrfProtection() && !CsrfToken::factory($apiFunc::class)->isValid()) {
+                if ($apiFunc->requiresCsrfProtection && !CsrfToken::factory($apiFunc::class)->isValid()) {
                     $result = new Result(false, I18n::msg('csrf_token_invalid'));
                     $apiFunc->result = $result;
 
@@ -209,16 +198,12 @@ abstract class ApiFunction
                 try {
                     $result = $apiFunc->execute();
 
-                    if (!$result instanceof Result) {
-                        throw new LogicException('Illegal result returned from api-function ' . Request::get(self::REQ_CALL_PARAM) . '. Expected a instance of ApiFunctionResult but got "' . get_debug_type($result) . '".');
-                    }
-
                     $apiFunc->result = $result;
-                    if ($result->requiresReboot()) {
+                    if ($result->requiresReboot) {
                         // add api call result to session
                         Login::startSession();
                         $results = Request::session(self::REQ_RESULT_PARAM, 'array', []);
-                        $result = $result->toJSON();
+                        $result = $result->toJson();
                         $key = sha1($result);
                         $results[$key] = $result;
                         Request::setSession(self::REQ_RESULT_PARAM, $results);
@@ -237,54 +222,24 @@ abstract class ApiFunction
         }
     }
 
-    /** @return bool */
-    public static function hasMessage()
+    final public static function hasMessage(): bool
     {
-        $apiFunc = self::factory();
-
-        if (!$apiFunc) {
-            return false;
-        }
-
-        $result = $apiFunc->getResult();
-        return $result && null !== $result->getMessage();
+        return null !== self::factory()?->result?->message;
     }
 
-    /**
-     * @param bool $formatted
-     * @return string
-     */
-    public static function getMessage($formatted = true)
+    final public static function getMessage(bool $formatted = true): string
     {
-        $apiFunc = self::factory();
+        $apiResult = self::factory()?->result;
         $message = '';
-        if ($apiFunc) {
-            $apiResult = $apiFunc->getResult();
-            if ($apiResult) {
-                if ($formatted) {
-                    $message = $apiResult->getFormattedMessage();
-                } else {
-                    $message = $apiResult->getMessage();
-                }
+        if ($apiResult) {
+            if ($formatted) {
+                $message = $apiResult->getFormattedMessage();
+            } else {
+                $message = $apiResult->message;
             }
         }
         // return a placeholder which can later be used by ajax requests to display messages
-        return '<div id="rex-message-container">' . $message . '</div>';
-    }
-
-    /** @return Result|null */
-    public function getResult()
-    {
-        return $this->result;
-    }
-
-    /**
-     * Csrf validation is enabled by default. Override this method and return `false` to disable it
-     * (e.g. for read-only endpoints or actions that must be callable by 3rd-party apps which can't know the csrf token).
-     */
-    protected function requiresCsrfProtection(): bool
-    {
-        return true;
+        return '<div id="rex-message-container">' . ($message ?? '') . '</div>';
     }
 
     /** @return array<string, class-string<ApiFunction>> */

--- a/src/ApiFunction/Result.php
+++ b/src/ApiFunction/Result.php
@@ -13,77 +13,35 @@ use function is_array;
  *
  * @see ApiFunction
  */
-class Result
+final readonly class Result
 {
-    /**
-     * Flag indicating whether the result of this api call needs to be rendered in a new sub-request.
-     * This is required in rare situations, when some low-level data was changed by the api-function.
-     *
-     * @var bool
-     */
-    private $requiresReboot;
-
     /**
      * @param bool $succeeded flag indicating if the api function was executed successfully
      * @param string|null $message optional message which will be visible to the end-user
+     * @param bool $requiresReboot flag indicating whether the result of this api call needs to be rendered in a new sub-request.
+     *     This is required in rare situations, when some low-level data was changed by the api-function.
      *
      * @psalm-taint-sink html $message
      */
     public function __construct(
-        private $succeeded,
-        private $message = null,
+        public bool $succeeded,
+        public ?string $message = null,
+        public bool $requiresReboot = false,
     ) {}
 
-    /**
-     * @param bool $requiresReboot
-     * @return void
-     */
-    public function setRequiresReboot($requiresReboot)
-    {
-        $this->requiresReboot = $requiresReboot;
-    }
-
-    /** @return bool */
-    public function requiresReboot()
-    {
-        return $this->requiresReboot;
-    }
-
-    /** @return string|null */
-    public function getFormattedMessage()
+    public function getFormattedMessage(): ?string
     {
         if (null === $this->message) {
             return null;
         }
 
-        if ($this->isSuccessfull()) {
+        if ($this->succeeded) {
             return Message::success($this->message);
         }
         return Message::error($this->message);
     }
 
-    /**
-     * Returns end-user friendly statusmessage.
-     *
-     * @return string|null a statusmessage
-     */
-    public function getMessage()
-    {
-        return $this->message;
-    }
-
-    /**
-     * Returns whether the api function was executed successfully.
-     *
-     * @return bool true on success, false on error
-     */
-    public function isSuccessfull()
-    {
-        return $this->succeeded;
-    }
-
-    /** @return string */
-    public function toJSON()
+    public function toJson(): string
     {
         return Type::string(json_encode([
             'succeeded' => $this->succeeded,
@@ -91,11 +49,7 @@ class Result
         ]));
     }
 
-    /**
-     * @param string $json
-     * @return self
-     */
-    public static function fromJSON($json)
+    public static function fromJson(string $json): self
     {
         $json = json_decode($json, true);
 

--- a/src/Content/ApiFunction/ArticleAdd.php
+++ b/src/Content/ApiFunction/ArticleAdd.php
@@ -16,7 +16,7 @@ use Redaxo\Core\Http\Request;
 #[AsApiFunction('article_add')]
 class ArticleAdd extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         if (!Core::requireUser()->hasPerm('addArticle[]')) {
             throw new ApiFunctionException('User has no permission to add articles!');

--- a/src/Content/ApiFunction/ArticleCopy.php
+++ b/src/Content/ApiFunction/ArticleCopy.php
@@ -20,7 +20,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('article_copy')]
 class ArticleCopy extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $articleId = Request::request('article_id', 'int');
         $clang = Request::request('clang', 'int', 1);
@@ -38,7 +38,7 @@ class ArticleCopy extends ApiFunction
                 $result = new Result(true, I18n::msg('content_articlecopied'));
                 Response::sendRedirect($context->getUrl([
                     'article_id' => $newId,
-                    'info' => $result->getMessage(),
+                    'info' => $result->message,
                 ]));
             } else {
                 $result = new Result(false, I18n::msg('content_errorcopyarticle'));

--- a/src/Content/ApiFunction/ArticleDelete.php
+++ b/src/Content/ApiFunction/ArticleDelete.php
@@ -16,7 +16,7 @@ use Redaxo\Core\Http\Request;
 #[AsApiFunction('article_delete')]
 class ArticleDelete extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         if (!Core::requireUser()->hasPerm('deleteArticle[]')) {
             throw new ApiFunctionException('User has no permission to delete articles!');

--- a/src/Content/ApiFunction/ArticleEdit.php
+++ b/src/Content/ApiFunction/ArticleEdit.php
@@ -16,7 +16,7 @@ use Redaxo\Core\Http\Request;
 #[AsApiFunction('article_edit')]
 class ArticleEdit extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         if (!Core::requireUser()->hasPerm('editArticle[]')) {
             throw new ApiFunctionException('User has no permission to edit articles!');

--- a/src/Content/ApiFunction/ArticleMove.php
+++ b/src/Content/ApiFunction/ArticleMove.php
@@ -18,12 +18,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('article_move')]
 class ArticleMove extends ApiFunction
 {
-    /**
-     * @throws ApiFunctionException
-     *
-     * @return Result
-     */
-    public function execute()
+    public function execute(): Result
     {
         // The article to move
         $articleId = Request::request('article_id', 'int');

--- a/src/Content/ApiFunction/ArticleSliceMove.php
+++ b/src/Content/ApiFunction/ArticleSliceMove.php
@@ -19,7 +19,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('article_slice_move')]
 class ArticleSliceMove extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $articleId = Request::request('article_id', 'int');
         $clang = Request::request('clang', 'int');

--- a/src/Content/ApiFunction/ArticleSliceStatusChange.php
+++ b/src/Content/ApiFunction/ArticleSliceStatusChange.php
@@ -18,7 +18,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('article_slice_status_change')]
 class ArticleSliceStatusChange extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $articleId = Request::request('article_id', 'int');
         $clang = Request::request('clang', 'int');

--- a/src/Content/ApiFunction/ArticleStatusChange.php
+++ b/src/Content/ApiFunction/ArticleStatusChange.php
@@ -17,7 +17,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('article_status_change')]
 class ArticleStatusChange extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $categoryId = Request::request('category_id', 'int');
         $articleId = Request::request('article_id', 'int');

--- a/src/Content/ApiFunction/ArticleToCategory.php
+++ b/src/Content/ApiFunction/ArticleToCategory.php
@@ -18,7 +18,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('article_to_category')]
 class ArticleToCategory extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $articleId = Request::request('article_id', 'int');
         $categoryId = Article::get($articleId)->getCategoryId();

--- a/src/Content/ApiFunction/ArticleToStartArticle.php
+++ b/src/Content/ApiFunction/ArticleToStartArticle.php
@@ -18,7 +18,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('article_to_startarticle')]
 class ArticleToStartArticle extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $articleId = Request::request('article_id', 'int');
         $categoryId = Article::get($articleId)->getCategoryId();

--- a/src/Content/ApiFunction/CategoryAdd.php
+++ b/src/Content/ApiFunction/CategoryAdd.php
@@ -16,7 +16,7 @@ use Redaxo\Core\Http\Request;
 #[AsApiFunction('category_add')]
 class CategoryAdd extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         if (!Core::requireUser()->hasPerm('addCategory[]')) {
             throw new ApiFunctionException('User has no permission to add categories!');

--- a/src/Content/ApiFunction/CategoryDelete.php
+++ b/src/Content/ApiFunction/CategoryDelete.php
@@ -16,7 +16,7 @@ use Redaxo\Core\Http\Request;
 #[AsApiFunction('category_delete')]
 class CategoryDelete extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         if (!Core::requireUser()->hasPerm('deleteCategory[]')) {
             throw new ApiFunctionException('User has no permission to delete categories!');

--- a/src/Content/ApiFunction/CategoryEdit.php
+++ b/src/Content/ApiFunction/CategoryEdit.php
@@ -16,7 +16,7 @@ use Redaxo\Core\Http\Request;
 #[AsApiFunction('category_edit')]
 class CategoryEdit extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         if (!Core::requireUser()->hasPerm('editCategory[]')) {
             throw new ApiFunctionException('User has no permission to edit categories!');

--- a/src/Content/ApiFunction/CategoryMove.php
+++ b/src/Content/ApiFunction/CategoryMove.php
@@ -18,7 +18,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('category_move')]
 class CategoryMove extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         // The category to move
         $articleId = Request::request('article_id', 'int');

--- a/src/Content/ApiFunction/CategoryStatusChange.php
+++ b/src/Content/ApiFunction/CategoryStatusChange.php
@@ -17,7 +17,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('category_status_change')]
 class CategoryStatusChange extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $categoryId = Request::request('category-id', 'int');
         $clang = Request::request('clang', 'int');

--- a/src/Content/ApiFunction/CategoryToArticle.php
+++ b/src/Content/ApiFunction/CategoryToArticle.php
@@ -18,7 +18,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('category_to_article')]
 class CategoryToArticle extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $articleId = Request::request('article_id', 'int');
         $categoryId = Article::get($articleId)->getCategoryId();

--- a/src/Content/ApiFunction/ContentCopy.php
+++ b/src/Content/ApiFunction/ContentCopy.php
@@ -17,12 +17,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('content_copy')]
 class ContentCopy extends ApiFunction
 {
-    /**
-     * @throws ApiFunctionException
-     *
-     * @return Result
-     */
-    public function execute()
+    public function execute(): Result
     {
         $articleId = Request::request('article_id', 'int');
         $clangA = Request::request('clang_a', 'int');

--- a/src/MetaInfo/ApiFunction/DefaultFieldsCreate.php
+++ b/src/MetaInfo/ApiFunction/DefaultFieldsCreate.php
@@ -22,7 +22,7 @@ use function sprintf;
 #[AsApiFunction('metainfo_default_fields_create')]
 class DefaultFieldsCreate extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         if (!Core::getUser()?->isAdmin()) {
             throw new ApiFunctionException('user has no permission for this operation!');

--- a/src/Security/ApiFunction/UserHasSession.php
+++ b/src/Security/ApiFunction/UserHasSession.php
@@ -15,8 +15,10 @@ use Redaxo\Core\Http\Response;
 #[AsApiFunction('user_has_session')]
 class UserHasSession extends ApiFunction
 {
-    /** @return never */
-    public function execute()
+    // this action supports to be callable by 3rd party apps, which can't know our valid csrf token
+    protected bool $requiresCsrfProtection = false;
+
+    public function execute(): never
     {
         if (!Request::isHttps()) {
             throw new ApiFunctionException('https is required');
@@ -36,11 +38,5 @@ class UserHasSession extends ApiFunction
 
         Response::sendJson(true);
         exit;
-    }
-
-    protected function requiresCsrfProtection(): bool
-    {
-        // this action supports to be callable by 3rd party apps, which can't know our valid csrf token
-        return false;
     }
 }

--- a/src/Security/ApiFunction/UserImpersonate.php
+++ b/src/Security/ApiFunction/UserImpersonate.php
@@ -19,8 +19,7 @@ use function sprintf;
 #[AsApiFunction('user_impersonate')]
 class UserImpersonate extends ApiFunction
 {
-    /** @return never */
-    public function execute()
+    public function execute(): never
     {
         $impersonate = Request::get('_impersonate');
 

--- a/src/Security/ApiFunction/UserRemoveAuthMethod.php
+++ b/src/Security/ApiFunction/UserRemoveAuthMethod.php
@@ -18,7 +18,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('user_remove_auth_method')]
 class UserRemoveAuthMethod extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $userId = Request::get('user_id', 'int');
         $user = Core::requireUser();

--- a/src/Security/ApiFunction/UserRemoveSession.php
+++ b/src/Security/ApiFunction/UserRemoveSession.php
@@ -18,7 +18,7 @@ use Redaxo\Core\Translation\I18n;
 #[AsApiFunction('user_remove_session')]
 class UserRemoveSession extends ApiFunction
 {
-    public function execute()
+    public function execute(): Result
     {
         $userId = Request::get('user_id', 'int');
         $user = Core::requireUser();

--- a/src/Security/ApiFunction/UserSessionStatus.php
+++ b/src/Security/ApiFunction/UserSessionStatus.php
@@ -14,8 +14,10 @@ use Redaxo\Core\Security\BackendLogin;
 #[AsApiFunction('user_session_status')]
 class UserSessionStatus extends ApiFunction
 {
-    /** @return never */
-    public function execute()
+    // this action supports to be callable by 3rd party apps, which can't know our valid csrf token
+    protected bool $requiresCsrfProtection = false;
+
+    public function execute(): never
     {
         $user = Core::getUser();
         if (!$user) {
@@ -31,11 +33,5 @@ class UserSessionStatus extends ApiFunction
         ]);
 
         exit;
-    }
-
-    protected function requiresCsrfProtection(): bool
-    {
-        // this action supports to be callable by 3rd party apps, which can't know our valid csrf token
-        return false;
     }
 }


### PR DESCRIPTION
## Summary

Modernizes the two main classes of the `ApiFunction` subsystem by replacing getter/setter methods with modern public properties (per `AGENTS.md`: "prefer modern public properties over getter/setter methods").

### `Result`
- Now a `final readonly` class.
- Constructor promotes `succeeded`, `message` and `requiresReboot` to public readonly properties.
- `isSuccessfull()`, `getMessage()`, `requiresReboot()` and `setRequiresReboot()` are gone.
- `toJSON()`/`fromJSON()` renamed to `toJson()`/`fromJson()` (camelCase).

### `ApiFunction`
- `getResult()` dissolved into a `public private(set) ?Result $result` property — externally read-only, internally writable via asymmetric visibility.
- `requiresCsrfProtection()` dissolved into a `protected bool $requiresCsrfProtection` property; subclasses override the default value instead of the method body.
- All `execute()` overrides in the 21 subclasses now declare their return type (`Result`, or `never` for `UserImpersonate`).

### Migration

`rector.php` ships migration rules covering every rename and method-to-property conversion, plus the
`new Result(...); $r->setRequiresReboot(true);` → `new Result(..., requiresReboot: true)` conversion via `SetterCallToConstructorArgumentRector`. Downstream addons pick up the migration via `composer rector`.
