### PR TITLE
chore(deps): Update Symfony packages to 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,11 +39,11 @@
         "ramsey/http-range": "^2.0.0",
         "scssphp/scssphp": "^1.13.0",
         "splitbrain/php-archive": "^1.4.2",
-        "symfony/console": "^7.4.13",
-        "symfony/http-foundation": "^7.4.13",
-        "symfony/runtime": "^7.4.13",
-        "symfony/var-dumper": "^7.4.8",
-        "symfony/yaml": "^7.4.13",
+        "symfony/console": "^8.1.0",
+        "symfony/http-foundation": "^8.1.0",
+        "symfony/runtime": "^8.1.0",
+        "symfony/var-dumper": "^8.1.0",
+        "symfony/yaml": "^8.1.0",
         "voku/anti-xss": "^4.1.43"
     },
     "require-dev": {


### PR DESCRIPTION
Updates all Symfony packages from `^7.4` to `^8.1`.

- `symfony/console`, `symfony/http-foundation`, `symfony/runtime`, `symfony/var-dumper`, `symfony/yaml` bumped to `^8.1.0`
- Transitive Symfony components updated to `v8.1.0`

Despite the major jump (7.4 → 8.1) no code changes were necessary — PHPStan, Psalm, the full test suite and the taint analysis all pass unchanged.
