### PR TITLE
fix: guard optional template key in article handler

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1768,16 +1768,10 @@
       <code><![CDATA[$data['priority']]]></code>
       <code><![CDATA[$data['priority']]]></code>
       <code><![CDATA[$data['priority']]]></code>
-      <code><![CDATA[$data['template']]]></code>
-      <code><![CDATA[$data['template']]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
     </MixedArgument>
-    <MixedArrayOffset>
-      <code><![CDATA[$templates[$data['template']]]]></code>
-      <code><![CDATA[$templates[$data['template']]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$data['path']]]></code>
       <code><![CDATA[$data['priority']]]></code>
@@ -1803,10 +1797,6 @@
       <code><![CDATA[$toSql->getValue('path')]]></code>
       <code><![CDATA[$toSql->getValue('path')]]></code>
     </PossiblyNullOperand>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$data['template']]]></code>
-      <code><![CDATA[$data['template']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="src/Content/ArticleRevision.php">
     <NoValue>

--- a/src/Content/ArticleHandler.php
+++ b/src/Content/ArticleHandler.php
@@ -49,6 +49,7 @@ final class ArticleHandler
         }
 
         $templates = Template::getTemplatesForCategory($data['category_id']);
+        $data['template'] ??= null;
 
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.
@@ -139,6 +140,7 @@ final class ArticleHandler
         $data['category_id'] = $ooArt->categoryId;
 
         $templates = Template::getTemplatesForCategory($data['category_id']);
+        $data['template'] ??= null;
 
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.

--- a/src/Content/ArticleHandler.php
+++ b/src/Content/ArticleHandler.php
@@ -11,10 +11,10 @@ use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Language\Language;
 use Redaxo\Core\Security\ComplexPermission;
 use Redaxo\Core\Translation\I18n;
+use Redaxo\Core\Util\Type;
 
 use function count;
 use function is_array;
-use function is_string;
 
 final class ArticleHandler
 {
@@ -50,7 +50,7 @@ final class ArticleHandler
         }
 
         $templates = Template::getTemplatesForCategory($data['category_id']);
-        $templateKey = isset($data['template']) && is_string($data['template']) ? $data['template'] : null;
+        $templateKey = isset($data['template']) ? Type::string($data['template']) : null;
 
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.
@@ -139,7 +139,7 @@ final class ArticleHandler
         $data['category_id'] = $ooArt->categoryId;
 
         $templates = Template::getTemplatesForCategory($data['category_id']);
-        $templateKey = isset($data['template']) && is_string($data['template']) ? $data['template'] : null;
+        $templateKey = isset($data['template']) ? Type::string($data['template']) : null;
 
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.

--- a/src/Content/ArticleHandler.php
+++ b/src/Content/ArticleHandler.php
@@ -55,10 +55,7 @@ final class ArticleHandler
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.
         if (null === $templateKey || !isset($templates[$templateKey])) {
-            $templateKey = null;
-            if (count($templates) > 0) {
-                $templateKey = key($templates);
-            }
+            $templateKey = array_key_first($templates);
         }
         $data['template'] = $templateKey;
 
@@ -147,10 +144,7 @@ final class ArticleHandler
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.
         if (null === $templateKey || !isset($templates[$templateKey])) {
-            $templateKey = null;
-            if (count($templates) > 0) {
-                $templateKey = key($templates);
-            }
+            $templateKey = array_key_first($templates);
         }
         $data['template'] = $templateKey;
 

--- a/src/Content/ArticleHandler.php
+++ b/src/Content/ArticleHandler.php
@@ -14,6 +14,7 @@ use Redaxo\Core\Translation\I18n;
 
 use function count;
 use function is_array;
+use function is_string;
 
 final class ArticleHandler
 {
@@ -49,16 +50,17 @@ final class ArticleHandler
         }
 
         $templates = Template::getTemplatesForCategory($data['category_id']);
-        $data['template'] ??= null;
+        $templateKey = isset($data['template']) && is_string($data['template']) ? $data['template'] : null;
 
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.
-        if (!isset($templates[$data['template']])) {
-            $data['template'] = null;
+        if (null === $templateKey || !isset($templates[$templateKey])) {
+            $templateKey = null;
             if (count($templates) > 0) {
-                $data['template'] = key($templates);
+                $templateKey = key($templates);
             }
         }
+        $data['template'] = $templateKey;
 
         $message = I18n::msg('article_added');
 
@@ -140,16 +142,17 @@ final class ArticleHandler
         $data['category_id'] = $ooArt->categoryId;
 
         $templates = Template::getTemplatesForCategory($data['category_id']);
-        $data['template'] ??= null;
+        $templateKey = isset($data['template']) && is_string($data['template']) ? $data['template'] : null;
 
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.
-        if (!isset($templates[$data['template']])) {
-            $data['template'] = null;
+        if (null === $templateKey || !isset($templates[$templateKey])) {
+            $templateKey = null;
             if (count($templates) > 0) {
-                $data['template'] = key($templates);
+                $templateKey = key($templates);
             }
         }
+        $data['template'] = $templateKey;
 
         if (isset($data['priority'])) {
             if ($data['priority'] <= 0) {

--- a/src/Content/ArticleHandler.php
+++ b/src/Content/ArticleHandler.php
@@ -50,14 +50,13 @@ final class ArticleHandler
         }
 
         $templates = Template::getTemplatesForCategory($data['category_id']);
-        $templateKey = isset($data['template']) ? Type::string($data['template']) : null;
+        $data['template'] = isset($data['template']) ? Type::string($data['template']) : null;
 
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.
-        if (null === $templateKey || !isset($templates[$templateKey])) {
-            $templateKey = array_key_first($templates);
+        if (null === $data['template'] || !isset($templates[$data['template']])) {
+            $data['template'] = array_key_first($templates);
         }
-        $data['template'] = $templateKey;
 
         $message = I18n::msg('article_added');
 
@@ -139,14 +138,13 @@ final class ArticleHandler
         $data['category_id'] = $ooArt->categoryId;
 
         $templates = Template::getTemplatesForCategory($data['category_id']);
-        $templateKey = isset($data['template']) ? Type::string($data['template']) : null;
+        $data['template'] = isset($data['template']) ? Type::string($data['template']) : null;
 
         // Wenn Template nicht vorhanden, dann entweder erlaubtes nehmen
         // oder leer setzen.
-        if (null === $templateKey || !isset($templates[$templateKey])) {
-            $templateKey = array_key_first($templates);
+        if (null === $data['template'] || !isset($templates[$data['template']])) {
+            $data['template'] = array_key_first($templates);
         }
-        $data['template'] = $templateKey;
 
         if (isset($data['priority'])) {
             if ($data['priority'] <= 0) {


### PR DESCRIPTION
Hi Gregor :)

kleiner Folgefix zu den Content-Refactorings:

In ArticleHandler::addArticle() und ArticleHandler::editArticle() wird auf `$data['template']` zugegriffen, obwohl der Key nicht immer mitgegeben wird.

Wenn `template` fehlt, kann ein `Undefined array key 'template'` auftauchen (je nach Error-Handling als Warning oder harter Fehler).

Fix ist bewusst klein:
- `template` wird defensiv behandelt, wenn der Key fehlt
- bestehende Fallback-Logik (erstes erlaubtes Template oder `null`) bleibt unverändert

Warum 2 Commits?
- Commit 1: Runtime-Problem gefixt (fehlender Key)
- Commit 2: Psalm-Follow-up, damit der Guard auch statisch sauber als `string|null` getypt ist
- also kein zusätzlicher Feature-Änderung, nur Analyse-/Typ-Sicherheit

Ich wollte nur den ungeschützten Zugriff entschärfen, sonst nichts am Verhalten drehen.
