### PR TITLE
refactor!: remove package.yml

### DIFF
--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -22,24 +22,6 @@
             </SchemaInfo>
           </value>
         </entry>
-        <entry key="package.yml">
-          <value>
-            <SchemaInfo>
-              <option name="name" value="package.yml" />
-              <option name="relativePathToSchema" value="schemas/package.json" />
-              <option name="schemaVersion" value="JSON Schema 7" />
-              <option name="patterns">
-                <list>
-                  <Item>
-                    <option name="pattern" value="true" />
-                    <option name="path" value="package.yml" />
-                    <option name="mappingKind" value="Pattern" />
-                  </Item>
-                </list>
-              </option>
-            </SchemaInfo>
-          </value>
-        </entry>
       </map>
     </state>
   </component>

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1451,31 +1451,17 @@
     </PossiblyNullReference>
   </file>
   <file src="src/Addon/Addon.php">
-    <MixedArgument>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$value]]></code>
-    </MixedOperand>
     <PossiblyFalseArgument>
       <code><![CDATA[$f]]></code>
       <code><![CDATA[$f]]></code>
     </PossiblyFalseArgument>
   </file>
   <file src="src/Addon/AddonManager.php">
-    <MixedArgument>
-      <code><![CDATA[$key]]></code>
-    </MixedArgument>
     <MixedArrayOffset>
       <code><![CDATA[$ps[$id]]]></code>
       <code><![CDATA[$requires[$id]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
-      <code><![CDATA[$key]]></code>
       <code><![CDATA[$normal[]]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ This repository contains the **REDAXO core** under `src/` (`Redaxo\Core\`), back
 
 ### Key concepts
 - **`Core` static class** (`src/Core.php`) — central application registry for paths, config, request, current user.
-- **Addon system** — `Addon` / `AddonManager` (`src/Addon/`). Each addon has a `package.yml` (metadata + page config) plus optional `boot.php` (runtime init) and `install.php` (schema/data setup — must be idempotent, runs on every `console migrate`).
+- **Addon system** — `Addon` / `AddonManager` (`src/Addon/`). Each addon is a subclass of `Addon`, registered via composer.json `extra.redaxo.addon-class`. Metadata comes from composer.json; integration happens through overridable hooks — `boot()` (runtime init), `install()`/`uninstall()` (schema/data setup — must be idempotent, runs on every `console migrate`), `getPages()` (backend pages) — plus the `$load` and `$defaultConfig` properties.
 - **Extension points** — REDAXO's hook/event system: register listeners with `Extension::register('NAME', ...)`, fire points with `Extension::registerPoint(new ExtensionPoint(...))`. Classes live under `Redaxo\Core\ExtensionPoint`. This is the primary integration mechanism for addons.
 - **Fragments** (`fragments/`) — template snippets rendered via `Fragment` (`src/View/Fragment.php`).
 - **Boot flow** — `AbstractProject` (Symfony `RuntimeInterface`) drives boot via `boot/core.php` → `boot/addons.php` → environment entry (`boot/backend.php`, `boot/frontend.php`, `boot/console.php`).

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -327,7 +327,6 @@ package_activate = aktivieren
 package_yes = ja
 package_no = nein
 package_caption = Liste der verfügbaren Packages
-package_invalid_yml_file = Die package.yml ist invalid:
 package_install_cant_copy_files = Fehler beim Kopieren des /assets Ordners!
 package_install_cant_delete_files = Fehler beim Löschen des /assets Ordners!
 package_jump_to = Zu "{0}" springen

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -326,7 +326,6 @@ package_activate = activate
 package_yes = yes
 package_no = no
 package_caption = List of available packages
-package_invalid_yml_file = The file package.yml is invalid:
 package_install_cant_copy_files = An error occurred when copying the /assets folder!
 package_install_cant_delete_files = An error occurred when deleting the /assets folder!
 package_jump_to = Jump to "{0}"

--- a/pages/system/report.html.php
+++ b/pages/system/report.html.php
@@ -23,7 +23,7 @@ foreach ($report as $title => $group) {
     foreach ($group as $label => $value) {
         if (SystemReport::TITLE_PACKAGES === $title || SystemReport::TITLE_REDAXO === $title) {
             if (null === $value) {
-                throw new RuntimeException('Package ' . $label . ' does not define a proper version in its package.yml.');
+                throw new RuntimeException('Package ' . $label . ' does not define a proper version in its composer.json.');
             }
             if (Version::isUnstable($value)) {
                 $value = '<i class="rex-icon rex-icon-unstable-version" title="' . I18n::msg('unstable_version') . '"></i> ' . escape($value);

--- a/schemas/package.json
+++ b/schemas/package.json
@@ -3,11 +3,6 @@
     "$id": "https://redaxo.org/schemas/package.json",
     "title": "JSON schema for REDAXO package.yml",
     "type": "object",
-    "properties": {
-        "default_config": {
-            "description": "Default values for Redaxo\\Core\\Config",
-            "type": "object"
-        }
-    },
+    "properties": {},
     "additionalProperties": true
 }

--- a/schemas/package.json
+++ b/schemas/package.json
@@ -1,8 +1,0 @@
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://redaxo.org/schemas/package.json",
-    "title": "JSON schema for REDAXO package.yml",
-    "type": "object",
-    "properties": {},
-    "additionalProperties": true
-}

--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -62,6 +62,13 @@ abstract class Addon
     /** Loading position relative to other addons during boot. Override to load this addon early or late. */
     public protected(set) LoadOrder $load = LoadOrder::Normal;
 
+    /**
+     * Default config values applied on install (only for keys that are not already set). Override to provide defaults.
+     *
+     * @var array<string, mixed>
+     */
+    public protected(set) array $defaultConfig = [];
+
     /** Lifecycle state of the addon. */
     public private(set) AddonState $state = AddonState::Uninstalled;
 

--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -16,7 +16,6 @@ use Redaxo\Core\Filesystem\File;
 use Redaxo\Core\Filesystem\Path;
 use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\Translation\I18n;
-use Redaxo\Core\Util\Exception\YamlParseException;
 use Redaxo\Core\Util\Formatter;
 use Redaxo\Core\Util\Type;
 use Redaxo\Core\View\Fragment;
@@ -33,10 +32,6 @@ use const JSON_THROW_ON_ERROR;
 
 abstract class Addon
 {
-    final public const string FILE_PACKAGE = 'package.yml';
-
-    private const string PROPERTIES_CACHE_FILE = 'packages.cache';
-
     /**
      * Array of all addons.
      *
@@ -78,9 +73,6 @@ abstract class Addon
      * @var array<string, mixed>
      */
     private array $properties = [];
-
-    /** Flag whether the properties of package.yml are loaded. */
-    private bool $propertiesLoaded = false;
 
     /** @var array<string, mixed>|null */
     private ?array $composerJson = null;
@@ -212,9 +204,6 @@ abstract class Addon
     /** @param non-empty-string $key */
     final public function hasProperty(string $key): bool
     {
-        if (!isset($this->properties[$key]) && !$this->propertiesLoaded) {
-            $this->loadProperties();
-        }
         return isset($this->properties[$key]);
     }
 
@@ -328,75 +317,6 @@ abstract class Addon
         return I18n::msg($key, ...$replacements);
     }
 
-    /** Loads the properties of package.yml. */
-    final public function loadProperties(bool $force = false): void
-    {
-        $file = $this->getPath(self::FILE_PACKAGE);
-        if (!is_file($file)) {
-            $this->propertiesLoaded = true;
-            return;
-        }
-
-        /** @var array<string, array{timestamp: int, data: array<string, mixed>}>|null $cache */
-        static $cache = null;
-        if (null === $cache) {
-            /** @var array<string, array{timestamp: int, data: array<string, mixed>}> $cache */
-            $cache = File::getCache(Path::coreCache(self::PROPERTIES_CACHE_FILE));
-        }
-        $id = $this->name;
-
-        if ($force) {
-            unset($cache[$id]);
-        }
-
-        $isCached = isset($cache[$id]);
-        $isBackendAdmin = Core::isBackend() && Core::getUser()?->admin;
-        if (!$isCached || (Core::getConsole() || $isBackendAdmin) && $cache[$id]['timestamp'] < filemtime($file)) {
-            try {
-                $properties = File::getConfig($file);
-
-                $cache[$id]['timestamp'] = filemtime($file);
-                $cache[$id]['data'] = $properties;
-
-                /** @var bool $registeredShutdown */
-                static $registeredShutdown = false;
-                if (!$registeredShutdown) {
-                    $registeredShutdown = true;
-                    register_shutdown_function(static function () use (&$cache) {
-                        foreach ($cache as $addon => $_) {
-                            if (!self::exists($addon)) {
-                                unset($cache[$addon]);
-                            }
-                        }
-                        File::putCache(Path::coreCache(self::PROPERTIES_CACHE_FILE), $cache);
-                    });
-                }
-            } catch (YamlParseException $exception) {
-                if ($this->isInstalled()) {
-                    throw $exception;
-                }
-
-                $properties = [];
-            }
-        } else {
-            $properties = $cache[$id]['data'];
-        }
-
-        $this->properties = [];
-        if ($properties) {
-            foreach ($properties as $key => $value) {
-                $key = Type::string($key);
-                if ('supportpage' !== $key) {
-                    $value = I18n::translateArray($value, false, $this->i18n(...));
-                } elseif (null !== $value && !preg_match('@^https?://@i', $value)) {
-                    $value = 'https://' . $value;
-                }
-                $this->properties[$key] = $value;
-            }
-        }
-        $this->propertiesLoaded = true;
-    }
-
     final public function getLicense(): ?string
     {
         /** @var string|list<string>|null $license */
@@ -428,12 +348,6 @@ abstract class Addon
         $cacheDir = $this->getCachePath();
         if (!Dir::delete($cacheDir)) {
             throw new RuntimeException('Addon cache directory "' . $cacheDir . '" is not writable.');
-        }
-
-        $cache = File::getCache($path = Path::coreCache(self::PROPERTIES_CACHE_FILE));
-        if ($cache) {
-            unset($cache[$this->name]);
-            File::putCache($path, $cache);
         }
 
         Extension::registerPoint(new AddonCacheDeleted($this));

--- a/src/Addon/AddonManager.php
+++ b/src/Addon/AddonManager.php
@@ -91,7 +91,7 @@ class AddonManager
             $this->addon->install();
             $successMessage = (string) $this->addon->getProperty('successmsg', '');
 
-            foreach ($this->addon->getProperty('default_config', []) as $key => $value) {
+            foreach ($this->addon->defaultConfig as $key => $value) {
                 if (!$this->addon->hasConfig($key)) {
                     $this->addon->setConfig($key, $value);
                 }

--- a/src/Addon/AddonManager.php
+++ b/src/Addon/AddonManager.php
@@ -14,7 +14,6 @@ use Redaxo\Core\Filesystem\File;
 use Redaxo\Core\Filesystem\Path;
 use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\Translation\I18n;
-use Redaxo\Core\Util\Exception\YamlParseException;
 use Redaxo\Core\Util\Str;
 use Redaxo\Core\Util\Type;
 
@@ -66,14 +65,6 @@ class AddonManager
     public function install(): bool
     {
         try {
-            // check package.yml
-            $addonFile = $this->addon->getPath(Addon::FILE_PACKAGE);
-            try {
-                File::getConfig($addonFile);
-            } catch (YamlParseException $e) {
-                throw new UserMessageException($this->i18n('invalid_yml_file') . ' ' . $e->getMessage());
-            }
-
             // check requirements and conflicts
             $message = '';
             if (!$this->checkRequirements()) {

--- a/src/Console/CommandLoader.php
+++ b/src/Console/CommandLoader.php
@@ -22,7 +22,7 @@ use function sprintf;
 /**
  * Discovers all commands that are marked with the {@see AsCommand} attribute and extend {@see AbstractCommand},
  * both in the core and in the active addons. Addons therefore register their commands simply by adding the
- * attribute to a command class — no `package.yml` configuration is required.
+ * attribute to a command class.
  *
  * Commands are returned as {@see LazyCommand}, so that listing the commands (e.g. `console list`) does not
  * instantiate every command class — only the command that is actually executed is instantiated.


### PR DESCRIPTION
Removes `package.yml` from addons entirely. It was already reduced to a single meaningful value (`default_config`); this finishes the job.

Two commits:

1. **`default_config` → `Addon::$defaultConfig`** — the last documented `package.yml` value now lives as an overridable `public protected(set) array $defaultConfig` property on the addon class, mirroring how `$load` is handled.
2. **Drop `package.yml` loading and its caching** — `loadProperties()`, the `packages.cache` properties cache, the install-time `package.yml` parse check and the `package.yml` JSON schema are gone.

The in-memory property store (`get`/`has`/`set`/`removeProperty`) stays — `successmsg` is still set from within the `install()` hook and read afterwards.

## Breaking changes

- Addons must no longer ship a `package.yml`. Config defaults move to the `$defaultConfig` property.
- `Addon::FILE_PACKAGE`, `Addon::loadProperties()` and the `package.yml` JSON schema are removed.
