### PR TITLE
refactor!: don't swallow `SqlException` to expose diagnostics

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1002,9 +1002,6 @@
     <PossiblyInvalidOperand>
       <code><![CDATA[$field->getAttribute('id')]]></code>
     </PossiblyInvalidOperand>
-    <PossiblyNullArgument>
-      <code><![CDATA[$warning]]></code>
-    </PossiblyNullArgument>
     <PossiblyNullOperand>
       <code><![CDATA[$field->getAttribute('id')]]></code>
     </PossiblyNullOperand>

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -247,7 +247,6 @@ setup_500 = Setup: Schritt 5 von 6 / Administrator
 setup_501 = Bitte geben Sie das Administratorlogin ein!
 setup_502 = Bitte geben Sie das Administratorpasswort ein!
 setup_503 = Dieses Login existiert schon.
-setup_504 = Der Administrator konnte nicht angelegt werden.
 setup_505 = Es existiert noch kein User. Bitte legen Sie einen an.
 setup_506 = Administrator anlegen
 setup_507 = Login
@@ -618,7 +617,6 @@ cronjob_no_cronjobs = Keine Cronjobs vorhanden
 cronjob_delete = löschen
 cronjob_really_delete = Cronjob wirklich löschen?
 cronjob_delete_success = Cronjob "{0}" wurde erfolgreich gelöscht!
-cronjob_delete_error = Cronjob "{0}" konnte nicht gelöscht werden!
 
 cronjob_execute = ausführen
 cronjob_execute_success = Cronjob "{0}" wurde erfolgreich ausgeführt!
@@ -671,9 +669,7 @@ cronjob_status_activated = aktiviert
 cronjob_status_deactivated = deaktiviert
 cronjob_status_invalid = fehlerhaft
 cronjob_status_activate_success = Cronjob "{0}" wurde aktiviert!
-cronjob_status_activate_error = Cronjob "{0}" konnte nicht aktiviert werden!
 cronjob_status_deactivate_success = Cronjob "{0}" wurde deaktiviert!
-cronjob_status_deactivate_error = Cronjob "{0}" konnte nicht deaktiviert werden!
 
 cronjob_error_no_name = Der Name darf nicht leer sein!
 cronjob_error_no_environment = Mindestens eine Umgebung muss ausgewählt werden!

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -246,7 +246,6 @@ setup_500 = Setup: step 5 of 6 / Administrator
 setup_501 = Please enter a administrator username!
 setup_502 = Please enter a administrator password!
 setup_503 = User account already exists!
-setup_504 = Could not create the administrator account.
 setup_505 = No users found. Please create a user.
 setup_506 = Create administrator account
 setup_507 = Username
@@ -585,7 +584,6 @@ cronjob_no_cronjobs = No cronjobs created
 cronjob_delete = delete
 cronjob_really_delete = Do you really want to delete this cronjob?
 cronjob_delete_success = Cronjob "{0}" was deleted successfully!
-cronjob_delete_error = Cronjob "{0}" could not be deleted!
 
 cronjob_execute = execute
 cronjob_execute_success = Cronjob "{0}" was executed successfully!
@@ -638,9 +636,7 @@ cronjob_status_activated = activated
 cronjob_status_deactivated = deactivated
 cronjob_status_invalid = invalid
 cronjob_status_activate_success = Cronjob "{0}" was activated!
-cronjob_status_activate_error = Cronjob "{0}" could not be activated!
 cronjob_status_deactivate_success = Cronjob "{0}" was deactivated!
-cronjob_status_deactivate_error = Cronjob "{0}" could not be deactivated!
 
 cronjob_error_no_name = The name must not be empty!
 cronjob_error_no_environment = At least one environment must be selected!

