### PR TITLE
fix: metainfo article status toggle failing for users with multiple mountpoints

### DIFF
--- a/redaxo/src/addons/metainfo/pages/content.metainfo.php
+++ b/redaxo/src/addons/metainfo/pages/content.metainfo.php
@@ -26,6 +26,7 @@ $articleStatus = $articleStatusTypes[$status][0];
 $articleIcon = $articleStatusTypes[$status][2];
 $structureContext = new rex_structure_context([
     'article_id' => rex_request('article_id', 'int'),
+    'category_id' => $article->getCategoryId(),
     'clang_id' => rex_request('clang', 'int'),
 ]);
 


### PR DESCRIPTION
Wenn einem Redakteur mehrere Benutzerprofile zugeordnet sind, die zusammen mehr als einen Struktur-Mountpoint ergeben, schlug der Status-Toggle in der Metainfo-Sidebar mit "user has no permission for this article!" fehl.

Ursache: rex_structure_context wurde ohne category_id instanziiert. Bei mehr als einem Mountpoint blieb category_id=0, und hasCategoryPerm(0) gibt für Nicht-Admins false zurück.

Fix: category_id wird jetzt direkt vom Artikel-Objekt übergeben.