### PR TITLE
feat: introduce Environment enum for the runtime environment

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -14,8 +14,6 @@ override(
     ])
 );
 
-expectedReturnValues(\Redaxo\Core\Core::getEnvironment(), 'frontend', 'backend', 'console');
-
 expectedArguments(Redaxo\Core\ExtensionPoint\Extension::register(), 2, \Redaxo\Core\ExtensionPoint\Extension::EARLY, \Redaxo\Core\ExtensionPoint\Extension::NORMAL, \Redaxo\Core\ExtensionPoint\Extension::LATE);
 
 expectedArguments(\Redaxo\Core\Filesystem\Finder::sort(), 0, \Redaxo\Core\Util\SortableIterator::KEYS, \Redaxo\Core\Util\SortableIterator::VALUES);

--- a/.tools/bin/console
+++ b/.tools/bin/console
@@ -2,7 +2,8 @@
 <?php
 
 use Project\Project;
+use Redaxo\Core\Environment;
 
 require_once dirname(__DIR__, 2) . '/vendor/autoload_runtime.php';
 
-return static fn (array $context) => new Project('console');
+return static fn (array $context) => new Project(Environment::Console);

--- a/.tools/bootstrap.php
+++ b/.tools/bootstrap.php
@@ -1,11 +1,12 @@
 <?php
 
 use Project\Project;
+use Redaxo\Core\Environment;
 use Redaxo\Core\ErrorHandler;
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-$project = new Project('console');
+$project = new Project(Environment::Console);
 
 $project->bootCore();
 $project->bootAddons();

--- a/.tools/project/public/index.php
+++ b/.tools/project/public/index.php
@@ -1,7 +1,8 @@
 <?php
 
 use Project\Project;
+use Redaxo\Core\Environment;
 
 require_once dirname(__DIR__, 3) . '/vendor/autoload_runtime.php';
 
-return static fn (array $context) => new Project('frontend');
+return static fn (array $context) => new Project(Environment::Frontend);

--- a/.tools/project/public/redaxo/index.php
+++ b/.tools/project/public/redaxo/index.php
@@ -1,7 +1,8 @@
 <?php
 
 use Project\Project;
+use Redaxo\Core\Environment;
 
 require_once dirname(__DIR__, 4) . '/vendor/autoload_runtime.php';
 
-return static fn (array $context) => new Project('backend');
+return static fn (array $context) => new Project(Environment::Backend);