--- a/pages/cronjob/cronjobs.php
+++ b/pages/cronjob/cronjobs.php
@@ -35,20 +35,14 @@ if (in_array($func, ['setstatus', 'delete', 'execute']) && !$csrfToken->isValid(
     $name = $manager->getName($oid);
     $status = (Request::request('oldstatus', 'int') + 1) % 2;
     $msg = 1 == $status ? 'status_activate' : 'status_deactivate';
-    if ($manager->setStatus($oid, $status)) {
-        echo Message::success(I18n::msg('cronjob_' . $msg . '_success', $name));
-    } else {
-        echo Message::error(I18n::msg('cronjob_' . $msg . '_error', $name));
-    }
+    $manager->setStatus($oid, $status);
+    echo Message::success(I18n::msg('cronjob_' . $msg . '_success', $name));
     $func = '';
 } elseif ('delete' == $func) {
     $manager = CronjobManager::factory();
     $name = $manager->getName($oid);
-    if ($manager->delete($oid)) {
-        echo Message::success(I18n::msg('cronjob_delete_success', $name));
-    } else {
-        echo Message::error(I18n::msg('cronjob_delete_error', $name));
-    }
+    $manager->delete($oid);
+    echo Message::success(I18n::msg('cronjob_delete_success', $name));
     $func = '';
 } elseif ('execute' == $func) {
     $manager = CronjobManager::factory();

--- a/pages/media_manager/effects.php
+++ b/pages/media_manager/effects.php
@@ -1,7 +1,6 @@
 <?php
 
 use Redaxo\Core\Core;
-use Redaxo\Core\Database\Exception\SqlException;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Database\Util;
 use Redaxo\Core\Exception\LogicException;
@@ -39,7 +38,6 @@ if (MediaManager::STATUS_SYSTEM_TYPE === (int) $sql->getValue('status')) {
 $typeName = (string) $sql->getValue('name');
 
 $info = '';
-$warning = '';
 
 // -------------- delete effect
 if ('delete' == $func && $effectId > 0) {
@@ -47,38 +45,30 @@ if ('delete' == $func && $effectId > 0) {
     //  $sql->setDebug();
     $sql->setTable(Core::getTablePrefix() . 'media_manager_type_effect');
     $sql->setWhere(['id' => $effectId]);
+    $sql->delete();
 
-    try {
-        $sql->delete();
+    Util::organizePriorities(
+        Core::getTablePrefix() . 'media_manager_type_effect',
+        'priority',
+        'type_id = ' . $typeId,
+        'priority, updatedate desc',
+    );
 
-        Util::organizePriorities(
-            Core::getTablePrefix() . 'media_manager_type_effect',
-            'priority',
-            'type_id = ' . $typeId,
-            'priority, updatedate desc',
-        );
+    $info = I18n::msg('media_manager_effect_deleted');
 
-        $info = I18n::msg('media_manager_effect_deleted');
+    MediaManager::deleteCacheByType($typeId);
 
-        MediaManager::deleteCacheByType($typeId);
+    Sql::factory()
+        ->setTable(Core::getTable('media_manager_type'))
+        ->setWhere(['id' => $typeId])
+        ->addGlobalUpdateFields()
+        ->update();
 
-        Sql::factory()
-            ->setTable(Core::getTable('media_manager_type'))
-            ->setWhere(['id' => $typeId])
-            ->addGlobalUpdateFields()
-            ->update();
-    } catch (SqlException) {
-        $warning = $sql->getError();
-    }
     $func = '';
 }
 
 if ('' != $info) {
     echo Message::info($info);
-}
-
-if ('' != $warning) {
-    echo Message::warning($warning);
 }
 
 $effects = [];

--- a/pages/media_manager/types.php
+++ b/pages/media_manager/types.php
@@ -38,21 +38,17 @@ if ('delete' == $func && $typeId > 0) {
     $sql = Sql::factory();
     //  $sql->setDebug();
 
-    try {
-        $sql->transactional(static function () use ($sql, $typeId) {
-            $sql->setTable(Core::getTablePrefix() . 'media_manager_type');
-            $sql->setWhere(['id' => $typeId]);
-            $sql->delete();
+    $sql->transactional(static function () use ($sql, $typeId) {
+        $sql->setTable(Core::getTablePrefix() . 'media_manager_type');
+        $sql->setWhere(['id' => $typeId]);
+        $sql->delete();
 
-            $sql->setTable(Core::getTablePrefix() . 'media_manager_type_effect');
-            $sql->setWhere(['type_id' => $typeId]);
-            $sql->delete();
-        });
+        $sql->setTable(Core::getTablePrefix() . 'media_manager_type_effect');
+        $sql->setWhere(['type_id' => $typeId]);
+        $sql->delete();
+    });
 
-        $success = I18n::msg('media_manager_type_deleted');
-    } catch (SqlException) {
-        $error = $sql->getError();
-    }
+    $success = I18n::msg('media_manager_type_deleted');
     $func = '';
 }
 
@@ -74,7 +70,10 @@ if ('copy' == $func && $typeId > 0) {
         $sql->setQuery('INSERT INTO ' . Core::getTablePrefix() . 'media_manager_type_effect (type_id, effect, parameters, priority, updatedate, updateuser, createdate, createuser) SELECT ?, effect, parameters, priority, ?, ?, ?, ? FROM ' . Core::getTablePrefix() . 'media_manager_type_effect WHERE type_id = ?', [$newTypeId, date(Sql::FORMAT_DATETIME), $login, date(Sql::FORMAT_DATETIME), $login, $typeId]);
 
         $success = I18n::msg('media_manager_type_copied');
-    } catch (SqlException) {
+    } catch (SqlException $e) {
+        if (Sql::ERROR_VIOLATE_UNIQUE_KEY !== $e->getErrorCode()) {
+            throw $e;
+        }
         $error = $sql->getError();
     }
 

--- a/pages/mediapool/media.list.php
+++ b/pages/mediapool/media.list.php
@@ -3,7 +3,6 @@
 use Redaxo\Core\ApiFunction\Exception\ApiFunctionException;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Core;
-use Redaxo\Core\Database\Exception\SqlException;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\ExtensionPoint\Extension;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
@@ -64,18 +63,14 @@ if ($hasCategoryPerm && 'updatecat_selectedmedia' == $mediaMethod) {
                 $db->setWhere(['filename' => $fileName]);
                 $db->setValue('category_id', $rexFileCategory);
                 $db->addGlobalUpdateFields();
-                try {
-                    $db->update();
-                    $success = I18n::msg('pool_selectedmedia_moved');
-                    MediaPoolCache::delete($fileName);
+                $db->update();
+                $success = I18n::msg('pool_selectedmedia_moved');
+                MediaPoolCache::delete($fileName);
 
-                    Extension::registerPoint(new ExtensionPoint('MEDIA_MOVED', null, [
-                        'filename' => $fileName,
-                        'category_id' => $rexFileCategory,
-                    ]));
-                } catch (SqlException) {
-                    $error = I18n::msg('pool_selectedmedia_error');
-                }
+                Extension::registerPoint(new ExtensionPoint('MEDIA_MOVED', null, [
+                    'filename' => $fileName,
+                    'category_id' => $rexFileCategory,
+                ]));
             }
         } else {
             $error = I18n::msg('pool_selectedmedia_error');

--- a/pages/setup/index.php
+++ b/pages/setup/index.php
@@ -1,7 +1,6 @@
 <?php
 
 use Redaxo\Core\Core;
-use Redaxo\Core\Database\Exception\SqlException;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\InvalidArgumentException;
 use Redaxo\Core\Filesystem\File;
@@ -361,11 +360,7 @@ if (6 === $step) {
                 $user->setDateTimeValue('password_changed', time());
                 $user->setArrayValue('previous_passwords', $passwordPolicy->updatePreviousPasswords(null, $redaxoUserPass));
                 $user->setValue('status', '1');
-                try {
-                    $user->insert();
-                } catch (SqlException) {
-                    $errors[] = Message::error(I18n::msg('setup_504'));
-                }
+                $user->insert();
             }
         }
     } else {

--- a/src/Addon/AddonManager.php
+++ b/src/Addon/AddonManager.php
@@ -7,7 +7,6 @@ use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Base\FactoryTrait;
 use Redaxo\Core\Config;
 use Redaxo\Core\Core;
-use Redaxo\Core\Database\Exception\SqlException;
 use Redaxo\Core\Exception\RuntimeException;
 use Redaxo\Core\Exception\UserMessageException;
 use Redaxo\Core\Filesystem\Dir;
@@ -122,8 +121,6 @@ class AddonManager
             return true;
         } catch (UserMessageException $e) {
             $this->message = $e->getMessage();
-        } catch (SqlException $e) {
-            $this->message = 'SQL error: ' . $e->getMessage();
         }
 
         $this->addon->setProperty('install', false);
@@ -182,8 +179,6 @@ class AddonManager
             return true;
         } catch (UserMessageException $e) {
             $this->message = $e->getMessage();
-        } catch (SqlException $e) {
-            $this->message = 'SQL error: ' . $e->getMessage();
         }
 
         $this->addon->setProperty('install', true);

--- a/src/Cronjob/CronjobManager.php
+++ b/src/Cronjob/CronjobManager.php
@@ -5,7 +5,6 @@ namespace Redaxo\Core\Cronjob;
 use DateTime;
 use Redaxo\Core\Core;
 use Redaxo\Core\Cronjob\Type\AbstractType;
-use Redaxo\Core\Database\Exception\SqlException;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\RuntimeException;
 use Redaxo\Core\ExtensionPoint\Extension;
@@ -64,47 +63,30 @@ final class CronjobManager
         throw new RuntimeException(sprintf('No cronjob found with id %s.', $id));
     }
 
