### PR TITLE
feat: discover `#[AsExtension]` methods to auto-register extensions

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -196,7 +196,6 @@
     <PossiblyInvalidArgument>
       <code><![CDATA[$REX['PATH_PROVIDER']]]></code>
       <code><![CDATA[$REX['URL_PROVIDER']]]></code>
-      <code><![CDATA[[MediaManager::class, 'init']]]></code>
     </PossiblyInvalidArgument>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$REX['PATH_PROVIDER']]]></code>

--- a/boot/addons.php
+++ b/boot/addons.php
@@ -37,6 +37,8 @@ Timer::measure('packages_boot', static function () use ($packageOrder) {
     }
 });
 
+Extension::registerByAttribute($this);
+
 // ----- all addons configs included
 Extension::registerPoint(new ExtensionPoint('PACKAGES_INCLUDED'));
 

--- a/boot/backend.php
+++ b/boot/backend.php
@@ -20,7 +20,6 @@ use Redaxo\Core\Http\Exception\NotFoundHttpException;
 use Redaxo\Core\Http\Request;
 use Redaxo\Core\Http\Response;
 use Redaxo\Core\Language\Language;
-use Redaxo\Core\MetaInfo\MetaInfo;
 use Redaxo\Core\Security\BackendLogin;
 use Redaxo\Core\Security\CsrfToken;
 use Redaxo\Core\Security\Login;
@@ -589,8 +588,6 @@ Core::setProperty('metainfo_metaTables', [
     'clang_' => Core::getTablePrefix() . 'clang',
 ]);
 
-Extension::register('PAGE_CHECKED', MetaInfo::extensionHandler(...));
-Extension::register('BACKUP_BEFORE_DB_IMPORT', MetaInfo::cleanup(...));
 Extension::register('STRUCTURE_CONTENT_SIDEBAR', function ($ep) {
     $subject = $ep->getSubject();
     $metaSidebar = include Path::core('pages/structure/content.metainfo.php');

--- a/boot/core.php
+++ b/boot/core.php
@@ -19,11 +19,8 @@ use Redaxo\Core\Http\Request;
 use Redaxo\Core\Http\Response;
 use Redaxo\Core\Language\Language;
 use Redaxo\Core\Language\LanguagePermission;
-use Redaxo\Core\MediaManager\MediaManager;
 use Redaxo\Core\MediaPool\MediaPoolPermission;
-use Redaxo\Core\Security\BackendLogin;
 use Redaxo\Core\Security\ComplexPermission;
-use Redaxo\Core\Security\UserRole;
 use Redaxo\Core\Translation\I18n;
 use Redaxo\Core\Util\Timer;
 use Redaxo\Core\Util\VarDumper;
@@ -104,9 +101,6 @@ ComplexPermission::register('structure', StructurePermission::class);
 ComplexPermission::register('modules', ModulePermission::class);
 ComplexPermission::register('media', MediaPoolPermission::class);
 
-Extension::register('COMPLEX_PERM_REMOVE_ITEM', [UserRole::class, 'removeOrReplaceItem']);
-Extension::register('COMPLEX_PERM_REPLACE_ITEM', [UserRole::class, 'removeOrReplaceItem']);
-
 // ----- SET CLANG
 if (!Core::isSetup()) {
     $clangId = Request::request('clang', 'int', Language::getStartId());
@@ -126,8 +120,6 @@ if ('cli' !== PHP_SAPI && !Core::isSetup()) {
     }
 }
 
-Extension::register('SESSION_REGENERATED', BackendLogin::sessionRegenerated(...));
-
 $nexttime = Core::isSetup() || Core::getConsole() ? 0 : (int) Core::getConfig('cronjob_nexttime', 0);
 if (0 !== $nexttime && time() >= $nexttime) {
     $env = CronjobExecutor::getCurrentEnvironment();
@@ -138,11 +130,6 @@ if (0 !== $nexttime && time() >= $nexttime) {
         }
     });
 }
