### PR TITLE
refactor!: replace addon install/status flags with AddonState enum

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1481,7 +1481,6 @@
     <MixedAssignment>
       <code><![CDATA[$key]]></code>
       <code><![CDATA[$normal[]]]></code>
-      <code><![CDATA[$reinstall]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
   </file>

--- a/pages/addon/details.help.php
+++ b/pages/addon/details.help.php
@@ -19,7 +19,7 @@ $version = $package->getVersion();
 $author = $package->getAuthor();
 $supportPage = $package->getSupportPage();
 if (is_readable($package->getPath('help.php'))) {
-    if (!$package->isAvailable() && is_readable($package->getPath('lang'))) {
+    if (!$package->isActivated() && is_readable($package->getPath('lang'))) {
         I18n::addDirectory($package->getPath('lang'));
     }
     ob_start();

--- a/pages/addon/list.php
+++ b/pages/addon/list.php
@@ -70,7 +70,7 @@ $getTableRow = static function (Addon $package) use ($getLink) {
 
     $class = '';
     $status = '&nbsp;';
-    if ($package->isAvailable()) {
+    if ($package->isActivated()) {
         $status = $getLink($package, 'deactivate', 'rex-icon-package-is-activated');
         $class .= ' rex-package-is-activated';
     } elseif ($package->isInstalled()) {

--- a/pages/credits.php
+++ b/pages/credits.php
@@ -91,7 +91,7 @@ $content .= '
 
         <tbody>';
 
-foreach (Addon::getAvailableAddons() as $package) {
+foreach (Addon::getActivatedAddons() as $package) {
     $helpUrl = Url::backendPage('packages', ['subpage' => 'help', 'package' => $package->name]);
 
     $license = '';

--- a/rector.php
+++ b/rector.php
@@ -414,8 +414,10 @@ return RectorConfig::configure()
     ->withConfiguredRule(RenameMethodRector::class, [
         new MethodCallRename(Addon\Addon::class, 'getRegisteredPackages', 'getRegisteredAddons'),
         new MethodCallRename(Addon\Addon::class, 'getInstalledPackages', 'getInstalledAddons'),
-        new MethodCallRename(Addon\Addon::class, 'getAvailablePackages', 'getAvailableAddons'),
+        new MethodCallRename(Addon\Addon::class, 'getAvailablePackages', 'getActivatedAddons'),
+        new MethodCallRename(Addon\Addon::class, 'getAvailableAddons', 'getActivatedAddons'),
         new MethodCallRename(Addon\Addon::class, 'getSetupPackages', 'getSetupAddons'),
+        new MethodCallRename(Addon\Addon::class, 'isAvailable', 'isActivated'),
 
         new MethodCallRename(ApiFunction\Result::class, 'toJSON', 'toJson'),
         new MethodCallRename(ApiFunction\Result::class, 'fromJSON', 'fromJson'),

--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -62,6 +62,9 @@ abstract class Addon
     /** Loading position relative to other addons during boot. Override to load this addon early or late. */
     public protected(set) LoadOrder $load = LoadOrder::Normal;
 
+    /** Lifecycle state of the addon. */
+    public private(set) AddonState $state = AddonState::Uninstalled;
+
     /**
      * Properties.
      *
@@ -214,16 +217,26 @@ abstract class Addon
         unset($this->properties[$key]);
     }
 
-    /** Returns if the addon is available (activated and installed). */
-    final public function isAvailable(): bool
+    /**
+     * Sets the lifecycle state of the addon.
+     *
+     * @internal
+     */
+    final public function setState(AddonState $state): void
     {
-        return $this->isInstalled() && (bool) $this->getProperty('status', false);
+        $this->state = $state;
     }
 
-    /** Returns if the addon is installed. */
+    /** Returns if the addon is activated (and therefore installed). */
+    final public function isActivated(): bool
+    {
+        return AddonState::Activated === $this->state;
+    }
+
+    /** Returns if the addon is installed (activated or not). */
     final public function isInstalled(): bool
     {
-        return (bool) $this->getProperty('install', false);
+        return AddonState::Uninstalled !== $this->state;
     }
 
     final public function getAuthor(?string $default = null): ?string
@@ -369,13 +382,10 @@ abstract class Addon
             $properties = $cache[$id]['data'];
         }
 
-        $this->properties = array_intersect_key($this->properties, ['install' => null, 'status' => null]);
+        $this->properties = [];
         if ($properties) {
             foreach ($properties as $key => $value) {
                 $key = Type::string($key);
-                if (isset($this->properties[$key])) {
-                    continue;
-                }
                 if ('supportpage' !== $key) {
                     $value = I18n::translateArray($value, false, $this->i18n(...));
                 } elseif (null !== $value && !preg_match('@^https?://@i', $value)) {
@@ -465,14 +475,14 @@ abstract class Addon
     /**
      * Install hook — runs on install/reinstall. Override for schema/data setup. Must be idempotent.
      *
-     * @throws UserMessageException
+     * @throws UserMessageException to abort the installation with a message
      */
     public function install(): void {}
 
     /**
      * Uninstall hook — runs on uninstall. Override for cleanup.
      *
-     * @throws UserMessageException
+     * @throws UserMessageException to abort the uninstallation with a message
      */
     public function uninstall(): void {}
 
@@ -497,13 +507,13 @@ abstract class Addon
     }
 
     /**
-     * Returns the available addons.
+     * Returns the activated addons.
      *
      * @return array<non-empty-string, self>
      */
-    final public static function getAvailableAddons(): array
+    final public static function getActivatedAddons(): array
     {
-        return self::filterPackages(self::$addons, 'isAvailable');
+        return self::filterPackages(self::$addons, 'isActivated');
     }
 
     /**
@@ -530,7 +540,7 @@ abstract class Addon
         } else {
             $config = [];
             foreach (Core::getProperty('setup_addons') as $addon) {
-                $config[(string) $addon]['install'] = false;
+                $config[(string) $addon]['state'] = AddonState::Uninstalled->value;
             }
         }
 
@@ -559,8 +569,7 @@ abstract class Addon
                 }
                 $addon = new $class($composerPackages[$addonName], $addonName);
             }
-            $addon->setProperty('install', $addonConfig['install'] ?? false);
-            $addon->setProperty('status', $addonConfig['status'] ?? false);
+            $addon->state = AddonState::from($addonConfig['state'] ?? AddonState::Uninstalled->value);
             self::$addons[$addonName] = $addon;
         }
     }

--- a/src/Addon/AddonManager.php
+++ b/src/Addon/AddonManager.php
@@ -29,7 +29,7 @@ use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
 
 /**
- * @phpstan-type TAddonConfig array<non-empty-string, array{class: class-string<Addon>, install: bool, status: bool}>
+ * @phpstan-type TAddonConfig array<non-empty-string, array{class: class-string<Addon>, state: value-of<AddonState>}>
  * @phpstan-type TAddonOrder list<non-empty-string>
  */
 class AddonManager
@@ -83,29 +83,13 @@ class AddonManager
                 throw new UserMessageException($message);
             }
 
-            $reinstall = $this->addon->getProperty('install');
-            $this->addon->setProperty('install', true);
+            $reinstall = $this->addon->isInstalled();
 
             I18n::addDirectory($this->addon->getPath('lang'));
 
-            // run install hook
+            // run install hook (can only abort by throwing a UserMessageException)
             $this->addon->install();
             $successMessage = (string) $this->addon->getProperty('successmsg', '');
-
-            /** @psalm-taint-escape html */
-            $instmsg = (string) $this->addon->getProperty('installmsg', '');
-            if ('' != $instmsg) {
-                throw new UserMessageException($instmsg);
-            }
-            if (!$this->addon->isInstalled()) {
-                throw new UserMessageException($this->i18n('no_reason'));
-            }
-
-            if (!$reinstall) {
-                $this->addon->setProperty('status', true);
-            }
-            static::saveConfig();
-            self::generateAddonOrder();
 
             foreach ($this->addon->getProperty('default_config', []) as $key => $value) {
                 if (!$this->addon->hasConfig($key)) {
@@ -121,6 +105,13 @@ class AddonManager
                 }
             }
 
+            // everything succeeded — commit (fresh installs are activated right away)
+            if (!$reinstall) {
+                $this->addon->setState(AddonState::Activated);
+            }
+            static::saveConfig();
+            self::generateAddonOrder();
+
             $this->message = $this->i18n($reinstall ? 'reinstalled' : 'installed', $this->addon->name);
             if ($successMessage) {
                 $this->message .= ' ' . $successMessage;
@@ -131,7 +122,6 @@ class AddonManager
             $this->message = $e->getMessage();
         }
 
-        $this->addon->setProperty('install', false);
         $this->message = $this->i18n('no_install', $this->addon->name) . '<br />' . $this->message;
 
         return false;
@@ -144,29 +134,19 @@ class AddonManager
      */
     public function uninstall(): bool
     {
-        $isActivated = $this->addon->isAvailable();
+        $originalState = $this->addon->state;
+        $isActivated = $this->addon->isActivated();
         if ($isActivated && !$this->deactivate()) {
             return false;
         }
 
         try {
-            $this->addon->setProperty('install', false);
-
             if (!$isActivated) {
                 I18n::addDirectory($this->addon->getPath('lang'));
             }
 
-            // run uninstall hook
+            // run uninstall hook (can only abort by throwing a UserMessageException)
             $this->addon->uninstall();
-
-            /** @psalm-taint-escape html */
-            $instmsg = (string) $this->addon->getProperty('installmsg', '');
-            if ('' != $instmsg) {
-                throw new UserMessageException($instmsg);
-            }
-            if ($this->addon->isInstalled()) {
-                throw new UserMessageException($this->i18n('no_reason'));
-            }
 
             // delete assets
             $assets = $this->addon->getAssetsPath();
@@ -179,6 +159,8 @@ class AddonManager
 
             Config::removeNamespace($this->addon->name);
 
+            // everything succeeded — commit the new state
+            $this->addon->setState(AddonState::Uninstalled);
             static::saveConfig();
             $this->message = $this->i18n('uninstalled', $this->addon->name);
 
@@ -187,11 +169,12 @@ class AddonManager
             $this->message = $e->getMessage();
         }
 
-        $this->addon->setProperty('install', true);
         if ($isActivated) {
-            $this->addon->setProperty('status', true);
+            // the deactivation was already committed — restore the previous state
+            $this->addon->setState($originalState);
+            static::saveConfig();
+            self::generateAddonOrder();
         }
-        static::saveConfig();
         $this->message = $this->i18n('no_uninstall', $this->addon->name) . '<br />' . $this->message;
 
         return false;
@@ -204,30 +187,19 @@ class AddonManager
      */
     public function activate(): bool
     {
-        if ($this->addon->isInstalled()) {
-            $state = '';
-            if (!$this->checkRequirements()) {
-                $state .= $this->message;
-            }
-            $state = $state ?: true;
-
-            if (true === $state) {
-                $this->addon->setProperty('status', true);
-                static::saveConfig();
-            }
-            if (true === $state) {
-                self::generateAddonOrder();
-            }
-        } else {
-            $state = $this->i18n('not_installed', $this->addon->name);
-        }
-
-        if (true !== $state) {
-            // error while config generation, rollback addon status
-            $this->addon->setProperty('status', false);
-            $this->message = $this->i18n('no_activation', $this->addon->name) . '<br />' . $state;
+        if (!$this->addon->isInstalled()) {
+            $this->message = $this->i18n('no_activation', $this->addon->name) . '<br />' . $this->i18n('not_installed', $this->addon->name);
             return false;
         }
+
+        if (!$this->checkRequirements()) {
+            $this->message = $this->i18n('no_activation', $this->addon->name) . '<br />' . $this->message;
+            return false;
+        }
+
+        $this->addon->setState(AddonState::Activated);
+        static::saveConfig();
+        self::generateAddonOrder();
 
         $this->message = $this->i18n('activated', $this->addon->name);
         return true;
@@ -240,10 +212,8 @@ class AddonManager
      */
     public function deactivate(): bool
     {
-        $state = $this->checkDependencies();
-
-        if ($state) {
-            $this->addon->setProperty('status', false);
+        if ($this->checkDependencies()) {
+            $this->addon->setState(AddonState::Installed);
             static::saveConfig();
 
             // clear cache of addon
@@ -275,7 +245,7 @@ class AddonManager
         $state = [];
 
         foreach (self::getRequiredAddons($this->addon) as $addonName) {
-            if (Addon::get($addonName)?->isAvailable()) {
+            if (Addon::get($addonName)?->isActivated()) {
                 continue;
             }
 
@@ -300,7 +270,7 @@ class AddonManager
         $i18nPrefix = 'package_dependencies_error_';
         $state = [];
 
-        foreach (Addon::getAvailableAddons() as $addon) {
+        foreach (Addon::getActivatedAddons() as $addon) {
             if ($addon === $this->addon) {
                 continue;
             }
@@ -368,7 +338,7 @@ class AddonManager
                 }
             }
         };
-        foreach (Addon::getAvailableAddons() as $addon) {
+        foreach (Addon::getActivatedAddons() as $addon) {
             $id = $addon->name;
             if (LoadOrder::Early === $addon->load) {
                 $early[] = $id;
@@ -397,8 +367,7 @@ class AddonManager
         $config = [];
         foreach (Addon::getRegisteredAddons() as $addonName => $addon) {
             $config[$addonName]['class'] = $addon::class;
-            $config[$addonName]['install'] = $addon->isInstalled();
-            $config[$addonName]['status'] = $addon->isAvailable();
+            $config[$addonName]['state'] = $addon->state->value;
         }
 
         self::saveAddonsData(config: $config);
@@ -423,12 +392,9 @@ class AddonManager
             }
             $config[$addonName]['class'] = $addonClasses[$addonName];
             if (!Addon::exists($addonName)) {
-                $config[$addonName]['install'] = false;
-                $config[$addonName]['status'] = false;
+                $config[$addonName]['state'] = AddonState::Uninstalled->value;
             } else {
-                $addon = Addon::require($addonName);
-                $config[$addonName]['install'] = $addon->isInstalled();
-                $config[$addonName]['status'] = $addon->isAvailable();
+                $config[$addonName]['state'] = Addon::require($addonName)->state->value;
             }
         }
         ksort($config);

--- a/src/Addon/AddonState.php
+++ b/src/Addon/AddonState.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Redaxo\Core\Addon;
+
+/** Lifecycle state of an addon. */
+enum AddonState: string
+{
+    /** Not installed. */
+    case Uninstalled = 'uninstalled';
+
+    /** Installed but not activated. */
+    case Installed = 'installed';
+
+    /** Installed and activated. */
+    case Activated = 'activated';
+}

--- a/src/Addon/ApiFunction/AddonOperation.php
+++ b/src/Addon/ApiFunction/AddonOperation.php
@@ -40,8 +40,8 @@ final class AddonOperation extends ApiFunction
         }
 
         if ('uninstall' == $function && !$package->isInstalled()
-            || 'activate' == $function && $package->isAvailable()
-            || 'deactivate' == $function && !$package->isAvailable()
+            || 'activate' == $function && $package->isActivated()
+            || 'deactivate' == $function && !$package->isActivated()
         ) {
             return new Result(true);
         }

--- a/src/Backend/Controller.php
+++ b/src/Backend/Controller.php
@@ -355,7 +355,7 @@ final class Controller
 
     public static function appendPackagePages(): void
     {
-        $addons = Core::isSafeMode() ? Addon::getSetupAddons() : Addon::getAvailableAddons();
+        $addons = Core::isSafeMode() ? Addon::getSetupAddons() : Addon::getActivatedAddons();
         foreach ($addons as $addon) {
             foreach ($addon->getPages() as $page) {
                 self::registerAddonPage($page, $addon);
@@ -515,7 +515,7 @@ final class Controller
     private static function includePath(string $path, array $context = []): mixed
     {
         return Timer::measure('Page: ' . Path::relative($path), function () use ($path, $context) {
-            foreach (Addon::getAvailableAddons() as $addon) {
+            foreach (Addon::getActivatedAddons() as $addon) {
                 if (str_starts_with($path, $addon->path . DIRECTORY_SEPARATOR)) {
                     return $addon->includeFile($path, $context);
                 }

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -272,7 +272,7 @@ final class ClassDiscovery
         $paths[] = __DIR__ . DIRECTORY_SEPARATOR;
 
         // Active addon paths
-        foreach (Addon::getAvailableAddons() as $addon) {
+        foreach (Addon::getActivatedAddons() as $addon) {
             $paths[] = $addon->path . DIRECTORY_SEPARATOR;
         }
 
@@ -366,7 +366,7 @@ final class ClassDiscovery
     private function getAddonHash(): string
     {
         $parts = [];
-        foreach (Addon::getAvailableAddons() as $addon) {
+        foreach (Addon::getActivatedAddons() as $addon) {
             $parts[] = $addon->name . ':' . $addon->getVersion();
         }
 

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -46,7 +46,7 @@ abstract class AbstractCommand extends Command
         if (false !== $file) {
             $file = realpath($file) ?: $file;
 
-            foreach (Addon::getAvailableAddons() as $addon) {
+            foreach (Addon::getActivatedAddons() as $addon) {
                 if (str_starts_with($file, $addon->path . DIRECTORY_SEPARATOR)) {
                     return $addon;
                 }

--- a/src/Console/Command/AddonActivateCommand.php
+++ b/src/Console/Command/AddonActivateCommand.php
@@ -18,7 +18,7 @@ final class AddonActivateCommand extends AbstractCommand
     public function __invoke(
         SymfonyStyle $io,
         #[Argument('The id of the addon, e.g. "yform"', suggestedValues: static function (): array {
-            return array_keys(array_filter(Addon::getRegisteredAddons(), static fn (Addon $addon): bool => !$addon->isAvailable()));
+            return array_keys(array_filter(Addon::getRegisteredAddons(), static fn (Addon $addon): bool => !$addon->isActivated()));
         })] string $addon,
     ): int {
         // the package manager don't know new packages in the addon folder

--- a/src/Console/Command/AddonDeactivateCommand.php
+++ b/src/Console/Command/AddonDeactivateCommand.php
@@ -18,7 +18,7 @@ final class AddonDeactivateCommand extends AbstractCommand
     public function __invoke(
         SymfonyStyle $io,
         #[Argument('The name of the addon, e.g. "yform"', suggestedValues: static function (): array {
-            return array_keys(Addon::getAvailableAddons());
+            return array_keys(Addon::getActivatedAddons());
         })] string $addon,
     ): int {
         // the package manager don't know new packages in the addon folder

--- a/src/Console/Command/AddonListCommand.php
+++ b/src/Console/Command/AddonListCommand.php
@@ -39,7 +39,7 @@ final class AddonListCommand extends AbstractCommand
                 'author' => $package->getAuthor(),
                 'version' => $package->getVersion(),
                 'installed' => $package->isInstalled(),
-                'activated' => $package->isAvailable(),
+                'activated' => $package->isActivated(),
                 'license' => $package->getLicense(),
             ];
 
@@ -60,7 +60,7 @@ final class AddonListCommand extends AbstractCommand
                 continue;
             }
 
-            if ($activatedOnly && !$package->isAvailable()) {
+            if ($activatedOnly && !$package->isActivated()) {
                 continue;
             }
 

--- a/src/ExtensionPoint/Extension.php
+++ b/src/ExtensionPoint/Extension.php
@@ -135,7 +135,7 @@ abstract class Extension
             } elseif (is_subclass_of($entry['class'], Addon::class)) {
                 if (null === $addonByClass) {
                     $addonByClass = [];
-                    foreach (Addon::getAvailableAddons() as $addon) {
+                    foreach (Addon::getActivatedAddons() as $addon) {
                         $addonByClass[$addon::class] = $addon;
                     }
                 }

--- a/src/SystemReport.php
+++ b/src/SystemReport.php
@@ -107,7 +107,7 @@ final class SystemReport
         }
 
         $packages = [];
-        foreach (Addon::getAvailableAddons() as $package) {
+        foreach (Addon::getActivatedAddons() as $package) {
             $packages[$package->name] = $package->getVersion();
         }
 


### PR DESCRIPTION
## Was

Ersetzt die getrennten `install`- und `status`-Properties eines Addons durch ein einziges typisiertes `AddonState`-Enum mit drei Zuständen: `Uninstalled`, `Installed`, `Activated`.

Bisher lagen Installations- und Aktivierungsstatus als generische Properties im selben Topf wie die addon-eigenen Werte aus `package.yml` — inklusive eines `array_intersect_key`-Hacks in `loadProperties()`, um sie beim Reload zu retten. Außerdem konnte die Kombination `install=false / status=true` zwar im Speicher kurz entstehen, war aber persistiert ohnehin unmöglich. Es gibt real nur drei Zustände — die bildet das Enum jetzt sauber ab.

## Änderungen

- Neues `AddonState`-Enum (string-backed) + typisierte `Addon::$state`-Property (`public private(set)`), gesetzt über `@internal setState()`.
- `addons.json` speichert `state` statt `install`/`status`. **Keine Migration** — bei bestehenden Dev-Installs schreibt `console migrate`/Sync das Format neu.
- `Addon::isAvailable()` → `isActivated()`, `Addon::getAvailableAddons()` → `getActivatedAddons()`. Der Begriff „available" entfällt zugunsten von „activated".
- Install-/Uninstall-Hooks brechen nur noch per `throw new UserMessageException(...)` ab; die alte `installmsg`-Property ist entfernt. `successmsg` bleibt für custom Erfolgsmeldungen.
- Die Lifecycle-Methoden (`install`/`uninstall`/`activate`/`deactivate`) committen den neuen State nur noch im Erfolgsfall — kein Vorab-Setzen mit Rollback mehr. Ausnahme: schlägt das Uninstall nach erfolgreichem Deaktivieren fehl, wird der vorherige Zustand wiederhergestellt (inkl. Load-Order-Regenerierung).
- Rector-Migrationsregeln für die umbenannten Methoden ergänzt.

## Breaking Changes

- `Addon::isAvailable()` und `Addon::getAvailableAddons()` umbenannt (Rector-Regeln vorhanden).
- `addons.json`-Format geändert (`install`/`status` → `state`).
- `installmsg`-Property wird nicht mehr ausgewertet — Hooks müssen über `UserMessageException` abbrechen.