### PR TITLE
refactor!: remove `allowed_doctypes` and `getDocTypes`/`isDocType`

### DIFF
--- a/.tools/phpstan/baseline/_loader.php
+++ b/.tools/phpstan/baseline/_loader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// total 264 errors
+// total 263 errors
 
 return ['includes' => [
     __DIR__ . '/argument.templateType.php',

--- a/.tools/phpstan/baseline/missingType.parameter.php
+++ b/.tools/phpstan/baseline/missingType.parameter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// total 70 errors
+// total 69 errors
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
@@ -212,11 +212,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Method Redaxo\\Core\\MediaPool\\Media::hasValue() has parameter $value with no type specified.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/MediaPool/Media.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Redaxo\\Core\\MediaPool\\Media::isDocType() has parameter $type with no type specified.',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/MediaPool/Media.php',
 ];

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -3421,13 +3421,10 @@
     </MixedOperand>
     <MixedReturnStatement>
       <code><![CDATA[$this->$value]]></code>
-      <code><![CDATA[Core::getProperty('allowed_doctypes', [])]]></code>
-      <code><![CDATA[Core::getProperty('allowed_doctypes', [])]]></code>
       <code><![CDATA[Core::getProperty('image_extensions', [])]]></code>
       <code><![CDATA[Core::getProperty('image_extensions', [])]]></code>
     </MixedReturnStatement>
     <NullableReturnStatement>
-      <code><![CDATA[Core::getProperty('allowed_doctypes', [])]]></code>
       <code><![CDATA[Core::getProperty('image_extensions', [])]]></code>
     </NullableReturnStatement>
   </file>

--- a/pages/mediapool/media.list.php
+++ b/pages/mediapool/media.list.php
@@ -294,11 +294,7 @@ foreach ($items as $media) {
         $thumbnail = '<i class="rex-mime rex-mime-error" title="' . I18n::msg('pool_file_does_not_exist') . '"></i><span class="sr-only">' . $media->getFileName() . '</span>';
     } else {
         $fileExt = File::extension($media->getFileName());
-        $iconClass = ' rex-mime-default';
-        if (Media::isDocType($fileExt)) {
-            $iconClass = ' rex-mime-' . $fileExt;
-        }
-        $thumbnail = '<i class="rex-mime' . $iconClass . '" title="' . $alt . '" data-extension="' . $fileExt . '"></i><span class="sr-only">' . $media->getFileName() . '</span>';
+        $thumbnail = '<i class="rex-mime rex-mime-' . escape($fileExt) . '" title="' . $alt . '" data-extension="' . $fileExt . '"></i><span class="sr-only">' . $media->getFileName() . '</span>';
 
         if (Media::isImageType(File::extension($media->getFileName()))) {
             $thumbnail = '<img class="thumbnail" src="' . Url::media($media->getFileName()) . '?buster=' . $media->getValue('updatedate') . '" width="80" height="80" alt="' . $alt . '" title="' . $alt . '" loading="lazy" />';

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -408,10 +408,6 @@
             "type": ["null", "object"]
 
         },
-        "allowed_doctypes": {
-            "description": "Allowed doctypes",
-            "type": "array"
-        },
         "image_extensions": {
             "description": "Image extensions",
             "type": "array"

--- a/setup/default.config.yml
+++ b/setup/default.config.yml
@@ -139,6 +139,5 @@ allowed_mime_types:
     mpeg: [video/mpeg]
     mpg: [video/mpeg]
     mp4: [video/mp4]
-allowed_doctypes: [avif, bmp, css, csv, doc, docx, eps, gif, gz, jpeg, jpg, mov, mp3, mp4, ogg, pdf, png, ppt, pptx, pps, ppsx, rar, rtf, srt, svg, swf, tar, tif, tiff, txt, vtt, webp, wma, xls, xlsx, zip]
 image_extensions: [avif, bmp, gif, jpeg, jpg, png, svg, tif, tiff, webp]
 sanitize_svgs: true

--- a/src/MediaPool/Media.php
+++ b/src/MediaPool/Media.php
@@ -251,19 +251,6 @@ class Media
         return is_file(Path::media($this->getFileName()));
     }
 
-    // allowed filetypes
-    /** @return list<string> */
-    public static function getDocTypes()
-    {
-        return Core::getProperty('allowed_doctypes', []);
-    }
-
-    /** @return bool */
-    public static function isDocType($type)
-    {
-        return in_array($type, self::getDocTypes());
-    }
-
     // allowed image upload types
     /** @return list<string> */
     public static function getImageTypes()


### PR DESCRIPTION
## Summary

- Removes the `allowed_doctypes` config key, which was misleading: it suggested upload filtering, but uploads are actually controlled via `blocked_extensions` and `allowed_mime_types`.
- Removes the now-unused `Media::getDocTypes()` and `Media::isDocType()` methods.
- Simplifies the only remaining usage in `pages/mediapool/media.list.php`: the mime icon CSS class (`rex-mime-<ext>`) is now always set. The SCSS only defines icons for 8 office extensions; for unknown extensions the class is a no-op and the generic `.rex-mime` rendering takes over — same visual result.

## Breaking changes

- `allowed_doctypes` config key removed.
- `Redaxo\Core\MediaPool\Media::getDocTypes()` removed.
- `Redaxo\Core\MediaPool\Media::isDocType()` removed.