### PR TITLE
refactor!: move addon config/order from database to filesystem

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2075,9 +2075,6 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Core.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[Type::array(self::getConfig('package-order', []))]]></code>
-    </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
@@ -2101,9 +2098,6 @@
       <code><![CDATA[$result | $item]]></code>
       <code><![CDATA[Config::get(self::CONFIG_NAMESPACE, $key, $default)]]></code>
     </MixedReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[list<non-empty-string>]]></code>
-    </MoreSpecificReturnType>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$server]]></code>
     </PossiblyUndefinedArrayOffset>

--- a/boot/addons.php
+++ b/boot/addons.php
@@ -2,6 +2,7 @@
 
 use Redaxo\Core\AbstractProject;
 use Redaxo\Core\Addon\Addon;
+use Redaxo\Core\Addon\AddonManager;
 use Redaxo\Core\Core;
 use Redaxo\Core\ExtensionPoint\Extension;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
@@ -17,7 +18,7 @@ Addon::initialize(!Core::isSetup());
 if (Core::isSetup() || Core::isSafeMode()) {
     $packageOrder = array_keys(Addon::getSetupAddons());
 } else {
-    $packageOrder = Core::getPackageOrder();
+    $packageOrder = AddonManager::getAddonOrder();
 }
 
 // in the first run, we register all folders for class- and fragment-loading,

--- a/boot/console.php
+++ b/boot/console.php
@@ -2,6 +2,7 @@
 
 use Redaxo\Core\AbstractProject;
 use Redaxo\Core\Addon\Addon;
+use Redaxo\Core\Addon\AddonManager;
 use Redaxo\Core\Console\Application;
 use Redaxo\Core\Console\Command\ListCommand;
 use Redaxo\Core\Console\CommandLoader;