-    public function setStatus(int $id, int $status): bool
+    public function setStatus(int $id, int $status): void
     {
         $this->sql->setTable(Core::getTable('cronjob'));
         $this->sql->setWhere(['id' => $id]);
         $this->sql->setValue('status', $status);
         $this->sql->addGlobalUpdateFields();
-        try {
-            $this->sql->update();
-            $success = true;
-        } catch (SqlException) {
-            $success = false;
-        }
+        $this->sql->update();
         $this->saveNextTime();
-        return $success;
     }
 
-    public function setExecutionStart(int $id, bool $reset = false): bool
+    public function setExecutionStart(int $id, bool $reset = false): void
     {
         $this->sql->setTable(Core::getTable('cronjob'));
         $this->sql->setWhere(['id' => $id]);
         $this->sql->setDateTimeValue('execution_start', $reset ? null : time());
-        try {
-            $this->sql->update();
-            return true;
-        } catch (SqlException) {
-            return false;
-        }
+        $this->sql->update();
     }
 
-    public function delete(int $id): bool
+    public function delete(int $id): void
     {
         $this->sql->setTable(Core::getTable('cronjob'));
         $this->sql->setWhere(['id' => $id]);
-        try {
-            $this->sql->delete();
-            $success = true;
-        } catch (SqlException) {
-            $success = false;
-        }
+        $this->sql->delete();
         $this->saveNextTime();
-        return $success;
     }
 
     /** @param callable(string,bool,string):void|null $callback Callback is called after every job execution (params: job name, success status, message) */
