### PR TITLE
fix: persist errormail throttle state via setConfig instead of getConfig

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -340,8 +340,8 @@ class Mailer extends PHPMailer
 
         if ($mail->Send()) {
             // Update configuration only if email was sent successfully
-            Core::getConfig('phpmailer_last_errors', $currentErrorsHash);
-            Core::getConfig('phpmailer_last_log_file_send_time', time());
+            Core::setConfig('phpmailer_last_errors', $currentErrorsHash);
+            Core::setConfig('phpmailer_last_log_file_send_time', time());
         }
     }
 


### PR DESCRIPTION
## Problem

In `Mailer::errorMail()` wurden der Hash der letzten Fehler und der Sende-Zeitstempel mit `getConfig` statt `setConfig` gespeichert:

```php
Core::getConfig('phpmailer_last_errors', $currentErrorsHash);
Core::getConfig('phpmailer_last_log_file_send_time', time());
```

Dadurch wurden die Werte nie persistiert – das zweite Argument wird von `getConfig` lediglich als Default-Wert interpretiert und verworfen. Die kombinierte Zeit-/Inhalts-Drosselung beim Versand von Fehler-Mails lief damit faktisch ins Leere.

## Ursache

Eingeschleppt in #5894, als das PhpMailer-Addon in den Core aufgelöst wurde. Im Original-Addon war es noch korrekt `$addon->setConfig(...)`; beim Umbau auf die `rex::`-Config-API ist `set` zu `get` verrutscht.

## Fix

Beide Aufrufe auf `setConfig` korrigiert.