### PR TITLE
refactor!: introduce subclass-based addon lifecycle

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1483,12 +1483,8 @@
       <code><![CDATA[$load]]></code>
       <code><![CDATA[$normal[]]]></code>
       <code><![CDATA[$reinstall]]></code>
-      <code><![CDATA[$successMessage]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$successMessage]]></code>
-    </MixedOperand>
   </file>
   <file src="src/Addon/NullAddon.php">
     <MixedReturnStatement>

--- a/addons/debug/composer.json
+++ b/addons/debug/composer.json
@@ -24,8 +24,17 @@
     },
 
     "autoload": {
+        "psr-4": {
+            "Redaxo\\Debug\\": "src/"
+        },
         "classmap": [
             "lib/"
         ]
+    },
+
+    "extra": {
+        "redaxo": {
+            "addon-class": "Redaxo\\Debug\\DebugAddon"
+        }
     }
 }

--- a/addons/debug/src/DebugAddon.php
+++ b/addons/debug/src/DebugAddon.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Redaxo\Debug;
+
+use Override;
+use Redaxo\Core\Addon\Addon;
+
+final class DebugAddon extends Addon
+{
+    #[Override]
+    public function boot(): void
+    {
+        $this->includeFile('boot.php');
+    }
+
+    #[Override]
+    public function install(): void
+    {
+        $this->includeFile('install.php');
+    }
+}

--- a/addons/test/composer.json
+++ b/addons/test/composer.json
@@ -19,5 +19,17 @@
     "require": {
         "php": "^8.5",
         "redaxo/core": "@dev"
+    },
+
+    "autoload": {
+        "psr-4": {
+            "Redaxo\\Test\\": "src/"
+        }
+    },
+
+    "extra": {
+        "redaxo": {
+            "addon-class": "Redaxo\\Test\\TestAddon"
+        }
     }
 }

--- a/addons/test/src/TestAddon.php
+++ b/addons/test/src/TestAddon.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Redaxo\Test;
+
+use Redaxo\Core\Addon\Addon;
+
+final class TestAddon extends Addon {}

--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -9,6 +9,7 @@ use Redaxo\Core\Addon\ExtensionPoint\AddonCacheDeleted;
 use Redaxo\Core\Config;
 use Redaxo\Core\Core;
 use Redaxo\Core\Exception\RuntimeException;
+use Redaxo\Core\Exception\UserMessageException;
 use Redaxo\Core\ExtensionPoint\Extension;
 use Redaxo\Core\Filesystem\Dir;
 use Redaxo\Core\Filesystem\File;
@@ -30,12 +31,9 @@ use const DIRECTORY_SEPARATOR;
 use const EXTR_SKIP;
 use const JSON_THROW_ON_ERROR;
 
