### PR TITLE
refactor!: remove html building methods toLink/toImage

### DIFF
--- a/.tools/phpstan/baseline/_loader.php
+++ b/.tools/phpstan/baseline/_loader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// total 269 errors
+// total 264 errors
 
 return ['includes' => [
     __DIR__ . '/argument.templateType.php',

--- a/.tools/phpstan/baseline/missingType.iterableValue.php
+++ b/.tools/phpstan/baseline/missingType.iterableValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// total 176 errors
+// total 171 errors
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
@@ -136,27 +136,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Content/StructureElement.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Method Redaxo\\Core\\Content\\StructureElement::_toAttributeString() has parameter $attributes with no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/StructureElement.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Method Redaxo\\Core\\Content\\StructureElement::getUrl() has parameter $params with no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/StructureElement.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Redaxo\\Core\\Content\\StructureElement::toLink() has parameter $attributes with no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/StructureElement.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Redaxo\\Core\\Content\\StructureElement::toLink() has parameter $params with no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/StructureElement.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Redaxo\\Core\\Content\\StructureElement::toLink() has parameter $sorroundAttributes with no value type specified in iterable type array.',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Content/StructureElement.php',
 ];
@@ -429,11 +409,6 @@ $ignoreErrors[] = [
     'rawMessage' => 'Method Redaxo\\Core\\MediaManager\\Effect\\WorkspaceEffect::getParams() return type has no value type specified in iterable type array.',
     'count' => 2,
     'path' => __DIR__ . '/../../../src/MediaManager/Effect/WorkspaceEffect.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Redaxo\\Core\\MediaPool\\Media::toImage() has parameter $params with no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/MediaPool/Media.php',
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Method Redaxo\\Core\\MediaPool\\MediaCategoryHandler::editCategory() has parameter $data with no value type specified in iterable type array.',

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2150,11 +2150,9 @@
     <MixedAssignment>
       <code><![CDATA[$prefix]]></code>
       <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$prefix]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedOperand>
     <MixedReturnStatement>
       <code><![CDATA[$this->$val]]></code>
@@ -3413,17 +3411,10 @@
     </PossiblyFalseArgument>
   </file>
   <file src="src/MediaPool/Media.php">
-    <MixedArgument>
-      <code><![CDATA[$filename]]></code>
-    </MixedArgument>
     <MixedAssignment>
-      <code><![CDATA[$name]]></code>
-      <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedOperand>
-      <code><![CDATA[$name]]></code>
-      <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
@@ -3439,9 +3430,6 @@
       <code><![CDATA[Core::getProperty('allowed_doctypes', [])]]></code>
       <code><![CDATA[Core::getProperty('image_extensions', [])]]></code>
     </NullableReturnStatement>
-    <PossiblyNullArgument>
-      <code><![CDATA[$this->getValue('med_description')]]></code>
-    </PossiblyNullArgument>
   </file>
   <file src="src/MediaPool/MediaCategoryHandler.php">
     <ArgumentTypeCoercion>

--- a/src/Content/StructureElement.php
+++ b/src/Content/StructureElement.php
@@ -14,8 +14,6 @@ use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\Language\Language;
 
 use function in_array;
-use function is_string;
-use function Redaxo\Core\View\escape;
 
 /**
  * Object Oriented Framework: Basisklasse für die Strukturkomponenten.
@@ -411,40 +409,6 @@ abstract class StructureElement
      * @return bool
      */
     abstract public function isPermitted();
-
-    /**
-     * Returns a link to this article.
-     *
-     * @param array $params Parameter für den Link
-     * @param array $attributes Attribute die dem Link hinzugefügt werden sollen. Default: array
-     * @param string $sorroundTag HTML-Tag-Name mit dem der Link umgeben werden soll, z.b. 'li', 'div'. Default: null
-     * @param array $sorroundAttributes Attribute die Umgebenden-Element hinzugefügt werden sollen. Default: array
-     *
-     * @return string
-     */
-    public function toLink(array $params = [], array $attributes = [], $sorroundTag = null, array $sorroundAttributes = [])
-    {
-        $name = $this->getName();
-        $link = '<a href="' . $this->getUrl($params) . '"' . $this->_toAttributeString($attributes) . ' title="' . escape($name) . '">' . escape($name) . '</a>';
-
-        if (null !== $sorroundTag && is_string($sorroundTag)) {
-            $link = '<' . $sorroundTag . $this->_toAttributeString($sorroundAttributes) . '>' . $link . '</' . $sorroundTag . '>';
-        }
-
-        return $link;
-    }
-
-    /** @return string */
-    protected function _toAttributeString(array $attributes)
-    {
-        $attr = '';
-
-        foreach ($attributes as $name => $value) {
-            $attr .= ' ' . $name . '="' . $value . '"';
-        }
-
-        return $attr;
-    }
 
     /**
      * Get an array of all parentCategories.

--- a/src/MediaPool/Media.php
+++ b/src/MediaPool/Media.php
@@ -15,8 +15,6 @@ use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\Util\Formatter;
 
 use function in_array;
-use function Redaxo\Core\View\escape;
-use function sprintf;
 
 /**
  * Object Oriented Framework: Bildet ein Medium des Medienpools ab.
@@ -231,48 +229,6 @@ class Media
     public function getCreateDate()
     {
         return $this->createdate;
-    }
-
-    /** @return string */
-    public function toImage(array $params = [])
-    {
-        if (!$this->isImage()) {
-            return '';
-        }
-
-        $filename = Url::media($this->getFileName());
-        $title = $this->getTitle();
-
-        if (!isset($params['alt'])) {
-            if ('' != $title) {
-                $params['alt'] = escape($title);
-            }
-        }
-
-        if (!isset($params['title'])) {
-            if ('' != $title) {
-                $params['title'] = escape($title);
-            }
-        }
-
-        Extension::registerPoint(new ExtensionPoint('MEDIA_TOIMAGE', '', ['filename' => &$filename, 'params' => &$params]));
-
-        $additional = '';
-        foreach ($params as $name => $value) {
-            $additional .= ' ' . $name . '="' . $value . '"';
-        }
-
-        return sprintf('<img src="%s"%s />', $filename, $additional);
-    }
-
-    /**
-     * @param string $attributes
-     *
-     * @return string
-     */
-    public function toLink($attributes = '')
-    {
-        return sprintf('<a href="%s" title="%s"%s>%s</a>', $this->getUrl(), $this->getValue('med_description'), $attributes, $this->getFileName());
     }
 
     /** @return bool */


### PR DESCRIPTION
Die Methoden gehören für mich strukturell nicht hier in die Core-Klassen und sie sind zu unflexibel.