-
-Extension::register('PACKAGES_INCLUDED', [MediaManager::class, 'init'], Extension::EARLY);
-Extension::register('MEDIA_UPDATED', [MediaManager::class, 'mediaUpdated']);
-Extension::register('MEDIA_DELETED', [MediaManager::class, 'mediaUpdated']);
-Extension::register('MEDIA_IS_IN_USE', [MediaManager::class, 'mediaIsInUse']);
 
 if (!Core::isSetup()) {
     Core::setProperty('start_article_id', Core::getConfig('start_article_id', 1));

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -5,6 +5,7 @@ namespace Redaxo\Core;
 use Composer\Autoload\ClassLoader;
 use Composer\InstalledVersions;
 use FilesystemIterator;
+use Generator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Redaxo\Core\Addon\Addon;
@@ -40,7 +41,7 @@ final class ClassDiscovery
     /** @var list<string>|null */
     private ?array $relevantPaths = null;
 
-    /** @var array<string, array<class-string, array<string, mixed>|object>>|null */
+    /** @var array<string, mixed>|null */
     private ?array $cacheData = null;
 
     private function __construct(
@@ -69,7 +70,9 @@ final class ClassDiscovery
         if (isset($cacheData[$cacheKey])) {
             // Reconstruct attribute instances from cached arrays (JSON roundtrip converts objects to arrays)
             $result = [];
-            foreach ($cacheData[$cacheKey] as $class => $entry) {
+            /** @var array<class-string, array<string, mixed>|object> $cached */
+            $cached = $cacheData[$cacheKey];
+            foreach ($cached as $class => $entry) {
                 /**
                  * @var TAttribute $attribute
                  * @psalm-suppress MixedMethodCall
@@ -83,13 +86,7 @@ final class ClassDiscovery
 
         $result = [];
 
-        foreach ($this->getRelevantClasses() as $class) {
-            if (!class_exists($class)) {
-                continue;
-            }
-
-            $reflection = new ReflectionClass($class);
-
+        foreach ($this->getReflections() as $reflection) {
             if ($reflection->isAbstract()) {
                 continue;
             }
@@ -105,7 +102,75 @@ final class ClassDiscovery
             }
 
             /** @var class-string<TParent> $class */
+            $class = $reflection->getName();
             $result[$class] = $attributes[0]->newInstance();
+        }
+
+        $this->saveCacheData($cacheKey, $result);
+
+        return $result;
+    }
+
+    /**
+     * Discovers all non-abstract methods (static and instance) that carry the given attribute.
+     *
+     * Each entry contains the declaring class, method name, whether the method is static,
+     * and the attribute instance. Methods inherited from parent classes are not duplicated —
+     * only the declaring class is reported.
+     *
+     * @template TAttribute of object
+     * @param class-string<TAttribute> $attributeClass
+     * @return list<array{class: class-string, method: string, isStatic: bool, attribute: TAttribute}>
+     */
+    public function discoverByMethodAttribute(string $attributeClass): array
+    {
+        $cacheKey = 'method:' . $attributeClass;
+        $cacheData = $this->loadCacheData();
+
+        if (isset($cacheData[$cacheKey])) {
+            /** @var list<array{class: class-string, method: string, isStatic: bool, attribute: array<string, mixed>|TAttribute}> $cached */
+            $cached = $cacheData[$cacheKey];
+            $result = [];
+            foreach ($cached as $entry) {
+                /**
+                 * @var TAttribute $attribute
+                 * @psalm-suppress MixedMethodCall
+                 */
+                $attribute = is_array($entry['attribute']) ? new $attributeClass(...$entry['attribute']) : $entry['attribute'];
+                $result[] = [
+                    'class' => $entry['class'],
+                    'method' => $entry['method'],
+                    'isStatic' => $entry['isStatic'],
+                    'attribute' => $attribute,
+                ];
+            }
+            return $result;
+        }
+
+        $result = [];
+
+        foreach ($this->getReflections() as $reflection) {
+            $class = $reflection->getName();
+
+            foreach ($reflection->getMethods() as $method) {
+                if ($method->isAbstract()) {
+                    continue;
+                }
+
+                // Skip methods inherited from a parent — they'll be reported on their declaring class.
+                if ($method->getDeclaringClass()->getName() !== $class) {
+                    continue;
+                }
+
+                foreach ($method->getAttributes($attributeClass) as $attribute) {
+                    $result[] = [
+                        'class' => $class,
+                        'method' => $method->getName(),
+                        'isStatic' => $method->isStatic(),
+                        'attribute' => $attribute->newInstance(),
+                    ];
+                }
+            }
         }
 
         $this->saveCacheData($cacheKey, $result);
@@ -116,6 +181,18 @@ final class ClassDiscovery
     public static function clearCache(): void
     {
         File::delete(self::getCacheFile());
+    }
+
+    /** @return Generator<int, ReflectionClass<object>> */
+    private function getReflections(): Generator
+    {
+        foreach ($this->getRelevantClasses() as $class) {
+            if (!class_exists($class)) {
+                continue;
+            }
+
+            yield new ReflectionClass($class);
+        }
     }
 
     /** @return list<string> */
@@ -250,14 +327,14 @@ final class ClassDiscovery
         return false;
     }
 
-    /** @return array<string, array<class-string, array<string, mixed>|object>> */
+    /** @return array<string, mixed> */
     private function loadCacheData(): array
     {
         if (null !== $this->cacheData) {
             return $this->cacheData;
         }
 
-        /** @var array{addons_hash?: string, files_hash?: string, data?: array<string, array<class-string, array<string, mixed>>>} $cache */
+        /** @var array{addons_hash?: string, files_hash?: string, data?: array<string, mixed>} $cache */
         $cache = File::getCache(self::getCacheFile());
 
         if (!isset($cache['addons_hash']) || $cache['addons_hash'] !== $this->getAddonHash()) {
@@ -274,8 +351,7 @@ final class ClassDiscovery
         return $this->cacheData = $cache['data'] ?? [];
     }
 
-    /** @param array<class-string, array<string, mixed>|object> $data */
-    private function saveCacheData(string $cacheKey, array $data): void
+    private function saveCacheData(string $cacheKey, mixed $data): void
     {
         $this->cacheData = $this->loadCacheData();
         $this->cacheData[$cacheKey] = $data;

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -118,6 +118,8 @@ class Application extends SymfonyApplication
             }
         }
 
+        Extension::registerByAttribute($this->project);
+
         Extension::registerPoint(new ExtensionPoint('PACKAGES_INCLUDED'));
 
         $this->project->boot();

--- a/src/ExtensionPoint/AsExtension.php
+++ b/src/ExtensionPoint/AsExtension.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Redaxo\Core\ExtensionPoint;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final readonly class AsExtension
+{
+    /** @param Extension::EARLY|Extension::NORMAL|Extension::LATE $level */
+    public function __construct(
+        public string $extensionPoint,
+        public int $level = Extension::NORMAL,
+    ) {}
+}

--- a/src/ExtensionPoint/Extension.php
+++ b/src/ExtensionPoint/Extension.php
@@ -2,8 +2,11 @@
 
 namespace Redaxo\Core\ExtensionPoint;
 
+use Redaxo\Core\AbstractProject;
 use Redaxo\Core\Base\FactoryTrait;
+use Redaxo\Core\ClassDiscovery;
 use Redaxo\Core\Exception\InvalidArgumentException;
+use Redaxo\Core\Exception\LogicException;
 use Redaxo\Core\Util\Timer;
 
 use function call_user_func;
@@ -11,6 +14,7 @@ use function in_array;
 use function is_array;
 use function is_int;
 use function is_string;
+use function sprintf;
 
 use const E_USER_WARNING;
 
@@ -105,6 +109,39 @@ abstract class Extension
 
         foreach ((array) $extensionPoint as $ep) {
             self::$extensions[$ep][$level][] = [$extension, $params];
+        }
+    }
+
+    /**
+     * Registers all extensions for methods carrying the `#[AsExtension]` attribute,
+     * discovered via {@see ClassDiscovery}.
+     *
+     * Static methods are bound to their class; non-static methods are only allowed
+     * on the project class (where the instance is available).
+     *
+     * @internal
+     */
+    public static function registerByAttribute(AbstractProject $project): void
+    {
+        foreach (ClassDiscovery::getInstance()->discoverByMethodAttribute(AsExtension::class) as $entry) {
+            if ($entry['isStatic']) {
+                $callable = [$entry['class'], $entry['method']];
+            } elseif ($project instanceof $entry['class']) {
+                $callable = [$project, $entry['method']];
+            } else {
+                throw new LogicException(sprintf(
+                    'Non-static #[AsExtension] is only allowed on the project class. Method "%s::%s()" is neither static nor defined on a parent of %s.',
+                    $entry['class'],
+                    $entry['method'],
+                    $project::class,
+                ));
+            }
+
+            self::register(
+                $entry['attribute']->extensionPoint,
+                $callable,
+                $entry['attribute']->level,
+            );
         }
     }
 

--- a/src/MediaManager/MediaManager.php
+++ b/src/MediaManager/MediaManager.php
@@ -4,6 +4,7 @@ namespace Redaxo\Core\MediaManager;
 
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
+use Redaxo\Core\ExtensionPoint\AsExtension;
 use Redaxo\Core\ExtensionPoint\Extension;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Filesystem\File;
@@ -464,6 +465,7 @@ class MediaManager
      * Checks if media is used by this addon.
      * @return list<string> Warning message as array
      */
+    #[AsExtension('MEDIA_IS_IN_USE')]
     public static function mediaIsInUse(ExtensionPoint $ep)
     {
         /** @var list<string> $warning */
@@ -491,12 +493,15 @@ class MediaManager
     }
 
     /** @return void */
+    #[AsExtension('MEDIA_UPDATED')]
+    #[AsExtension('MEDIA_DELETED')]
     public static function mediaUpdated(ExtensionPoint $ep)
     {
         self::deleteCache((string) $ep->getParam('filename'));
     }
 
     /** @return void */
+    #[AsExtension('PACKAGES_INCLUDED', level: Extension::EARLY)]
     public static function init()
     {
         // --- handle image request

--- a/src/MetaInfo/MetaInfo.php
+++ b/src/MetaInfo/MetaInfo.php
@@ -8,6 +8,7 @@ use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Database\Table;
 use Redaxo\Core\Database\Util;
 use Redaxo\Core\Exception\InvalidArgumentException;
+use Redaxo\Core\ExtensionPoint\AsExtension;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\MetaInfo\Database\Table as MetaInfoTable;
@@ -243,6 +244,7 @@ class MetaInfo
      *
      * @return void
      */
+    #[AsExtension('PAGE_CHECKED')]
     public static function extensionHandler(ExtensionPoint $ep)
     {
         $page = $ep->getSubject();
@@ -270,6 +272,7 @@ class MetaInfo
      * @param ExtensionPoint|array $epOrParams
      * @return void
      */
+    #[AsExtension('BACKUP_BEFORE_DB_IMPORT')]
     public static function cleanup($epOrParams)
     {
         $params = $epOrParams instanceof ExtensionPoint ? $epOrParams->getParams() : $epOrParams;

--- a/src/Security/BackendLogin.php
+++ b/src/Security/BackendLogin.php
@@ -7,6 +7,7 @@ use Override;
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\LogicException;
+use Redaxo\Core\ExtensionPoint\AsExtension;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Http\Request;
 use Redaxo\Core\Http\Response;
@@ -378,6 +379,7 @@ class BackendLogin extends Login
      * @internal
      * @param ExtensionPoint<null> $ep
      */
+    #[AsExtension('SESSION_REGENERATED')]
     public static function sessionRegenerated(ExtensionPoint $ep): void
     {
         if (self::class === $ep->getParam('class')) {

--- a/src/Security/UserRole.php
+++ b/src/Security/UserRole.php
@@ -4,6 +4,7 @@ namespace Redaxo\Core\Security;
 
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
+use Redaxo\Core\ExtensionPoint\AsExtension;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 
 use function count;
@@ -98,6 +99,8 @@ final class UserRole
         return new self($roles);
     }
 
+    #[AsExtension('COMPLEX_PERM_REMOVE_ITEM')]
+    #[AsExtension('COMPLEX_PERM_REPLACE_ITEM')]
     public static function removeOrReplaceItem(ExtensionPoint $ep): void
     {
         $params = $ep->getParams();


### PR DESCRIPTION
## Summary

Adds a new way to register extension listeners: annotate any static method with `#[AsExtension('EP_NAME')]` and `ClassDiscovery` auto-registers it at boot — no more manual `Extension::register()` in `boot.php`.

- New attribute `Redaxo\Core\ExtensionPoint\AsExtension` (`TARGET_METHOD | IS_REPEATABLE`)
- New `ClassDiscovery::discoverByMethodAttribute()` — scans relevant classes for method-level attributes, caches like the existing class-level discovery
- New `Extension::registerByAttribute(AbstractProject)` (`@internal`) — wires discovered methods into the extension system; static methods are bound to their class, non-static methods are only allowed on the project class (`AbstractProject` subclass)
- Wired into `boot/addons.php` and `Console\Application::loadPackages()`, both directly before `PACKAGES_INCLUDED` fires

## Example

```php
use Redaxo\Core\ExtensionPoint\AsExtension;
use Redaxo\Core\ExtensionPoint\Extension;
use Redaxo\Core\ExtensionPoint\ExtensionPoint;

final class MyListeners
{
    #[AsExtension('MEDIA_IS_IN_USE', level: Extension::EARLY)]
    public static function checkUsage(ExtensionPoint $ep): void { /* … */ }
}
```

Instance methods on the project class (subclass of `AbstractProject`) also work — the project instance is bound automatically.

## Core refactor (second commit)

Existing unconditional listener registrations in `boot/core.php` and `boot/backend.php` are migrated to the attribute:

| Method | EP(s) |
|---|---|
| `UserRole::removeOrReplaceItem` | `COMPLEX_PERM_REMOVE_ITEM`, `COMPLEX_PERM_REPLACE_ITEM` |
| `BackendLogin::sessionRegenerated` | `SESSION_REGENERATED` |
| `MediaManager::init` | `PACKAGES_INCLUDED` (EARLY) |
| `MediaManager::mediaUpdated` | `MEDIA_UPDATED`, `MEDIA_DELETED` |
| `MediaManager::mediaIsInUse` | `MEDIA_IS_IN_USE` |
| `MetaInfo::extensionHandler` | `PAGE_CHECKED` |
| `MetaInfo::cleanup` | `BACKUP_BEFORE_DB_IMPORT` |

Conditional registrations and closures are left untouched.