@@ -25,7 +26,7 @@ Core::setProperty('console', $application);
 Addon::initialize(!Core::isSetup());
 
 if (!Core::isSetup()) {
-    foreach (Core::getPackageOrder() as $packageId) {
+    foreach (AddonManager::getAddonOrder() as $packageId) {
         Addon::require($packageId)->enlist();
     }
 

--- a/rector.php
+++ b/rector.php
@@ -443,6 +443,8 @@ return RectorConfig::configure()
         new MethodCallRename(Cronjob\CronjobManager::class, 'hasManager', 'hasExecutor'),
     ])
     ->withConfiguredRule(RenameStaticMethodRector::class, [
+        new RenameStaticMethod(Core::class, 'getPackageConfig', Addon\AddonManager::class, 'getAddonConfig'),
+        new RenameStaticMethod(Core::class, 'getPackageOrder', Addon\AddonManager::class, 'getAddonOrder'),
         new RenameStaticMethod(Core::class, 'getVersionHash', Util\Version::class, 'gitHash'),
         new RenameStaticMethod(Util\Str::class, 'versionSplit', Util\Version::class, 'split'),
         new RenameStaticMethod(Util\Str::class, 'versionCompare', Util\Version::class, 'compare'),

--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -509,7 +509,7 @@ abstract class Addon
     final public static function initialize(bool $dbExists = true): void
     {
         if ($dbExists) {
-            $config = Core::getPackageConfig();
+            $config = AddonManager::getAddonConfig();
         } else {
             $config = [];
             foreach (Core::getProperty('setup_addons') as $addon) {

--- a/src/Addon/AddonManager.php
+++ b/src/Addon/AddonManager.php
@@ -7,7 +7,6 @@ use Composer\InstalledVersions;
 use Redaxo\Core\Backend\Controller;
 use Redaxo\Core\Base\FactoryTrait;
 use Redaxo\Core\Config;
-use Redaxo\Core\Core;
 use Redaxo\Core\Exception\RuntimeException;
 use Redaxo\Core\Exception\UserMessageException;
 use Redaxo\Core\Filesystem\Dir;
@@ -24,13 +23,22 @@ use function is_array;
 use function is_string;
 use function sprintf;
 
+use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
 
+/**
+ * @phpstan-type TAddonConfig array<non-empty-string, array{class: class-string<Addon>, install: bool, status: bool}>
+ * @phpstan-type TAddonOrder list<non-empty-string>
+ */
 class AddonManager
 {
     use FactoryTrait;
 
-    protected bool $generatePackageOrder = true;
+    /** @var array{config: TAddonConfig, order: TAddonOrder}|null */
+    private static ?array $addonsData = null;
+
     protected string $message = '';
 
     final protected function __construct(
@@ -97,9 +105,7 @@ class AddonManager
                 $this->addon->setProperty('status', true);
             }
             static::saveConfig();
-            if ($this->generatePackageOrder) {
-                self::generatePackageOrder();
-            }
+            self::generateAddonOrder();
 
             foreach ($this->addon->getProperty('default_config', []) as $key => $value) {
                 if (!$this->addon->hasConfig($key)) {
@@ -209,8 +215,8 @@ class AddonManager
                 $this->addon->setProperty('status', true);
                 static::saveConfig();
             }
-            if (true === $state && $this->generatePackageOrder) {
-                self::generatePackageOrder();
+            if (true === $state) {
+                self::generateAddonOrder();
             }
         } else {
             $state = $this->i18n('not_installed', $this->addon->name);
@@ -243,9 +249,7 @@ class AddonManager
             // clear cache of addon
             $this->addon->clearCache();
 
-            if ($this->generatePackageOrder) {
-                self::generatePackageOrder();
-            }
+            self::generateAddonOrder();
 
             $this->message = $this->i18n('deactivated', $this->addon->name);
             return true;
@@ -330,16 +334,28 @@ class AddonManager
         return I18n::msg($fullKey, ...$replacements);
     }
 
-    /** Generates the addon order. */
-    public static function generatePackageOrder(): void
+    /** @return TAddonConfig */
+    public static function getAddonConfig(): array
     {
-        /** @var list<string> $early */
+        return self::loadAddonsData()['config'];
+    }
+
+    /** @return TAddonOrder */
+    public static function getAddonOrder(): array
+    {
+        return self::loadAddonsData()['order'];
+    }
+
+    /** Generates the addon order. */
+    public static function generateAddonOrder(): void
+    {
+        /** @var list<non-empty-string> $early */
         $early = [];
-        /** @var list<string> $normal */
+        /** @var list<non-empty-string> $normal */
         $normal = [];
-        /** @var list<string> $late */
+        /** @var list<non-empty-string> $late */
         $late = [];
-        /** @var array<string, array<string, true>> $requires */
+        /** @var array<non-empty-string, array<non-empty-string, true>> $requires */
         $requires = [];
 
         $add = static function ($id) use (&$add, &$normal, &$requires) {
@@ -369,7 +385,10 @@ class AddonManager
                 }
             }
         }
-        Core::setConfig('package-order', array_merge($early, $normal, array_keys($requires), $late));
+
+        /** @var TAddonOrder $order */
+        $order = array_merge($early, $normal, array_keys($requires), $late);
+        self::saveAddonsData(order: $order);
     }
 
     /** Saves the addon config. */
@@ -381,13 +400,14 @@ class AddonManager
             $config[$addonName]['install'] = $addon->isInstalled();
             $config[$addonName]['status'] = $addon->isAvailable();
         }
-        Core::setConfig('package-config', $config);
+
+        self::saveAddonsData(config: $config);
     }
 
     /** Synchronizes the addons with the file system. */
     public static function synchronizeWithFileSystem(): void
     {
-        $config = Core::getPackageConfig();
+        $config = self::getAddonConfig();
         $registeredAddons = Addon::getRegisteredAddons();
         $packages = self::getComposerPackages();
         $addonClasses = self::getAddonClasses();
@@ -413,8 +433,45 @@ class AddonManager
         }
         ksort($config);
 
-        Core::setConfig('package-config', $config);
+        self::saveAddonsData(config: $config);
         Addon::initialize();
+    }
+
+    /** @return array{config: TAddonConfig, order: TAddonOrder} */
+    private static function loadAddonsData(): array
+    {
+        if (null !== self::$addonsData) {
+            return self::$addonsData;
+        }
+
+        $file = Path::coreData('addons.json');
+        if (!is_file($file)) {
+            return self::$addonsData = ['config' => [], 'order' => []];
+        }
+
+        /** @var array{config: TAddonConfig, order: TAddonOrder} $data */
+        $data = File::getCache($file) ?? ['config' => [], 'order' => []];
+
+        return self::$addonsData = $data;
+    }
+
+    /**
+     * @param TAddonConfig|null $config
+     * @param TAddonOrder|null $order
+     */
+    private static function saveAddonsData(?array $config = null, ?array $order = null): void
+    {
+        $data = self::loadAddonsData();
+
+        if (null !== $config) {
+            $data['config'] = $config;
+        }
+        if (null !== $order) {
+            $data['order'] = $order;
+        }
+
+        self::$addonsData = $data;
+        File::put(Path::coreData('addons.json'), (string) json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
     }
 
     /**

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -8,6 +8,7 @@ use Override;
 use ParseError;
 use Redaxo\Core\AbstractProject;
 use Redaxo\Core\Addon\Addon;
+use Redaxo\Core\Addon\AddonManager;
 use Redaxo\Core\Console\Command\AbstractCommand;
 use Redaxo\Core\Console\Command\OnlySetupAddonsInterface;
 use Redaxo\Core\Console\Command\StandaloneInterface;
@@ -119,7 +120,7 @@ class Application extends SymfonyApplication
         if (!Core::isSetup()) {
             // boot all known packages in the defined order
             // which reflects dependencies before consumers
-            foreach (Core::getPackageOrder() as $packageId) {
+            foreach (AddonManager::getAddonOrder() as $packageId) {
                 Addon::require($packageId)->boot();
             }
         }

--- a/src/Console/Command/MigrateCommand.php
+++ b/src/Console/Command/MigrateCommand.php
@@ -4,7 +4,6 @@ namespace Redaxo\Core\Console\Command;
 
 use Redaxo\Core\Addon\Addon;
 use Redaxo\Core\Addon\AddonManager;
-use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\UserMessageException;
 use Redaxo\Core\Filesystem\File;
@@ -47,7 +46,7 @@ final class MigrateCommand extends AbstractCommand implements StandaloneInterfac
         // align registered addons with composer state: drop config of orphaned addons, register new ones
         AddonManager::synchronizeWithFileSystem();
 
-        $packages = array_merge(['core'], Core::getPackageOrder());
+        $packages = array_merge(['core'], AddonManager::getAddonOrder());
 
         $io->section('Migrating');
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -3,7 +3,6 @@
 namespace Redaxo\Core;
 
 use Composer\InstalledVersions;
-use Redaxo\Core\Addon\Addon;
 use Redaxo\Core\Console\Application;
 use Redaxo\Core\Database\Configuration as DatabaseConfiguration;
 use Redaxo\Core\Exception\InvalidArgumentException;
@@ -453,21 +452,6 @@ final class Core
             return Formatter::version($version, $format);
         }
         return $version;
-    }
-
-    /**
-     * @return array<non-empty-string, array{class: class-string<Addon>, install: bool, status: bool}>
-     * @psalm-suppress MixedReturnTypeCoercion
-     */
-    public static function getPackageConfig(): array
-    {
-        return Type::array(self::getConfig('package-config', []));
-    }
-
-    /** @return list<non-empty-string> */
-    public static function getPackageOrder(): array
-    {
-        return Type::array(self::getConfig('package-order', []));
     }
 
     /**

--- a/src/Setup/Importer.php
+++ b/src/Setup/Importer.php
@@ -172,10 +172,10 @@ class Importer
         AddonManager::synchronizeWithFileSystem();
 
         // enlist activated packages to ensure that all their classess are known in autoloader and can be referenced in other package's install.php
-        foreach (Core::getPackageOrder() as $packageId) {
+        foreach (AddonManager::getAddonOrder() as $packageId) {
             Addon::require($packageId)->enlist();
         }
-        foreach (Core::getPackageOrder() as $packageId) {
+        foreach (AddonManager::getAddonOrder() as $packageId) {
             $package = Addon::require($packageId);
             $manager = AddonManager::factory($package);
 


### PR DESCRIPTION
Store addon install/status and load order in `data/core/addons.json` instead of the `rex_config` database table. This decouples addon state from the database, simplifying deployments and paving the way for deeper Composer integration.

## Changes

- Add `AddonManager::getAddonConfig()` / `getAddonOrder()` reading from `addons.json`
- Add `AddonManager::saveAddonsData()` with optional `config`/`order` params
- Rename `AddonManager::generatePackageOrder()` to `generateAddonOrder()`
- Remove `Core::getPackageConfig()` / `Core::getPackageOrder()` (moved to `AddonManager`)
- Remove unused `$generatePackageOrder` property
- Add rector rules for the renamed static methods

The on-disk shape is `{config, order}`: `config` is persisted addon state (all registered addons, alphabetical), `order` is the dependency-sorted boot order of the available addons (a derived cache, intentionally kept separate from `config`).

## Breaking changes

`Core::getPackageConfig()` and `Core::getPackageOrder()` have been moved to `AddonManager::getAddonConfig()` and `AddonManager::getAddonOrder()`. Rector rules are included for the rename.