@@ -232,23 +214,17 @@ final class CronjobManager
         return $this->getExecutor()->tryExecute($cronjob, $job['name'], $params, $log, $job['id']);
     }
 
-    public function setNextTime(int $id, string $interval, bool $resetExecutionStart = false): bool
+    public function setNextTime(int $id, string $interval, bool $resetExecutionStart = false): void
     {
         $nexttime = self::calculateNextTime(json_decode($interval, true));
         $nexttime = $nexttime ? Sql::datetime($nexttime) : null;
         $add = $resetExecutionStart ? ', execution_start = NULL' : '';
-        try {
-            $this->sql->setQuery('
-                UPDATE  ' . Core::getTable('cronjob') . '
-                SET     nexttime = ?' . $add . '
-                WHERE   id = ?
-            ', [$nexttime, $id]);
-            $success = true;
-        } catch (SqlException) {
-            $success = false;
-        }
+        $this->sql->setQuery('
+            UPDATE  ' . Core::getTable('cronjob') . '
+            SET     nexttime = ?' . $add . '
+            WHERE   id = ?
+        ', [$nexttime, $id]);
         $this->saveNextTime();
-        return $success;
     }
 
     public function getMinNextTime(): ?int

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -369,17 +369,16 @@ class Form extends AbstractForm
                     $sql->insert();
                 }
             }
-            $saved = true;
-        } catch (SqlException) {
-            $saved = false;
+        } catch (SqlException $e) {
+            $errno = $e->getErrorCode();
+            if (null === $errno || !isset($this->errorMessages[$errno])) {
+                throw $e;
+            }
+            return $errno;
         }
 
         // ----- EXTENSION POINT
-        if ($saved) {
-            return Extension::registerPoint(new ExtensionPoint('REX_FORM_SAVED', $saved, ['form' => $this, 'sql' => $sql]));
-        }
-
-        return $sql->getMysqlErrno();
+        return Extension::registerPoint(new ExtensionPoint('REX_FORM_SAVED', true, ['form' => $this, 'sql' => $sql]));
     }
 
     /** @return bool|int */
