### PR TITLE
refactor!: remove `use_gzip` config option

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2856,12 +2856,6 @@
     </MixedAssignment>
   </file>
   <file src="src/Http/Response.php">
-    <FalsableReturnStatement>
-      <code><![CDATA[$content]]></code>
-    </FalsableReturnStatement>
-    <InvalidFalsableReturnType>
-      <code><![CDATA[string]]></code>
-    </InvalidFalsableReturnType>
     <InvalidOperand>
       <code><![CDATA[filesize($file)]]></code>
     </InvalidOperand>
@@ -2880,7 +2874,6 @@
     </PossiblyFalseOperand>
     <PossiblyNullArgument>
       <code><![CDATA[$value]]></code>
-      <code><![CDATA[preg_replace('/\s+/', '', $_SERVER['HTTP_ACCEPT_ENCODING'])]]></code>
       <code><![CDATA[preg_replace('@<!--DYN-->.*<!--/DYN-->@U', '', $content)]]></code>
     </PossiblyNullArgument>
     <PossiblyNullOperand>

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -275,10 +275,6 @@
             "description": "Max age for HSTS header (seconds)",
             "type": "integer"
         },
-        "use_gzip": {
-            "description": "Use gzip encoding",
-            "$ref": "#/definitions/bool-or-environment"
-        },
         "use_etag": {
             "description": "Use Etag header",
             "$ref": "#/definitions/bool-or-environment"

--- a/setup/default.config.yml
+++ b/setup/default.config.yml
@@ -56,7 +56,6 @@ lang_fallback: [en_gb, de_de]
 use_https: false
 use_hsts: false
 hsts_max_age: 31536000 # 1 year
-use_gzip: false
 use_etag: true
 start_page: structure
 timezone: Europe/Berlin

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -19,7 +19,6 @@ use function ini_get;
 use function is_resource;
 use function sprintf;
 
-use const FORCE_GZIP;
 use const PHP_SAPI;
 
 final class Response
@@ -291,11 +290,6 @@ final class Response
             }
         }
 
-        // ----- GZIP
-        if (true === Core::getProperty('use_gzip') || Core::getProperty('use_gzip') === $environment) {
-            $content = self::sendGzip($content);
-        }
-
         self::cleanOutputBuffers();
 
         header('HTTP/1.1 ' . self::$httpStatus);
@@ -409,38 +403,6 @@ final class Response
             exit;
         }
         self::$sentEtag = true;
-    }
-
-    /**
-     * Encodes the content with GZIP/X-GZIP if the browser supports one of them.
-     *
-     * HTTP_ACCEPT_ENCODING feature
-     */
-    private static function sendGzip(string $content): string
-    {
-        $enc = '';
-        $encodings = [];
-        $supportsGzip = false;
-
-        // Check if it supports gzip
-        if (isset($_SERVER['HTTP_ACCEPT_ENCODING'])) {
-            $encodings = explode(',', strtolower(preg_replace('/\s+/', '', $_SERVER['HTTP_ACCEPT_ENCODING'])));
-        }
-
-        if ((in_array('gzip', $encodings) || in_array('x-gzip', $encodings) || isset($_SERVER['---------------']))
-            && function_exists('ob_gzhandler')
-            && !ini_get('zlib.output_compression')
-        ) {
-            $enc = in_array('x-gzip', $encodings) ? 'x-gzip' : 'gzip';
-            $supportsGzip = true;
-        }
-
-        if ($supportsGzip) {
-            header('Content-Encoding: ' . $enc);
-            $content = gzencode($content, 9, FORCE_GZIP);
-        }
-
-        return $content;
     }
 
     // method inspired by https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Cookie.php


### PR DESCRIPTION
## Summary
- Removes the `use_gzip` config option and the `Response::sendGzip()` method that gzipped the response body in PHP.
- Application-side gzip is better handled by the webserver (nginx, Apache `mod_deflate`) or PHP's `zlib.output_compression`. Those support brotli/zstd, set `Vary: Accept-Encoding` correctly, and avoid spending PHP time on compression that runs before `fastcgi_finish_request`.
- Follows the same direction as #6514 (`use_last_modified` removal).