--- a/boot/core.php
+++ b/boot/core.php
@@ -111,7 +111,7 @@ if (!Core::isSetup()) {
 
 // ----------------- HTTPS REDIRECT
 if ('cli' !== PHP_SAPI && !Core::isSetup()) {
-    if ((true === Core::getProperty('use_https') || Core::getEnvironment() === Core::getProperty('use_https')) && !Request::isHttps()) {
+    if ((true === Core::getProperty('use_https') || Core::getEnvironment()->value === Core::getProperty('use_https')) && !Request::isHttps()) {
         Response::enforceHttps();
     }
 

--- a/src/AbstractProject.php
+++ b/src/AbstractProject.php
@@ -54,15 +54,14 @@ abstract class AbstractProject implements RunnerInterface
     public string $backendDirectory = 'redaxo';
 
     public function __construct(
-        /** @var 'frontend'|'backend'|'console' */
-        public readonly string $environment,
+        public readonly Environment $environment,
     ) {}
 
     public function boot(): void {}
 
     final public function bootCore(): void
     {
-        if ('console' === $this->environment) {
+        if (Environment::Console === $this->environment) {
             set_time_limit(0);
 
             // setup a minimal exception handler to print early errors,
@@ -75,7 +74,7 @@ abstract class AbstractProject implements RunnerInterface
         }
 
         $REX = [];
-        $REX['REDAXO'] = 'frontend' !== $this->environment;
+        $REX['REDAXO'] = Environment::Frontend !== $this->environment;
         $REX['PATH_PROVIDER'] = new DefaultPathProvider($this, true);
         $REX['URL_PROVIDER'] = new DefaultPathProvider($this, false);
 
@@ -104,7 +103,7 @@ abstract class AbstractProject implements RunnerInterface
     {
         $this->bootCore();
 
-        require dirname(__DIR__) . '/boot/' . $this->environment . '.php';
+        require dirname(__DIR__) . '/boot/' . $this->environment->value . '.php';
 
         return 0;
     }

--- a/src/Content/ArticleHandler.php
+++ b/src/Content/ArticleHandler.php
@@ -911,6 +911,6 @@ class ArticleHandler
     /** @return string */
     private static function getUser()
     {
-        return Core::getUser()->login ?? Core::getEnvironment();
+        return Core::getUser()->login ?? Core::getEnvironment()->value;
     }
 }

--- a/src/Content/CategoryHandler.php
+++ b/src/Content/CategoryHandler.php
@@ -569,6 +569,6 @@ class CategoryHandler
     /** @return string */
     private static function getUser()
     {
-        return Core::getUser()->login ?? Core::getEnvironment();
+        return Core::getUser()->login ?? Core::getEnvironment()->value;
     }
 }

--- a/src/Content/ContentHandler.php
+++ b/src/Content/ContentHandler.php
@@ -388,6 +388,6 @@ class ContentHandler
     /** @return string */
     private static function getUser()
     {
-        return Core::getUser()->login ?? Core::getEnvironment();
+        return Core::getUser()->login ?? Core::getEnvironment()->value;
     }
 }

--- a/src/Core.php
+++ b/src/Core.php
@@ -223,33 +223,26 @@ final class Core
         return Setup::isEnabled();
     }
 
-    /** Returns if the environment is the backend. */
+    /** Returns if the environment is the backend (the console counts as backend, too). */
     public static function isBackend(): bool
     {
-        return (bool) self::getProperty('redaxo', false);
+        return Environment::Frontend !== self::getEnvironment();
     }
 
     /** Returns if the environment is the frontend. */
     public static function isFrontend(): bool
     {
-        if (self::getConsole()) {
-            return false;
-        }
-        return !self::getProperty('redaxo', false);
+        return Environment::Frontend === self::getEnvironment();
     }
 
-    /**
-     * Returns the environment.
-     *
-     * @return 'console'|'backend'|'frontend'
-     */
-    public static function getEnvironment(): string
+    /** Returns the environment. */
+    public static function getEnvironment(): Environment
     {
         if (self::getConsole()) {
-            return 'console';
+            return Environment::Console;
         }
 
-        return self::isBackend() ? 'backend' : 'frontend';
+        return self::getProperty('redaxo', false) ? Environment::Backend : Environment::Frontend;
     }
 
     /** Returns if the debug mode is active. */

--- a/src/Cronjob/CronjobExecutor.php
+++ b/src/Cronjob/CronjobExecutor.php
@@ -10,6 +10,7 @@ use Redaxo\Core\Cronjob\Type\ExportType;
 use Redaxo\Core\Cronjob\Type\OptimizeTableType;
 use Redaxo\Core\Cronjob\Type\PurgeMailerArchiveType;
 use Redaxo\Core\Cronjob\Type\UrlRequestType;
+use Redaxo\Core\Environment;
 use Redaxo\Core\Filesystem\Path;
 use Redaxo\Core\Http\Request;
 use Redaxo\Core\Log\LogFile;
@@ -94,10 +95,10 @@ final class CronjobExecutor
             }
         }
 
