### PR TITLE
refactor: clean up version handling

### DIFF
--- a/pages/setup/index.php
+++ b/pages/setup/index.php
@@ -291,7 +291,6 @@ if ($step > 4 && $createdb > -1) {
 
     if (0 == count($errors)) {
         LanguageHandler::generateCache();
-        Core::setConfig('version', Core::getVersion());
     } else {
         $step = 4;
         $context->setParam('step', $step);

--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -257,14 +257,7 @@ abstract class Addon
     /** @param string|null $format See {@link Formatter::version()} */
     final public function getVersion(?string $format = null): string
     {
-        $version = $this->getProperty('version');
-
-        if (null === $version) {
-            $version = InstalledVersions::getPrettyVersion($this->package) ?? '';
-            $this->setProperty('version', $version);
-        }
-
-        Type::string($version);
+        $version = InstalledVersions::getPrettyVersion($this->package) ?? '';
 
         if ($format) {
             return Formatter::version($version, $format);

--- a/src/Console/Command/SetupRunCommand.php
+++ b/src/Console/Command/SetupRunCommand.php
@@ -454,7 +454,6 @@ final class SetupRunCommand extends AbstractCommand implements OnlySetupAddonsIn
         }
 
         LanguageHandler::generateCache();
-        Core::setConfig('version', Core::getVersion());
 
         // ---------------------------------- Step 5 . Create User
         $io->title('Step 5 of 5 / User');

--- a/src/Core.php
+++ b/src/Core.php
@@ -143,11 +143,6 @@ final class Core
                     throw new InvalidArgumentException(sprintf('"%s" property: expecting $value to be an instance of %s, "%s" found.', $key, Application::class, get_debug_type($value)));
                 }
                 break;
-            case 'version':
-                if (!is_string($value) || !preg_match('/^\d+(?:\.\d+)*(?:\.x)*(?:-\w+)?$/', $value)) {
-                    throw new InvalidArgumentException(sprintf('"%s" property: expecting $value to be a valid version string, got %s.', $key, is_string($value) ? '"' . $value . '"' : get_debug_type($value)));
-                }
-                break;
         }
         $exists = isset(self::$properties[$key]);
         self::$properties[$key] = $value;
@@ -174,7 +169,6 @@ final class Core
      *      ($key is 'timezone' ? string :
      *      ($key is 'table_prefix' ? non-empty-string :
      *      ($key is 'temp_prefix' ? non-empty-string :
-     *      ($key is 'version' ? string :
      *      ($key is 'server' ? string :
      *      ($key is 'servername' ? string :
      *      ($key is 'error_email' ? string :
@@ -189,7 +183,7 @@ final class Core
      *      ($key is 'setup' ? bool|array<string, int> :
      *      ($key is 'setup_addons' ? non-empty-string[] :
      *      mixed|null
-     *      )))))))))))))))))))))))))))
+     *      ))))))))))))))))))))))))))
      * ) The value for $key or $default if $key cannot be found
      */
     public static function getProperty(string $key, mixed $default = null): mixed
@@ -433,19 +427,12 @@ final class Core
      */
     public static function getVersion(?string $format = null): string
     {
-        /** @psalm-taint-escape file */
-        $version = self::getProperty('version');
+        $version = Type::string(InstalledVersions::getPrettyVersion('redaxo/core'));
 
-        if (!$version) {
-            $version = Type::string(InstalledVersions::getPrettyVersion('redaxo/core'));
-
-            // On feature branches Composer returns "dev-<branch>", which is not
-            // a meaningful version. Fall back to a generic dev version.
-            if (str_starts_with($version, 'dev-')) {
-                $version = '6.x-dev';
-            }
-
-            self::setProperty('version', $version);
+        // On feature branches Composer returns "dev-<branch>", which is not
+        // a meaningful version. Fall back to a generic dev version.
+        if (str_starts_with($version, 'dev-')) {
+            $version = '6.x-dev';
         }
 
         if ($format) {


### PR DESCRIPTION
## Was

Räumt das Version-Handling in `Core` und `Addon` auf.

Der erste Commit wirft die write-only `version`-Core-Config raus (ein 5.x-Relikt der Versions-Diff-Update-Erkennung; 6.x updatet über idempotente `install.php` / `console migrate`).

Aufbauend darauf liest der zweite Commit die Version nur noch aus Composer:

- Die `version`-Property wurde ohnehin nur von `getVersion()` selbst als In-Memory-Cache gesetzt — niemand sonst schreibt sie mehr. Composers `InstalledVersions` cached `installed.php` bereits statisch, die Memoization sparte also nichts.
- `getVersion()` liest jetzt direkt aus `InstalledVersions`.
- Entfernt den toten `version`-Validierungs-`case` in `Core::setProperty()`, den `version`-Eintrag in der `getProperty()`-Type-Map und den obsoleten `@psalm-taint-escape file` (der Composer-Wert ist keine Taint-Quelle — per `composer taint` verifiziert).
- Für Addons ist Composer damit Single Source of Truth: ein verirrtes `version:` in der `package.yml` kann die Composer-Version nicht mehr überschreiben.

Alle Checks grün (PHPUnit, PHPStan, Psalm, Taint, CS).