### PR TITLE
refactor!: make addon load order a typed property

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1480,7 +1480,6 @@
     </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$key]]></code>
-      <code><![CDATA[$load]]></code>
       <code><![CDATA[$normal[]]]></code>
       <code><![CDATA[$reinstall]]></code>
       <code><![CDATA[$value]]></code>

--- a/addons/debug/package.yml
+++ b/addons/debug/package.yml
@@ -1,5 +1,3 @@
-load: early
-
 page:
     title: translate:debug
     perm: admin

--- a/addons/debug/src/DebugAddon.php
+++ b/addons/debug/src/DebugAddon.php
@@ -4,9 +4,12 @@ namespace Redaxo\Debug;
 
 use Override;
 use Redaxo\Core\Addon\Addon;
+use Redaxo\Core\Addon\LoadOrder;
 
 final class DebugAddon extends Addon
 {
+    public protected(set) LoadOrder $load = LoadOrder::Early;
+
     #[Override]
     public function boot(): void
     {

--- a/schemas/package.json
+++ b/schemas/package.json
@@ -30,11 +30,6 @@
             "additionalProperties": {
                 "type": "string"
             }
-        },
-        "load": {
-            "description": "Loading position",
-            "enum": ["early", "normal", "late"],
-            "default": "normal"
         }
     },
     "additionalProperties": true,

--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -58,6 +58,9 @@ abstract class Addon
         }
     }
 
+    /** Loading position relative to other addons during boot. Override to load this addon early or late. */
+    public protected(set) LoadOrder $load = LoadOrder::Normal;
+
     /**
      * Properties.
      *

--- a/src/Addon/AddonManager.php
+++ b/src/Addon/AddonManager.php
@@ -354,14 +354,13 @@ class AddonManager
         };
         foreach (Addon::getAvailableAddons() as $addon) {
             $id = $addon->name;
-            $load = $addon->getProperty('load');
-            if ('early' === $load) {
+            if (LoadOrder::Early === $addon->load) {
                 $early[] = $id;
-            } elseif ('late' === $load) {
+            } elseif (LoadOrder::Late === $addon->load) {
                 $late[] = $id;
             } else {
                 foreach (self::getRequiredAddons($addon) as $addonId) {
-                    if (!in_array($addonId, $normal) && !in_array(Addon::get($addonId)?->getProperty('load'), ['early', 'late'])) {
+                    if (!in_array($addonId, $normal) && !in_array(Addon::get($addonId)?->load, [LoadOrder::Early, LoadOrder::Late], true)) {
                         $requires[$id][$addonId] = true;
                     }
                 }

--- a/src/Addon/LoadOrder.php
+++ b/src/Addon/LoadOrder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Redaxo\Core\Addon;
+
+/** Loading position of an addon relative to others during boot. */
+enum LoadOrder
+{
+    /** Loaded before normal addons, ignoring dependencies. */
+    case Early;
+
+    /** Loaded in dependency order (default). */
+    case Normal;
+
+    /** Loaded after normal addons, ignoring dependencies. */
+    case Late;
+}


### PR DESCRIPTION
## Was

Der `load`-Schlüssel aus der `package.yml` wird durch eine getypte Enum-Property `LoadOrder` auf der `Addon`-Basisklasse ersetzt. Subklassen überschreiben sie einfach, statt `load:` in der `package.yml` zu deklarieren.

```php
// Addon (Basisklasse)
public protected(set) LoadOrder $load = LoadOrder::Normal;

// DebugAddon
public protected(set) LoadOrder $load = LoadOrder::Early;
```

## Details

- Neues `enum LoadOrder { Early; Normal; Late; }` (pure enum, keine Backing-Values — `load` wird nur per Identität verglichen, nie serialisiert).
- Die Property ist `public protected(set)`: überall lesbar, aber nur vom Addon selbst setzbar.
- `AddonManager::generatePackageOrder()` liest jetzt `$addon->load` statt `getProperty('load')`.
- `load: early` aus `addons/debug/package.yml` und der `load`-Eintrag aus dem JSON-Schema (`schemas/package.json`) entfernt.

## BREAKING CHANGE

Addons müssen ihre Load-Reihenfolge jetzt über die `$load`-Property ihrer Addon-Klasse setzen; der `load`-Schlüssel in der `package.yml` wird nicht mehr ausgewertet.