### PR TITLE
ci: automatically publish subtree splits of project and debug

### DIFF
--- a/.github/subtree-splits.json
+++ b/.github/subtree-splits.json
@@ -1,0 +1,16 @@
+{
+    "sub-splits": [
+        {
+            "name": "project",
+            "directory": "project",
+            "target": "git@github.com:redaxo/project.git",
+            "target-branch": "6.x"
+        },
+        {
+            "name": "debug",
+            "directory": "addons/debug",
+            "target": "git@github.com:redaxo/debug.git",
+            "target-branch": "2.x"
+        }
+    ]
+}

--- a/.github/workflows/subtree-split.yml
+++ b/.github/workflows/subtree-split.yml
@@ -7,6 +7,8 @@ on:
         paths:
             - project/**
             - addons/debug/**
+            - .github/subtree-splits.json
+            - .github/workflows/subtree-split.yml
 
 permissions:
     contents: read

--- a/.github/workflows/subtree-split.yml
+++ b/.github/workflows/subtree-split.yml
@@ -1,0 +1,49 @@
+name: Subtree split
+
+on:
+    push:
+        branches:
+            - 6.x
+        paths:
+            - project/**
+            - addons/debug/**
+
+permissions:
+    contents: read
+
+concurrency:
+    group: subtree-split
+    cancel-in-progress: false
+
+jobs:
+    split:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+                with:
+                    fetch-depth: 0
+                    persist-credentials: false
+
+            -   name: Configure Git credentials
+                uses: frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4 # 1.1.0
+                with:
+                    authentication: x-access-token:${{ secrets.BOT_TOKEN }}
+                    user_name: rex-bot
+                    user_email: rex-bot@users.noreply.github.com
+
+            -   name: Cache splitsh-lite
+                uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+                with:
+                    path: ./.splitsh
+                    key: ${{ runner.os }}-splitsh-v1.0.1
+
+            -   name: Publish sub-splits
+                uses: frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7 # 1.1.0
+                with:
+                    source-branch: 6.x
+                    config-path: ./.github/subtree-splits.json
+                    splitsh-path: ./.splitsh/splitsh-lite
+                    splitsh-version: v1.0.1


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically publishes the git subtree splits of `project/` and `addons/debug/` to their standalone repositories on every push to `6.x`.

## How it works

- Uses [`frankdejonge/use-subsplit-publish`](https://github.com/frankdejonge/use-subsplit-publish), which installs and runs [`splitsh-lite`](https://github.com/splitsh/lite) — so the split repos keep the faithful, hash-stable history of their subdirectory (same approach as the local `.tools/bin/update-subtree-splits` script, just automated).
- Configuration lives in `.github/subtree-splits.json`:
  - `project/` → `redaxo/project` @ `6.x`
  - `addons/debug/` → `redaxo/debug` @ `2.x`
- Pushes are authenticated as `rex-bot` via `BOT_TOKEN`.

## Notes

- The trigger is restricted to changes under `project/**` and `addons/debug/**`, so core-only pushes don't spawn unnecessary runs. This is safe because splitsh produces a deterministic hash per prefix that only changes when that prefix changes.
- splitsh-lite is pinned to `v1.0.1` — the latest version with prebuilt binaries (`v2.0.0` ships no release assets).
- Verified end-to-end against throwaway test branches before merging.

The local `.tools/bin/update-subtree-splits` script stays as a manual fallback.