### PR TITLE
feat: add Module::isAllowedInCategory() to restrict modules per category

### DIFF
--- a/pages/structure/content.php
+++ b/pages/structure/content.php
@@ -8,6 +8,7 @@ use Redaxo\Core\Content\Article;
 use Redaxo\Core\Content\ArticleCache;
 use Redaxo\Core\Content\ArticleSlice;
 use Redaxo\Core\Content\ArticleSliceAction;
+use Redaxo\Core\Content\Category;
 use Redaxo\Core\Content\ContentHandler;
 use Redaxo\Core\Content\ExtensionPoint\ArticleContentUpdated;
 use Redaxo\Core\Content\Module;
@@ -143,7 +144,8 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
             // ------------- MODUL IST VORHANDEN
 
             // ----- RECHTE AM MODUL ?
-            if ('delete' != $function && !Template::checkModuleAllowed($templateKey, $ctype, $moduleKey)) {
+            $category = $categoryId > 0 ? Category::get($categoryId) : null;
+            if ('delete' != $function && (!Template::checkModuleAllowed($templateKey, $ctype, $moduleKey) || !$module->isAllowedInCategory($category))) {
                 $globalWarning = I18n::msg('no_rights_to_this_function');
                 $sliceId = 0;
                 $function = '';

--- a/src/Content/ArticleContentEditor.php
+++ b/src/Content/ArticleContentEditor.php
@@ -170,8 +170,11 @@ class ArticleContentEditor extends ArticleContent
         $menuMoveupAction = [];
         $menuMovedownAction = [];
         if (Core::requireUser()->getComplexPerm('modules')->hasPerm($moduleKey)) {
-            $templateHasModule = !$this->template || Template::checkModuleAllowed($this->template, $this->ctype, $moduleKey);
-            if ($templateHasModule) {
+            $module = Module::get($moduleKey);
+            $category = $this->category_id > 0 ? Category::get($this->category_id) : null;
+            $moduleAllowed = (!$this->template || Template::checkModuleAllowed($this->template, $this->ctype, $moduleKey))
+                && (null === $module || $module->isAllowedInCategory($category));
+            if ($moduleAllowed) {
                 // edit
                 $item = [];
                 $item['label'] = I18n::msg('edit');
@@ -190,7 +193,7 @@ class ArticleContentEditor extends ArticleContent
             $item['attributes']['data-confirm'] = I18n::msg('confirm_delete_block');
             $menuDeleteAction = $item;
 
-            if ($templateHasModule && Core::requireUser()->hasPerm('publishSlice[]')) {
+            if ($moduleAllowed && Core::requireUser()->hasPerm('publishSlice[]')) {
                 // status
                 $item = [];
                 $statusName = $sliceStatus ? 'online' : 'offline';
@@ -201,7 +204,7 @@ class ArticleContentEditor extends ArticleContent
                 $menuStatusAction = $item;
             }
 
-            if ($templateHasModule && Core::requireUser()->hasPerm('moveSlice[]')) {
+            if ($moduleAllowed && Core::requireUser()->hasPerm('moveSlice[]')) {
                 // moveup
                 $item = [];
                 $item['hidden_label'] = I18n::msg('module') . ' article_content_editor.php' . $moduleName . ' ' . I18n::msg('move_slice_up');
@@ -350,11 +353,13 @@ class ArticleContentEditor extends ArticleContent
             $template = $this->template ? Template::get($this->template) : null;
             $contentSections = $template?->getContentSections() ?? [new ContentSection(1, 'Content')];
 
+            $category = $this->category_id > 0 ? Category::get($this->category_id) : null;
+
             $this->MODULESELECT = [];
             foreach ($contentSections as $section) {
                 foreach (Module::getAll() as $module) {
                     if (Core::requireUser()->getComplexPerm('modules')->hasPerm($module->key)) {
-                        if (!$template || $template->isModuleAllowed($section, $module)) {
+                        if ((!$template || $template->isModuleAllowed($section, $module)) && $module->isAllowedInCategory($category)) {
                             $this->MODULESELECT[$section->id][] = ['name' => I18n::translate($module->name), 'key' => $module->key];
                         }
                     }

--- a/src/Content/Module.php
+++ b/src/Content/Module.php
@@ -55,6 +55,18 @@ abstract class Module
         return self::$instances = $instances;
     }
 
+    /**
+     * Whether this module is allowed in the given category.
+     * `null` means root level (articles without a category).
+     * The default implementation allows the module everywhere.
+     *
+     * Override this to restrict to specific categories.
+     */
+    public function isAllowedInCategory(?Category $category): bool
+    {
+        return true;
+    }
+
     /** Render the backend edit form. */
     abstract public function input(ArticleSlice $slice): string;
 


### PR DESCRIPTION
## Summary
- New `Module::isAllowedInCategory(?Category $category): bool` (default `true`) — analog to `Template::isAllowedInCategory()`. Modules can override it to restrict where they may be used.
- Module selection in the slice editor (`ArticleContentEditor::preArticle`) and the slice menu (`getSliceMenu`) filter modules based on the current category.
- The save handler in `pages/structure/content.php` rejects add/edit for modules not allowed in the target category (delete still works, so existing slices remain removable).

## Example
```php
#[AsModule(key: 'product-detail', name: 'Produkt-Detail')]
final class ProductDetailModule extends Module
{
    public function isAllowedInCategory(?Category $category): bool
    {
        return $category?->getId() === 5;
    }
    // ...
}
```

Closes #4643