@@ -392,16 +391,15 @@ class Form extends AbstractForm
 
         try {
             $deleteSql->delete();
-            $deleted = true;
-        } catch (SqlException) {
-            $deleted = false;
+        } catch (SqlException $e) {
+            $errno = $e->getErrorCode();
+            if (null === $errno || !isset($this->errorMessages[$errno])) {
+                throw $e;
+            }
+            return $errno;
         }
 
         // ----- EXTENSION POINT
-        if ($deleted) {
-            return Extension::registerPoint(new ExtensionPoint('REX_FORM_DELETED', $deleted, ['form' => $this, 'sql' => $deleteSql]));
-        }
-
-        return $deleteSql->getMysqlErrno();
+        return Extension::registerPoint(new ExtensionPoint('REX_FORM_DELETED', true, ['form' => $this, 'sql' => $deleteSql]));
     }
 }

--- a/src/MetaInfo/Database/Table.php
+++ b/src/MetaInfo/Database/Table.php
@@ -2,7 +2,6 @@
 
 namespace Redaxo\Core\MetaInfo\Database;
 
-use Redaxo\Core\Database\Exception\SqlException;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\InvalidArgumentException;
 
@@ -42,9 +41,8 @@ class Table
      * @param int|null $length
      * @param string|null $default
      * @param bool $nullable
-     * @return bool
      */
-    public function addColumn($name, $type, $length, $default = null, $nullable = true)
+    public function addColumn($name, $type, $length, $default = null, $nullable = true): void
     {
         $sql = Sql::factory($this->DBID);
 
@@ -71,12 +69,7 @@ class Table
             $qry .= ' NOT NULL';
         }
 
-        try {
-            $sql->setQuery($qry);
-            return true;
-        } catch (SqlException) {
-            return false;
-        }
+        $sql->setQuery($qry);
     }
 
     /**
@@ -86,9 +79,8 @@ class Table
      * @param int|null $length
      * @param string|null $default
      * @param bool $nullable
-     * @return bool
      */
-    public function editColumn($oldname, $name, $type, $length, $default = null, $nullable = true)
+    public function editColumn($oldname, $name, $type, $length, $default = null, $nullable = true): void
     {
         $sql = Sql::factory($this->DBID);
 
@@ -115,31 +107,18 @@ class Table
             $qry .= ' NOT NULL';
         }
 
-        try {
-            $sql->setQuery($qry);
-            return true;
-        } catch (SqlException) {
-            return false;
-        }
+        $sql->setQuery($qry);
     }
 
-    /**
-     * @param string $name
-     * @return bool
-     */
-    public function deleteColumn($name)
+    /** @param string $name */
+    public function deleteColumn($name): void
     {
         $sql = Sql::factory($this->DBID);
 
         $qry = 'ALTER TABLE ' . $sql->escapeIdentifier($this->getTableName()) . ' DROP ';
         $qry .= $sql->escapeIdentifier($name);
 
-        try {
-            $sql->setQuery($qry);
-            return true;
-        } catch (SqlException) {
-            return false;
-        }
+        $sql->setQuery($qry);
     }
 
     /**

--- a/src/MetaInfo/Form/MetaInfoForm.php
+++ b/src/MetaInfo/Form/MetaInfoForm.php
@@ -193,7 +193,9 @@ class MetaInfoForm extends Form
         if (true === ($result = parent::delete())) {
             // Prios neu setzen, damit keine lücken entstehen
             $this->organizePriorities(1, 2);
-            return $this->tableManager->deleteColumn($columnName);
+            $this->tableManager->deleteColumn($columnName);
+
+            return true;
         }
 
         return $result;
@@ -304,14 +306,14 @@ class MetaInfoForm extends Form
 
             if ($this->isEditMode()) {
                 // Spalte in der Tabelle veraendern
-                $tmRes = $this->tableManager->editColumn($fieldOldName, $fieldName, $fieldDbType, $fieldDbLength, $fieldDefault);
+                $this->tableManager->editColumn($fieldOldName, $fieldName, $fieldDbType, $fieldDbLength, $fieldDefault);
             } else {
                 // Spalte in der Tabelle anlegen
-                $tmRes = $this->tableManager->addColumn($fieldName, $fieldDbType, $fieldDbLength, $fieldDefault);
+                $this->tableManager->addColumn($fieldName, $fieldDbType, $fieldDbLength, $fieldDefault);
             }
             Cache::delete();
 
-            return $tmRes;
+            return true;
         }
 
         return false;

--- a/src/MetaInfo/MetaInfo.php
+++ b/src/MetaInfo/MetaInfo.php
@@ -159,7 +159,9 @@ class MetaInfo
         Util::organizePriorities(Core::getTablePrefix() . 'metainfo_field', 'priority', 'name LIKE ' . $prefix, 'priority, updatedate');
 
         $tableManager = new MetaInfoTable($metaTable);
-        return $tableManager->addColumn($name, $fieldDbType, $fieldDbLength, $default);
+        $tableManager->addColumn($name, $fieldDbType, $fieldDbLength, $default);
+
+        return true;
     }
 
     /** @return bool|string */