-final class Addon implements AddonInterface
+abstract class Addon implements AddonInterface
 {
-    public const string FILE_PACKAGE = 'package.yml';
-    public const string FILE_BOOT = 'boot.php';
-    public const string FILE_INSTALL = 'install.php';
-    public const string FILE_UNINSTALL = 'uninstall.php';
+    final public const string FILE_PACKAGE = 'package.yml';
 
     private const string PROPERTIES_CACHE_FILE = 'packages.cache';
 
@@ -74,11 +72,11 @@ final class Addon implements AddonInterface
     /** @var array<string, mixed>|null */
     private ?array $composerJson = null;
 
-    private function __construct(
+    final private function __construct(
         /** @var non-empty-string Composer package name */
-        public readonly string $package,
+        final public readonly string $package,
         /** @var non-empty-string Name of the addon */
-        public readonly string $name,
+        final public readonly string $name,
     ) {}
 
     /**
@@ -87,7 +85,7 @@ final class Addon implements AddonInterface
      * @param string $addon Addon name
      * @return AddonInterface If the addon exists, a `Addon` is returned, otherwise a `NullAddon`
      */
-    public static function get(string $addon): AddonInterface
+    final public static function get(string $addon): AddonInterface
     {
         if (!isset(self::$addons[$addon])) {
             return NullAddon::getInstance();
@@ -101,7 +99,7 @@ final class Addon implements AddonInterface
      *
      * @psalm-assert =non-empty-string $addon
      */
-    public static function require(string $addon): self
+    final public static function require(string $addon): self
     {
         if (!isset(self::$addons[$addon])) {
             throw new RuntimeException(sprintf('Required addon "%s" does not exist.', $addon));
@@ -117,73 +115,73 @@ final class Addon implements AddonInterface
      *
      * @psalm-assert-if-true =non-empty-string $addon
      */
-    public static function exists(string $addon): bool
+    final public static function exists(string $addon): bool
     {
         return isset(self::$addons[$addon]);
     }
 
     #[Override]
-    public function getPath(string $file = ''): string
+    final public function getPath(string $file = ''): string
     {
         return Path::addon($this->name, $file);
     }
 
     #[Override]
-    public function getAssetsPath(string $file = ''): string
+    final public function getAssetsPath(string $file = ''): string
     {
         return Path::addonAssets($this->name, $file);
     }
 
     #[Override]
-    public function getAssetsUrl(string $file = ''): string
+    final public function getAssetsUrl(string $file = ''): string
     {
         return Url::addonAssets($this->name, $file);
     }
 
     #[Override]
-    public function getDataPath(string $file = ''): string
+    final public function getDataPath(string $file = ''): string
     {
         return Path::addonData($this->name, $file);
     }
 
     #[Override]
-    public function getCachePath(string $file = ''): string
+    final public function getCachePath(string $file = ''): string
     {
         return Path::addonCache($this->name, $file);
     }
 
     #[Override]
-    public function setConfig(string|array $key, mixed $value = null): bool
+    final public function setConfig(string|array $key, mixed $value = null): bool
     {
         return Config::set($this->name, $key, $value);
     }
 
     #[Override]
-    public function getConfig(?string $key = null, mixed $default = null): mixed
+    final public function getConfig(?string $key = null, mixed $default = null): mixed
     {
         return Config::get($this->name, $key, $default);
     }
 
     #[Override]
-    public function hasConfig(?string $key = null): bool
+    final public function hasConfig(?string $key = null): bool
     {
         return Config::has($this->name, $key);
     }
 
     #[Override]
-    public function removeConfig(string $key): bool
+    final public function removeConfig(string $key): bool
     {
         return Config::remove($this->name, $key);
     }
 
     #[Override]
-    public function setProperty(string $key, mixed $value): void
+    final public function setProperty(string $key, mixed $value): void
     {
         $this->properties[$key] = $value;
     }
 
     #[Override]
-    public function getProperty(string $key, mixed $default = null): mixed
+    final public function getProperty(string $key, mixed $default = null): mixed
     {
         if ($this->hasProperty($key)) {
             return $this->properties[$key];
@@ -192,7 +190,7 @@ final class Addon implements AddonInterface
     }
 
     #[Override]
-    public function hasProperty(string $key): bool
+    final public function hasProperty(string $key): bool
     {
         if (!isset($this->properties[$key]) && !$this->propertiesLoaded) {
             $this->loadProperties();
@@ -201,25 +199,25 @@ final class Addon implements AddonInterface
     }
 
     #[Override]
-    public function removeProperty(string $key): void
+    final public function removeProperty(string $key): void
     {
         unset($this->properties[$key]);
     }
 
     #[Override]
-    public function isAvailable(): bool
+    final public function isAvailable(): bool
     {
         return $this->isInstalled() && (bool) $this->getProperty('status', false);
     }
 
     #[Override]
-    public function isInstalled(): bool
+    final public function isInstalled(): bool
     {
         return (bool) $this->getProperty('install', false);
     }
 
     #[Override]
-    public function getAuthor(?string $default = null): ?string
+    final public function getAuthor(?string $default = null): ?string
     {
         $composerJson = $this->getComposerJson();
 
@@ -235,7 +233,7 @@ final class Addon implements AddonInterface
     }
 
     #[Override]
-    public function getVersion(?string $format = null): string
+    final public function getVersion(?string $format = null): string
     {
         $version = $this->getProperty('version');
 
@@ -253,7 +251,7 @@ final class Addon implements AddonInterface
     }
 
     #[Override]
-    public function getSupportPage(?string $default = null): ?string
+    final public function getSupportPage(?string $default = null): ?string
     {
         $composerJson = $this->getComposerJson();
 
@@ -270,7 +268,7 @@ final class Addon implements AddonInterface
     }
 
     #[Override]
-    public function includeFile(string $file, array $context = []): mixed
+    final public function includeFile(string $file, array $context = []): mixed
     {
         $__file = $file;
         $__context = $context;
@@ -291,7 +289,7 @@ final class Addon implements AddonInterface
     }
 
     #[Override]
-    public function i18n(string $key, string|int ...$replacements): string
+    final public function i18n(string $key, string|int ...$replacements): string
     {
         $fullKey = $this->name . '_' . $key;
         if (I18n::hasMsgOrFallback($fullKey)) {
@@ -301,7 +299,7 @@ final class Addon implements AddonInterface
     }
 
     /** Loads the properties of package.yml. */
-    public function loadProperties(bool $force = false): void
+    final public function loadProperties(bool $force = false): void
     {
         $file = $this->getPath(self::FILE_PACKAGE);
         if (!is_file($file)) {
@@ -372,7 +370,7 @@ final class Addon implements AddonInterface
         $this->propertiesLoaded = true;
     }
 
-    public function getLicense(): ?string
+    final public function getLicense(): ?string
     {
         /** @var string|list<string>|null $license */
         $license = $this->getComposerJson()['license'] ?? null;
@@ -398,7 +396,7 @@ final class Addon implements AddonInterface
     }
 
     /** Clears the cache of the addon. */
-    public function clearCache(): void
+    final public function clearCache(): void
     {
         $cacheDir = $this->getCachePath();
         if (!Dir::delete($cacheDir)) {
@@ -414,7 +412,7 @@ final class Addon implements AddonInterface
         Extension::registerPoint(new AddonCacheDeleted($this));
     }
 
-    public function enlist(): void
+    final public function enlist(): void
     {
         $folder = $this->getPath();
 
@@ -428,19 +426,29 @@ final class Addon implements AddonInterface
         }
     }
 
-    public function boot(): void
-    {
-        if (is_readable($this->getPath(self::FILE_BOOT))) {
-            $this->includeFile(self::FILE_BOOT);
-        }
-    }
+    /** Boot hook — runs on every request after all addons are enlisted. Override to register listeners etc. */
+    public function boot(): void {}
+
+    /**
+     * Install hook — runs on install/reinstall. Override for schema/data setup. Must be idempotent.
+     *
+     * @throws UserMessageException
+     */
+    public function install(): void {}
+
+    /**
+     * Uninstall hook — runs on uninstall. Override for cleanup.
+     *
+     * @throws UserMessageException
+     */
+    public function uninstall(): void {}
 
     /**
      * Returns the registered addons.
      *
      * @return array<non-empty-string, self>
      */
-    public static function getRegisteredAddons(): array
+    final public static function getRegisteredAddons(): array
     {
         return self::$addons;
     }
@@ -450,7 +458,7 @@ final class Addon implements AddonInterface
      *
      * @return array<non-empty-string, self>
      */
-    public static function getInstalledAddons(): array
+    final public static function getInstalledAddons(): array
     {
         return self::filterPackages(self::$addons, 'isInstalled');
     }
@@ -460,7 +468,7 @@ final class Addon implements AddonInterface
      *
      * @return array<non-empty-string, self>
      */
-    public static function getAvailableAddons(): array
+    final public static function getAvailableAddons(): array
     {
         return self::filterPackages(self::$addons, 'isAvailable');
     }
@@ -470,7 +478,7 @@ final class Addon implements AddonInterface
      *
      * @return array<non-empty-string, self>
      */
-    public static function getSetupAddons(): array
+    final public static function getSetupAddons(): array
     {
         $addons = [];
         foreach ((array) Core::getProperty('setup_addons', []) as $addon) {
@@ -482,7 +490,7 @@ final class Addon implements AddonInterface
     }
 
     /** Initializes all addons. */
-    public static function initialize(bool $dbExists = true): void
+    final public static function initialize(bool $dbExists = true): void
     {
         if ($dbExists) {
             $config = Core::getPackageConfig();
@@ -494,6 +502,7 @@ final class Addon implements AddonInterface
         }
 
         $composerPackages = AddonManager::getComposerPackages();
+        $addonClasses = null;
 
         $addons = self::$addons;
         self::$addons = [];
@@ -502,7 +511,21 @@ final class Addon implements AddonInterface
                 continue;
             }
 
-            $addon = $addons[$addonName] ?? new self($composerPackages[$addonName], $addonName);
+            if (isset($addons[$addonName])) {
+                $addon = $addons[$addonName];
+            } else {
+                $class = $addonConfig['class'] ?? null;
+                if (!is_string($class) || !is_subclass_of($class, self::class)) {
+                    // bootstrap fallback: config has no (valid) class — e.g. fresh setup, brand-new addon,
+                    // class rename after composer update without sync. Sync will refresh the config.
+                    $addonClasses ??= AddonManager::getAddonClasses();
+                    if (!isset($addonClasses[$addonName])) {
+                        throw new RuntimeException(sprintf('Addon "%s" must declare its addon class via composer.json `extra.redaxo.addon-class`.', $addonName));
+                    }
+                    $class = $addonClasses[$addonName];
+                }
+                $addon = new $class($composerPackages[$addonName], $addonName);
+            }
             $addon->setProperty('install', $addonConfig['install'] ?? false);
             $addon->setProperty('status', $addonConfig['status'] ?? false);
             self::$addons[$addonName] = $addon;
@@ -514,7 +537,7 @@ final class Addon implements AddonInterface
      *
      * @return array<string, mixed>
      */
-    public function getComposerJson(): array
+    final public function getComposerJson(): array
     {
         if (null !== $this->composerJson) {
             return $this->composerJson;

--- a/src/Addon/AddonManager.php
+++ b/src/Addon/AddonManager.php
@@ -2,6 +2,7 @@
 
 namespace Redaxo\Core\Addon;
 
+use Composer\Autoload\ClassLoader;
 use Composer\InstalledVersions;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Base\FactoryTrait;
@@ -19,7 +20,11 @@ use Redaxo\Core\Util\Str;
 use Redaxo\Core\Util\Type;
 
 use function in_array;
+use function is_array;
+use function is_string;
 use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
 
 class AddonManager
 {
@@ -75,20 +80,17 @@ class AddonManager
 
             I18n::addDirectory($this->addon->getPath('lang'));
 
-            // include install.php
-            $successMessage = '';
-            if (is_readable($this->addon->getPath(Addon::FILE_INSTALL))) {
-                $this->addon->includeFile(Addon::FILE_INSTALL);
-                $successMessage = $this->addon->getProperty('successmsg', '');
+            // run install hook
+            $this->addon->install();
+            $successMessage = (string) $this->addon->getProperty('successmsg', '');
 
-                /** @psalm-taint-escape html */
-                $instmsg = (string) $this->addon->getProperty('installmsg', '');
-                if ('' != $instmsg) {
-                    throw new UserMessageException($instmsg);
-                }
-                if (!$this->addon->isInstalled()) {
-                    throw new UserMessageException($this->i18n('no_reason'));
-                }
+            /** @psalm-taint-escape html */
+            $instmsg = (string) $this->addon->getProperty('installmsg', '');
+            if ('' != $instmsg) {
+                throw new UserMessageException($instmsg);
+            }
+            if (!$this->addon->isInstalled()) {
+                throw new UserMessageException($this->i18n('no_reason'));
             }
 
             if (!$reinstall) {
@@ -144,22 +146,20 @@ class AddonManager
         try {
             $this->addon->setProperty('install', false);
 
-            // include uninstall.php
-            if (is_readable($this->addon->getPath(Addon::FILE_UNINSTALL))) {
-                if (!$isActivated) {
-                    I18n::addDirectory($this->addon->getPath('lang'));
-                }
+            if (!$isActivated) {
+                I18n::addDirectory($this->addon->getPath('lang'));
+            }
 
-                $this->addon->includeFile(Addon::FILE_UNINSTALL);
+            // run uninstall hook
+            $this->addon->uninstall();
 
-                /** @psalm-taint-escape html */
-                $instmsg = (string) $this->addon->getProperty('installmsg', '');
-                if ('' != $instmsg) {
-                    throw new UserMessageException($instmsg);
-                }
-                if ($this->addon->isInstalled()) {
-                    throw new UserMessageException($this->i18n('no_reason'));
-                }
+            /** @psalm-taint-escape html */
+            $instmsg = (string) $this->addon->getProperty('installmsg', '');
+            if ('' != $instmsg) {
+                throw new UserMessageException($instmsg);
+            }
+            if ($this->addon->isInstalled()) {
+                throw new UserMessageException($this->i18n('no_reason'));
             }
 
             // delete assets
@@ -378,7 +378,7 @@ class AddonManager
     {
         $config = [];
         foreach (Addon::getRegisteredAddons() as $addonName => $addon) {
-            $config[$addonName]['package'] = $addon->package;
+            $config[$addonName]['class'] = $addon::class;
             $config[$addonName]['install'] = $addon->isInstalled();
             $config[$addonName]['status'] = $addon->isAvailable();
         }
@@ -391,6 +391,7 @@ class AddonManager
         $config = Core::getPackageConfig();
         $registeredAddons = Addon::getRegisteredAddons();
         $packages = self::getComposerPackages();
+        $addonClasses = self::getAddonClasses();
 
         foreach (array_diff_key($registeredAddons, $packages) as $addonName => $addon) {
             $manager = self::factory($addon);
@@ -398,6 +399,10 @@ class AddonManager
             unset($config[$addonName]);
         }
         foreach ($packages as $addonName => $package) {
+            if (!isset($addonClasses[$addonName])) {
+                throw new RuntimeException(sprintf('Addon "%s" must declare its addon class via composer.json `extra.redaxo.addon-class`.', $addonName));
+            }
+            $config[$addonName]['class'] = $addonClasses[$addonName];
             if (!Addon::exists($addonName)) {
                 $config[$addonName]['install'] = false;
                 $config[$addonName]['status'] = false;
@@ -411,6 +416,64 @@ class AddonManager
 
         Core::setConfig('package-config', $config);
         Addon::initialize();
+    }
+
+    /**
+     * Returns the addon-class mapping for all registered `redaxo-addon` packages, read from `vendor/composer/installed.json`.
+     *
+     * Used by setup and sync to write the resolved classes into the package-config. Normal request boots
+     * read the class directly from the package-config and never call this.
+     *
+     * @internal
+     *
+     * @return array<non-empty-string, class-string<Addon>>
+     */
+    public static function getAddonClasses(): array
+    {
+        $classes = [];
+
+        foreach (ClassLoader::getRegisteredLoaders() as $vendorDir => $_loader) {
+            $jsonPath = $vendorDir . '/composer/installed.json';
+            if (!is_file($jsonPath)) {
+                continue;
+            }
+
+            $json = File::get($jsonPath);
+            if (!$json) {
+                continue;
+            }
+
+            /** @var array{packages?: list<array<string, mixed>>} $data */
+            $data = Type::array(json_decode($json, true, flags: JSON_THROW_ON_ERROR));
+
+            foreach ($data['packages'] ?? [] as $package) {
+                if (($package['type'] ?? null) !== 'redaxo-addon') {
+                    continue;
+                }
+
+                $name = Path::basename(Type::string($package['name'] ?? ''));
+                /** @var array<string, mixed> $extra */
+                $extra = is_array($package['extra'] ?? null) ? $package['extra'] : [];
+                /** @var array<string, mixed> $redaxoExtra */
+                $redaxoExtra = is_array($extra['redaxo'] ?? null) ? $extra['redaxo'] : [];
+                $class = $redaxoExtra['addon-class'] ?? null;
+
+                if (!is_string($class) || '' === $class || '' === $name) {
+                    continue;
+                }
+                if (!class_exists($class)) {
+                    throw new RuntimeException(sprintf('Addon class "%s" of addon "%s" does not exist.', $class, $name));
+                }
+                if (!is_subclass_of($class, Addon::class)) {
+                    throw new RuntimeException(sprintf('Addon class "%s" of addon "%s" must extend %s.', $class, $name, Addon::class));
+                }
+
+                /** @var class-string<Addon> $class */
+                $classes[$name] = $class;
+            }
+        }
+
+        return $classes;
     }
 
     /** @return array<non-empty-string, non-empty-string> */

--- a/src/Core.php
+++ b/src/Core.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core;
 
 use Composer\InstalledVersions;
+use Redaxo\Core\Addon\Addon;
 use Redaxo\Core\Console\Application;
 use Redaxo\Core\Database\Configuration as DatabaseConfiguration;
 use Redaxo\Core\Exception\InvalidArgumentException;
@@ -455,7 +456,7 @@ final class Core
     }
 
     /**
-     * @return array<non-empty-string, array{install: bool, status: bool}>
+     * @return array<non-empty-string, array{class: class-string<Addon>, install: bool, status: bool}>
      * @psalm-suppress MixedReturnTypeCoercion
      */
     public static function getPackageConfig(): array

--- a/src/ExtensionPoint/Extension.php
+++ b/src/ExtensionPoint/Extension.php
@@ -3,6 +3,7 @@
 namespace Redaxo\Core\ExtensionPoint;
 
 use Redaxo\Core\AbstractProject;
+use Redaxo\Core\Addon\Addon;
 use Redaxo\Core\Base\FactoryTrait;
 use Redaxo\Core\ClassDiscovery;
 use Redaxo\Core\Exception\InvalidArgumentException;
@@ -116,21 +117,39 @@ abstract class Extension
      * Registers all extensions for methods carrying the `#[AsExtension]` attribute,
      * discovered via {@see ClassDiscovery}.
      *
-     * Static methods are bound to their class; non-static methods are only allowed
-     * on the project class (where the instance is available).
+     * Static methods are bound to their class; non-static methods are allowed on
+     * the project class and on addon classes (where the instance is available).
      *
      * @internal
      */
     public static function registerByAttribute(AbstractProject $project): void
     {
+        /** @var array<class-string<Addon>, Addon>|null $addonByClass */
+        $addonByClass = null;
+
         foreach (ClassDiscovery::getInstance()->discoverByMethodAttribute(AsExtension::class) as $entry) {
             if ($entry['isStatic']) {
                 $callable = [$entry['class'], $entry['method']];
             } elseif ($project instanceof $entry['class']) {
                 $callable = [$project, $entry['method']];
+            } elseif (is_subclass_of($entry['class'], Addon::class)) {
+                if (null === $addonByClass) {
+                    $addonByClass = [];
+                    foreach (Addon::getAvailableAddons() as $addon) {
+                        $addonByClass[$addon::class] = $addon;
+                    }
+                }
+                if (!isset($addonByClass[$entry['class']])) {
+                    throw new LogicException(sprintf(
+                        'Non-static #[AsExtension] on addon class "%s::%s()" cannot be registered: addon is not available.',
+                        $entry['class'],
+                        $entry['method'],
+                    ));
+                }
+                $callable = [$addonByClass[$entry['class']], $entry['method']];
             } else {
                 throw new LogicException(sprintf(
-                    'Non-static #[AsExtension] is only allowed on the project class. Method "%s::%s()" is neither static nor defined on a parent of %s.',
+                    'Non-static #[AsExtension] is only allowed on the project class or on addon classes. Method "%s::%s()" is neither static nor defined on a parent of %s or on a registered addon class.',
                     $entry['class'],
                     $entry['method'],
                     $project::class,


### PR DESCRIPTION
## Summary

Addons now declare a concrete `Addon` subclass via `composer.json` → `extra.redaxo.addon-class`. The class provides overridable `boot()`, `install()` and `uninstall()` methods, replacing the implicit `boot.php` / `install.php` / `uninstall.php` files that were loaded in an opaque context (no clear `$this`, no IDE/type support).

### Key changes

- `Addon` is `abstract`, ctor `private` (no external instantiation), all infrastructure methods are `final` — only the three lifecycle hooks are meant to be overridden.
- Class mapping is resolved from `installed.json` once and cached in the package-config; normal request boots do **zero** additional I/O. A lazy fallback re-reads `installed.json` only when the cache is missing/invalid (fresh install, rename without sync) for bootstrap resilience.
- `AddonManager::synchronizeWithFileSystem()` writes the resolved class into the package-config; `AddonManager::saveConfig()` keeps it in sync on install/uninstall/activate.
- New helper `AddonManager::getAddonClasses()` (`@internal`) iterates registered Composer loaders to find all `redaxo-addon` entries with their declared class — robust against phar/multi-loader setups (PHPStan etc.).
- `#[AsExtension]` on **non-static** methods now also works on addon classes, not just on the project class. The instance is resolved via `Addon::getAvailableAddons()` (consistent with `ClassDiscovery`'s scan scope).
- Removed the `Addon::FILE_BOOT` / `FILE_INSTALL` / `FILE_UNINSTALL` constants and the magic auto-include.

### Special case: `debug` addon

The `debug` addon keeps its `boot.php` / `install.php` files for now to make 5.x → 6.x merges less painful — `DebugAddon::boot()` / `install()` simply delegate via `$this->includeFile(...)`. This is **not** a recommended pattern for other addons; it's a transitional convenience for this single addon.

### Notes

- Psalm baseline got slightly smaller (-10 entries) since the Clockwork-related mixed-type findings moved from `boot.php` / `install.php` into `DebugAddon.php`, and a few were resolved on the way.