-        if ('backend' === Core::getEnvironment() && 'cronjob/cronjobs' == Request::get('page') && 'execute' == Request::get('func')) {
+        if (Environment::Backend === Core::getEnvironment() && 'cronjob/cronjobs' == Request::get('page') && 'execute' == Request::get('func')) {
             $environment = 'backend_manual';
         } else {
-            $environment = Core::getEnvironment();
+            $environment = Core::getEnvironment()->value;
         }
 
         $log = LogFile::factory(Path::log('cronjob.log'), 2_000_000);

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -1387,7 +1387,7 @@ class Sql implements Iterator
     public function addGlobalUpdateFields(?string $user = null): static
     {
         if (!$user) {
-            $user = Core::getUser()->login ?? Core::getEnvironment();
+            $user = Core::getUser()->login ?? Core::getEnvironment()->value;
         }
 
         $this->setDateTimeValue('updatedate', time());
@@ -1400,7 +1400,7 @@ class Sql implements Iterator
     public function addGlobalCreateFields(?string $user = null): static
     {
         if (!$user) {
-            $user = Core::getUser()->login ?? Core::getEnvironment();
+            $user = Core::getUser()->login ?? Core::getEnvironment()->value;
         }
 
         $this->setDateTimeValue('createdate', time());

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Redaxo\Core;
+
+/** The runtime environment in which REDAXO is running. */
+enum Environment: string
+{
+    case Frontend = 'frontend';
+    case Backend = 'backend';
+    case Console = 'console';
+}

--- a/src/Filesystem/DefaultPathProvider.php
+++ b/src/Filesystem/DefaultPathProvider.php
@@ -4,6 +4,7 @@ namespace Redaxo\Core\Filesystem;
 
 use Redaxo\Core\AbstractProject;
 use Redaxo\Core\Addon\Addon;
+use Redaxo\Core\Environment;
 use Redaxo\Core\Exception\InvalidArgumentException;
 use Redaxo\Core\Exception\LogicException;
 use Redaxo\Core\Util\Type;
@@ -36,7 +37,7 @@ class DefaultPathProvider
             $this->backend = $project->backendDirectory;
             $this->core = Type::string(realpath($project->corePath)) . '/';
         } else {
-            $this->base = 'frontend' === $project->environment ? './' : '../';
+            $this->base = Environment::Frontend === $project->environment ? './' : '../';
             $this->frontend = '';
             $this->backend = str_ends_with($this->base, '../') ? '' : $this->base . $project->backendDirectory . '/';
             $this->core = $this->base;

--- a/src/Security/CsrfToken.php
+++ b/src/Security/CsrfToken.php
@@ -107,7 +107,7 @@ final readonly class CsrfToken
 
     private static function getBaseSessionKey(): string
     {
-        return 'csrf_tokens_' . Core::getEnvironment();
+        return 'csrf_tokens_' . Core::getEnvironment()->value;
     }
 
     private static function generateToken(): string


### PR DESCRIPTION
## What

Introduces a backed `Environment` enum (`Frontend` / `Backend` / `Console`) for the runtime environment, replacing the stringly-typed `'frontend'|'backend'|'console'`.

## Changes

- New `src/Environment.php` — a plain backed string enum (no methods).
- `AbstractProject::$environment` is now typed `Environment` instead of a `@var` string literal; entry points (`.tools/bin/console`, `bootstrap.php`, the `index.php` files) pass enum cases.
- `Core::getEnvironment(): Environment` is the single source of truth (reads the `redaxo` property directly).
- `Core::isBackend()` / `isFrontend()` now delegate to `getEnvironment()`.
- String consumers (`createuser`/`updateuser` fallback, `CsrfToken`, cronjob log, `use_https` redirect) use `->value`.
- Removed the now-obsolete `expectedReturnValues()` for `getEnvironment()` from `.phpstorm.meta.php` (PhpStorm knows enum cases natively).

## Behavior

Unchanged. `isBackend()` still returns `true` in the console environment (`isBackend()` == `Frontend !== getEnvironment()`), matching the original intent that console-gated code runs in the backend context. Whether console should become its own distinct context is left as a separate discussion.

## Out of scope

The cronjob environment (`frontend`/`backend`/`script` + `backend_manual`, persisted in the DB) is a separate value set and is intentionally left untouched.