### PR TITLE
refactor!: modernize the extension point system

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,6 +14,9 @@ $finder = Finder::create()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
+    ->exclude([
+        'project/var',
+    ])
     ->append([
         __FILE__,
         __DIR__ . '/.tools/bin/console',

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -14,8 +14,6 @@ override(
     ])
 );
 
-expectedArguments(Redaxo\Core\ExtensionPoint\Extension::register(), 2, \Redaxo\Core\ExtensionPoint\Extension::EARLY, \Redaxo\Core\ExtensionPoint\Extension::NORMAL, \Redaxo\Core\ExtensionPoint\Extension::LATE);
-
 expectedArguments(\Redaxo\Core\Filesystem\Finder::sort(), 0, \Redaxo\Core\Util\SortableIterator::KEYS, \Redaxo\Core\Util\SortableIterator::VALUES);
 expectedArguments(\Redaxo\Core\Util\SortableIterator::__construct(), 1, \Redaxo\Core\Util\SortableIterator::KEYS, \Redaxo\Core\Util\SortableIterator::VALUES);
 

--- a/.tools/phpstan/baseline/missingType.iterableValue.php
+++ b/.tools/phpstan/baseline/missingType.iterableValue.php
@@ -74,26 +74,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Content/ContentHandler.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Method Redaxo\\Core\\Content\\ExtensionPoint\\SliceMenu::addAdditionalActions() has parameter $additionalActions with no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/ExtensionPoint/SliceMenu.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Redaxo\\Core\\Content\\ExtensionPoint\\SliceMenu::getAdditionalActions() return type has no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/ExtensionPoint/SliceMenu.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Redaxo\\Core\\Content\\ExtensionPoint\\SliceMenu::setAdditionalActions() has parameter $additionalActions with no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/ExtensionPoint/SliceMenu.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Property Redaxo\\Core\\Content\\ExtensionPoint\\SliceMenu::$additionalActions type has no value type specified in iterable type array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Content/ExtensionPoint/SliceMenu.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Method Redaxo\\Core\\Content\\Linkmap\\ArticleListRenderer::renderList() has parameter $articles with no value type specified in iterable type array.',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Content/Linkmap/ArticleListRenderer.php',

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2320,11 +2320,6 @@
       <code><![CDATA[$frame['type']]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
-  <file src="src/ExtensionPoint/Extension.php">
-    <InvalidCast>
-      <code><![CDATA[$level]]></code>
-    </InvalidCast>
-  </file>
   <file src="src/Filesystem/DefaultPathProvider.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->backend . $file]]></code>
@@ -3451,13 +3446,13 @@
       <code><![CDATA[setValue]]></code>
     </MixedMethodCall>
     <MixedOperand>
-      <code><![CDATA[$ep->getSubject()]]></code>
-      <code><![CDATA[$ep->getSubject()]]></code>
+      <code><![CDATA[$ep->subject]]></code>
+      <code><![CDATA[$ep->subject]]></code>
       <code><![CDATA[$params['id']]]></code>
     </MixedOperand>
     <MixedReturnStatement>
-      <code><![CDATA[$ep->getSubject()]]></code>
-      <code><![CDATA[$ep->getSubject()]]></code>
+      <code><![CDATA[$ep->subject]]></code>
+      <code><![CDATA[$ep->subject]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/MetaInfo/Handler/LanguageHandler.php">
@@ -3475,12 +3470,12 @@
       <code><![CDATA[$params['activeItem']]]></code>
     </MixedAssignment>
     <MixedOperand>
-      <code><![CDATA[$ep->getSubject()]]></code>
-      <code><![CDATA[$ep->getSubject()]]></code>
+      <code><![CDATA[$ep->subject]]></code>
+      <code><![CDATA[$ep->subject]]></code>
     </MixedOperand>
     <MixedReturnStatement>
-      <code><![CDATA[$ep->getSubject()]]></code>
-      <code><![CDATA[$ep->getSubject()]]></code>
+      <code><![CDATA[$ep->subject]]></code>
+      <code><![CDATA[$ep->subject]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/MetaInfo/Handler/MediaHandler.php">
@@ -3518,7 +3513,7 @@
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$catId]]></code>
-      <code><![CDATA[$ep->getSubject()]]></code>
+      <code><![CDATA[$ep->subject]]></code>
     </MixedOperand>
     <MixedReturnStatement>
       <code><![CDATA[$warning]]></code>
@@ -4142,9 +4137,9 @@
       <code><![CDATA[$subjectActual]]></code>
     </MixedAssignment>
     <MixedOperand>
-      <code><![CDATA[$ep->getSubject()]]></code>
-      <code><![CDATA[$ep->getSubject()]]></code>
-      <code><![CDATA[$ep->getSubject()]]></code>
+      <code><![CDATA[$ep->subject]]></code>
+      <code><![CDATA[$ep->subject]]></code>
+      <code><![CDATA[$ep->subject]]></code>
     </MixedOperand>
   </file>
   <file src="tests/HttpClient/RequestTest.php">

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ This repository contains the **REDAXO core** under `src/` (`Redaxo\Core\`), back
 ### Key concepts
 - **`Core` static class** (`src/Core.php`) — central application registry for paths, config, request, current user.
 - **Addon system** — `Addon` / `AddonManager` (`src/Addon/`). Each addon is a subclass of `Addon`, registered via composer.json `extra.redaxo.addon-class`. Metadata comes from composer.json; integration happens through overridable hooks — `boot()` (runtime init), `install()`/`uninstall()` (schema/data setup — must be idempotent, runs on every `console migrate`), `getPages()` (backend pages) — plus the `$load` and `$defaultConfig` properties.
-- **Extension points** — REDAXO's hook/event system: register listeners with `Extension::register('NAME', ...)`, fire points with `Extension::registerPoint(new ExtensionPoint(...))`. Classes live under `Redaxo\Core\ExtensionPoint`. This is the primary integration mechanism for addons.
+- **Extension points** — REDAXO's hook/event system: register listeners with `Extension::register('NAME', ...)`, fire points with `Extension::dispatch(new ExtensionPoint(...))`. Classes live under `Redaxo\Core\ExtensionPoint`. This is the primary integration mechanism for addons.
 - **Fragments** (`fragments/`) — template snippets rendered via `Fragment` (`src/View/Fragment.php`).
 - **Boot flow** — `AbstractProject` (Symfony `RuntimeInterface`) drives boot via `boot/core.php` → `boot/addons.php` → environment entry (`boot/backend.php`, `boot/frontend.php`, `boot/console.php`).
 

--- a/addons/debug/boot.php
+++ b/addons/debug/boot.php
@@ -138,10 +138,10 @@ if ('cli' === PHP_SAPI) {
     Extension::register(ConsoleShutdown::NAME, static function (ConsoleShutdown $extensionPoint) use ($shutdownFn) {
         $shutdownFn();
 
-        $command = $extensionPoint->getCommand();
-        $input = $extensionPoint->getInput();
-        // $output = $extensionPoint->getOutput();
-        $exitCode = $extensionPoint->getExitCode();
+        $command = $extensionPoint->command;
+        $input = $extensionPoint->input;
+        // $output = $extensionPoint->output;
+        $exitCode = $extensionPoint->exitCode;
 
         // we need to make sure that the storage path exists after actions like cache:clear
         rex_debug_clockwork::ensureStoragePath();

--- a/addons/debug/lib/extensions/extension_debug.php
+++ b/addons/debug/lib/extensions/extension_debug.php
@@ -2,6 +2,7 @@
 
 use Redaxo\Core\Core;
 use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Util\Formatter;
 use Redaxo\Core\Util\Timer;
@@ -9,20 +10,20 @@ use Redaxo\Core\Util\Timer;
 /**
  * @internal
  */
-class rex_extension_debug extends Extension
+final class rex_extension_debug extends Extension
 {
     private static array $extensionPoints = [];
     private static array $extensions = [];
     private static array $listeners = [];
 
-    public static function registerPoint(ExtensionPoint $extensionPoint)
+    public static function dispatch(ExtensionPoint $extensionPoint): mixed
     {
         $coreTimer = Core::getProperty('timer');
         $absDur = $coreTimer->getDelta();
 
         $timer = new Timer();
         $epStart = microtime(true);
-        $res = parent::registerPoint($extensionPoint);
+        $res = parent::dispatch($extensionPoint);
         $epEnd = microtime(true);
         $epDur = $timer->getDelta();
 
@@ -30,10 +31,10 @@ class rex_extension_debug extends Extension
 
         self::$extensionPoints[] = [
             '#' => count(self::$extensionPoints),
-            'ep' => $extensionPoint->getName(),
-            'subject' => $extensionPoint->getSubject(),
+            'ep' => $extensionPoint->name,
+            'subject' => $extensionPoint->subject,
             'params' => $extensionPoint->getParams() ?: '',
-            'read_only' => $extensionPoint->isReadonly(),
+            'read_only' => $extensionPoint->readonly,
             'started at (ms)' => $absDur,
             'duration (ms)' => $epDur,
             'memory' => $memory,
@@ -41,11 +42,11 @@ class rex_extension_debug extends Extension
         ];
 
         $data = rex_debug::getTrace([Extension::class]);
-        $data['listeners'] = self::$listeners[$extensionPoint->getName()] ?? [];
+        $data['listeners'] = self::$listeners[$extensionPoint->name] ?? [];
 
         rex_debug_clockwork::getInstance()
-            ->event('EP: ' . $extensionPoint->getName(), [
-                'subject' => $extensionPoint->getSubject(),
+            ->event('EP: ' . $extensionPoint->name, [
+                'subject' => $extensionPoint->subject,
                 'params' => $extensionPoint->getParams(),
                 'result' => $res,
                 'start' => $epStart,
@@ -56,9 +57,9 @@ class rex_extension_debug extends Extension
         return $res;
     }
 
-    public static function register($extensionPoint, callable $extension, $level = self::NORMAL, array $params = [])
+    public static function register(string|array $extensionPoint, callable $extension, ExtensionLevel $level = ExtensionLevel::Normal): void
     {
-        parent::register($extensionPoint, $extension, $level, $params);
+        parent::register($extensionPoint, $extension, $level);
 
         $trace = rex_debug::getTrace([Extension::class]);
         if (!is_array($extensionPoint)) {

--- a/boot/addons.php
+++ b/boot/addons.php
@@ -41,6 +41,6 @@ Timer::measure('packages_boot', static function () use ($packageOrder) {
 Extension::registerByAttribute($this);
 
 // ----- all addons configs included
-Extension::registerPoint(new ExtensionPoint('PACKAGES_INCLUDED'));
+Extension::dispatch(new ExtensionPoint('PACKAGES_INCLUDED'));
 
 $this->boot();

--- a/boot/backend.php
+++ b/boot/backend.php
@@ -415,7 +415,7 @@ if (Core::getConfig('article_work_version', false)) {
         $params = $ep->getParams();
         $articleId = Type::int($params['article_id']);
         $clangId = Type::int($params['clang']);
-        $return = Type::string($ep->getSubject());
+        $return = Type::string($ep->subject);
 
         $workingVersionEmpty = true;
         $gw = Sql::factory();
@@ -449,7 +449,7 @@ if (Core::getConfig('article_work_version', false)) {
                     $article = Type::instanceOf(Article::get($articleId, $clangId), Article::class);
                     ArticleRevision::setSessionArticleRevision($articleId, ArticleRevision::LIVE);
                     $params['slice_revision'] = ArticleRevision::LIVE;
-                    $return = Extension::registerPoint(
+                    $return = Extension::dispatch(
                         new ArticleContentUpdated($article, 'work_to_live', $return),
                     );
                 }
@@ -589,7 +589,7 @@ Core::setProperty('metainfo_metaTables', [
 ]);
 
 Extension::register('STRUCTURE_CONTENT_SIDEBAR', function ($ep) {
-    $subject = $ep->getSubject();
+    $subject = $ep->subject;
     $metaSidebar = include Path::core('pages/structure/content.metainfo.php');
     return $metaSidebar . $subject;
 });
@@ -606,7 +606,7 @@ if (Core::getUser()) {
     Controller::appendPackagePages();
 }
 
-$pages = Extension::registerPoint(new ExtensionPoint('PAGES_PREPARED', Controller::getPages()));
+$pages = Extension::dispatch(new ExtensionPoint('PAGES_PREPARED', Controller::getPages()));
 Controller::setPages($pages);
 
 // Set Startpage
@@ -632,7 +632,7 @@ if ('content' == Controller::getCurrentPagePart(1)) {
 
 // ----- EXTENSION POINT
 // page variable validated
-Extension::registerPoint(new ExtensionPoint('PAGE_CHECKED', $page, ['pages' => $pages], true));
+Extension::dispatch(new ExtensionPoint('PAGE_CHECKED', $page, ['pages' => $pages], true));
 
 if (in_array($page, ['profile', 'login'], true)) {
     Asset::addJsFile(Url::coreAssets('webauthn.js'), [Asset::JS_IMMUTABLE => true]);

--- a/boot/core.php
+++ b/boot/core.php
@@ -148,10 +148,10 @@ if (!Core::isSetup()) {
         Extension::register(
             ['ART_SLICES_COPY', 'SLICE_ADD', 'SLICE_UPDATE', 'SLICE_MOVE', 'SLICE_DELETE'],
             static function (ExtensionPoint $ep) {
-                $type = match ($ep->getName()) {
+                $type = match ($ep->name) {
                     'ART_SLICES_COPY' => 'slices_copy',
                     'SLICE_MOVE' => 'slice_' . $ep->getParam('direction'),
-                    default => strtolower($ep->getName()),
+                    default => strtolower($ep->name),
                 };
 
                 $articleId = $ep->getParam('article_id');

--- a/boot/frontend.php
+++ b/boot/frontend.php
@@ -46,9 +46,9 @@ $content = ob_get_clean();
 // trigger api functions. the api function is responsible for checking permissions.
 ApiFunction::handleCall();
 
-if (Extension::isRegistered('FE_OUTPUT')) {
+if (Extension::hasExtensions('FE_OUTPUT')) {
     // ----- EXTENSION POINT
-    Extension::registerPoint(new ExtensionPoint('FE_OUTPUT', $content));
+    Extension::dispatch(new ExtensionPoint('FE_OUTPUT', $content));
 
     return;
 }

--- a/fragments/core/navigations/meta.php
+++ b/fragments/core/navigations/meta.php
@@ -38,7 +38,7 @@ if (count($items) > 0) {
         $listItems[] = '<li>' . $listItem . '</li>';
     }
 
-    $listItems = Extension::registerPoint(new ExtensionPoint('META_NAVI', $listItems));
+    $listItems = Extension::dispatch(new ExtensionPoint('META_NAVI', $listItems));
 
     if (count($listItems) > 0) {
         echo '  <div class="rex-nav-meta">

--- a/pages/layout/top.php
+++ b/pages/layout/top.php
@@ -70,7 +70,7 @@ if (Core::getProperty('theme')) {
 }
 
 // ----- EXTENSION POINT
-$bodyAttr = Extension::registerPoint(new ExtensionPoint('PAGE_BODY_ATTR', $bodyAttr));
+$bodyAttr = Extension::dispatch(new ExtensionPoint('PAGE_BODY_ATTR', $bodyAttr));
 
 $body = '';
 foreach ($bodyAttr as $k => $v) {
@@ -148,7 +148,7 @@ if ($user && $hasNavigation) {
         }
     }
 
-    $n = Extension::registerPoint(new ExtensionPoint('PAGE_NAVIGATION', $n));
+    $n = Extension::dispatch(new ExtensionPoint('PAGE_NAVIGATION', $n));
 
     $blocks = $n->getNavigation();
 
@@ -214,7 +214,7 @@ if (!Request::isPJAXContainer('#rex-js-page-container')) {
     $fragment->setVar('jsFiles', Asset::getJsFilesWithOptions());
     $fragment->setVar('jsProperties', json_encode(Asset::getJsProperties()), false);
     $fragment->setVar('favicon', Asset::getFavicon());
-    $fragment->setVar('pageHeader', Extension::registerPoint(new ExtensionPoint('PAGE_HEADER', '')), false);
+    $fragment->setVar('pageHeader', Extension::dispatch(new ExtensionPoint('PAGE_HEADER', '')), false);
     $fragment->setVar('bodyAttr', $body, false);
     echo $fragment->parse('core/top.php');
 
@@ -223,7 +223,7 @@ if (!Request::isPJAXContainer('#rex-js-page-container')) {
     $metaNavigation = $fragment->parse('core/navigations/meta.php');
 
     $fragment = new Fragment();
-    // $fragment->setVar('pageHeader', Extension::registerPoint(new ExtensionPoint('PAGE_HEADER', '')), false);
+    // $fragment->setVar('pageHeader', Extension::dispatch(new ExtensionPoint('PAGE_HEADER', '')), false);
     $fragment->setVar('meta_navigation', $metaNavigation, false);
     echo $fragment->parse('core/header.php');
 }

--- a/pages/media_manager/types.php
+++ b/pages/media_manager/types.php
@@ -176,7 +176,7 @@ if ('' == $func) {
     }
 
     Extension::register('REX_FORM_CONTROL_FIELDS', static function (ExtensionPoint $ep) {
-        $controlFields = $ep->getSubject();
+        $controlFields = $ep->subject;
         $form = $ep->getParam('form');
         $sql = $form->getSql();
 

--- a/pages/mediapool/media.detail.php
+++ b/pages/mediapool/media.detail.php
@@ -106,7 +106,7 @@ if (Request::post('btn_update', 'string')) {
                 MediaHandler::updateMedia($filename, $data);
 
                 if ($gf->getValue('category_id') != $rexFileCategory) {
-                    Extension::registerPoint(new ExtensionPoint('MEDIA_MOVED', null, [
+                    Extension::dispatch(new ExtensionPoint('MEDIA_MOVED', null, [
                         'filename' => $filename,
                         'category_id' => $rexFileCategory,
                     ]));
@@ -209,7 +209,7 @@ if ('' != $openerLink) {
 }
 
 // ----- EXTENSION POINT
-$sidebar = Extension::registerPoint(new ExtensionPoint('MEDIA_DETAIL_SIDEBAR', $sidebar, [
+$sidebar = Extension::dispatch(new ExtensionPoint('MEDIA_DETAIL_SIDEBAR', $sidebar, [
     'id' => $fileId,
     'filename' => $fname,
     'media' => $gf,
@@ -248,7 +248,7 @@ if ($TPERM) {
     $fragment->setVar('elements', $formElements, false);
     $panel .= $fragment->parse('core/form/form.php');
 
-    $panel .= Extension::registerPoint(new ExtensionPoint('MEDIA_FORM_EDIT', '', ['id' => $fileId, 'media' => $gf]));
+    $panel .= Extension::dispatch(new ExtensionPoint('MEDIA_FORM_EDIT', '', ['id' => $fileId, 'media' => $gf]));
 
     $panel .= $addExtInfo;
 

--- a/pages/mediapool/media.list.php
+++ b/pages/mediapool/media.list.php
@@ -67,7 +67,7 @@ if ($hasCategoryPerm && 'updatecat_selectedmedia' == $mediaMethod) {
                 $success = I18n::msg('pool_selectedmedia_moved');
                 MediaPoolCache::delete($fileName);
 
-                Extension::registerPoint(new ExtensionPoint('MEDIA_MOVED', null, [
+                Extension::dispatch(new ExtensionPoint('MEDIA_MOVED', null, [
                     'filename' => $fileName,
                     'category_id' => $rexFileCategory,
                 ]));
@@ -301,7 +301,7 @@ foreach ($items as $media) {
 
     // Register new EP MEDIA_LIST_THUMBNAIL - fuer Vorschau-Manipulation z.B. fuer Plyr/Lottie
     // ----- EXTENSION POINT
-    $thumbnail = Extension::registerPoint(new ExtensionPoint('MEDIA_LIST_THUMBNAIL', $thumbnail, [
+    $thumbnail = Extension::dispatch(new ExtensionPoint('MEDIA_LIST_THUMBNAIL', $thumbnail, [
         'id' => $media->id,
         'filename' => $media->fileName,
         'media' => $media,
@@ -338,7 +338,7 @@ foreach ($items as $media) {
                     <td class="rex-table-action"><a class="rex-link-expanded" href="' . $ilink . '">' . I18n::msg('edit') . '</a></td>
                     <td class="rex-table-action">';
 
-    $panel .= Extension::registerPoint(new ExtensionPoint('MEDIA_LIST_FUNCTIONS', $openerLink, [
+    $panel .= Extension::dispatch(new ExtensionPoint('MEDIA_LIST_FUNCTIONS', $openerLink, [
         'media' => $media, // new
         'file_id' => $media->id, // @deprecated
         'file_name' => $media->fileName, // @deprecated

--- a/pages/mediapool/media.php
+++ b/pages/mediapool/media.php
@@ -39,7 +39,7 @@ if (Core::requireUser()->getComplexPerm('media')->hasAll()) {
 }
 
 // ----- EXTENSION POINT
-echo Extension::registerPoint(new ExtensionPoint('PAGE_MEDIAPOOL_HEADER', '', [
+echo Extension::dispatch(new ExtensionPoint('PAGE_MEDIAPOOL_HEADER', '', [
     'subpage' => $subpage,
     'category_id' => $rexFileCategory,
 ]));
@@ -77,7 +77,7 @@ $context = new Context([
 ]);
 
 // ----- EXTENSION POINT
-$toolbar = Extension::registerPoint(new ExtensionPoint('MEDIA_LIST_TOOLBAR', $toolbar, [
+$toolbar = Extension::dispatch(new ExtensionPoint('MEDIA_LIST_TOOLBAR', $toolbar, [
     'subpage' => $subpage,
     'category_id' => $rexFileCategory,
 ]));

--- a/pages/profile/index.php
+++ b/pages/profile/index.php
@@ -115,7 +115,7 @@ if ($update && !$error) {
     $updateuser->update();
     User::clearInstance($userId);
 
-    Extension::registerPoint(new ExtensionPoint('PROFILE_UPDATED', '', [
+    Extension::dispatch(new ExtensionPoint('PROFILE_UPDATED', '', [
         'user_id' => $userId,
         'user' => User::require($userId),
     ], true));
@@ -178,7 +178,7 @@ if (Request::post('upd_psw_button', 'bool')) {
         }
         $login->changedPassword($userpswNew1);
 
-        Extension::registerPoint(new ExtensionPoint('PASSWORD_UPDATED', '', [
+        Extension::dispatch(new ExtensionPoint('PASSWORD_UPDATED', '', [
             'user_id' => $userId,
             'user' => User::require($userId),
             'password' => $userpswNew2,

--- a/pages/structure/content.php
+++ b/pages/structure/content.php
@@ -95,7 +95,7 @@ echo View::clangSwitchAsButtons($context);
 echo View::structureBreadcrumb($categoryId ?? 0, $articleId, $clang);
 
 // ----- EXTENSION POINT
-echo Extension::registerPoint(new ExtensionPoint('STRUCTURE_CONTENT_HEADER', '', [
+echo Extension::dispatch(new ExtensionPoint('STRUCTURE_CONTENT_HEADER', '', [
     'article_id' => $articleId,
     'clang' => $clang,
     'function' => $function,
@@ -225,7 +225,7 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
                         if ('edit' == $function) {
                             $newsql->addGlobalUpdateFields();
 
-                            Extension::registerPoint(new ExtensionPoint('SLICE_UPDATE', '', [
+                            Extension::dispatch(new ExtensionPoint('SLICE_UPDATE', '', [
                                 'slice_id' => $sliceId,
                                 'article_id' => $articleId,
                                 'clang_id' => $clang,
@@ -248,13 +248,13 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
                             ];
 
                             // ----- EXTENSION POINT
-                            $info = Extension::registerPoint(new ExtensionPoint('SLICE_UPDATED', $info, $epParams));
-                            $info = Extension::registerPoint(new ArticleContentUpdated($OOArt, 'slice_updated', $info));
+                            $info = Extension::dispatch(new ExtensionPoint('SLICE_UPDATED', $info, $epParams));
+                            $info = Extension::dispatch(new ArticleContentUpdated($OOArt, 'slice_updated', $info));
                         } else {
                             $newsql->addGlobalUpdateFields();
                             $newsql->addGlobalCreateFields();
 
-                            Extension::registerPoint(new ExtensionPoint('SLICE_ADD', '', [
+                            Extension::dispatch(new ExtensionPoint('SLICE_ADD', '', [
                                 'article_id' => $articleId,
                                 'clang_id' => $clang,
                                 'slice_revision' => $sliceRevision,
@@ -286,8 +286,8 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
                             ];
 
                             // ----- EXTENSION POINT
-                            $info = Extension::registerPoint(new ExtensionPoint('SLICE_ADDED', $info, $epParams));
-                            $info = Extension::registerPoint(new ArticleContentUpdated($OOArt, 'slice_added', $info));
+                            $info = Extension::dispatch(new ExtensionPoint('SLICE_ADDED', $info, $epParams));
+                            $info = Extension::dispatch(new ArticleContentUpdated($OOArt, 'slice_added', $info));
                         }
                     } else {
                         // make delete
@@ -308,8 +308,8 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
                             ];
 
                             // ----- EXTENSION POINT
-                            $globalInfo = Extension::registerPoint(new ExtensionPoint('SLICE_DELETED', $globalInfo, $epParams));
-                            $globalInfo = Extension::registerPoint(new ArticleContentUpdated($OOArt, 'slice_deleted', $globalInfo));
+                            $globalInfo = Extension::dispatch(new ExtensionPoint('SLICE_DELETED', $globalInfo, $epParams));
+                            $globalInfo = Extension::dispatch(new ArticleContentUpdated($OOArt, 'slice_deleted', $globalInfo));
                         } else {
                             $globalWarning = I18n::msg('block_not_deleted');
                         }
@@ -324,7 +324,7 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
                     $EA->update();
                     ArticleCache::delete($articleId, $clang);
 
-                    Extension::registerPoint(new ExtensionPoint('STRUCTURE_CONTENT_ARTICLE_UPDATED', '', [
+                    Extension::dispatch(new ExtensionPoint('STRUCTURE_CONTENT_ARTICLE_UPDATED', '', [
                         'id' => $articleId,
                         'clang' => $clang,
                     ]));
@@ -426,7 +426,7 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
     }
 
     // ----- EXTENSION POINT
-    $contentMain .= Extension::registerPoint(new ExtensionPoint('STRUCTURE_CONTENT_BEFORE_SLICES', '', [
+    $contentMain .= Extension::dispatch(new ExtensionPoint('STRUCTURE_CONTENT_BEFORE_SLICES', '', [
         'article_id' => $articleId,
         'clang' => $clang,
         'function' => $function,
@@ -443,7 +443,7 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
     // ------------------------------------------ END: AUSGABE
 
     // ----- EXTENSION POINT
-    $contentMain .= Extension::registerPoint(new ExtensionPoint('STRUCTURE_CONTENT_AFTER_SLICES', '', [
+    $contentMain .= Extension::dispatch(new ExtensionPoint('STRUCTURE_CONTENT_AFTER_SLICES', '', [
         'article_id' => $articleId,
         'clang' => $clang,
         'function' => $function,
@@ -458,7 +458,7 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
     $contentMain = '<section id="rex-js-page-main-content" data-pjax-container="#rex-js-page-main-content">' . $contentMain . '</section>';
 
     // ----- EXTENSION POINT
-    $contentSidebar = Extension::registerPoint(new ExtensionPoint('STRUCTURE_CONTENT_SIDEBAR', '', [
+    $contentSidebar = Extension::dispatch(new ExtensionPoint('STRUCTURE_CONTENT_SIDEBAR', '', [
         'article_id' => $articleId,
         'clang' => $clang,
         'function' => $function,

--- a/pages/structure/index.php
+++ b/pages/structure/index.php
@@ -55,7 +55,7 @@ if (0 == $structureContext->getClangId()) {
 }
 
 // --------------------- Extension Point
-echo Extension::registerPoint(new ExtensionPoint('PAGE_STRUCTURE_HEADER_PRE', '', [
+echo Extension::dispatch(new ExtensionPoint('PAGE_STRUCTURE_HEADER_PRE', '', [
     'context' => $structureContext->getContext(),
 ]));
 
@@ -92,7 +92,7 @@ if ($user->hasPerm('addCategory[]') && $structureContext->hasCategoryPermission(
 $dataColspan = 5;
 
 // --------------------- Extension Point
-echo Extension::registerPoint(new ExtensionPoint('PAGE_STRUCTURE_HEADER', '', [
+echo Extension::dispatch(new ExtensionPoint('PAGE_STRUCTURE_HEADER', '', [
     'category_id' => $structureContext->getCategoryId(),
     'clang' => $structureContext->getClangId(),
 ]));
@@ -162,7 +162,7 @@ $echo .= '
 // --------------------- KATEGORIE ADD FORM
 
 if ('add_cat' == $structureContext->getFunction() && $user->hasPerm('addCategory[]') && $structureContext->hasCategoryPermission()) {
-    $metaButtons = Extension::registerPoint(new ExtensionPoint('CAT_FORM_BUTTONS', '', [
+    $metaButtons = Extension::dispatch(new ExtensionPoint('CAT_FORM_BUTTONS', '', [
         'id' => $structureContext->getCategoryId(),
         'clang' => $structureContext->getClangId(),
     ]));
@@ -182,7 +182,7 @@ if ('add_cat' == $structureContext->getFunction() && $user->hasPerm('addCategory
                 </tr>';
 
     // ----- EXTENSION POINT
-    $echo .= Extension::registerPoint(new ExtensionPoint('CAT_FORM_ADD', '', [
+    $echo .= Extension::dispatch(new ExtensionPoint('CAT_FORM_ADD', '', [
         'id' => $structureContext->getCategoryId(),
         'clang' => $structureContext->getClangId(),
         'data_colspan' => ($dataColspan + 1),
@@ -231,7 +231,7 @@ if ($KAT->getRows() > 0) {
                 // --------------------- KATEGORIE EDIT FORM
 
                 // ----- EXTENSION POINT
-                $metaButtons = Extension::registerPoint(new ExtensionPoint('CAT_FORM_BUTTONS', '', [
+                $metaButtons = Extension::dispatch(new ExtensionPoint('CAT_FORM_BUTTONS', '', [
                     'id' => $structureContext->getEditId(),
                     'clang' => $structureContext->getClangId(),
                 ]));
@@ -255,7 +255,7 @@ if ($KAT->getRows() > 0) {
                     </tr>';
 
                 // ----- EXTENSION POINT
-                $echo .= Extension::registerPoint(new ExtensionPoint('CAT_FORM_EDIT', '', [
+                $echo .= Extension::dispatch(new ExtensionPoint('CAT_FORM_EDIT', '', [
                     'id' => $structureContext->getEditId(),
                     'clang' => $structureContext->getClangId(),
                     'category' => $KAT,
@@ -356,7 +356,7 @@ if ($structureContext->getCategoryId() > 0 || (0 == $structureContext->getCatego
         $artAddLink = '<a class="rex-link-expanded" href="' . $structureContext->getContext()->getUrl(['function' => 'add_art', 'artstart' => $structureContext->getArtStart()]) . '"' . Core::getAccesskey(I18n::msg('article_add'), 'add_2') . '><i class="rex-icon rex-icon-add-article"></i></a>';
     }
 
-    $articleOrderBy = Extension::registerPoint(new ExtensionPoint('PAGE_STRUCTURE_ARTICLE_ORDER_BY', 'priority, name', [
+    $articleOrderBy = Extension::dispatch(new ExtensionPoint('PAGE_STRUCTURE_ARTICLE_ORDER_BY', 'priority, name', [
         'category_id' => $structureContext->getCategoryId(),
         'article_id' => $structureContext->getArticleId(),
         'clang' => $structureContext->getClangId(),

--- a/pages/system/clangs.php
+++ b/pages/system/clangs.php
@@ -120,7 +120,7 @@ $content .= '
 // Add form
 if ('addclang' == $func) {
     // ----- EXTENSION POINT
-    $metaButtons = Extension::registerPoint(new ExtensionPoint('CLANG_FORM_BUTTONS', ''));
+    $metaButtons = Extension::dispatch(new ExtensionPoint('CLANG_FORM_BUTTONS', ''));
 
     // ggf wiederanzeige des add forms, falls ungueltige id uebermittelt
     $content .= '
@@ -136,7 +136,7 @@ if ('addclang' == $func) {
             ';
 
     // ----- EXTENSION POINT
-    $content .= Extension::registerPoint(new ExtensionPoint('CLANG_FORM_ADD', ''));
+    $content .= Extension::dispatch(new ExtensionPoint('CLANG_FORM_ADD', ''));
 }
 
 $sql = Sql::factory()->setQuery('SELECT * FROM ' . Core::getTable('clang') . ' ORDER BY priority');
@@ -154,7 +154,7 @@ foreach ($sql as $row) {
     // Edit form
     if ('editclang' == $func && $clangId == $langId) {
         // ----- EXTENSION POINT
-        $metaButtons = Extension::registerPoint(new ExtensionPoint('CLANG_FORM_BUTTONS', '', ['id' => $clangId, 'sql' => $sql]));
+        $metaButtons = Extension::dispatch(new ExtensionPoint('CLANG_FORM_BUTTONS', '', ['id' => $clangId, 'sql' => $sql]));
 
         $content .= '
                     <tr class="mark">
@@ -168,7 +168,7 @@ foreach ($sql as $row) {
                     </tr>';
 
         // ----- EXTENSION POINT
-        $content .= Extension::registerPoint(new ExtensionPoint('CLANG_FORM_EDIT', '', ['id' => $clangId, 'sql' => $sql]));
+        $content .= Extension::dispatch(new ExtensionPoint('CLANG_FORM_EDIT', '', ['id' => $clangId, 'sql' => $sql]));
     } else {
         $editLink = Url::currentBackendPage(['func' => 'editclang', 'clang_id' => $langId]) . '#clang';
 

--- a/pages/user/users.php
+++ b/pages/user/users.php
@@ -192,7 +192,7 @@ if ($warnings) {
         Core::getProperty('login')->changedPassword($passwordHash);
     }
 
-    Extension::registerPoint(new ExtensionPoint('USER_UPDATED', '', [
+    Extension::dispatch(new ExtensionPoint('USER_UPDATED', '', [
         'id' => $userId,
         'user' => $user,
         'password' => $userpsw,
@@ -219,7 +219,7 @@ if ($warnings) {
 
         User::clearInstance($userId);
 
-        Extension::registerPoint(new ExtensionPoint('USER_DELETED', '', [
+        Extension::dispatch(new ExtensionPoint('USER_DELETED', '', [
             'id' => $userId,
             'user' => $user,
         ], true));
@@ -260,7 +260,7 @@ if ($warnings) {
         $fUNCADD = '';
         $info[] = I18n::msg('user_added');
 
-        Extension::registerPoint(new ExtensionPoint('USER_ADDED', '', [
+        Extension::dispatch(new ExtensionPoint('USER_ADDED', '', [
             'id' => $adduser->getLastId(),
             'user' => User::require($adduser->getLastId()),
             'password' => $userpsw,

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -18,6 +18,8 @@ parameters:
         - setup
         - src
         - tests
+    excludePaths:
+        - .tools/project/var
     # https://phpstan.org/config-reference#universal-object-crates
     universalObjectCratesClasses:
         - Redaxo\Core\View\Fragment
@@ -39,7 +41,7 @@ parameters:
         - '#^Constructor of class .*Field has an unused parameter \$tag.#'
         - '#^Offset .* on .* always exists#'
         # https://github.com/phpstan/phpstan/issues/10698
-        - '#^Parameter \#1 \$extensionPoint of static method Redaxo\\Core\\ExtensionPoint\\Extension\:\:registerPoint\(\) expects Redaxo\\Core\\ExtensionPoint\\ExtensionPoint\<(.+)\>, Redaxo\\Core\\ExtensionPoint\\ExtensionPoint\<\1\> given\.$#'
+        - '#^Parameter \#1 \$extensionPoint of static method Redaxo\\Core\\ExtensionPoint\\Extension\:\:dispatch\(\) expects Redaxo\\Core\\ExtensionPoint\\ExtensionPoint\<(.+)\>, Redaxo\\Core\\ExtensionPoint\\ExtensionPoint\<\1\> given\.$#'
         -   identifiers: [possiblyImpure.functionCall, possiblyImpure.methodCall]
         -
             identifier: missingType.checkedException

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,7 +12,8 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
-        <directory name=".tools/project"/>
+        <directory name=".tools/project/public"/>
+        <directory name=".tools/project/src"/>
         <directory name="addons"/>
         <directory name="boot"/>
         <directory name="fragments"/>
@@ -21,7 +22,6 @@
         <directory name="src"/>
         <directory name="tests"/>
         <ignoreFiles>
-            <directory name=".tools/project/var"/>
             <directory name="vendor"/>
             <file name=".phpstorm.meta.php" />
         </ignoreFiles>

--- a/psalm.xml
+++ b/psalm.xml
@@ -21,6 +21,7 @@
         <directory name="src"/>
         <directory name="tests"/>
         <ignoreFiles>
+            <directory name=".tools/project/var"/>
             <directory name="vendor"/>
             <file name=".phpstorm.meta.php" />
         </ignoreFiles>

--- a/rector.php
+++ b/rector.php
@@ -133,6 +133,8 @@ return RectorConfig::configure()
         Php81\FuncCall\NullToStrictStringFuncCallArgRector::class,
         TypeDeclaration\ArrowFunction\AddArrowFunctionReturnTypeRector::class,
         TypeDeclaration\Closure\AddClosureVoidReturnTypeWhereNoReturnRector::class,
+
+        '.tools/project/var',
     ])
 
     // Upgrade REDAXO 5 to 6
@@ -448,8 +450,13 @@ return RectorConfig::configure()
         new RenameStaticMethod(Core::class, 'getPackageConfig', Addon\AddonManager::class, 'getAddonConfig'),
         new RenameStaticMethod(Core::class, 'getPackageOrder', Addon\AddonManager::class, 'getAddonOrder'),
         new RenameStaticMethod(Core::class, 'getVersionHash', Util\Version::class, 'gitHash'),
+
+        new RenameStaticMethod(ExtensionPoint\Extension::class, 'registerPoint', ExtensionPoint\Extension::class, 'dispatch'),
+        new RenameStaticMethod(ExtensionPoint\Extension::class, 'isRegistered', ExtensionPoint\Extension::class, 'hasExtensions'),
+
         new RenameStaticMethod(Util\Str::class, 'versionSplit', Util\Version::class, 'split'),
         new RenameStaticMethod(Util\Str::class, 'versionCompare', Util\Version::class, 'compare'),
+
         new RenameStaticMethod(View\View::class, 'addCssFile', View\Asset::class, 'addCssFile'),
         new RenameStaticMethod(View\View::class, 'getCssFiles', View\Asset::class, 'getCssFiles'),
         new RenameStaticMethod(View\View::class, 'addJsFile', View\Asset::class, 'addJsFile'),
@@ -564,6 +571,30 @@ return RectorConfig::configure()
         new MethodCallToPropertyFetch(Content\StructureElement::class, 'getCreateUser', 'createUser'),
         new MethodCallToPropertyFetch(Content\StructureElement::class, 'getUpdateUser', 'updateUser'),
 
+        new MethodCallToPropertyFetch(ExtensionPoint\ExtensionPoint::class, 'getName', 'name'),
+        new MethodCallToPropertyFetch(ExtensionPoint\ExtensionPoint::class, 'getSubject', 'subject'),
+        new MethodCallToPropertyFetch(ExtensionPoint\ExtensionPoint::class, 'isReadonly', 'readonly'),
+        new MethodCallToPropertyFetch(Console\ExtensionPoint\ConsoleShutdown::class, 'getCommand', 'command'),
+        new MethodCallToPropertyFetch(Console\ExtensionPoint\ConsoleShutdown::class, 'getInput', 'input'),
+        new MethodCallToPropertyFetch(Console\ExtensionPoint\ConsoleShutdown::class, 'getOutput', 'output'),
+        new MethodCallToPropertyFetch(Console\ExtensionPoint\ConsoleShutdown::class, 'getExitCode', 'exitCode'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\ArticleContentUpdated::class, 'getArticle', 'article'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\ArticleContentUpdated::class, 'getAction', 'action'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getContext', 'context'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getFragment', 'fragment'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getArticleId', 'articleId'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getClangId', 'languageId'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getCtypeId', 'contentSectionId'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getModuleId', 'moduleKey'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getSliceId', 'sliceId'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'hasPerm', 'hasPerm'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getMenuEditAction', 'menuEditAction'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getMenuDeleteAction', 'menuDeleteAction'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getMenuStatusAction', 'menuStatusAction'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getMenuMoveupAction', 'menuMoveupAction'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getMenuMovedownAction', 'menuMovedownAction'),
+        new MethodCallToPropertyFetch(Content\ExtensionPoint\SliceMenu::class, 'getAdditionalActions', 'additionalActions'),
+
         new MethodCallToPropertyFetch(Language\Language::class, 'getId', 'id'),
         new MethodCallToPropertyFetch(Language\Language::class, 'getCode', 'code'),
         new MethodCallToPropertyFetch(Language\Language::class, 'getName', 'name'),
@@ -612,6 +643,15 @@ return RectorConfig::configure()
 
         new MethodCallToPropertyAssign(Content\ArticleSliceAction::class, 'setSave', 'save'),
 
+        new MethodCallToPropertyAssign(Content\ExtensionPoint\SliceMenu::class, 'setMenuEditAction', 'menuEditAction'),
+        new MethodCallToPropertyAssign(Content\ExtensionPoint\SliceMenu::class, 'setMenuDeleteAction', 'menuDeleteAction'),
+        new MethodCallToPropertyAssign(Content\ExtensionPoint\SliceMenu::class, 'setMenuStatusAction', 'menuStatusAction'),
+        new MethodCallToPropertyAssign(Content\ExtensionPoint\SliceMenu::class, 'setMenuMoveupAction', 'menuMoveupAction'),
+        new MethodCallToPropertyAssign(Content\ExtensionPoint\SliceMenu::class, 'setMenuMovedownAction', 'menuMovedownAction'),
+        new MethodCallToPropertyAssign(Content\ExtensionPoint\SliceMenu::class, 'setAdditionalActions', 'additionalActions'),
+
+        new MethodCallToPropertyAssign(ExtensionPoint\ExtensionPoint::class, 'setSubject', 'subject'),
+
         new MethodCallToPropertyAssign(Security\Login::class, 'setCache', 'cache'),
         new MethodCallToPropertyAssign(Security\Login::class, 'setSqlDb', 'DB'),
         new MethodCallToPropertyAssign(Security\Login::class, 'setSystemId', 'systemId'),
@@ -648,6 +688,7 @@ return RectorConfig::configure()
         new ReplaceArgumentDefaultValue(ExtensionPoint\Extension::class, 'register', 0, 'STRUCTURE_CONTENT_SLICE_ADDED', 'SLICE_ADDED'),
         new ReplaceArgumentDefaultValue(ExtensionPoint\Extension::class, 'register', 0, 'STRUCTURE_CONTENT_SLICE_UPDATED', 'SLICE_UPDATED'),
         new ReplaceArgumentDefaultValue(ExtensionPoint\Extension::class, 'register', 0, 'STRUCTURE_CONTENT_SLICE_DELETED', 'SLICE_DELETED'),
+        new ReplaceArgumentDefaultValue(ExtensionPoint\Extension::class, 'register', 0, 'STRUCTURE_CONTENT_SLICE_MENU', '\\' . Content\ExtensionPoint\SliceMenu::class . '::NAME'),
 
         new ReplaceArgumentDefaultValue(Util\Markdown::class, 'parse', 1, false, $options = [
             new Expr\ArrayItem(new Expr\ConstFetch(new Name('false')), new Expr\ClassConstFetch(new Name(Util\Markdown::class), 'SOFT_LINE_BREAKS')),
@@ -677,6 +718,11 @@ return RectorConfig::configure()
         new RenameClassConstFetch(MetaInfo\Database\Table::class, 'FIELD_REX_LINKLIST_WIDGET', 'FIELD_REX_LINK_WIDGET'),
         new RenameClassConstFetch(MetaInfo\Form\DefaultType::class, 'REX_MEDIALIST_WIDGET', 'REX_MEDIA_WIDGET'),
         new RenameClassConstFetch(MetaInfo\Form\DefaultType::class, 'REX_LINKLIST_WIDGET', 'REX_LINK_WIDGET'),
+
+        new RenameClassAndConstFetch(ExtensionPoint\Extension::class, 'EARLY', ExtensionPoint\ExtensionLevel::class, 'Early'),
+        new RenameClassAndConstFetch(ExtensionPoint\Extension::class, 'NORMAL', ExtensionPoint\ExtensionLevel::class, 'Normal'),
+        new RenameClassAndConstFetch(ExtensionPoint\Extension::class, 'LATE', ExtensionPoint\ExtensionLevel::class, 'Late'),
+
         new RenameClassAndConstFetch(View\View::class, 'JS_ASYNC', View\Asset::class, 'JS_ASYNC'),
         new RenameClassAndConstFetch(View\View::class, 'JS_DEFERED', View\Asset::class, 'JS_DEFERED'),
         new RenameClassAndConstFetch(View\View::class, 'JS_IMMUTABLE', View\Asset::class, 'JS_IMMUTABLE'),

--- a/src/Addon/Addon.php
+++ b/src/Addon/Addon.php
@@ -350,7 +350,7 @@ abstract class Addon
             throw new RuntimeException('Addon cache directory "' . $cacheDir . '" is not writable.');
         }
 
-        Extension::registerPoint(new AddonCacheDeleted($this));
+        Extension::dispatch(new AddonCacheDeleted($this));
     }
 
     final public function enlist(): void

--- a/src/Addon/ExtensionPoint/AddonCacheDeleted.php
+++ b/src/Addon/ExtensionPoint/AddonCacheDeleted.php
@@ -14,6 +14,6 @@ final class AddonCacheDeleted extends ExtensionPoint
 
     public function __construct(Addon $package)
     {
-        parent::__construct(self::NAME, $package, [], true);
+        parent::__construct(self::NAME, $package, readonly: true);
     }
 }

--- a/src/Backend/Style.php
+++ b/src/Backend/Style.php
@@ -15,7 +15,7 @@ final class Style
     /** Converts Backend SCSS files to CSS. */
     public static function compile(): void
     {
-        $scssFiles = Extension::registerPoint(new ExtensionPoint('BE_STYLE_SCSS_FILES', []));
+        $scssFiles = Extension::dispatch(new ExtensionPoint('BE_STYLE_SCSS_FILES', []));
 
         /** @var list<array{root_dir?: string, scss_files: string|list<string>, css_file: string, copy_dest?: string}> */
         $scssFiles = [
@@ -33,7 +33,7 @@ final class Style
             ],
         ];
 
-        $scssFiles = Extension::registerPoint(new ExtensionPoint('BE_STYLE_SCSS_COMPILE', $scssFiles));
+        $scssFiles = Extension::dispatch(new ExtensionPoint('BE_STYLE_SCSS_COMPILE', $scssFiles));
 
         foreach ($scssFiles as $file) {
             $compiler = new ScssCompiler();

--- a/src/Backup/Backup.php
+++ b/src/Backup/Backup.php
@@ -155,7 +155,7 @@ class Backup
         // ----- EXTENSION POINT
         $filesize = filesize($filename);
         $msg = '';
-        $msg = Extension::registerPoint(new ExtensionPoint('BACKUP_BEFORE_DB_IMPORT', $msg, [
+        $msg = Extension::dispatch(new ExtensionPoint('BACKUP_BEFORE_DB_IMPORT', $msg, [
             'content' => $conts,
             'filename' => $filename,
             'filesize' => $filesize,
@@ -192,7 +192,7 @@ class Backup
         Config::refresh();
 
         // ----- EXTENSION POINT
-        $msg = Extension::registerPoint(new ExtensionPoint('BACKUP_AFTER_DB_IMPORT', $msg, [
+        $msg = Extension::dispatch(new ExtensionPoint('BACKUP_AFTER_DB_IMPORT', $msg, [
             'content' => $conts,
             'filename' => $filename,
             'filesize' => $filesize,
@@ -233,7 +233,7 @@ class Backup
          * @var Tar $tar
          * @psalm-ignore-var
          */
-        $tar = Extension::registerPoint(new ExtensionPoint('BACKUP_BEFORE_FILE_IMPORT', $tar));
+        $tar = Extension::dispatch(new ExtensionPoint('BACKUP_BEFORE_FILE_IMPORT', $tar));
 
         // require import skript to do some userside-magic
         self::importScript(str_replace('.tar.gz', '.php', $filename), self::IMPORT_ARCHIVE, self::IMPORT_EVENT_PRE);
@@ -243,7 +243,7 @@ class Backup
         $msg = I18n::msg('backup_file_imported') . '<br />';
 
         // ----- EXTENSION POINT
-        Extension::registerPoint(new ExtensionPoint('BACKUP_AFTER_FILE_IMPORT', $tar));
+        Extension::dispatch(new ExtensionPoint('BACKUP_AFTER_FILE_IMPORT', $tar));
 
         // require import skript to do some userside-magic
         self::importScript(str_replace('.tar.gz', '.php', $filename), self::IMPORT_ARCHIVE, self::IMPORT_EVENT_POST);
@@ -282,7 +282,7 @@ class Backup
         $insertSize = 4000;
 
         // ----- EXTENSION POINT
-        Extension::registerPoint(new ExtensionPoint('BACKUP_BEFORE_DB_EXPORT'));
+        Extension::dispatch(new ExtensionPoint('BACKUP_BEFORE_DB_EXPORT'));
 
         // Versionsstempel hinzufügen
         fwrite($fp, '## Redaxo Database Dump Version ' . Core::getVersion('%s') . $nl);
@@ -338,11 +338,11 @@ class Backup
         $hasContent = true;
 
         // Den Dateiinhalt geben wir nur dann weiter, wenn es unbedingt notwendig ist.
-        if (Extension::isRegistered('BACKUP_AFTER_DB_EXPORT')) {
+        if (Extension::hasExtensions('BACKUP_AFTER_DB_EXPORT')) {
             $content = File::require($filename);
             $hashBefore = md5($content);
             // ----- EXTENSION POINT
-            $content = Extension::registerPoint(new ExtensionPoint('BACKUP_AFTER_DB_EXPORT', $content));
+            $content = Extension::dispatch(new ExtensionPoint('BACKUP_AFTER_DB_EXPORT', $content));
             $hashAfter = md5($content);
 
             if ($hashAfter != $hashBefore) {
@@ -410,14 +410,14 @@ class Backup
         $tar->create($archivePath);
 
         // ----- EXTENSION POINT
-        $tar = Extension::registerPoint(new ExtensionPoint('BACKUP_BEFORE_FILE_EXPORT', $tar));
+        $tar = Extension::dispatch(new ExtensionPoint('BACKUP_BEFORE_FILE_EXPORT', $tar));
 
         foreach ($folders as $item) {
             self::addFolderToTar($tar, Url::frontend(), $item);
         }
 
         // ----- EXTENSION POINT
-        $tar = Extension::registerPoint(new ExtensionPoint('BACKUP_AFTER_FILE_EXPORT', $tar));
+        $tar = Extension::dispatch(new ExtensionPoint('BACKUP_AFTER_FILE_EXPORT', $tar));
 
         $tar->close();
     }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -41,6 +41,6 @@ final class Cache
         }
 
         // ----- EXTENSION POINT
-        return Extension::registerPoint(new ExtensionPoint('CACHE_DELETED', I18n::msg('delete_cache_message')));
+        return Extension::dispatch(new ExtensionPoint('CACHE_DELETED', I18n::msg('delete_cache_message')));
     }
 }

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -12,10 +12,14 @@ use Redaxo\Core\Addon\Addon;
 use Redaxo\Core\Filesystem\File;
 use Redaxo\Core\Filesystem\Path;
 use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
 use RuntimeException;
 
 use function array_key_exists;
 use function class_exists;
+use function function_exists;
 use function implode;
 use function is_array;
 use function is_dir;
@@ -67,115 +71,149 @@ final class ClassDiscovery
         $cacheKey = $attributeClass . ($parentClass ? '|' . $parentClass : '');
         $cacheData = $this->loadCacheData();
 
-        if (isset($cacheData[$cacheKey])) {
-            // Reconstruct attribute instances from cached arrays (JSON roundtrip converts objects to arrays)
-            $result = [];
-            /** @var array<class-string, array<string, mixed>|object> $cached */
-            $cached = $cacheData[$cacheKey];
-            foreach ($cached as $class => $entry) {
-                /**
-                 * @var TAttribute $attribute
-                 * @psalm-suppress MixedMethodCall
-                 */
-                $attribute = is_array($entry) ? new $attributeClass(...$entry) : $entry;
-                $result[$class] = $attribute;
+        if (!isset($cacheData[$cacheKey])) {
+            // Only the attribute arguments are cached (always constant expressions, hence var_export-safe);
+            // the instance is reconstructed below from the known attribute class.
+            $raw = [];
+
+            foreach ($this->getReflections() as $reflection) {
+                if ($reflection->isAbstract()) {
+                    continue;
+                }
+
+                $attributes = $reflection->getAttributes($attributeClass);
+
+                if ([] === $attributes) {
+                    continue;
+                }
+
+                if (null !== $parentClass && !$reflection->isSubclassOf($parentClass)) {
+                    continue;
+                }
+
+                $raw[$reflection->getName()] = $attributes[0]->getArguments();
             }
-            /** @var array<class-string<TParent>, TAttribute> */
-            return $result;
+
+            $this->saveCacheData($cacheKey, $raw);
+            $cacheData[$cacheKey] = $raw;
         }
+
+        /** @var array<class-string<TParent>, array<int|string, mixed>> $cached */
+        $cached = $cacheData[$cacheKey];
 
         $result = [];
-
-        foreach ($this->getReflections() as $reflection) {
-            if ($reflection->isAbstract()) {
-                continue;
-            }
-
-            $attributes = $reflection->getAttributes($attributeClass);
-
-            if ([] === $attributes) {
-                continue;
-            }
-
-            if (null !== $parentClass && !$reflection->isSubclassOf($parentClass)) {
-                continue;
-            }
-
-            /** @var class-string<TParent> $class */
-            $class = $reflection->getName();
-            $result[$class] = $attributes[0]->newInstance();
+        foreach ($cached as $class => $arguments) {
+            /**
+             * @var TAttribute $attribute
+             * @psalm-suppress MixedMethodCall
+             */
+            $attribute = new $attributeClass(...$arguments);
+            $result[$class] = $attribute;
         }
 
-        $this->saveCacheData($cacheKey, $result);
-
+        /** @var array<class-string<TParent>, TAttribute> */
         return $result;
     }
 
     /**
      * Discovers all non-abstract methods (static and instance) that carry the given attribute.
      *
-     * Each entry contains the declaring class, method name, whether the method is static,
-     * and the attribute instance. Methods inherited from parent classes are not duplicated —
-     * only the declaring class is reported.
+     * Each entry contains the declaring class, method name, whether the method is static, the class/interface types of
+     * the method's first parameter (a list, so union types are fully captured), and the attribute instance. Methods
+     * inherited from parent classes are not duplicated — only the declaring class is reported.
      *
      * @template TAttribute of object
      * @param class-string<TAttribute> $attributeClass
-     * @return list<array{class: class-string, method: string, isStatic: bool, attribute: TAttribute}>
+     * @return list<array{class: class-string, method: string, isStatic: bool, firstParameterTypes: list<class-string>, attribute: TAttribute}>
      */
     public function discoverByMethodAttribute(string $attributeClass): array
     {
         $cacheKey = 'method:' . $attributeClass;
         $cacheData = $this->loadCacheData();
 
-        if (isset($cacheData[$cacheKey])) {
-            /** @var list<array{class: class-string, method: string, isStatic: bool, attribute: array<string, mixed>|TAttribute}> $cached */
-            $cached = $cacheData[$cacheKey];
-            $result = [];
-            foreach ($cached as $entry) {
-                /**
-                 * @var TAttribute $attribute
-                 * @psalm-suppress MixedMethodCall
-                 */
-                $attribute = is_array($entry['attribute']) ? new $attributeClass(...$entry['attribute']) : $entry['attribute'];
-                $result[] = [
-                    'class' => $entry['class'],
-                    'method' => $entry['method'],
-                    'isStatic' => $entry['isStatic'],
-                    'attribute' => $attribute,
-                ];
+        if (!isset($cacheData[$cacheKey])) {
+            // Only the attribute arguments are cached (always constant expressions, hence var_export-safe);
+            // the instance is reconstructed below from the known attribute class.
+            $raw = [];
+
+            foreach ($this->getReflections() as $reflection) {
+                $class = $reflection->getName();
+
+                foreach ($reflection->getMethods() as $method) {
+                    if ($method->isAbstract()) {
+                        continue;
+                    }
+
+                    // Skip methods inherited from a parent — they'll be reported on their declaring class.
+                    if ($method->getDeclaringClass()->getName() !== $class) {
+                        continue;
+                    }
+
+                    $attributes = $method->getAttributes($attributeClass);
+                    if ([] === $attributes) {
+                        continue;
+                    }
+
+                    $firstParameterTypes = self::classTypes(($method->getParameters()[0] ?? null)?->getType());
+
+                    foreach ($attributes as $attribute) {
+                        $raw[] = [
+                            'class' => $class,
+                            'method' => $method->getName(),
+                            'isStatic' => $method->isStatic(),
+                            'firstParameterTypes' => $firstParameterTypes,
+                            'arguments' => $attribute->getArguments(),
+                        ];
+                    }
+                }
             }
-            return $result;
+
+            $this->saveCacheData($cacheKey, $raw);
+            $cacheData[$cacheKey] = $raw;
         }
+
+        /** @var list<array{class: class-string, method: string, isStatic: bool, firstParameterTypes: list<class-string>, arguments: array<int|string, mixed>}> $cached */
+        $cached = $cacheData[$cacheKey];
 
         $result = [];
+        foreach ($cached as $entry) {
+            /**
+             * @var TAttribute $attribute
+             * @psalm-suppress MixedMethodCall
+             */
+            $attribute = new $attributeClass(...$entry['arguments']);
+            $result[] = [
+                'class' => $entry['class'],
+                'method' => $entry['method'],
+                'isStatic' => $entry['isStatic'],
+                'firstParameterTypes' => $entry['firstParameterTypes'],
+                'attribute' => $attribute,
+            ];
+        }
 
-        foreach ($this->getReflections() as $reflection) {
-            $class = $reflection->getName();
+        return $result;
+    }
 
-            foreach ($reflection->getMethods() as $method) {
-                if ($method->isAbstract()) {
-                    continue;
-                }
+    /**
+     * Returns the class/interface type names of a parameter type, flattening union types.
+     * Built-in types (including `null` from a nullable type) are omitted.
+     *
+     * @return list<class-string>
+     */
+    private static function classTypes(?ReflectionType $type): array
+    {
+        $parts = $type instanceof ReflectionUnionType ? $type->getTypes() : [$type];
 
-                // Skip methods inherited from a parent — they'll be reported on their declaring class.
-                if ($method->getDeclaringClass()->getName() !== $class) {
-                    continue;
-                }
-
-                foreach ($method->getAttributes($attributeClass) as $attribute) {
-                    $result[] = [
-                        'class' => $class,
-                        'method' => $method->getName(),
-                        'isStatic' => $method->isStatic(),
-                        'attribute' => $attribute->newInstance(),
-                    ];
-                }
+        $classTypes = [];
+        foreach ($parts as $part) {
+            if ($part instanceof ReflectionNamedType && !$part->isBuiltin()) {
+                /** @var class-string $name */
+                $name = $part->getName();
+                $classTypes[] = $name;
             }
         }
 
-        $this->saveCacheData($cacheKey, $result);
-
-        return $result;
+        return $classTypes;
     }
 
     public static function clearCache(): void
@@ -334,10 +372,18 @@ final class ClassDiscovery
             return $this->cacheData;
         }
 
-        /** @var array{addons_hash?: string, files_hash?: string, data?: array<string, mixed>} $cache */
-        $cache = File::getCache(self::getCacheFile());
+        // The cache is a plain PHP file (var_export + include) so it benefits from OpCache. It only ever holds
+        // scalars, arrays and enums (attribute arguments are constant expressions), never arbitrary objects, so
+        // including it cannot instantiate unexpected classes.
+        $file = self::getCacheFile();
+        if (!is_file($file)) {
+            return $this->cacheData = [];
+        }
 
-        if (!isset($cache['addons_hash']) || $cache['addons_hash'] !== $this->getAddonHash()) {
+        /** @var mixed $cache */
+        $cache = include $file;
+
+        if (!is_array($cache) || !isset($cache['addons_hash']) || $cache['addons_hash'] !== $this->getAddonHash()) {
             return $this->cacheData = [];
         }
 
@@ -348,7 +394,10 @@ final class ClassDiscovery
             }
         }
 
-        return $this->cacheData = $cache['data'] ?? [];
+        /** @var array<string, mixed> $data */
+        $data = $cache['data'] ?? [];
+
+        return $this->cacheData = $data;
     }
 
     private function saveCacheData(string $cacheKey, mixed $data): void
@@ -356,11 +405,16 @@ final class ClassDiscovery
         $this->cacheData = $this->loadCacheData();
         $this->cacheData[$cacheKey] = $data;
 
-        File::putCache(self::getCacheFile(), [
+        $file = self::getCacheFile();
+        File::put($file, '<?php' . "\n\n" . 'return ' . var_export([
             'addons_hash' => $this->getAddonHash(),
             'files_hash' => $this->getPhpFilesHash(),
             'data' => $this->cacheData,
-        ]);
+        ], true) . ';' . "\n");
+
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($file, true);
+        }
     }
 
     private function getAddonHash(): string
@@ -402,7 +456,7 @@ final class ClassDiscovery
 
     private static function getCacheFile(): string
     {
-        return Path::coreCache('class_discovery.cache');
+        return Path::coreCache('class_discovery.php');
     }
 
     private static function findClassLoader(): ClassLoader

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -81,7 +81,7 @@ class Application extends SymfonyApplication
 
         $exitCode = parent::doRunCommand($command, $input, $output);
 
-        Extension::registerPoint(new ConsoleShutdown($command, $input, $output, $exitCode));
+        Extension::dispatch(new ConsoleShutdown($command, $input, $output, $exitCode));
 
         return $exitCode;
     }
@@ -127,7 +127,7 @@ class Application extends SymfonyApplication
 
         Extension::registerByAttribute($this->project);
 
-        Extension::registerPoint(new ExtensionPoint('PACKAGES_INCLUDED'));
+        Extension::dispatch(new ExtensionPoint('PACKAGES_INCLUDED'));
 
         $this->project->boot();
     }

--- a/src/Console/Command/UserDeleteCommand.php
+++ b/src/Console/Command/UserDeleteCommand.php
@@ -56,7 +56,7 @@ final class UserDeleteCommand extends AbstractCommand
 
         User::clearInstance($user->id);
 
-        Extension::registerPoint(new ExtensionPoint('USER_DELETED', '', [
+        Extension::dispatch(new ExtensionPoint('USER_DELETED', '', [
             'id' => $user->id,
             'user' => $user,
         ], true));

--- a/src/Console/Command/UserSetPasswordCommand.php
+++ b/src/Console/Command/UserSetPasswordCommand.php
@@ -84,7 +84,7 @@ final class UserSetPasswordCommand extends AbstractCommand
             ->setValue('password_change_required', (int) $passwordChangeRequired)
             ->update();
 
-        Extension::registerPoint(new ExtensionPoint('PASSWORD_UPDATED', '', [
+        Extension::dispatch(new ExtensionPoint('PASSWORD_UPDATED', '', [
             'user_id' => $id,
             'user' => $user,
             'password' => $password,

--- a/src/Console/ExtensionPoint/ConsoleShutdown.php
+++ b/src/Console/ExtensionPoint/ConsoleShutdown.php
@@ -8,36 +8,16 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /** @extends ExtensionPoint<null> */
-class ConsoleShutdown extends ExtensionPoint
+final class ConsoleShutdown extends ExtensionPoint
 {
-    public const NAME = 'CONSOLE_SHUTDOWN';
+    public const string NAME = 'CONSOLE_SHUTDOWN';
 
     public function __construct(
-        private Command $command,
-        private InputInterface $input,
-        private OutputInterface $output,
-        private int $exitCode,
+        public readonly Command $command,
+        public readonly InputInterface $input,
+        public readonly OutputInterface $output,
+        public readonly int $exitCode,
     ) {
-        parent::__construct(self::NAME, null, [], true);
-    }
-
-    public function getCommand(): Command
-    {
-        return $this->command;
-    }
-
-    public function getInput(): InputInterface
-    {
-        return $this->input;
-    }
-
-    public function getOutput(): OutputInterface
-    {
-        return $this->output;
-    }
-
-    public function getExitCode(): int
-    {
-        return $this->exitCode;
+        parent::__construct(self::NAME, null, readonly: true);
     }
 }

--- a/src/Content/Article.php
+++ b/src/Content/Article.php
@@ -177,6 +177,6 @@ final class Article extends StructureElement
     #[Override]
     public function isPermitted(): bool
     {
-        return (bool) Extension::registerPoint(new ExtensionPoint('ART_IS_PERMITTED', true, ['element' => $this]));
+        return (bool) Extension::dispatch(new ExtensionPoint('ART_IS_PERMITTED', true, ['element' => $this]));
     }
 }

--- a/src/Content/ArticleContent.php
+++ b/src/Content/ArticleContent.php
@@ -137,7 +137,7 @@ class ArticleContent extends ArticleContentBase
             $CONTENT = parent::getArticle($curctype);
         }
 
-        return Extension::registerPoint(new ExtensionPoint('ART_CONTENT', $CONTENT, [
+        return Extension::dispatch(new ExtensionPoint('ART_CONTENT', $CONTENT, [
             'ctype' => $curctype,
             'article' => $this,
         ]));

--- a/src/Content/ArticleContentBase.php
+++ b/src/Content/ArticleContentBase.php
@@ -79,7 +79,7 @@ class ArticleContentBase
         }
 
         // ----- EXTENSION POINT
-        Extension::registerPoint(new ExtensionPoint('ART_INIT', '', [
+        Extension::dispatch(new ExtensionPoint('ART_INIT', '', [
             'article' => $this,
             'article_id' => $articleId,
             'clang' => $this->clang,
@@ -313,7 +313,7 @@ class ArticleContentBase
 
         $output = $module->output($slice);
 
-        $output = Extension::registerPoint(new ExtensionPoint(
+        $output = Extension::dispatch(new ExtensionPoint(
             'SLICE_OUTPUT',
             $output,
             [
@@ -487,7 +487,7 @@ class ArticleContentBase
             ORDER BY {$prefix}article_slice.priority
             SQL;
 
-        $query = Extension::registerPoint(new ExtensionPoint('ART_SLICES_QUERY', $query, ['article' => $this]));
+        $query = Extension::dispatch(new ExtensionPoint('ART_SLICES_QUERY', $query, ['article' => $this]));
 
         $artDataSql = Sql::factory();
         $artDataSql->setDebug($this->debug);
@@ -541,7 +541,7 @@ class ArticleContentBase
                 // --------------- ENDE EINZELNER SLICE
 
                 // --------------- EP: SLICE_SHOW
-                $sliceContent = Extension::registerPoint(
+                $sliceContent = Extension::dispatch(
                     new ExtensionPoint(
                         'SLICE_SHOW',
                         $sliceContent,

--- a/src/Content/ArticleContentEditor.php
+++ b/src/Content/ArticleContentEditor.php
@@ -104,7 +104,7 @@ class ArticleContentEditor extends ArticleContent
             }
 
             // EP for changing the module preview
-            $panel .= Extension::registerPoint(new ExtensionPoint('SLICE_BE_PREVIEW', $content, [
+            $panel .= Extension::dispatch(new ExtensionPoint('SLICE_BE_PREVIEW', $content, [
                 'article_id' => $this->article_id,
                 'clang' => $this->clang,
                 'ctype' => $this->ctype,
@@ -232,7 +232,7 @@ class ArticleContentEditor extends ArticleContent
         }
 
         // ----- EXTENSION POINT
-        Extension::registerPoint($ep = new SliceMenu(
+        Extension::dispatch($ep = new SliceMenu(
             $menuEditAction,
             $menuDeleteAction,
             $menuStatusAction,
@@ -249,11 +249,11 @@ class ArticleContentEditor extends ArticleContent
         ));
 
         $actionItems = [];
-        if ($ep->getMenuEditAction()) {
-            $actionItems[] = $ep->getMenuEditAction();
+        if ($ep->menuEditAction) {
+            $actionItems[] = $ep->menuEditAction;
         }
-        if ($ep->getMenuDeleteAction()) {
-            $actionItems[] = $ep->getMenuDeleteAction();
+        if ($ep->menuDeleteAction) {
+            $actionItems[] = $ep->menuDeleteAction;
         }
         if (count($actionItems) > 0) {
             $fragment = new Fragment();
@@ -261,24 +261,24 @@ class ArticleContentEditor extends ArticleContent
             $headerRight .= $fragment->parse('core/structure/content/slice_menu_action.php');
         }
 
-        if ($ep->getMenuStatusAction()) {
+        if ($ep->menuStatusAction) {
             $fragment = new Fragment();
-            $fragment->setVar('items', [$ep->getMenuStatusAction()], false);
+            $fragment->setVar('items', [$ep->menuStatusAction], false);
             $headerRight .= $fragment->parse('core/structure/content/slice_menu_action.php');
         }
 
-        if (count($ep->getAdditionalActions()) > 0) {
+        if (count($ep->additionalActions) > 0) {
             $fragment = new Fragment();
-            $fragment->setVar('items', $ep->getAdditionalActions(), false);
+            $fragment->setVar('items', $ep->additionalActions, false);
             $headerRight .= $fragment->parse('core/structure/content/slice_menu_ep.php');
         }
 
         $moveItems = [];
-        if ($ep->getMenuMoveupAction()) {
-            $moveItems[] = $ep->getMenuMoveupAction();
+        if ($ep->menuMoveupAction) {
+            $moveItems[] = $ep->menuMoveupAction;
         }
-        if ($ep->getMenuMovedownAction()) {
-            $moveItems[] = $ep->getMenuMovedownAction();
+        if ($ep->menuMovedownAction) {
+            $moveItems[] = $ep->menuMovedownAction;
         }
         if (count($moveItems) > 0) {
             $fragment = new Fragment();
@@ -329,7 +329,7 @@ class ArticleContentEditor extends ArticleContent
         $fragment->setVar('button_label', I18n::msg('add_block'));
         $fragment->setVar('items', $items, false);
         $select = $fragment->parse('core/structure/content/module_select.php');
-        $select = Extension::registerPoint(new ExtensionPoint(
+        $select = Extension::dispatch(new ExtensionPoint(
             'STRUCTURE_CONTENT_MODULE_SELECT',
             $select,
             [

--- a/src/Content/ArticleHandler.php
+++ b/src/Content/ArticleHandler.php
@@ -96,7 +96,7 @@ class ArticleHandler
             ArticleCache::delete($id, $key);
 
             // ----- EXTENSION POINT
-            $message = Extension::registerPoint(new ExtensionPoint('ART_ADDED', $message, [
+            $message = Extension::dispatch(new ExtensionPoint('ART_ADDED', $message, [
                 'id' => $id,
                 'clang' => $key,
                 'status' => 0,
@@ -189,7 +189,7 @@ class ArticleHandler
         ArticleCache::delete($articleId);
 
         // ----- EXTENSION POINT
-        $message = Extension::registerPoint(new ExtensionPoint('ART_UPDATED', $message, [
+        $message = Extension::dispatch(new ExtensionPoint('ART_UPDATED', $message, [
             'id' => $articleId,
             'article' => clone $EA,
             'article_old' => clone $thisArt,
@@ -229,7 +229,7 @@ class ArticleHandler
                 self::newArtPrio($parentId, $clang, 0, 1);
 
                 // ----- EXTENSION POINT
-                $message = Extension::registerPoint(new ExtensionPoint('ART_DELETED', $message, [
+                $message = Extension::dispatch(new ExtensionPoint('ART_DELETED', $message, [
                     'id' => $articleId,
                     'clang' => $clang,
                     'parent_id' => $parentId,
@@ -286,7 +286,7 @@ class ArticleHandler
         $message = '';
         if ($ART->getRows() > 0) {
             $parentId = (int) $ART->getValue('parent_id');
-            $message = Extension::registerPoint(new ExtensionPoint('ART_PRE_DELETED', $message, [
+            $message = Extension::dispatch(new ExtensionPoint('ART_PRE_DELETED', $message, [
                 'id' => $id,
                 'parent_id' => $parentId,
                 'name' => $ART->getValue('name'),
@@ -355,7 +355,7 @@ class ArticleHandler
             ArticleCache::delete($articleId, $clang);
 
             // ----- EXTENSION POINT
-            Extension::registerPoint(new ExtensionPoint('ART_STATUS', null, [
+            Extension::dispatch(new ExtensionPoint('ART_STATUS', null, [
                 'id' => $articleId,
                 'clang' => $clang,
                 'status' => $newstatus,
@@ -385,7 +385,7 @@ class ArticleHandler
             ];
 
             // ----- EXTENSION POINT
-            $artStatusTypes = Extension::registerPoint(new ExtensionPoint('ART_STATUS_TYPES', $artStatusTypes));
+            $artStatusTypes = Extension::dispatch(new ExtensionPoint('ART_STATUS_TYPES', $artStatusTypes));
         }
 
         return $artStatusTypes;
@@ -483,7 +483,7 @@ class ArticleHandler
         ArticleCache::delete($artId);
 
         foreach (Language::getAllIds() as $clang) {
-            Extension::registerPoint(new ExtensionPoint('ART_TO_CAT', '', [
+            Extension::dispatch(new ExtensionPoint('ART_TO_CAT', '', [
                 'id' => $artId,
                 'clang' => $clang,
             ]));
@@ -541,7 +541,7 @@ class ArticleHandler
         ArticleCache::delete($artId);
 
         foreach (Language::getAllIds() as $clang) {
-            Extension::registerPoint(new ExtensionPoint('CAT_TO_ART', '', [
+            Extension::dispatch(new ExtensionPoint('CAT_TO_ART', '', [
                 'id' => $artId,
                 'clang' => $clang,
             ]));
@@ -652,7 +652,7 @@ class ArticleHandler
         ComplexPermission::replaceItem('structure', $altId, $neuId);
 
         foreach (Language::getAllIds() as $clang) {
-            Extension::registerPoint(new ExtensionPoint('ART_TO_STARTARTICLE', '', [
+            Extension::dispatch(new ExtensionPoint('ART_TO_STARTARTICLE', '', [
                 'id' => $neuId,
                 'id_old' => $altId,
                 'clang' => $clang,
@@ -784,7 +784,7 @@ class ArticleHandler
                     // Prios neu berechnen
                     self::newArtPrio($toCatId, $clang, 1, 0);
 
-                    Extension::registerPoint(new ExtensionPoint('ART_COPIED', null, [
+                    Extension::dispatch(new ExtensionPoint('ART_COPIED', null, [
                         'id_source' => $id,
                         'id' => $newId,
                         'clang' => $clang,
@@ -869,7 +869,7 @@ class ArticleHandler
                     self::newArtPrio($toCatId, $clang, 1, 0);
                     self::newArtPrio($fromCatId, $clang, 1, 0);
 
-                    Extension::registerPoint(new ExtensionPoint('ART_MOVED', null, [
+                    Extension::dispatch(new ExtensionPoint('ART_MOVED', null, [
                         'id' => $id,
                         'clang' => $clang,
                         'category_id' => $parentId,

--- a/src/Content/Category.php
+++ b/src/Content/Category.php
@@ -164,6 +164,6 @@ final class Category extends StructureElement
     #[Override]
     public function isPermitted(): bool
     {
-        return (bool) Extension::registerPoint(new ExtensionPoint('CAT_IS_PERMITTED', true, ['element' => $this]));
+        return (bool) Extension::dispatch(new ExtensionPoint('CAT_IS_PERMITTED', true, ['element' => $this]));
     }
 }

--- a/src/Content/CategoryHandler.php
+++ b/src/Content/CategoryHandler.php
@@ -122,7 +122,7 @@ class CategoryHandler
 
             // ----- EXTENSION POINT
             // Objekte clonen, damit diese nicht von der extension veraendert werden koennen
-            $message = Extension::registerPoint(new ExtensionPoint('CAT_ADDED', $message, [
+            $message = Extension::dispatch(new ExtensionPoint('CAT_ADDED', $message, [
                 'category' => clone $AART,
                 'id' => $id,
                 'parent_id' => $categoryId,
@@ -222,7 +222,7 @@ class CategoryHandler
 
         // ----- EXTENSION POINT
         // Objekte clonen, damit diese nicht von der extension veraendert werden koennen
-        $message = Extension::registerPoint(new ExtensionPoint('CAT_UPDATED', $message, [
+        $message = Extension::dispatch(new ExtensionPoint('CAT_UPDATED', $message, [
             'id' => $categoryId,
 
             'category' => clone $EKAT,
@@ -280,7 +280,7 @@ class CategoryHandler
                         self::newCatPrio($parentId, $clang, 0, 1);
 
                         // ----- EXTENSION POINT
-                        $message = Extension::registerPoint(new ExtensionPoint('CAT_DELETED', $message, [
+                        $message = Extension::dispatch(new ExtensionPoint('CAT_DELETED', $message, [
                             'id' => $categoryId,
                             'parent_id' => $parentId,
                             'clang' => $clang,
@@ -340,7 +340,7 @@ class CategoryHandler
             ArticleCache::delete($categoryId, $clang);
 
             // ----- EXTENSION POINT
-            Extension::registerPoint(new ExtensionPoint('CAT_STATUS', null, [
+            Extension::dispatch(new ExtensionPoint('CAT_STATUS', null, [
                 'id' => $categoryId,
                 'clang' => $clang,
                 'status' => $newstatus,
@@ -370,7 +370,7 @@ class CategoryHandler
             ];
 
             // ----- EXTENSION POINT
-            $catStatusTypes = Extension::registerPoint(new ExtensionPoint('CAT_STATUS_TYPES', $catStatusTypes));
+            $catStatusTypes = Extension::dispatch(new ExtensionPoint('CAT_STATUS_TYPES', $catStatusTypes));
         }
 
         return $catStatusTypes;
@@ -539,7 +539,7 @@ class CategoryHandler
         foreach (Language::getAllIds() as $clang) {
             self::newCatPrio((int) $fcat->getValue('parent_id'), $clang, 0, 1);
 
-            Extension::registerPoint(new ExtensionPoint('CAT_MOVED', null, [
+            Extension::dispatch(new ExtensionPoint('CAT_MOVED', null, [
                 'id' => $fromCat,
                 'clang_id' => $clang, // deprecated, use "clang" instead
                 'clang' => $clang,

--- a/src/Content/ContentHandler.php
+++ b/src/Content/ContentHandler.php
@@ -69,7 +69,7 @@ class ContentHandler
         $article = Article::require($articleId, $clangId);
 
         // ----- EXTENSION POINT
-        $message = Extension::registerPoint(new ExtensionPoint('SLICE_ADDED', $message, [
+        $message = Extension::dispatch(new ExtensionPoint('SLICE_ADDED', $message, [
             'article_id' => $articleId,
             'clang' => $clangId,
             'function' => '',
@@ -82,7 +82,7 @@ class ContentHandler
             'slice_revision' => $data['revision'],
         ]));
 
-        return Extension::registerPoint(new ArticleContentUpdated($article, 'slice_added', $message));
+        return Extension::dispatch(new ArticleContentUpdated($article, 'slice_added', $message));
     }
 
     /**
@@ -121,7 +121,7 @@ class ContentHandler
             $ctype = $CM->getValue('ctype_id');
             $sliceRevision = $CM->getValue('revision');
 
-            Extension::registerPoint(new ExtensionPoint('SLICE_MOVE', '', [
+            Extension::dispatch(new ExtensionPoint('SLICE_MOVE', '', [
                 'direction' => $direction,
                 'slice_id' => $sliceId,
                 'article_id' => $articleId,
@@ -158,7 +158,7 @@ class ContentHandler
 
                 $info = I18n::msg('slice_moved');
                 $article = Article::get($articleId, $clang);
-                $info = Extension::registerPoint(new ArticleContentUpdated($article, 'slice_moved', $info));
+                $info = Extension::dispatch(new ArticleContentUpdated($article, 'slice_moved', $info));
             } else {
                 throw new InvalidArgumentException('Unsupported move direction "' . $direction . '".');
             }
@@ -185,7 +185,7 @@ class ContentHandler
             return false;
         }
 
-        Extension::registerPoint(new ExtensionPoint('SLICE_DELETE', '', [
+        Extension::dispatch(new ExtensionPoint('SLICE_DELETE', '', [
             'slice_id' => $sliceId,
             'article_id' => $curr->getValue('article_id'),
             'clang_id' => $curr->getValue('clang_id'),
@@ -227,7 +227,7 @@ class ContentHandler
 
         ArticleCache::deleteContent($article->id, $article->clangId);
 
-        Extension::registerPoint(new ArticleContentUpdated($article, 'slice_status'));
+        Extension::dispatch(new ArticleContentUpdated($article, 'slice_status'));
     }
 
     /**
@@ -255,7 +255,7 @@ class ContentHandler
             $gc->setQuery('select * from ' . Core::getTablePrefix() . 'article_slice where article_id=? and clang_id=? and revision=?', [$fromId, $fromClang, $revision]);
         }
 
-        Extension::registerPoint(new ExtensionPoint('ART_SLICES_COPY', '', [
+        Extension::dispatch(new ExtensionPoint('ART_SLICES_COPY', '', [
             'article_id' => $toId,
             'clang_id' => $toClang,
             'slice_revision' => $revision,
@@ -336,7 +336,7 @@ class ContentHandler
         ArticleCache::deleteContent($toId, $toClang);
 
         $article = Article::require($toId, $toClang);
-        Extension::registerPoint(new ArticleContentUpdated($article, 'content_copied'));
+        Extension::dispatch(new ArticleContentUpdated($article, 'content_copied'));
 
         return true;
     }
@@ -367,7 +367,7 @@ class ContentHandler
             $articleContent = $CONT->getArticle();
 
             // ----- EXTENSION POINT
-            $articleContent = Extension::registerPoint(new ExtensionPoint('GENERATE_FILTER', $articleContent, [
+            $articleContent = Extension::dispatch(new ExtensionPoint('GENERATE_FILTER', $articleContent, [
                 'id' => $articleId,
                 'clang' => $clangId,
                 'article' => $CONT,

--- a/src/Content/ExtensionPoint/ArticleContentUpdated.php
+++ b/src/Content/ExtensionPoint/ArticleContentUpdated.php
@@ -8,33 +8,22 @@ use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 /**
  * @extends ExtensionPoint<string>
  */
-class ArticleContentUpdated extends ExtensionPoint
+final class ArticleContentUpdated extends ExtensionPoint
 {
-    public const NAME = 'ART_CONTENT_UPDATED';
-
-    private Article $article;
-    private string $action;
+    public const string NAME = 'ART_CONTENT_UPDATED';
 
     /** @param array<string, mixed> $params */
-    public function __construct(Article $article, string $action, string $subject = '', array $params = [], bool $readonly = false)
-    {
+    public function __construct(
+        public readonly Article $article,
+        public readonly string $action,
+        string $subject = '',
+        array $params = [],
+        bool $readonly = false,
+    ) {
         // for BC 'simple' attach params
         $params['article_id'] = $article->id;
         $params['clang'] = $article->clangId;
 
         parent::__construct(self::NAME, $subject, $params, $readonly);
-
-        $this->article = $article;
-        $this->action = $action;
-    }
-
-    public function getArticle(): Article
-    {
-        return $this->article;
-    }
-
-    public function getAction(): string
-    {
-        return $this->action;
     }
 }

--- a/src/Content/ExtensionPoint/SliceMenu.php
+++ b/src/Content/ExtensionPoint/SliceMenu.php
@@ -2,18 +2,18 @@
 
 namespace Redaxo\Core\Content\ExtensionPoint;
 
-use Redaxo\Core\ExtensionPoint\Extension;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Http\Context;
 
 /**
  * @extends ExtensionPoint<null>
  */
-class SliceMenu extends ExtensionPoint
+final class SliceMenu extends ExtensionPoint
 {
-    public const NAME = 'SLICE_MENU';
+    public const string NAME = 'SLICE_MENU';
 
-    private array $additionalActions = [];
+    /** @var list<array<string, mixed>> */
+    public array $additionalActions = [];
 
     /**
      * @param array{label?: string, url?: string, attributes?: array{class: list<string>, title: string}} $menuEditAction
@@ -23,151 +23,20 @@ class SliceMenu extends ExtensionPoint
      * @param array{hidden_label?: string, url?: string, icon?: string, attributes?: array{class: list<string>, title: string}} $menuMovedownAction
      */
     public function __construct(
-        private array $menuEditAction,
-        private array $menuDeleteAction,
-        private array $menuStatusAction,
-        private array $menuMoveupAction,
-        private array $menuMovedownAction,
-        private Context $context,
-        private string $fragment,
-        private int $articleId,
-        private int $clang,
-        private int $ctype,
-        private string $moduleKey,
-        private int $sliceId,
-        private bool $hasPerm,
+        public array $menuEditAction,
+        public array $menuDeleteAction,
+        public array $menuStatusAction,
+        public array $menuMoveupAction,
+        public array $menuMovedownAction,
+        public readonly Context $context,
+        public readonly string $fragment,
+        public readonly int $articleId,
+        public readonly int $languageId,
+        public readonly int $contentSectionId,
+        public readonly string $moduleKey,
+        public readonly int $sliceId,
+        public readonly bool $hasPerm,
     ) {
         parent::__construct(self::NAME);
-    }
-
-    /** @return array{label?: string, url?: string, attributes?: array{class: list<string>, title: string}} */
-    public function getMenuEditAction(): array
-    {
-        return $this->menuEditAction;
-    }
-
-    /** @param array{label?: string, url?: string, attributes?: array{class: list<string>, title: string}} $menuEditAction */
-    public function setMenuEditAction(array $menuEditAction): void
-    {
-        $this->menuEditAction = $menuEditAction;
-    }
-
-    /** @return array{label?: string, url?: string, attributes?: array{class: list<string>, title: string, data-confirm: string}} */
-    public function getMenuDeleteAction(): array
-    {
-        return $this->menuDeleteAction;
-    }
-
-    /** @param array{label?: string, url?: string, attributes?: array{class: list<string>, title: string, data-confirm: string}} $menuDeleteAction */
-    public function setMenuDeleteAction(array $menuDeleteAction): void
-    {
-        $this->menuDeleteAction = $menuDeleteAction;
-    }
-
-    /** @return array{label?: string, url?: string, attributes?: array{class: list<string>}} */
-    public function getMenuStatusAction(): array
-    {
-        return $this->menuStatusAction;
-    }
-
-    /** @param array{label?: string, url?: string, attributes?: array{class: list<string>}} $menuStatusAction */
-    public function setMenuStatusAction(array $menuStatusAction): void
-    {
-        $this->menuStatusAction = $menuStatusAction;
-    }
-
-    /** @return array{hidden_label?: string, url?: string, icon?: string, attributes?: array{class: list<string>, title: string}} */
-    public function getMenuMoveupAction(): array
-    {
-        return $this->menuMoveupAction;
-    }
-
-    /** @param array{hidden_label?: string, url?: string, icon?: string, attributes?: array{class: list<string>, title: string}} $menuMoveupAction */
-    public function setMenuMoveupAction(array $menuMoveupAction): void
-    {
-        $this->menuMoveupAction = $menuMoveupAction;
-    }
-
-    /** @return array{hidden_label?: string, url?: string, icon?: string, attributes?: array{class: list<string>, title: string}} */
-    public function getMenuMovedownAction(): array
-    {
-        return $this->menuMovedownAction;
-    }
-
-    /** @param array{hidden_label?: string, url?: string, icon?: string, attributes?: array{class: list<string>, title: string}} $menuMovedownAction */
-    public function setMenuMovedownAction(array $menuMovedownAction): void
-    {
-        $this->menuMovedownAction = $menuMovedownAction;
-    }
-
-    public function getAdditionalActions(): array
-    {
-        // ----- EXTENSION POINT / for BC reasons we wrap the old and pre-existing EP here
-        $menuItemsEp = [];
-
-        $menuItemsEp = Extension::registerPoint(new ExtensionPoint(
-            'STRUCTURE_CONTENT_SLICE_MENU',
-            $menuItemsEp,
-            [
-                'article_id' => $this->articleId,
-                'clang' => $this->clang,
-                'ctype' => $this->ctype,
-                'module_key' => $this->moduleKey,
-                'slice_id' => $this->sliceId,
-                'perm' => $this->hasPerm,
-            ],
-        ));
-
-        return array_merge($this->additionalActions, $menuItemsEp);
-    }
-
-    public function setAdditionalActions(array $additionalActions): void
-    {
-        $this->additionalActions = $additionalActions;
-    }
-
-    public function addAdditionalActions(array $additionalActions): void
-    {
-        $this->additionalActions = array_merge($this->additionalActions, $additionalActions);
-    }
-
-    public function getContext(): Context
-    {
-        return $this->context;
-    }
-
-    public function getFragment(): string
-    {
-        return $this->fragment;
-    }
-
-    public function getArticleId(): int
-    {
-        return $this->articleId;
-    }
-
-    public function getClangId(): int
-    {
-        return $this->clang;
-    }
-
-    public function getCtypeId(): int
-    {
-        return $this->ctype;
-    }
-
-    public function getModuleKey(): string
-    {
-        return $this->moduleKey;
-    }
-
-    public function getSliceId(): int
-    {
-        return $this->sliceId;
-    }
-
-    public function hasPerm(): bool
-    {
-        return $this->hasPerm;
     }
 }

--- a/src/ExtensionPoint/AsExtension.php
+++ b/src/ExtensionPoint/AsExtension.php
@@ -7,9 +7,12 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final readonly class AsExtension
 {
-    /** @param Extension::EARLY|Extension::NORMAL|Extension::LATE $level */
+    /**
+     * @param string|null $extensionPoint Name of the extension point. May be omitted if the extension method's first
+     *     parameter is typed as a concrete {@see ExtensionPoint} subclass — the name is then derived from that class.
+     */
     public function __construct(
-        public string $extensionPoint,
-        public int $level = Extension::NORMAL,
+        public ?string $extensionPoint = null,
+        public ExtensionLevel $level = ExtensionLevel::Normal,
     ) {}
 }

--- a/src/ExtensionPoint/Extension.php
+++ b/src/ExtensionPoint/Extension.php
@@ -6,39 +6,34 @@ use Redaxo\Core\AbstractProject;
 use Redaxo\Core\Addon\Addon;
 use Redaxo\Core\Base\FactoryTrait;
 use Redaxo\Core\ClassDiscovery;
-use Redaxo\Core\Exception\InvalidArgumentException;
 use Redaxo\Core\Exception\LogicException;
 use Redaxo\Core\Util\Timer;
 
 use function call_user_func;
-use function in_array;
+use function constant;
+use function defined;
 use function is_array;
-use function is_int;
 use function is_string;
 use function sprintf;
-
-use const E_USER_WARNING;
 
 /**
  * Klasse die Einsprungpunkte zur Erweiterung der Kernfunktionalitaet bietet.
  */
-abstract class Extension
+class Extension
 {
     use FactoryTrait;
-
-    public const EARLY = -1;
-    public const NORMAL = 0;
-    public const LATE = 1;
 
     /**
      * Array of registered extensions.
      *
-     * @var array<string, array<self::*, list<array{callable, array<string, mixed>}>>>
+     * @var array<string, array<string, list<callable>>>
      */
     private static array $extensions = [];
 
+    final private function __construct() {}
+
     /**
-     * Registers an extension point.
+     * Dispatches an extension point, running all registered extensions.
      *
      * @template T
      * @param ExtensionPoint<T> $extensionPoint Extension point
@@ -46,38 +41,36 @@ abstract class Extension
      *
      * @psalm-taint-specialize
      */
-    public static function registerPoint(ExtensionPoint $extensionPoint)
+    public static function dispatch(ExtensionPoint $extensionPoint): mixed
     {
         if ($factoryClass = static::getExplicitFactoryClass()) {
-            return $factoryClass::registerPoint($extensionPoint);
+            return $factoryClass::dispatch($extensionPoint);
         }
 
-        $name = $extensionPoint->getName();
+        $name = $extensionPoint->name;
 
         Timer::measure('EP: ' . $name, static function () use ($extensionPoint, $name) {
-            foreach ([self::EARLY, self::NORMAL, self::LATE] as $level) {
-                if (!isset(self::$extensions[$name][$level]) || !is_array(self::$extensions[$name][$level])) {
+            foreach (ExtensionLevel::cases() as $level) {
+                if (!isset(self::$extensions[$name][$level->name]) || !is_array(self::$extensions[$name][$level->name])) {
                     continue;
                 }
 
-                foreach (self::$extensions[$name][$level] as $extensionAndParams) {
-                    [$extension, $params] = $extensionAndParams;
-                    $extensionPoint->setExtensionParams($params);
+                foreach (self::$extensions[$name][$level->name] as $extension) {
                     /** @var T|null $subject */
                     $subject = call_user_func($extension, $extensionPoint);
                     // Update subject only if the EP is not readonly and the extension has returned something
-                    if ($extensionPoint->isReadonly()) {
+                    if ($extensionPoint->readonly) {
                         continue;
                     }
                     if (null === $subject) {
                         continue;
                     }
-                    $extensionPoint->setSubject($subject);
+                    $extensionPoint->subject = $subject;
                 }
             }
         });
 
-        return $extensionPoint->getSubject();
+        return $extensionPoint->subject;
     }
 
     /**
@@ -86,30 +79,17 @@ abstract class Extension
      * @template T as ExtensionPoint
      * @param string|list<string> $extensionPoint Name(s) of extension point(s)
      * @param callable(T):mixed $extension Callback extension
-     * @param self::* $level Runlevel (`Extension::EARLY`, `Extension::NORMAL` or `Extension::LATE`)
-     * @param array<string, mixed> $params Additional params
-     * @return void
+     * @param ExtensionLevel $level Run level (`ExtensionLevel::Early`, `ExtensionLevel::Normal` or `ExtensionLevel::Late`)
      */
-    public static function register($extensionPoint, callable $extension, $level = self::NORMAL, array $params = [])
+    public static function register(string|array $extensionPoint, callable $extension, ExtensionLevel $level = ExtensionLevel::Normal): void
     {
         if ($factoryClass = static::getExplicitFactoryClass()) {
-            $factoryClass::register($extensionPoint, $extension, $level, $params);
+            $factoryClass::register($extensionPoint, $extension, $level);
             return;
         }
 
-        // bc
-        if (is_string($level)) {
-            trigger_error(__METHOD__ . ': Argument $level should be one of the constants ' . self::class . '::EARLY/NORMAL/LATE, but string "' . $level . '" given', E_USER_WARNING);
-
-            $level = (int) $level;
-        }
-
-        if (!in_array($level, [self::EARLY, self::NORMAL, self::LATE], true)) {
-            throw new InvalidArgumentException('Argument $level should be one of the constants ' . self::class . '::EARLY/NORMAL/LATE, but "' . (is_int($level) ? $level : get_debug_type($level)) . '" given');
-        }
-
         foreach ((array) $extensionPoint as $ep) {
-            self::$extensions[$ep][$level][] = [$extension, $params];
+            self::$extensions[$ep][$level->name][] = $extension;
         }
     }
 
@@ -122,7 +102,7 @@ abstract class Extension
      *
      * @internal
      */
-    public static function registerByAttribute(AbstractProject $project): void
+    final public static function registerByAttribute(AbstractProject $project): void
     {
         /** @var array<class-string<Addon>, Addon>|null $addonByClass */
         $addonByClass = null;
@@ -156,8 +136,11 @@ abstract class Extension
                 ));
             }
 
+            $extensionPoint = $entry['attribute']->extensionPoint
+                ?? self::resolveExtensionPointNames($entry['firstParameterTypes'], $entry['class'], $entry['method']);
+
             self::register(
-                $entry['attribute']->extensionPoint,
+                $extensionPoint,
                 $callable,
                 $entry['attribute']->level,
             );
@@ -165,16 +148,54 @@ abstract class Extension
     }
 
     /**
-     * Checks whether an extension is registered for the given extension point.
+     * Derives the extension point name(s) from the type of an extension method's first parameter,
+     * used when `#[AsExtension]` is given without an explicit name. A union type registers the
+     * extension for every listed extension point.
+     *
+     * @param list<class-string> $firstParameterTypes
+     * @return non-empty-list<string>
+     */
+    private static function resolveExtensionPointNames(array $firstParameterTypes, string $class, string $method): array
+    {
+        $names = [];
+
+        foreach ($firstParameterTypes as $type) {
+            if (!is_subclass_of($type, ExtensionPoint::class)) {
+                continue;
+            }
+
+            // The name is the EP class' `NAME` constant if defined, otherwise its FQCN — matching the
+            // name an instance of that class reports when dispatched.
+            if (defined($type . '::NAME')) {
+                /** @var mixed $name */
+                $name = constant($type . '::NAME');
+                $names[] = is_string($name) ? $name : $type;
+            } else {
+                $names[] = $type;
+            }
+        }
+
+        if ([] === $names) {
+            throw new LogicException(sprintf(
+                '#[AsExtension] without an explicit extension point name on "%s::%s()" requires the first parameter to be typed as one or more %s subclasses.',
+                $class,
+                $method,
+                ExtensionPoint::class,
+            ));
+        }
+
+        return $names;
+    }
+
+    /**
+     * Checks whether any extension is registered for the given extension point.
      *
      * @param string $extensionPoint Name of extension point
-     *
-     * @return bool
      */
-    public static function isRegistered($extensionPoint)
+    public static function hasExtensions(string $extensionPoint): bool
     {
         if ($factoryClass = static::getExplicitFactoryClass()) {
-            return $factoryClass::isRegistered($extensionPoint);
+            return $factoryClass::hasExtensions($extensionPoint);
         }
         return !empty(self::$extensions[$extensionPoint]);
     }

--- a/src/ExtensionPoint/ExtensionLevel.php
+++ b/src/ExtensionPoint/ExtensionLevel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Redaxo\Core\ExtensionPoint;
+
+/** Run level controlling the order in which extensions of an extension point are executed. */
+enum ExtensionLevel
+{
+    /** Executed before normal extensions. */
+    case Early;
+
+    /** Executed in registration order (default). */
+    case Normal;
+
+    /** Executed after normal extensions. */
+    case Late;
+}

--- a/src/ExtensionPoint/ExtensionPoint.php
+++ b/src/ExtensionPoint/ExtensionPoint.php
@@ -11,104 +11,43 @@ use Redaxo\Core\Exception\LogicException;
  */
 class ExtensionPoint
 {
-    /** @var array<string, mixed> */
-    private array $extensionParams = [];
-
     /**
-     * @param string $name
      * @param T $subject
      * @param array<string, mixed> $params
-     * @param bool $readonly
      */
     public function __construct(
-        private $name,
-        private $subject = null,
+        final public readonly string $name,
+        final public mixed $subject = null {
+            set {
+                if ($this->readonly ?? false) { // @phpstan-ignore nullCoalesce.property
+                    throw new LogicException('Subject can\'t be adjusted in readonly extension points.');
+                }
+                $this->subject = $value;
+            }
+        },
         private array $params = [],
-        private $readonly = false,
+        final public readonly bool $readonly = false,
     ) {}
 
-    /**
-     * Returns the name.
-     *
-     * @return string
-     */
-    public function getName()
+    /** Sets a param. */
+    final public function setParam(string $key, mixed $value): void
     {
-        return $this->name;
-    }
-
-    /**
-     * Sets the subject.
-     *
-     * @param T $subject
-     * @return void
-     */
-    public function setSubject($subject)
-    {
-        if ($this->isReadonly()) {
-            throw new LogicException('Subject can\'t be adjusted in readonly extension points.');
-        }
-        $this->subject = $subject;
-    }
-
-    /**
-     * Returns the subject.
-     *
-     * @return T
-     */
-    public function getSubject()
-    {
-        return $this->subject;
-    }
-
-    /**
-     * Sets a param.
-     *
-     * @param string $key
-     * @param mixed $value
-     * @return void
-     */
-    public function setParam($key, $value)
-    {
-        if ($this->isReadonly()) {
+        if ($this->readonly) {
             throw new LogicException('Params can\'t be adjusted in readonly extension points.');
         }
         $this->params[$key] = $value;
     }
 
-    /**
-     * Sets the specific params for the next extension.
-     * @param array<string, mixed> $params
-     * @return void
-     */
-    public function setExtensionParams(array $params)
+    /** Returns whether the given param exists. */
+    final public function hasParam(string $key): bool
     {
-        $this->extensionParams = $params;
+        return isset($this->params[$key]);
     }
 
-    /**
-     * Returns whether the given param exists.
-     *
-     * @param string $key
-     *
-     * @return bool
-     */
-    public function hasParam($key)
+    /** Returns the param for the given key. */
+    final public function getParam(string $key, mixed $default = null): mixed
     {
-        return isset($this->params[$key]) || isset($this->extensionParams[$key]);
-    }
-
-    /**
-     * Returns the param for the given key.
-     *
-     * @param string $key
-     * @param mixed $default
-     *
-     * @return mixed
-     */
-    public function getParam($key, $default = null)
-    {
-        return $this->extensionParams[$key] ?? $this->params[$key] ?? $default;
+        return $this->params[$key] ?? $default;
     }
 
     /**
@@ -116,18 +55,8 @@ class ExtensionPoint
      *
      * @return array<string, mixed>
      */
-    public function getParams()
+    final public function getParams(): array
     {
-        return array_merge($this->params, $this->extensionParams);
-    }
-
-    /**
-     * Returns whether the extension point is readonly.
-     *
-     * @return bool
-     */
-    public function isReadonly()
-    {
-        return $this->readonly;
+        return $this->params;
     }
 }

--- a/src/Filesystem/Url.php
+++ b/src/Filesystem/Url.php
@@ -117,12 +117,12 @@ final class Url
         // ----- get clang
         // Wenn eine rexExtension vorhanden ist, immer die clang mitgeben!
         // Die rexExtension muss selbst entscheiden was sie damit macht
-        if (!Language::exists($clang) && (Language::count() > 1 || Extension::isRegistered('URL_REWRITE'))) {
+        if (!Language::exists($clang) && (Language::count() > 1 || Extension::hasExtensions('URL_REWRITE'))) {
             $clang = Language::getCurrentId();
         }
 
         // ----- EXTENSION POINT
-        $url = Extension::registerPoint(new ExtensionPoint('URL_REWRITE', '', ['id' => $id, 'clang' => $clang, 'params' => $params]));
+        $url = Extension::dispatch(new ExtensionPoint('URL_REWRITE', '', ['id' => $id, 'clang' => $clang, 'params' => $params]));
 
         if ('' == $url) {
             if (Language::count() > 1) {

--- a/src/Form/AbstractForm.php
+++ b/src/Form/AbstractForm.php
@@ -615,7 +615,7 @@ abstract class AbstractForm
     public static function getInputClassName($inputType)
     {
         // ----- EXTENSION POINT
-        $className = Extension::registerPoint(new ExtensionPoint('REX_FORM_INPUT_CLASS', '', ['inputType' => $inputType]));
+        $className = Extension::dispatch(new ExtensionPoint('REX_FORM_INPUT_CLASS', '', ['inputType' => $inputType]));
 
         if ($className) {
             return $className;
@@ -643,7 +643,7 @@ abstract class AbstractForm
     public static function getInputTagName($inputType)
     {
         // ----- EXTENSION POINT
-        $inputTag = Extension::registerPoint(new ExtensionPoint('REX_FORM_INPUT_TAG', '', ['inputType' => $inputType]));
+        $inputTag = Extension::dispatch(new ExtensionPoint('REX_FORM_INPUT_TAG', '', ['inputType' => $inputType]));
 
         if ($inputTag) {
             return $inputTag;
@@ -676,7 +676,7 @@ abstract class AbstractForm
         // ----- EXTENSION POINT
         /** @var array<string, scalar> $inputAttr */
         $inputAttr = [];
-        $inputAttr = Extension::registerPoint(new ExtensionPoint('REX_FORM_INPUT_ATTRIBUTES', $inputAttr, ['inputType' => $inputType]));
+        $inputAttr = Extension::dispatch(new ExtensionPoint('REX_FORM_INPUT_ATTRIBUTES', $inputAttr, ['inputType' => $inputType]));
 
         if ($inputAttr) {
             return $inputAttr;
@@ -1103,7 +1103,7 @@ abstract class AbstractForm
     {
         $this->init();
 
-        Extension::registerPoint(new ExtensionPoint('REX_FORM_GET', $this, [], true));
+        Extension::dispatch(new ExtensionPoint('REX_FORM_GET', $this, [], true));
 
         if (!$this->applyUrl) {
             $this->setApplyUrl($this->getUrl(['func' => '']));

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -119,7 +119,7 @@ class Form extends AbstractForm
         $controlFields['abort'] = I18n::msg('form_abort');
 
         // ----- EXTENSION POINT
-        $controlFields = Extension::registerPoint(new ExtensionPoint('REX_FORM_CONTROL_FIELDS', $controlFields, ['form' => $this]));
+        $controlFields = Extension::dispatch(new ExtensionPoint('REX_FORM_CONTROL_FIELDS', $controlFields, ['form' => $this]));
 
         $controlElements = [];
         foreach ($controlFields as $name => $label) {
@@ -378,7 +378,7 @@ class Form extends AbstractForm
         }
 
         // ----- EXTENSION POINT
-        return Extension::registerPoint(new ExtensionPoint('REX_FORM_SAVED', true, ['form' => $this, 'sql' => $sql]));
+        return Extension::dispatch(new ExtensionPoint('REX_FORM_SAVED', true, ['form' => $this, 'sql' => $sql]));
     }
 
     /** @return bool|int */
@@ -400,6 +400,6 @@ class Form extends AbstractForm
         }
 
         // ----- EXTENSION POINT
-        return Extension::registerPoint(new ExtensionPoint('REX_FORM_DELETED', true, ['form' => $this, 'sql' => $deleteSql]));
+        return Extension::dispatch(new ExtensionPoint('REX_FORM_DELETED', true, ['form' => $this, 'sql' => $deleteSql]));
     }
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -241,9 +241,9 @@ final class Response
     public static function sendPage(string $content): void
     {
         // ----- EXTENSION POINT
-        $content = Extension::registerPoint(new ExtensionPoint('OUTPUT_FILTER', $content));
+        $content = Extension::dispatch(new ExtensionPoint('OUTPUT_FILTER', $content));
 
-        $hasShutdownExtension = Extension::isRegistered('RESPONSE_SHUTDOWN');
+        $hasShutdownExtension = Extension::hasExtensions('RESPONSE_SHUTDOWN');
         if ($hasShutdownExtension) {
             self::$closeConnection = true;
         }
@@ -255,7 +255,7 @@ final class Response
             // unlock session
             session_write_close();
 
-            Extension::registerPoint(new ExtensionPoint('RESPONSE_SHUTDOWN', $content, [], true));
+            Extension::dispatch(new ExtensionPoint('RESPONSE_SHUTDOWN', $content, [], true));
         }
     }
 

--- a/src/Language/LanguageHandler.php
+++ b/src/Language/LanguageHandler.php
@@ -73,7 +73,7 @@ final class LanguageHandler
 
         // ----- EXTENSION POINT
         $clang = Language::require($id);
-        Extension::registerPoint(new ExtensionPoint('CLANG_ADDED', '', [
+        Extension::dispatch(new ExtensionPoint('CLANG_ADDED', '', [
             'id' => $clang->id,
             'name' => $clang->name,
             'clang' => $clang,
@@ -107,7 +107,7 @@ final class LanguageHandler
 
         // ----- EXTENSION POINT
         $clang = Language::require($id);
-        Extension::registerPoint(new ExtensionPoint('CLANG_UPDATED', '', [
+        Extension::dispatch(new ExtensionPoint('CLANG_UPDATED', '', [
             'id' => $clang->id,
             'name' => $clang->name,
             'clang' => $clang,
@@ -145,7 +145,7 @@ final class LanguageHandler
         Cache::delete();
 
         // ----- EXTENSION POINT
-        Extension::registerPoint(new ExtensionPoint('CLANG_DELETED', '', [
+        Extension::dispatch(new ExtensionPoint('CLANG_DELETED', '', [
             'id' => $clang->id,
             'name' => $clang->name,
             'clang' => $clang,

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -81,7 +81,7 @@ class Mailer extends PHPMailer
         $this->archive = Core::getConfig('phpmailer_archive');
         parent::__construct($exceptions);
 
-        Extension::registerPoint(new ExtensionPoint('PHPMAILER_CONFIG', $this));
+        Extension::dispatch(new ExtensionPoint('PHPMAILER_CONFIG', $this));
     }
 
     protected function addOrEnqueueAnAddress($kind, $address, $name)
@@ -127,7 +127,7 @@ class Mailer extends PHPMailer
             $logging = (int) Core::getConfig('phpmailer_logging');
             $detourModeActive = Core::getConfig('phpmailer_detour_mode') && '' !== Core::getConfig('phpmailer_test_address');
 
-            Extension::registerPoint(new ExtensionPoint('PHPMAILER_PRE_SEND', $this));
+            Extension::dispatch(new ExtensionPoint('PHPMAILER_PRE_SEND', $this));
 
             if ($detourModeActive && isset($this->xHeader['to'])) {
                 $this->prepareDetourMode();
@@ -151,7 +151,7 @@ class Mailer extends PHPMailer
                 $this->log('OK');
             }
 
-            Extension::registerPoint(new ExtensionPoint('PHPMAILER_POST_SEND', $this));
+            Extension::dispatch(new ExtensionPoint('PHPMAILER_POST_SEND', $this));
 
             return true;
         });

--- a/src/MediaManager/MediaManager.php
+++ b/src/MediaManager/MediaManager.php
@@ -6,6 +6,7 @@ use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\ExtensionPoint\AsExtension;
 use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Filesystem\File;
 use Redaxo\Core\Filesystem\Path;
@@ -111,14 +112,14 @@ class MediaManager
     {
         $this->type = $type;
 
-        Extension::registerPoint(new ExtensionPoint('MEDIA_MANAGER_INIT', $this, [
+        Extension::dispatch(new ExtensionPoint('MEDIA_MANAGER_INIT', $this, [
             'type' => $type,
             'file' => $this->originalFilename,
         ], true));
 
         if (!$this->isCached()) {
             $set = $this->effectsFromType($type);
-            $set = Extension::registerPoint(new ExtensionPoint('MEDIA_MANAGER_FILTERSET', $set, ['rex_media_type' => $type]));
+            $set = Extension::dispatch(new ExtensionPoint('MEDIA_MANAGER_FILTERSET', $set, ['rex_media_type' => $type]));
 
             if (0 == count($set)) {
                 $this->useCache = false;
@@ -354,7 +355,7 @@ class MediaManager
     /** @return never */
     public function sendMedia()
     {
-        Extension::registerPoint(new ExtensionPoint('MEDIA_MANAGER_BEFORE_SEND', $this, []));
+        Extension::dispatch(new ExtensionPoint('MEDIA_MANAGER_BEFORE_SEND', $this, []));
 
         Response::cleanOutputBuffers();
 
@@ -397,7 +398,7 @@ class MediaManager
             $this->media->sendMedia($CacheFilename, $headerCacheFilename, $this->useCache);
         }
 
-        Extension::registerPoint(new ExtensionPoint('MEDIA_MANAGER_AFTER_SEND', $this, []));
+        Extension::dispatch(new ExtensionPoint('MEDIA_MANAGER_AFTER_SEND', $this, []));
 
         exit;
     }
@@ -469,7 +470,7 @@ class MediaManager
     public static function mediaIsInUse(ExtensionPoint $ep)
     {
         /** @var list<string> $warning */
-        $warning = $ep->getSubject();
+        $warning = $ep->subject;
         $filename = $ep->getParam('filename');
         assert(is_string($filename));
 
@@ -501,7 +502,7 @@ class MediaManager
     }
 
     /** @return void */
-    #[AsExtension('PACKAGES_INCLUDED', level: Extension::EARLY)]
+    #[AsExtension('PACKAGES_INCLUDED', ExtensionLevel::Early)]
     public static function init()
     {
         // --- handle image request
@@ -567,7 +568,7 @@ class MediaManager
 
         $url = Url::frontendController($params);
 
-        return Extension::registerPoint(new ExtensionPoint('MEDIA_MANAGER_URL', $url, [
+        return Extension::dispatch(new ExtensionPoint('MEDIA_MANAGER_URL', $url, [
             'type' => $type,
             'file' => $file,
             'buster' => $params['buster'] ?? null,

--- a/src/MediaPool/Media.php
+++ b/src/MediaPool/Media.php
@@ -126,7 +126,7 @@ final class Media
 
     public function getUrl(): string
     {
-        $url = Extension::registerPoint(new ExtensionPoint('MEDIA_URL_REWRITE', '', ['media' => $this]));
+        $url = Extension::dispatch(new ExtensionPoint('MEDIA_URL_REWRITE', '', ['media' => $this]));
         return $url ?: Url::media($this->fileName);
     }
 
@@ -192,6 +192,6 @@ final class Media
     /** Returns whether the element is permitted. */
     public function isPermitted(): bool
     {
-        return (bool) Extension::registerPoint(new ExtensionPoint('MEDIA_IS_PERMITTED', true, ['element' => $this]));
+        return (bool) Extension::dispatch(new ExtensionPoint('MEDIA_IS_PERMITTED', true, ['element' => $this]));
     }
 }

--- a/src/MediaPool/MediaCategoryHandler.php
+++ b/src/MediaPool/MediaCategoryHandler.php
@@ -42,7 +42,7 @@ final class MediaCategoryHandler
 
         MediaPoolCache::deleteCategoryList($parentId);
 
-        Extension::registerPoint(new ExtensionPoint('MEDIA_CATEGORY_ADDED', [
+        Extension::dispatch(new ExtensionPoint('MEDIA_CATEGORY_ADDED', [
             'id' => $db->getLastId(),
             'parent_id' => $parentId,
             'name' => $name,
@@ -75,7 +75,7 @@ final class MediaCategoryHandler
             throw new UserMessageException(I18n::msg('pool_kat_not_deleted'));
         }
 
-        Extension::registerPoint(new ExtensionPoint('MEDIA_CATEGORY_DELETED', ['id' => $categoryId]));
+        Extension::dispatch(new ExtensionPoint('MEDIA_CATEGORY_DELETED', ['id' => $categoryId]));
 
         return I18n::msg('pool_kat_deleted');
     }
@@ -85,7 +85,7 @@ final class MediaCategoryHandler
     {
         /** @var list<string> $warning */
         $warning = [];
-        $warning = Extension::registerPoint(new ExtensionPoint('MEDIA_CATEGORY_IS_IN_USE', $warning, [
+        $warning = Extension::dispatch(new ExtensionPoint('MEDIA_CATEGORY_IS_IN_USE', $warning, [
             'id' => $categoryId,
         ]));
 
@@ -116,7 +116,7 @@ final class MediaCategoryHandler
 
         MediaPoolCache::deleteCategory($categoryId);
 
-        Extension::registerPoint(new ExtensionPoint('MEDIA_CATEGORY_UPDATED', [
+        Extension::dispatch(new ExtensionPoint('MEDIA_CATEGORY_UPDATED', [
             'id' => $categoryId,
             'name' => $catName,
         ]));

--- a/src/MediaPool/MediaHandler.php
+++ b/src/MediaPool/MediaHandler.php
@@ -97,7 +97,7 @@ final class MediaHandler
         // Entscheidung respektieren
         /** @var string|null $errorMessage */
         $errorMessage = null;
-        $errorMessage = Extension::registerPoint(new ExtensionPoint('MEDIA_ADD', $errorMessage, [
+        $errorMessage = Extension::dispatch(new ExtensionPoint('MEDIA_ADD', $errorMessage, [
             'file' => $data['file'],
             'title' => $title,
             'filename' => $data['file']['name_new'],
@@ -168,7 +168,7 @@ final class MediaHandler
         $return['old_filename'] = $data['file']['name'];
         $return['ok'] = 1;
 
-        Extension::registerPoint(new ExtensionPoint('MEDIA_ADDED', '', $return));
+        Extension::dispatch(new ExtensionPoint('MEDIA_ADDED', '', $return));
 
         return $return;
     }
@@ -272,7 +272,7 @@ final class MediaHandler
         $return['type'] = $filetype;
         $return['filetype'] = $filetype;
 
-        Extension::registerPoint(new ExtensionPoint('MEDIA_UPDATED', '', $return));
+        Extension::dispatch(new ExtensionPoint('MEDIA_UPDATED', '', $return));
 
         return $return;
     }
@@ -294,7 +294,7 @@ final class MediaHandler
         File::delete(Path::media($filename));
         MediaPoolCache::delete($filename);
 
-        Extension::registerPoint(new ExtensionPoint('MEDIA_DELETED', '', [
+        Extension::dispatch(new ExtensionPoint('MEDIA_DELETED', '', [
             'filename' => $filename,
         ]));
     }
@@ -382,7 +382,7 @@ final class MediaHandler
             $countQueryParams = $queryParams;
 
             // EP is called twice, once for count query and once for data query
-            $countQuery = Extension::registerPoint(new ExtensionPoint('MEDIA_LIST_QUERY', $countQuery, [
+            $countQuery = Extension::dispatch(new ExtensionPoint('MEDIA_LIST_QUERY', $countQuery, [
                 'queryParams' => &$countQueryParams,
             ]));
             assert(is_array($countQueryParams)); // @phpstan-ignore function.alreadyNarrowedType
@@ -398,7 +398,7 @@ final class MediaHandler
         }
 
         // EP to modify the media list query
-        $query = Extension::registerPoint(new ExtensionPoint('MEDIA_LIST_QUERY', $query, [
+        $query = Extension::dispatch(new ExtensionPoint('MEDIA_LIST_QUERY', $query, [
             'queryParams' => &$queryParams,
         ]));
         assert(is_array($queryParams)); // @phpstan-ignore function.alreadyNarrowedType

--- a/src/MediaPool/MediaPool.php
+++ b/src/MediaPool/MediaPool.php
@@ -99,7 +99,7 @@ final class MediaPool
         }
 
         // ----- EXTENSION POINT
-        $warning = Extension::registerPoint(new ExtensionPoint('MEDIA_IS_IN_USE', $warning, [
+        $warning = Extension::dispatch(new ExtensionPoint('MEDIA_IS_IN_USE', $warning, [
             'filename' => $filename,
         ]));
 

--- a/src/MetaInfo/Form/MetaInfoForm.php
+++ b/src/MetaInfo/Form/MetaInfoForm.php
@@ -51,7 +51,7 @@ class MetaInfoForm extends Form
 
         // ----- EXTENSION POINT
         // IDs aller Feldtypen bei denen das Parameter-Feld eingeblendet werden soll
-        $typeFields = Extension::registerPoint(new ExtensionPoint('METAINFO_TYPE_FIELDS', [Table::FIELD_SELECT, Table::FIELD_RADIO, Table::FIELD_CHECKBOX, Table::FIELD_REX_MEDIA_WIDGET, Table::FIELD_REX_LINK_WIDGET, Table::FIELD_DATE, Table::FIELD_DATETIME]));
+        $typeFields = Extension::dispatch(new ExtensionPoint('METAINFO_TYPE_FIELDS', [Table::FIELD_SELECT, Table::FIELD_RADIO, Table::FIELD_CHECKBOX, Table::FIELD_REX_MEDIA_WIDGET, Table::FIELD_REX_LINK_WIDGET, Table::FIELD_DATE, Table::FIELD_DATETIME]));
 
         $field = $this->addReadOnlyField('prefix', $this->metaPrefix);
         $field->setLabel(I18n::msg('minfo_field_label_prefix'));

--- a/src/MetaInfo/Handler/AbstractHandler.php
+++ b/src/MetaInfo/Handler/AbstractHandler.php
@@ -469,7 +469,7 @@ abstract class AbstractHandler
                 default:
                     // ----- EXTENSION POINT
                     [$field, $tag, $tagAttr, $id, $label, $labelIt] =
-                        Extension::registerPoint(new ExtensionPoint(
+                        Extension::dispatch(new ExtensionPoint(
                             'METAINFO_CUSTOM_FIELD',
                             [
                                 $field,

--- a/src/MetaInfo/Handler/ArticleHandler.php
+++ b/src/MetaInfo/Handler/ArticleHandler.php
@@ -42,7 +42,7 @@ class ArticleHandler extends AbstractHandler
 
         ArticleCache::deleteMeta($params['id'], $params['clang']);
 
-        Extension::registerPoint(new ExtensionPoint('ART_META_UPDATED', '', $params));
+        Extension::dispatch(new ExtensionPoint('ART_META_UPDATED', '', $params));
 
         return $params;
     }

--- a/src/MetaInfo/Handler/CategoryHandler.php
+++ b/src/MetaInfo/Handler/CategoryHandler.php
@@ -7,6 +7,7 @@ use Redaxo\Core\Content\Category;
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Http\Request;
 
@@ -27,10 +28,10 @@ class CategoryHandler extends AbstractHandler
         if ($fields->getRows() >= 1) {
             $return = '<a class="btn btn-default collapsed" data-toggle="collapse" href="#' . self::CONTAINER . '"><i class="rex-icon rex-icon-structure-category-metainfo"></i></a>';
 
-            return $ep->getSubject() . $return;
+            return $ep->subject . $return;
         }
 
-        return $ep->getSubject();
+        return $ep->subject;
     }
 
     /** @return array */
@@ -108,10 +109,10 @@ class CategoryHandler extends AbstractHandler
             </tr>';
 
         // Bei CAT_ADDED und CAT_UPDATED nur speichern und kein Formular zurückgeben
-        if ('CAT_UPDATED' == $ep->getName() || 'CAT_ADDED' == $ep->getName()) {
-            return $ep->getSubject();
+        if ('CAT_UPDATED' == $ep->name || 'CAT_ADDED' == $ep->name) {
+            return $ep->subject;
         }
-        return $ep->getSubject() . $result;
+        return $ep->subject . $result;
     }
 }
 
@@ -120,7 +121,7 @@ $categoryHandler = new CategoryHandler();
 Extension::register('CAT_FORM_ADD', $categoryHandler->extendForm(...));
 Extension::register('CAT_FORM_EDIT', $categoryHandler->extendForm(...));
 
-Extension::register('CAT_ADDED', $categoryHandler->extendForm(...), Extension::EARLY);
-Extension::register('CAT_UPDATED', $categoryHandler->extendForm(...), Extension::EARLY);
+Extension::register('CAT_ADDED', $categoryHandler->extendForm(...), ExtensionLevel::Early);
+Extension::register('CAT_UPDATED', $categoryHandler->extendForm(...), ExtensionLevel::Early);
 
 Extension::register('CAT_FORM_BUTTONS', $categoryHandler->renderToggleButton(...));

--- a/src/MetaInfo/Handler/LanguageHandler.php
+++ b/src/MetaInfo/Handler/LanguageHandler.php
@@ -5,6 +5,7 @@ namespace Redaxo\Core\MetaInfo\Handler;
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Http\Request;
 
@@ -23,10 +24,10 @@ class LanguageHandler extends AbstractHandler
         if ($fields->getRows() >= 1) {
             $return = '<a class="btn btn-default collapsed" data-toggle="collapse" href="#' . self::CONTAINER . '"><i class="rex-icon rex-icon-structure-category-metainfo"></i></a>';
 
-            return $ep->getSubject() . $return;
+            return $ep->subject . $return;
         }
 
-        return $ep->getSubject();
+        return $ep->subject;
     }
 
     /** @return array */
@@ -83,10 +84,10 @@ class LanguageHandler extends AbstractHandler
             </tr>';
 
         // Bei CLANG_ADDED und CLANG_UPDATED nur speichern und kein Formular zurückgeben
-        if ('CLANG_UPDATED' == $ep->getName() || 'CLANG_ADDED' == $ep->getName()) {
-            return $ep->getSubject();
+        if ('CLANG_UPDATED' == $ep->name || 'CLANG_ADDED' == $ep->name) {
+            return $ep->subject;
         }
-        return $ep->getSubject() . $result;
+        return $ep->subject . $result;
     }
 }
 
@@ -95,7 +96,7 @@ $languageHandler = new LanguageHandler();
 Extension::register('CLANG_FORM_ADD', $languageHandler->extendForm(...));
 Extension::register('CLANG_FORM_EDIT', $languageHandler->extendForm(...));
 
-Extension::register('CLANG_ADDED', $languageHandler->extendForm(...), Extension::EARLY);
-Extension::register('CLANG_UPDATED', $languageHandler->extendForm(...), Extension::EARLY);
+Extension::register('CLANG_ADDED', $languageHandler->extendForm(...), ExtensionLevel::Early);
+Extension::register('CLANG_UPDATED', $languageHandler->extendForm(...), ExtensionLevel::Early);
 
 Extension::register('CLANG_FORM_BUTTONS', $languageHandler->renderToggleButton(...));

--- a/src/MetaInfo/Handler/MediaHandler.php
+++ b/src/MetaInfo/Handler/MediaHandler.php
@@ -7,6 +7,7 @@ use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\LogicException;
 use Redaxo\Core\Exception\RuntimeException;
 use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\Http\Request;
@@ -33,7 +34,7 @@ class MediaHandler extends AbstractHandler
     public static function isMediaInUse(ExtensionPoint $ep)
     {
         $params = $ep->getParams();
-        $warning = $ep->getSubject();
+        $warning = $ep->subject;
 
         $sql = Sql::factory();
         $sql->setQuery('SELECT `name`, `type_id` FROM `' . Core::getTablePrefix() . 'metainfo_field` WHERE `type_id` IN(6,7)');
@@ -191,13 +192,13 @@ class MediaHandler extends AbstractHandler
     public function extendForm(ExtensionPoint $ep)
     {
         $params = $ep->getParams();
-        $params['save'] = in_array($ep->getName(), ['MEDIA_ADDED', 'MEDIA_UPDATED'], true);
+        $params['save'] = in_array($ep->name, ['MEDIA_ADDED', 'MEDIA_UPDATED'], true);
 
         // Nur beim EDIT gibts auch ein Medium zum bearbeiten
-        if ('MEDIA_FORM_EDIT' == $ep->getName()) {
+        if ('MEDIA_FORM_EDIT' == $ep->name) {
             $params['activeItem'] = $params['media'];
             unset($params['media']);
-        } elseif ('MEDIA_ADDED' == $ep->getName()) {
+        } elseif ('MEDIA_ADDED' == $ep->name) {
             $sql = Sql::factory();
 
             $qry = 'SELECT id FROM ' . Core::getTablePrefix() . 'media WHERE filename=:filename';
@@ -209,7 +210,7 @@ class MediaHandler extends AbstractHandler
             }
         }
 
-        return $ep->getSubject() . parent::renderFormAndSave(self::PREFIX, $params);
+        return $ep->subject . parent::renderFormAndSave(self::PREFIX, $params);
     }
 }
 
@@ -218,7 +219,7 @@ $mediaHandler = new MediaHandler();
 Extension::register('MEDIA_FORM_EDIT', $mediaHandler->extendForm(...));
 Extension::register('MEDIA_FORM_ADD', $mediaHandler->extendForm(...));
 
-Extension::register('MEDIA_ADDED', $mediaHandler->extendForm(...), Extension::EARLY);
-Extension::register('MEDIA_UPDATED', $mediaHandler->extendForm(...), Extension::EARLY);
+Extension::register('MEDIA_ADDED', $mediaHandler->extendForm(...), ExtensionLevel::Early);
+Extension::register('MEDIA_UPDATED', $mediaHandler->extendForm(...), ExtensionLevel::Early);
 
 Extension::register('MEDIA_IS_IN_USE', MediaHandler::isMediaInUse(...));

--- a/src/MetaInfo/MetaInfo.php
+++ b/src/MetaInfo/MetaInfo.php
@@ -251,7 +251,7 @@ class MetaInfo
     #[AsExtension('PAGE_CHECKED')]
     public static function extensionHandler(ExtensionPoint $ep)
     {
-        $page = $ep->getSubject();
+        $page = $ep->subject;
         $mainpage = Controller::getCurrentPagePart(1);
 
         // additional javascripts

--- a/src/Security/ComplexPermission.php
+++ b/src/Security/ComplexPermission.php
@@ -96,12 +96,12 @@ abstract class ComplexPermission
     /** Should be called if an item is removed. */
     final public static function removeItem(string $key, int|string $item): void
     {
-        Extension::registerPoint(new ExtensionPoint('COMPLEX_PERM_REMOVE_ITEM', '', ['key' => $key, 'item' => $item], true));
+        Extension::dispatch(new ExtensionPoint('COMPLEX_PERM_REMOVE_ITEM', '', ['key' => $key, 'item' => $item], true));
     }
 
     /** Should be called if an item is replaced. */
     final public static function replaceItem(string $key, int|string $item, int|string $new): void
     {
-        Extension::registerPoint(new ExtensionPoint('COMPLEX_PERM_REPLACE_ITEM', '', ['key' => $key, 'item' => $item, 'new' => $new], true));
+        Extension::dispatch(new ExtensionPoint('COMPLEX_PERM_REPLACE_ITEM', '', ['key' => $key, 'item' => $item, 'new' => $new], true));
     }
 }

--- a/src/Security/Login.php
+++ b/src/Security/Login.php
@@ -7,6 +7,7 @@ use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\LogicException;
 use Redaxo\Core\Exception\RuntimeException;
 use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Http\Request;
 use Redaxo\Core\Translation\I18n;
@@ -350,10 +351,10 @@ class Login
 
             // We don't know here if packages have already been loaded
             // Therefore we call the extension point twice, directly and after PACKAGES_INCLUDED
-            Extension::registerPoint($extensionPoint);
+            Extension::dispatch($extensionPoint);
             Extension::register('PACKAGES_INCLUDED', static function () use ($extensionPoint) {
-                Extension::registerPoint($extensionPoint);
-            }, Extension::EARLY);
+                Extension::dispatch($extensionPoint);
+            }, ExtensionLevel::Early);
         }
 
         // session-id is shared between frontend/backend or even redaxo instances per server because it's the same http session

--- a/src/Translation/I18n.php
+++ b/src/Translation/I18n.php
@@ -210,7 +210,7 @@ class I18n
     {
         $fallback = "[translate:$key]";
 
-        $msg = Extension::registerPoint(new ExtensionPoint('I18N_MISSING_TRANSLATION', $fallback, [
+        $msg = Extension::dispatch(new ExtensionPoint('I18N_MISSING_TRANSLATION', $fallback, [
             'key' => $key,
             'args' => $replacements,
         ]));

--- a/src/Util/Editor.php
+++ b/src/Util/Editor.php
@@ -79,7 +79,7 @@ class Editor
             $editorUrl = str_replace('%f', $filePath, $editorUrl);
         }
 
-        return Extension::registerPoint(new ExtensionPoint('EDITOR_URL', $editorUrl, [
+        return Extension::dispatch(new ExtensionPoint('EDITOR_URL', $editorUrl, [
             'file' => $filePath,
             'line' => (int) $line,
         ]));

--- a/src/View/DataList.php
+++ b/src/View/DataList.php
@@ -1206,7 +1206,7 @@ class DataList implements UrlProviderInterface
      */
     public function get()
     {
-        Extension::registerPoint(new ExtensionPoint('REX_LIST_GET', $this, [], true));
+        Extension::dispatch(new ExtensionPoint('REX_LIST_GET', $this, [], true));
 
         $s = "\n";
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -109,14 +109,14 @@ class View
             $subtitle = '';
         }
 
-        $title = Extension::registerPoint(new ExtensionPoint('PAGE_TITLE', $head));
+        $title = Extension::dispatch(new ExtensionPoint('PAGE_TITLE', $head));
 
         $fragment = new Fragment();
         $fragment->setVar('heading', $title, false);
         $fragment->setVar('subtitle', $subtitle, false);
         $return = $fragment->parse('core/page/header.php');
 
-        return $return . Extension::registerPoint(new ExtensionPoint('PAGE_TITLE_SHOWN', ''));
+        return $return . Extension::dispatch(new ExtensionPoint('PAGE_TITLE_SHOWN', ''));
     }
 
     /**
@@ -326,7 +326,7 @@ class View
         $fragment->setVar('elements', $formElements, false);
         $panel .= $fragment->parse('core/form/form.php');
 
-        $panel .= Extension::registerPoint(new ExtensionPoint('MEDIA_FORM_ADD', ''));
+        $panel .= Extension::dispatch(new ExtensionPoint('MEDIA_FORM_ADD', ''));
 
         if ($fileChooser) {
             $e = [];

--- a/tests/ExtensionPoint/ExtensionTest.php
+++ b/tests/ExtensionPoint/ExtensionTest.php
@@ -4,6 +4,7 @@ namespace Redaxo\Core\Tests\ExtensionPoint;
 
 use PHPUnit\Framework\TestCase;
 use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 
 /** @internal */
@@ -19,40 +20,40 @@ final class ExtensionTest extends TestCase
         parent::tearDown();
     }
 
-    public function testIsRegistered(): void
+    public function testHasExtensions(): void
     {
         $EP = 'TEST_IS_REGISTERED';
 
-        self::assertFalse(Extension::isRegistered($EP), 'isRegistered() returns false for non-registered extension points');
+        self::assertFalse(Extension::hasExtensions($EP), 'hasExtensions() returns false for non-registered extension points');
 
         Extension::register($EP, static function () {});
 
-        self::assertTrue(Extension::isRegistered($EP), 'isRegistered() returns true for registered extension points');
+        self::assertTrue(Extension::hasExtensions($EP), 'hasExtensions() returns true for registered extension points');
     }
 
-    public function testRegisterPoint(): void
+    public function testDispatch(): void
     {
         $EP = 'TEST_EP';
 
         $EPParam = null;
         Extension::register($EP, static function (ExtensionPoint $ep) use (&$EPParam) {
-            $EPParam = $ep->getName();
-            return $ep->getSubject() . ' test2';
+            $EPParam = $ep->name;
+            return $ep->subject . ' test2';
         });
 
         Extension::register($EP, static function () {});
 
         Extension::register($EP, static function (ExtensionPoint $ep) {
-            return $ep->getSubject() . ' test3';
+            return $ep->subject . ' test3';
         });
 
-        $result = Extension::registerPoint(new ExtensionPoint($EP, 'test'));
+        $result = Extension::dispatch(new ExtensionPoint($EP, 'test'));
 
         self::assertEquals($EP, $EPParam, '$params["extension_point"] contains the extension point name');
-        self::assertEquals('test test2 test3', $result, 'registerPoint() returns the returned value of last extension');
+        self::assertEquals('test test2 test3', $result, 'dispatch() returns the returned value of last extension');
     }
 
-    public function testRegisterPointReadOnly(): void
+    public function testDispatchReadOnly(): void
     {
         $EP = 'TEST_EP_READ_ONLY';
 
@@ -62,16 +63,16 @@ final class ExtensionTest extends TestCase
 
         $subjectActual = null;
         Extension::register($EP, static function (ExtensionPoint $ep) use (&$subjectActual) {
-            $subjectActual = $ep->getSubject();
+            $subjectActual = $ep->subject;
         });
 
         $subject = 'test';
-        Extension::registerPoint(new ExtensionPoint($EP, $subject, [], true));
+        Extension::dispatch(new ExtensionPoint($EP, $subject, [], true));
 
         self::assertEquals($subject, $subjectActual, "read-only extention points don't change subject param");
     }
 
-    public function testRegisterPointWithParams(): void
+    public function testDispatchWithParams(): void
     {
         $EP = 'TEST_EP_WITH_PARAMS';
 
@@ -81,7 +82,7 @@ final class ExtensionTest extends TestCase
         });
 
         $myparam = 'myparam';
-        Extension::registerPoint(new ExtensionPoint($EP, null, ['myparam' => $myparam]));
+        Extension::dispatch(new ExtensionPoint($EP, null, ['myparam' => $myparam]));
 
         self::assertEquals($myparam, $myparamActual, 'additional params will be available in extentions');
     }
@@ -92,19 +93,19 @@ final class ExtensionTest extends TestCase
 
         $callback = static function ($str) {
             return static function (ExtensionPoint $ep) use ($str) {
-                return $ep->getSubject() . $str . ' ';
+                return $ep->subject . $str . ' ';
             };
         };
 
-        Extension::register($EP, $callback('late1'), Extension::LATE);
+        Extension::register($EP, $callback('late1'), ExtensionLevel::Late);
         Extension::register($EP, $callback('normal1'));
-        Extension::register($EP, $callback('early1'), Extension::EARLY);
-        Extension::register($EP, $callback('late2'), Extension::LATE);
-        Extension::register($EP, $callback('normal2'), Extension::NORMAL);
-        Extension::register($EP, $callback('early2'), Extension::EARLY);
+        Extension::register($EP, $callback('early1'), ExtensionLevel::Early);
+        Extension::register($EP, $callback('late2'), ExtensionLevel::Late);
+        Extension::register($EP, $callback('normal2'), ExtensionLevel::Normal);
+        Extension::register($EP, $callback('early2'), ExtensionLevel::Early);
 
         $expected = 'early1 early2 normal1 normal2 late1 late2 ';
-        $actual = Extension::registerPoint(new ExtensionPoint($EP, ''));
+        $actual = Extension::dispatch(new ExtensionPoint($EP, ''));
 
         self::assertEquals($expected, $actual);
     }
@@ -121,7 +122,7 @@ final class ExtensionTest extends TestCase
         /** @var string|null $subject */
         $subject = null;
 
-        self::assertSame('foo', Extension::registerPoint(new ExtensionPoint($EP1, $subject)));
-        self::assertSame('foo', Extension::registerPoint(new ExtensionPoint($EP2, $subject)));
+        self::assertSame('foo', Extension::dispatch(new ExtensionPoint($EP1, $subject)));
+        self::assertSame('foo', Extension::dispatch(new ExtensionPoint($EP2, $subject)));
     }
 }


### PR DESCRIPTION
- Rename `Extension::registerPoint()` to `dispatch()` and `isRegistered()` to
  `hasExtensions()` to make the dispatch semantics explicit (it fires a point,
  it doesn't register one).
- Replace the `Extension::EARLY/NORMAL/LATE` int constants with an
  `ExtensionLevel` enum.
- Drop the per-extension `$params` passthrough on `Extension::register()` and
  `ExtensionPoint`; bind extra data via a closure instead.
- Convert `ExtensionPoint` and its subclasses (`SliceMenu`, `ConsoleShutdown`,
  `ArticleContentUpdated`, `AddonCacheDeleted`) from getters/setters to public
  properties — readonly where applicable, with the `subject` write guard moved
  into a property hook.
- Make the `#[AsExtension]` extension-point name optional: derive it from the
  first parameter's `ExtensionPoint` subclass type, including union types (the
  extension is then registered for every listed point).
- Rewrite the `ClassDiscovery` cache as a `var_export`-ed PHP file
  (OpCache-friendly, enum-safe, no `unserialize`); it now also caches the
  first-parameter types needed for the resolution above.
- Remove the legacy `STRUCTURE_CONTENT_SLICE_MENU` extension point, superseded
  by the typed `SliceMenu` extension point.
- Add rector rules to migrate the renames and getter/setter-to-property
  conversions, and exclude the test project's `var/` from the tooling.

