### PR TITLE
fix: tolerate vanishing sub-directories in recursive cleanup paths

### DIFF
--- a/redaxo/src/core/functions/function_rex_other.php
+++ b/redaxo/src/core/functions/function_rex_other.php
@@ -16,7 +16,8 @@ function rex_delete_cache()
         ->recursive()
         ->childFirst()
         ->ignoreFiles(['.htaccess', '.redaxo'], false)
-        ->ignoreSystemStuff(false);
+        ->ignoreSystemStuff(false)
+        ->ignoreUnreadableDirs();
     rex_dir::deleteIterator($finder);
 
     rex_autoload::removeCache();

--- a/redaxo/src/core/lib/util/dir.php
+++ b/redaxo/src/core/lib/util/dir.php
@@ -108,7 +108,7 @@ class rex_dir
             return true;
         }
 
-        if (!self::deleteIterator(rex_finder::factory($dir)->recursive()->childFirst()->ignoreSystemStuff(false))) {
+        if (!self::deleteIterator(rex_finder::factory($dir)->recursive()->childFirst()->ignoreSystemStuff(false)->ignoreUnreadableDirs())) {
             return false;
         }
 
@@ -126,7 +126,7 @@ class rex_dir
      */
     public static function deleteFiles($dir, $recursive = true)
     {
-        $iterator = rex_finder::factory($dir)->recursive($recursive)->filesOnly()->ignoreSystemStuff(false);
+        $iterator = rex_finder::factory($dir)->recursive($recursive)->filesOnly()->ignoreSystemStuff(false)->ignoreUnreadableDirs();
         return self::deleteIterator($iterator);
     }
 

--- a/redaxo/src/core/lib/util/finder.php
+++ b/redaxo/src/core/lib/util/finder.php
@@ -30,6 +30,7 @@ class rex_finder implements IteratorAggregate, Countable
     /** @var list<string> */
     private array $ignoreDirsRecursive = [];
     private bool $ignoreSystemStuff = true;
+    private bool $ignoreUnreadableDirs = false;
     /** @var false|rex_sortable_iterator::*|callable(mixed, mixed): int */
     private $sort = false;
 
@@ -174,6 +175,25 @@ class rex_finder implements IteratorAggregate, Countable
     }
 
     /**
+     * Silently skips sub-directories that can not be opened on recursive descent
+     * (e.g. because they vanished between scandir() and descent in a concurrent run,
+     * or because permissions deny access).
+     *
+     * Default is `false`: an unreadable sub-directory throws `UnexpectedValueException`
+     * mid-iteration. Enable only when partial loss is acceptable — typically for
+     * cleanup loops over a tree that other workers may modify in parallel.
+     * Don't enable for backup/copy paths where read errors must surface.
+     *
+     * @return $this
+     */
+    public function ignoreUnreadableDirs(bool $ignore = true)
+    {
+        $this->ignoreUnreadableDirs = $ignore;
+
+        return $this;
+    }
+
+    /**
      * Sorts the elements.
      *
      * @param rex_sortable_iterator::*|callable(mixed, mixed): int $sort Sort mode, see {@link rex_sortable_iterator::__construct()}
@@ -239,8 +259,9 @@ class rex_finder implements IteratorAggregate, Countable
         });
 
         if ($this->recursive) {
+            $flags = $this->ignoreUnreadableDirs ? RecursiveIteratorIterator::CATCH_GET_CHILD : 0;
             /** @var Traversable<string, SplFileInfo> */
-            $iterator = new RecursiveIteratorIterator($iterator, $this->recursiveMode);
+            $iterator = new RecursiveIteratorIterator($iterator, $this->recursiveMode, $flags);
         }
 
         if ($this->sort) {

--- a/redaxo/src/core/tests/util/finder_test.php
+++ b/redaxo/src/core/tests/util/finder_test.php
@@ -93,4 +93,38 @@ final class rex_finder_test extends TestCase
         $iterator = rex_finder::factory($this->getPath())->recursive()->ignoreSystemStuff(false);
         $this->assertIteratorContains($iterator, ['file1.txt', 'file2.yml', 'dir1', 'dir1/file3.txt', 'dir1/dir', 'dir2', 'dir2/file4.yml', 'dir2/dir', 'dir2/dir/file5.yml', 'dir2/dir1', 'dir', '.DS_Store', 'dir1/Thumbs.db']);
     }
+
+    public function testIgnoreUnreadableDirsToleratesVanishingSubdir(): void
+    {
+        // Race condition: a sub-directory is listed by scandir() but disappears
+        // before RecursiveDirectoryIterator descends into it (e.g. concurrent
+        // rex_delete_cache() calls on a multi-worker PHP server).
+        // With ignoreUnreadableDirs() the iteration must keep going instead of
+        // throwing UnexpectedValueException.
+        $sub = $this->getPath('dir2/dir');
+
+        foreach (rex_finder::factory($this->getPath())->recursive()->ignoreUnreadableDirs() as $file) {
+            if ($file->isDir() && (string) $file === rtrim($sub, '/')) {
+                rex_dir::delete($sub);
+            }
+        }
+
+        self::assertDirectoryDoesNotExist($sub);
+    }
+
+    public function testRecursiveThrowsOnVanishingSubdirByDefault(): void
+    {
+        // Default semantics: an unreadable/vanishing sub-directory surfaces as
+        // UnexpectedValueException. Callers like backup/copy rely on this so
+        // partial reads can't pass for success.
+        $sub = $this->getPath('dir2/dir');
+
+        $this->expectException(UnexpectedValueException::class);
+
+        foreach (rex_finder::factory($this->getPath())->recursive() as $file) {
+            if ($file->isDir() && (string) $file === rtrim($sub, '/')) {
+                rex_dir::delete($sub);
+            }
+        }
+    }
 }


### PR DESCRIPTION
`rex_finder` wraps `RecursiveDirectoryIterator` in `RecursiveIteratorIterator`. When a sub-directory disappears between `scandir()` listing it and `RecursiveDirectoryIterator::__construct` opening it on descent (or simply isn't readable), PHP throws `UnexpectedValueException` mid-iteration.

The race regularly hits the visual-tests workflow (4 parallel PHP-CLI workers + repeated `cache:clear`) where `rex_delete_cache()` walks `redaxo/cache/` with `childFirst` while another worker rebuilds or wipes the same tree. The exception ends up in `system.log` and pops up in the log-page screenshot until the next CI run flushes it.

Add an opt-in `rex_finder::ignoreUnreadableDirs()` that activates `RecursiveIteratorIterator::CATCH_GET_CHILD`, and enable it on the cleanup paths only:

- `rex_dir::delete()` / `rex_dir::deleteFiles()`
- `rex_delete_cache()`

Default semantics stay strict so callers like backup/copy still surface read errors instead of silently producing a partial result.