@@ -205,7 +207,9 @@ class MetaInfo
         Util::organizePriorities(Core::getTablePrefix() . 'metainfo_field', 'priority', 'name LIKE ' . $prefix, 'priority, updatedate desc');
 
         $tableManager = new MetaInfoTable($metaTable);
-        return $tableManager->deleteColumn($name);
+        $tableManager->deleteColumn($name);
+
+        return true;
     }
 
     /**

--- a/src/Setup/Importer.php
+++ b/src/Setup/Importer.php
@@ -7,7 +7,6 @@ use Redaxo\Core\Addon\AddonManager;
 use Redaxo\Core\Backup\Backup;
 use Redaxo\Core\Config;
 use Redaxo\Core\Core;
-use Redaxo\Core\Database\Exception\SqlException;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\UserMessageException;
 use Redaxo\Core\Filesystem\Path;
@@ -33,8 +32,6 @@ class Importer
             include Path::core('setup/update.php');
         } catch (UserMessageException $e) {
             $errMsg .= $e->getMessage();
-        } catch (SqlException $e) {
-            $errMsg .= 'SQL error: ' . $e->getMessage();
         }
 
         Core::setProperty('version', $version);
@@ -101,8 +98,6 @@ class Importer
             include Path::core('setup/install.php');
         } catch (UserMessageException $e) {
             $errMsg .= $e->getMessage();
-        } catch (SqlException $e) {
-            $errMsg .= 'SQL error: ' . $e->getMessage();
         }
 
         if ('' == $errMsg) {
@@ -122,8 +117,6 @@ class Importer
             include Path::core('setup/install.php');
         } catch (UserMessageException $e) {
             $errMsg .= $e->getMessage();
-        } catch (SqlException $e) {
-            $errMsg .= 'SQL error: ' . $e->getMessage();
         }
 
         self::prepareAddons();


### PR DESCRIPTION
## Summary

Several call sites caught `SqlException` and replaced it with a generic i18n message or silently returned `false`/`null`, hiding the actual query, parameters and PDO error and making troubleshooting hard.

This PR either removes the catches entirely (so the exception propagates to the regular exception page with full trace) or narrows them to the specific error codes that are actually expected to occur in normal use.

### Removed catches

Any SQL failure here indicates a bug — show the exception page:

- `pages/media_manager/effects.php` — delete effect
- `pages/media_manager/types.php` — delete type
- `pages/mediapool/media.list.php` — move selected media
- `pages/setup/index.php` — initial admin user insert (drops `setup_504`)
- `src/Setup/Importer.php` — wrappers around `setup/install.php` and `setup/update.php`. `UserMessageException` is still caught — that one is intentionally thrown for user-facing messages
- `src/Addon/AddonManager.php` — same rationale as `Importer`
- `src/Cronjob/CronjobManager.php` — `setStatus`, `setExecutionStart`, `delete`, `setNextTime` (drops `cronjob_*_error` keys)
- `src/MetaInfo/Database/Table.php` — `addColumn`, `editColumn`, `deleteColumn`

### Narrowed catches

- `pages/media_manager/types.php` — copy type now only catches `ERROR_VIOLATE_UNIQUE_KEY` (existing `… Kopie` name)
- `src/Form/Form.php` — `save`/`delete` only translate the error into an `int` errno if an explicit `addErrorMessage(...)` mapping is registered, otherwise the exception propagates

## Breaking changes

- `CronjobManager::setStatus`, `setExecutionStart`, `delete`, `setNextTime`: return type changed from `bool` to `void`.
- `MetaInfo\Database\Table::addColumn`, `editColumn`, `deleteColumn`: return type changed from `bool` to `void`.