### PR TITLE
refactor!: remove `use_last_modified` config option

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -204,9 +204,6 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="boot/frontend.php">
-    <InvalidScalarArgument>
-      <code><![CDATA[$article->getValue('updatedate')]]></code>
-    </InvalidScalarArgument>
     <MixedAssignment>
       <code><![CDATA[$article]]></code>
       <code><![CDATA[$article]]></code>

--- a/boot/frontend.php
+++ b/boot/frontend.php
@@ -194,4 +194,4 @@ if ($artId == Article::getNotfoundArticleId() && $artId != Article::getSiteStart
 }
 
 // ----- inhalt ausgeben
-Response::sendPage($content, $article->getValue('updatedate'));
+Response::sendPage($content);

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -283,10 +283,6 @@
             "description": "Use Etag header",
             "$ref": "#/definitions/bool-or-environment"
         },
-        "use_last_modified": {
-            "description": "Use Last-Modified header (not recommended)",
-            "$ref": "#/definitions/bool-or-environment"
-        },
         "start_page": {
             "description": "Default start page for backend",
             "type": "string"

--- a/setup/default.config.yml
+++ b/setup/default.config.yml
@@ -58,7 +58,6 @@ use_hsts: false
 hsts_max_age: 31536000 # 1 year
 use_gzip: false
 use_etag: true
-use_last_modified: false
 start_page: structure
 timezone: Europe/Berlin
 http_client_proxy: null

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -238,10 +238,8 @@ final class Response
      * Sends a page to client.
      *
      * The page content can be modified by the Extension Point OUTPUT_FILTER
-     *
-     * @param int|null $lastModified HTTP Last-Modified Timestamp
      */
-    public static function sendPage(string $content, ?int $lastModified = null): void
+    public static function sendPage(string $content): void
     {
         // ----- EXTENSION POINT
         $content = Extension::registerPoint(new ExtensionPoint('OUTPUT_FILTER', $content));
@@ -251,7 +249,7 @@ final class Response
             self::$closeConnection = true;
         }
 
-        self::sendContent($content, null, $lastModified);
+        self::sendContent($content);
 
         // ----- EXTENSION POINT - (read only)
         if ($hasShutdownExtension) {
@@ -281,9 +279,7 @@ final class Response
 
         if (self::HTTP_OK == self::$httpStatus) {
             // ----- Last-Modified
-            if (!self::$sentLastModified
-                && (true === Core::getProperty('use_last_modified') || Core::getProperty('use_last_modified') === $environment)
-            ) {
+            if (!self::$sentLastModified && null !== $lastModified) {
                 self::sendLastModified($lastModified);
             }
 


### PR DESCRIPTION
## Summary

- The `Last-Modified` header was fed from the article's `updatedate`, which doesn't reflect dynamic content (DB queries in modules, external APIs, included articles). In any non-trivial setup the header lied and risked stale browser/proxy caches.
- `use_etag` already covers cache validation correctly (content-hash based) and stays on by default — so dropping `use_last_modified` is no functional regression for the common case.
- Callers that genuinely know when their content changed can still pass `$lastModified` to `sendContent()` / `sendResource()` / `sendJson()`; the header is now sent purely based on that argument and no longer gated by config.

## Breaking changes

- Removed config option `use_last_modified`.
- Removed `$lastModified` parameter from `Response::sendPage()`.
- `Response::sendContent()` / `sendResource()` / `sendJson()` keep the `$lastModified` parameter, but its behavior changed: when set, the header is always sent (no longer config-gated).