### PR TITLE
fix: harden permission checks in structure api functions

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2011,31 +2011,6 @@
       <code><![CDATA[getId]]></code>
     </MixedMethodCall>
   </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_article2category.php">
-    <PossiblyNullReference>
-      <code><![CDATA[getCategoryId]]></code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_article2startarticle.php">
-    <PossiblyNullReference>
-      <code><![CDATA[getCategoryId]]></code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_article_move.php">
-    <PossiblyNullReference>
-      <code><![CDATA[getCategoryId]]></code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_category2article.php">
-    <PossiblyNullReference>
-      <code><![CDATA[getCategoryId]]></code>
-    </PossiblyNullReference>
-  </file>
-  <file src="redaxo/src/addons/structure/lib/api_functions/api_category_move.php">
-    <PossiblyNullReference>
-      <code><![CDATA[getCategoryId]]></code>
-    </PossiblyNullReference>
-  </file>
   <file src="redaxo/src/addons/structure/lib/article.php">
     <MixedReturnStatement>
       <code><![CDATA[rex_addon::get('structure')->getProperty('article_id', 1)]]></code>

--- a/redaxo/src/addons/structure/lib/api_functions/api_article2category.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article2category.php
@@ -9,19 +9,27 @@ class rex_api_article2category extends rex_api_function
 {
     public function execute()
     {
-        $articleId = rex_request('article_id', 'int');
-        $categoryId = rex_article::get($articleId)->getCategoryId();
         $user = rex::requireUser();
-
-        // Check permissions
-        if ($user->hasPerm('article2category[]') && $user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
-            if (rex_article_service::article2category($articleId)) {
-                return new rex_api_result(true, rex_i18n::msg('content_tocategory_ok'));
-            }
-
-            return new rex_api_result(false, rex_i18n::msg('content_tocategory_failed'));
+        if (!$user->hasPerm('article2category[]')) {
+            throw new rex_api_exception('User has no permission to convert articles to categories!');
         }
-        throw new rex_api_exception('User has no permission for this article!');
+
+        $articleId = rex_request('article_id', 'int');
+
+        $article = rex_article::get($articleId);
+        if (!$article instanceof rex_article) {
+            throw new rex_api_exception('Unable to find article with id "' . $articleId . '"!');
+        }
+
+        if (!$user->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
+        if (rex_article_service::article2category($articleId)) {
+            return new rex_api_result(true, rex_i18n::msg('content_tocategory_ok'));
+        }
+
+        return new rex_api_result(false, rex_i18n::msg('content_tocategory_failed'));
     }
 
     protected function requiresCsrfProtection()

--- a/redaxo/src/addons/structure/lib/api_functions/api_article2startarticle.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article2startarticle.php
@@ -9,20 +9,27 @@ class rex_api_article2startarticle extends rex_api_function
 {
     public function execute()
     {
-        $articleId = rex_request('article_id', 'int');
-        $categoryId = rex_article::get($articleId)->getCategoryId();
         $user = rex::requireUser();
-
-        // Check permissions
-        if ($user->hasPerm('article2startarticle[]') && $user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
-            if (rex_article_service::article2startarticle($articleId)) {
-                return new rex_api_result(true, rex_i18n::msg('content_tostartarticle_ok'));
-            }
-
-            return new rex_api_result(false, rex_i18n::msg('content_tostartarticle_failed'));
+        if (!$user->hasPerm('article2startarticle[]')) {
+            throw new rex_api_exception('User has no permission to convert articles to start articles!');
         }
 
-        throw new rex_api_exception('user has no permission for this article!');
+        $articleId = rex_request('article_id', 'int');
+
+        $article = rex_article::get($articleId);
+        if (!$article instanceof rex_article) {
+            throw new rex_api_exception('Unable to find article with id "' . $articleId . '"!');
+        }
+
+        if (!$user->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
+        if (rex_article_service::article2startarticle($articleId)) {
+            return new rex_api_result(true, rex_i18n::msg('content_tostartarticle_ok'));
+        }
+
+        return new rex_api_result(false, rex_i18n::msg('content_tostartarticle_failed'));
     }
 
     protected function requiresCsrfProtection()

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_add.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_add.php
@@ -9,15 +9,19 @@ class rex_api_article_add extends rex_api_function
 {
     public function execute()
     {
-        if (!rex::requireUser()->hasPerm('addArticle[]')) {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('addArticle[]')) {
             throw new rex_api_exception('User has no permission to add articles!');
         }
 
         $categoryId = rex_request('category_id', 'int');
 
-        // check permissions
-        if (!rex::requireUser()->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
-            throw new rex_api_exception('user has no permission for this category!');
+        if (0 !== $categoryId && !rex_category::get($categoryId)) {
+            throw new rex_api_exception('Unable to find category with id "' . $categoryId . '"!');
+        }
+
+        if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
         }
 
         $data = [];

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_copy.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_copy.php
@@ -9,32 +9,46 @@ class rex_api_article_copy extends rex_api_function
 {
     public function execute()
     {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('copyArticle[]')) {
+            throw new rex_api_exception('User has no permission to copy articles!');
+        }
+
         $articleId = rex_request('article_id', 'int');
         $clang = rex_request('clang', 'int', 1);
         // The destination category in which the given article will be copied
         $categoryCopyIdNew = rex_request('category_copy_id_new', 'int');
-        $user = rex::requireUser();
+
+        $article = rex_article::get($articleId);
+        if (!$article instanceof rex_article) {
+            throw new rex_api_exception('Unable to find article with id "' . $articleId . '"!');
+        }
+
+        if (0 !== $categoryCopyIdNew && !rex_category::get($categoryCopyIdNew)) {
+            throw new rex_api_exception('Unable to find category with id "' . $categoryCopyIdNew . '"!');
+        }
+
+        if (
+            !$user->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($categoryCopyIdNew)
+        ) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
 
         $context = new rex_context([
             'page' => rex_be_controller::getCurrentPage(),
             'clang' => $clang,
         ]);
 
-        if ($user->hasPerm('copyArticle[]') && $user->getComplexPerm('structure')->hasCategoryPerm($categoryCopyIdNew)) {
-            if (false !== ($newId = rex_article_service::copyArticle($articleId, $categoryCopyIdNew))) {
-                $result = new rex_api_result(true, rex_i18n::msg('content_articlecopied'));
-                rex_response::sendRedirect($context->getUrl([
-                    'article_id' => $newId,
-                    'info' => $result->getMessage(),
-                ], false));
-            } else {
-                $result = new rex_api_result(false, rex_i18n::msg('content_errorcopyarticle'));
-            }
-
-            return $result;
+        if (false !== ($newId = rex_article_service::copyArticle($articleId, $categoryCopyIdNew))) {
+            $result = new rex_api_result(true, rex_i18n::msg('content_articlecopied'));
+            rex_response::sendRedirect($context->getUrl([
+                'article_id' => $newId,
+                'info' => $result->getMessage(),
+            ], false));
         }
 
-        throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        return new rex_api_result(false, rex_i18n::msg('content_errorcopyarticle'));
     }
 
     protected function requiresCsrfProtection()

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_delete.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_delete.php
@@ -9,17 +9,22 @@ class rex_api_article_delete extends rex_api_function
 {
     public function execute()
     {
-        if (!rex::requireUser()->hasPerm('deleteArticle[]')) {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('deleteArticle[]')) {
             throw new rex_api_exception('User has no permission to delete articles!');
         }
 
-        $categoryId = rex_request('category_id', 'int');
         $articleId = rex_request('article_id', 'int');
 
-        // Check permissions
-        if (!rex::requireUser()->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
-            throw new rex_api_exception('user has no permission for this category!');
+        $article = rex_article::get($articleId);
+        if (!$article instanceof rex_article) {
+            throw new rex_api_exception('Unable to find article with id "' . $articleId . '"!');
         }
+
+        if (!$user->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
         return new rex_api_result(true, rex_article_service::deleteArticle($articleId));
     }
 

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_edit.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_edit.php
@@ -9,20 +9,26 @@ class rex_api_article_edit extends rex_api_function
 {
     public function execute()
     {
-        if (!rex::requireUser()->hasPerm('editArticle[]')) {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('editArticle[]')) {
             throw new rex_api_exception('User has no permission to edit articles!');
         }
 
-        $categoryId = rex_request('category_id', 'int');
         $articleId = rex_request('article_id', 'int');
         $clang = rex_request('clang', 'int');
 
-        // check permissions
-        if (!rex::requireUser()->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
-            throw new rex_api_exception('user has no permission for this category!');
+        $article = rex_article::get($articleId, $clang);
+        if (!$article instanceof rex_article) {
+            throw new rex_api_exception('Unable to find article with id "' . $articleId . '" and clang "' . $clang . '"!');
         }
 
-        // --------------------- ARTIKEL EDIT
+        if (
+            !$user->getComplexPerm('clang')->hasPerm($clang)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())
+        ) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
         $data = [];
         $data['priority'] = rex_post('article-position', 'int');
         $data['name'] = rex_post('article-name', 'string');

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_move.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_move.php
@@ -12,24 +12,39 @@ class rex_api_article_move extends rex_api_function
      */
     public function execute()
     {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('moveArticle[]')) {
+            throw new rex_api_exception('User has no permission to move articles!');
+        }
+
         // The article to move
         $articleId = rex_request('article_id', 'int');
-        $categoryId = rex_article::get($articleId)->getCategoryId();
         // The destination category in which the given category will be moved
         $categoryIdNew = rex_request('category_id_new', 'int');
 
-        $user = rex::requireUser();
-
-        // Check permissions
-        if ($user->hasPerm('moveArticle[]') && $user->getComplexPerm('structure')->hasCategoryPerm($categoryIdNew)) {
-            if (rex_article_service::moveArticle($articleId, $categoryId, $categoryIdNew)) {
-                return new rex_api_result(true, rex_i18n::msg('content_articlemoved'));
-            }
-
-            return new rex_api_result(false, rex_i18n::msg('content_errormovearticle'));
+        $article = rex_article::get($articleId);
+        if (!$article instanceof rex_article) {
+            throw new rex_api_exception('Unable to find article with id "' . $articleId . '"!');
         }
 
-        throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        if (0 !== $categoryIdNew && !rex_category::get($categoryIdNew)) {
+            throw new rex_api_exception('Unable to find category with id "' . $categoryIdNew . '"!');
+        }
+
+        $categoryId = $article->getCategoryId();
+
+        if (
+            !$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($categoryIdNew)
+        ) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
+        if (rex_article_service::moveArticle($articleId, $categoryId, $categoryIdNew)) {
+            return new rex_api_result(true, rex_i18n::msg('content_articlemoved'));
+        }
+
+        return new rex_api_result(false, rex_i18n::msg('content_errormovearticle'));
     }
 
     protected function requiresCsrfProtection()

--- a/redaxo/src/addons/structure/lib/api_functions/api_article_status.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_article_status.php
@@ -9,20 +9,30 @@ class rex_api_article_status extends rex_api_function
 {
     public function execute()
     {
-        $categoryId = rex_request('category_id', 'int');
+        $user = rex::requireUser();
+        if (!$user->hasPerm('publishArticle[]')) {
+            throw new rex_api_exception('User has no permission to publish articles!');
+        }
+
         $articleId = rex_request('article_id', 'int');
         $clang = rex_request('clang', 'int');
         $status = rex_request('art_status', 'int', null);
-        $user = rex::requireUser();
 
-        // check permissions
-        if ($user->getComplexPerm('structure')->hasCategoryPerm($categoryId) && $user->hasPerm('publishArticle[]')) {
-            rex_article_service::articleStatus($articleId, $clang, $status);
-
-            return new rex_api_result(true, rex_i18n::msg('article_status_updated'));
+        $article = rex_article::get($articleId, $clang);
+        if (!$article instanceof rex_article) {
+            throw new rex_api_exception('Unable to find article with id "' . $articleId . '" and clang "' . $clang . '"!');
         }
 
-        throw new rex_api_exception('user has no permission for this article!');
+        if (
+            !$user->getComplexPerm('clang')->hasPerm($clang)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())
+        ) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
+        rex_article_service::articleStatus($articleId, $clang, $status);
+
+        return new rex_api_result(true, rex_i18n::msg('article_status_updated'));
     }
 
     protected function requiresCsrfProtection()

--- a/redaxo/src/addons/structure/lib/api_functions/api_category2article.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category2article.php
@@ -9,19 +9,28 @@ class rex_api_category2Article extends rex_api_function
 {
     public function execute()
     {
-        $articleId = rex_request('article_id', 'int');
-        $categoryId = rex_article::get($articleId)->getCategoryId();
         $user = rex::requireUser();
-
-        // Check permissions: article2category and category2article share the same permission: article2category
-        if ($user->hasPerm('article2category[]') && $user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
-            if (rex_article_service::category2article($articleId)) {
-                return new rex_api_result(true, rex_i18n::msg('content_toarticle_ok'));
-            }
-
-            return new rex_api_result(false, rex_i18n::msg('content_toarticle_failed'));
+        // article2category and category2article share the same permission: article2category
+        if (!$user->hasPerm('article2category[]')) {
+            throw new rex_api_exception('User has no permission to convert categories to articles!');
         }
-        throw new rex_api_exception('User has no permission for this article!');
+
+        $articleId = rex_request('article_id', 'int');
+
+        $article = rex_article::get($articleId);
+        if (!$article instanceof rex_article) {
+            throw new rex_api_exception('Unable to find article with id "' . $articleId . '"!');
+        }
+
+        if (!$user->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
+        if (rex_article_service::category2article($articleId)) {
+            return new rex_api_result(true, rex_i18n::msg('content_toarticle_ok'));
+        }
+
+        return new rex_api_result(false, rex_i18n::msg('content_toarticle_failed'));
     }
 
     protected function requiresCsrfProtection()

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_add.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_add.php
@@ -9,15 +9,19 @@ class rex_api_category_add extends rex_api_function
 {
     public function execute()
     {
-        if (!rex::requireUser()->hasPerm('addCategory[]')) {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('addCategory[]')) {
             throw new rex_api_exception('User has no permission to add categories!');
         }
 
         $parentId = rex_request('parent-category-id', 'int');
 
-        // check permissions
-        if (!rex::requireUser()->getComplexPerm('structure')->hasCategoryPerm($parentId)) {
-            throw new rex_api_exception('user has no permission for this category!');
+        if (0 !== $parentId && !rex_category::get($parentId)) {
+            throw new rex_api_exception('Unable to find category with id "' . $parentId . '"!');
+        }
+
+        if (!$user->getComplexPerm('structure')->hasCategoryPerm($parentId)) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
         }
 
         // prepare and validate parameters

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_delete.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_delete.php
@@ -9,15 +9,19 @@ class rex_api_category_delete extends rex_api_function
 {
     public function execute()
     {
-        if (!rex::requireUser()->hasPerm('deleteCategory[]')) {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('deleteCategory[]')) {
             throw new rex_api_exception('User has no permission to delete categories!');
         }
 
         $catId = rex_request('category-id', 'int');
 
-        // check permissions
-        if (!rex::requireUser()->getComplexPerm('structure')->hasCategoryPerm($catId)) {
-            throw new rex_api_exception('user has no permission for this category!');
+        if (!rex_category::get($catId)) {
+            throw new rex_api_exception('Unable to find category with id "' . $catId . '"!');
+        }
+
+        if (!$user->getComplexPerm('structure')->hasCategoryPerm($catId)) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
         }
 
         return new rex_api_result(true, rex_category_service::deleteCategory($catId));

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_edit.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_edit.php
@@ -9,18 +9,23 @@ class rex_api_category_edit extends rex_api_function
 {
     public function execute()
     {
-        if (!rex::requireUser()->hasPerm('editCategory[]')) {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('editCategory[]')) {
             throw new rex_api_exception('User has no permission to edit categories!');
         }
 
         $catId = rex_request('category-id', 'int');
         $clangId = rex_request('clang', 'int');
 
-        $user = rex::requireUser();
+        if (!rex_category::get($catId, $clangId)) {
+            throw new rex_api_exception('Unable to find category with id "' . $catId . '" and clang "' . $clangId . '"!');
+        }
 
-        // check permissions
-        if (!$user->getComplexPerm('structure')->hasCategoryPerm($catId)) {
-            throw new rex_api_exception('user has no permission for this category!');
+        if (
+            !$user->getComplexPerm('clang')->hasPerm($clangId)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($catId)
+        ) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
         }
 
         // prepare and validate parameters

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_move.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_move.php
@@ -9,28 +9,36 @@ class rex_api_category_move extends rex_api_function
 {
     public function execute()
     {
-        // The category to move
-        $articleId = rex_request('article_id', 'int');
-        $categoryId = rex_article::get($articleId)->getCategoryId();
+        $user = rex::requireUser();
+        if (!$user->hasPerm('moveCategory[]')) {
+            throw new rex_api_exception('User has no permission to move categories!');
+        }
+
+        // The category to move (parameter name is `article_id` for historical reasons)
+        $categoryId = rex_request('article_id', 'int');
         // The destination category in which the given category will be moved
         $categoryIdNew = rex_request('category_id_new', 'int');
 
-        $user = rex::requireUser();
-
-        // Check permissions
-        if (
-            $user->hasPerm('moveCategory[]')
-            && $user->getComplexPerm('structure')->hasCategoryPerm($categoryId)
-            && $user->getComplexPerm('structure')->hasCategoryPerm($categoryIdNew)
-        ) {
-            if ($categoryId != $categoryIdNew && rex_category_service::moveCategory($categoryId, $categoryIdNew)) {
-                return new rex_api_result(true, rex_i18n::msg('category_moved'));
-            }
-
-            return new rex_api_result(false, rex_i18n::msg('content_error_movecategory'));
+        if (!rex_category::get($categoryId)) {
+            throw new rex_api_exception('Unable to find category with id "' . $categoryId . '"!');
         }
 
-        throw new rex_api_exception('user has no permission for this category!');
+        if (0 !== $categoryIdNew && !rex_category::get($categoryIdNew)) {
+            throw new rex_api_exception('Unable to find category with id "' . $categoryIdNew . '"!');
+        }
+
+        if (
+            !$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($categoryIdNew)
+        ) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
+        if ($categoryId !== $categoryIdNew && rex_category_service::moveCategory($categoryId, $categoryIdNew)) {
+            return new rex_api_result(true, rex_i18n::msg('category_moved'));
+        }
+
+        return new rex_api_result(false, rex_i18n::msg('content_error_movecategory'));
     }
 
     protected function requiresCsrfProtection()

--- a/redaxo/src/addons/structure/lib/api_functions/api_category_status.php
+++ b/redaxo/src/addons/structure/lib/api_functions/api_category_status.php
@@ -9,18 +9,29 @@ class rex_api_category_status extends rex_api_function
 {
     public function execute()
     {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('publishCategory[]')) {
+            throw new rex_api_exception('User has no permission to publish categories!');
+        }
+
         $categoryId = rex_request('category-id', 'int');
         $clang = rex_request('clang', 'int');
         $status = rex_request('cat_status', 'int', null);
-        $user = rex::requireUser();
 
-        // Check permissions
-        if ($user->getComplexPerm('structure')->hasCategoryPerm($categoryId) && $user->hasPerm('publishCategory[]')) {
-            rex_category_service::categoryStatus($categoryId, $clang, $status);
-            return new rex_api_result(true, rex_i18n::msg('category_status_updated'));
+        if (!rex_category::get($categoryId, $clang)) {
+            throw new rex_api_exception('Unable to find category with id "' . $categoryId . '" and clang "' . $clang . '"!');
         }
 
-        throw new rex_api_exception('User has no permission for this category!');
+        if (
+            !$user->getComplexPerm('clang')->hasPerm($clang)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)
+        ) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
+        rex_category_service::categoryStatus($categoryId, $clang, $status);
+
+        return new rex_api_result(true, rex_i18n::msg('category_status_updated'));
     }
 
     protected function requiresCsrfProtection()

--- a/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content.php
@@ -9,6 +9,11 @@ class rex_api_content_move_slice extends rex_api_function
 {
     public function execute()
     {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('moveSlice[]')) {
+            throw new rex_api_exception('User has no permission to move slices!');
+        }
+
         $articleId = rex_request('article_id', 'int');
         $clang = rex_request('clang', 'int');
         $sliceId = rex_request('slice_id', 'int');
@@ -18,20 +23,7 @@ class rex_api_content_move_slice extends rex_api_function
         if (!$ooArt instanceof rex_article) {
             throw new rex_api_exception('Unable to find article with id "' . $articleId . '" and clang "' . $clang . '"!');
         }
-        $categoryId = $ooArt->getCategoryId();
 
-        $user = rex::requireUser();
-
-        // check permissions
-        if (!$user->hasPerm('moveSlice[]')) {
-            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
-        }
-
-        if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
-            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
-        }
-
-        // modul und rechte vorhanden ?
         $CM = rex_sql::factory();
         $CM->setQuery('select * from ' . rex::getTablePrefix() . 'article_slice left join ' . rex::getTablePrefix() . 'module on ' . rex::getTablePrefix() . 'article_slice.module_id=' . rex::getTablePrefix() . 'module.id where ' . rex::getTablePrefix() . 'article_slice.id=? and clang_id=?', [$sliceId, $clang]);
         if (1 != $CM->getRows()) {
@@ -39,12 +31,16 @@ class rex_api_content_move_slice extends rex_api_function
         }
         $moduleId = (int) $CM->getValue(rex::getTablePrefix() . 'article_slice.module_id');
 
-        // ----- RECHTE AM MODUL ?
-        if ($user->getComplexPerm('modules')->hasPerm($moduleId)) {
-            $message = rex_content_service::moveSlice($sliceId, $clang, $direction);
-        } else {
+        if (
+            !$user->getComplexPerm('clang')->hasPerm($clang)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($ooArt->getCategoryId())
+            || !$user->getComplexPerm('modules')->hasPerm($moduleId)
+        ) {
             throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
         }
+
+        $message = rex_content_service::moveSlice($sliceId, $clang, $direction);
+
         return new rex_api_result(true, $message);
     }
 

--- a/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_copy.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_copy.php
@@ -12,27 +12,34 @@ class rex_api_content_copy extends rex_api_function
      */
     public function execute()
     {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('copyContent[]')) {
+            throw new rex_api_exception('User has no permission to copy content!');
+        }
+
         $articleId = rex_request('article_id', 'int');
         $clangA = rex_request('clang_a', 'int');
         $clangB = rex_request('clang_b', 'int');
         $overwrite = rex_request('overwrite', 'bool', false);
 
-        $user = rex::requireUser();
-
-        // Check permissions
-        if (
-            $user->hasPerm('copyContent[]')
-            && $user->getComplexPerm('clang')->hasPerm($clangA)
-            && $user->getComplexPerm('clang')->hasPerm($clangB)
-        ) {
-            if (rex_content_service::copyContent($articleId, $articleId, $clangA, $clangB, null, $overwrite)) {
-                return new rex_api_result(true, rex_i18n::msg('content_contentcopy'));
-            }
-
-            return new rex_api_result(true, rex_i18n::msg('content_errorcopy'));
+        $article = rex_article::get($articleId, $clangA);
+        if (!$article instanceof rex_article) {
+            throw new rex_api_exception('Unable to find article with id "' . $articleId . '" and clang "' . $clangA . '"!');
         }
 
-        throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        if (
+            !$user->getComplexPerm('clang')->hasPerm($clangA)
+            || !$user->getComplexPerm('clang')->hasPerm($clangB)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())
+        ) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
+        if (rex_content_service::copyContent($articleId, $articleId, $clangA, $clangB, null, $overwrite)) {
+            return new rex_api_result(true, rex_i18n::msg('content_contentcopy'));
+        }
+
+        return new rex_api_result(false, rex_i18n::msg('content_errorcopy'));
     }
 
     protected function requiresCsrfProtection()

--- a/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_slice_status.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_slice_status.php
@@ -9,6 +9,11 @@ class rex_api_content_slice_status extends rex_api_function
 {
     public function execute()
     {
+        $user = rex::requireUser();
+        if (!$user->hasPerm('publishSlice[]')) {
+            throw new rex_api_exception('User has no permission to publish slices!');
+        }
+
         $articleId = rex_request('article_id', 'int');
         $clang = rex_request('clang', 'int');
 
@@ -17,10 +22,10 @@ class rex_api_content_slice_status extends rex_api_function
             throw new rex_api_exception('Unable to find article with id "' . $articleId . '" and clang "' . $clang . '"!');
         }
 
-        $user = rex::requireUser();
-        $categoryId = $article->getCategoryId();
-
-        if (!$user->hasPerm('publishSlice[]') || !$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
+        if (
+            !$user->getComplexPerm('clang')->hasPerm($clang)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($article->getCategoryId())
+        ) {
             throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
         }
 


### PR DESCRIPTION
## Summary

Several api functions in the structure addon (and content plugin) trusted request-supplied IDs for permission decisions, missed existence checks, and skipped clang-permission checks for clang-specific actions.

This PR restructures all 17 api functions to a consistent pattern:

- **Action permission first**: the global `hasPerm('xyz[]')` check runs before any DB lookup — prevents resource-id enumeration via the existence error
- **Existence check**: verify the requested article / category exists (with clang where the action is clang-specific)
- **CategoryId from the article, not the request**: previously a user with permission for category A could pass `category_id=A` together with `article_id=B` (in category B) and bypass the check
- **Clang permission**: now checked whenever the action targets a specific clang (edit, status, slice operations, content copy) — was missing in most places
- **Source AND target perm for move/copy**: previously only the target category was checked, so a user could move/copy any foreign article into their own category
- **`if (||)` for same-message resource checks**, separate `if`s with specific messages so support can tell "missing action permission" apart from "missing resource permission"

Also fixes a small bug in `api_content_copy` where the failure path returned `rex_api_result(true, ...)` instead of `false`.

## Affected files

17 api functions under `redaxo/src/addons/structure/lib/api_functions/` and `redaxo/src/addons/structure/plugins/content/lib/api_functions/`.

## Test plan

- [x] `composer cs` — no changes
- [x] `composer phpstan` — no errors
- [x] `composer psalm` — no errors
- [x] `composer phpunit` — 602 tests, 1365 assertions, OK
- [ ] manual smoke test in BE: add/edit/delete/move/copy article and category, slice ops, with full-admin and mountpoint user