### PR TITLE
feat: support #[AsExtension] on instance methods of arbitrary classes

### DIFF
--- a/.tools/bootstrap.php
+++ b/.tools/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 use Project\Project;
+use Redaxo\Core\Core;
 use Redaxo\Core\Environment;
 use Redaxo\Core\ErrorHandler;
 
@@ -9,6 +10,11 @@ require_once dirname(__DIR__) . '/vendor/autoload.php';
 $project = new Project(Environment::Console);
 
 $project->bootCore();
+
+// Run tests in debug mode so caches that key off it (e.g. class discovery) self-invalidate on file changes,
+// ensuring attribute discovery always reflects the current sources (such as newly added test fixtures).
+Core::setProperty('debug', ['enabled' => true]);
+
 $project->bootAddons();
 
 // use original error handlers of the tools

--- a/src/ExtensionPoint/Extension.php
+++ b/src/ExtensionPoint/Extension.php
@@ -30,6 +30,15 @@ class Extension
      */
     private static array $extensions = [];
 
+    /**
+     * Object instances backing non-static `#[AsExtension]` methods, in registration order.
+     * Populated via {@see self::registerInstance()} and read lazily on dispatch: an attributed method
+     * runs once for every registered instance that is an `instanceof` the method's declaring class.
+     *
+     * @var list<object>
+     */
+    private static array $instances = [];
+
     final private function __construct() {}
 
     /**
@@ -56,16 +65,7 @@ class Extension
                 }
 
                 foreach (self::$extensions[$name][$level->name] as $extension) {
-                    /** @var T|null $subject */
-                    $subject = call_user_func($extension, $extensionPoint);
-                    // Update subject only if the EP is not readonly and the extension has returned something
-                    if ($extensionPoint->readonly) {
-                        continue;
-                    }
-                    if (null === $subject) {
-                        continue;
-                    }
-                    $extensionPoint->subject = $subject;
+                    self::runExtension($extensionPoint, $extension);
                 }
             }
         });
@@ -94,11 +94,34 @@ class Extension
     }
 
     /**
+     * Registers an object instance to back non-static `#[AsExtension]` methods.
+     *
+     * Instances are matched to attributed methods by `instanceof` on dispatch, so an instance also serves
+     * attributed methods declared on its parent classes. Multiple instances (of the same or related classes)
+     * may be registered; each attributed method then runs once per matching instance, in registration order.
+     *
+     * The instances are read lazily on dispatch, so this may be called at any point before the extension
+     * point is actually dispatched (e.g. only on the page where the extension is relevant).
+     *
+     * @see self::registerByAttribute()
+     */
+    public static function registerInstance(object $instance): void
+    {
+        if ($factoryClass = static::getExplicitFactoryClass()) {
+            $factoryClass::registerInstance($instance);
+            return;
+        }
+
+        self::$instances[] = $instance;
+    }
+
+    /**
      * Registers all extensions for methods carrying the `#[AsExtension]` attribute,
      * discovered via {@see ClassDiscovery}.
      *
-     * Static methods are bound to their class; non-static methods are allowed on
-     * the project class and on addon classes (where the instance is available).
+     * Static methods are bound to their class. Non-static methods on the project class or on addon classes
+     * are bound to those (already available) instances; all other non-static methods run on dispatch for every
+     * matching instance registered via {@see self::registerInstance()}.
      *
      * @internal
      */
@@ -128,12 +151,26 @@ class Extension
                 }
                 $callable = [$addonByClass[$entry['class']], $entry['method']];
             } else {
-                throw new LogicException(sprintf(
-                    'Non-static #[AsExtension] is only allowed on the project class or on addon classes. Method "%s::%s()" is neither static nor defined on a parent of %s or on a registered addon class.',
-                    $entry['class'],
-                    $entry['method'],
-                    $project::class,
-                ));
+                // Generic instance method: the backing objects are resolved lazily on dispatch from the
+                // instances registered via self::registerInstance(). Resolving lazily (rather than here at boot)
+                // keeps registration timing flexible — instances only need to exist when the EP fires. The method
+                // runs once per matching instance, chaining the subject between them exactly like separately
+                // registered extensions (see self::dispatch()). If no instance matches, it is simply a no-op.
+                $class = $entry['class'];
+                $method = $entry['method'];
+                $callable = static function (ExtensionPoint $ep) use ($class, $method): mixed {
+                    foreach (self::$instances as $instance) {
+                        if (!$instance instanceof $class) {
+                            continue;
+                        }
+
+                        /** @var callable(ExtensionPoint<mixed>):mixed $callback */
+                        $callback = [$instance, $method];
+                        self::runExtension($ep, $callback);
+                    }
+
+                    return $ep->subject;
+                };
             }
 
             $extensionPoint = $entry['attribute']->extensionPoint
@@ -198,5 +235,24 @@ class Extension
             return $factoryClass::hasExtensions($extensionPoint);
         }
         return !empty(self::$extensions[$extensionPoint]);
+    }
+
+    /**
+     * Runs a single extension callback against the extension point and applies its return value to the subject,
+     * honoring the "readonly" flag and the convention that a `null` return means "no change". Shared by
+     * {@see self::dispatch()} and the instance-method wrapper built in {@see self::registerByAttribute()}.
+     *
+     * @param ExtensionPoint<mixed> $extensionPoint
+     */
+    private static function runExtension(ExtensionPoint $extensionPoint, callable $extension): void
+    {
+        /** @var mixed $result */
+        $result = call_user_func($extension, $extensionPoint);
+
+        if ($extensionPoint->readonly || null === $result) {
+            return;
+        }
+
+        $extensionPoint->subject = $result;
     }
 }

--- a/src/MetaInfo/Handler/CategoryHandler.php
+++ b/src/MetaInfo/Handler/CategoryHandler.php
@@ -6,7 +6,7 @@ use Redaxo\Core\Content\ArticleCache;
 use Redaxo\Core\Content\Category;
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
-use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\AsExtension;
 use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Http\Request;
@@ -19,6 +19,7 @@ final class CategoryHandler extends AbstractHandler
     public const PREFIX = 'cat_';
     public const CONTAINER = 'rex-structure-category-metainfo';
 
+    #[AsExtension('CAT_FORM_BUTTONS')]
     public function renderToggleButton(ExtensionPoint $ep): string
     {
         $restrictionsCondition = $this->buildFilterCondition($ep->getParams());
@@ -85,6 +86,10 @@ final class CategoryHandler extends AbstractHandler
         return $field;
     }
 
+    #[AsExtension('CAT_FORM_ADD')]
+    #[AsExtension('CAT_FORM_EDIT')]
+    #[AsExtension('CAT_ADDED', ExtensionLevel::Early)]
+    #[AsExtension('CAT_UPDATED', ExtensionLevel::Early)]
     public function extendForm(ExtensionPoint $ep): string
     {
         $params = $ep->getParams();
@@ -112,13 +117,3 @@ final class CategoryHandler extends AbstractHandler
         return $ep->subject . $result;
     }
 }
-
-$categoryHandler = new CategoryHandler();
-
-Extension::register('CAT_FORM_ADD', $categoryHandler->extendForm(...));
-Extension::register('CAT_FORM_EDIT', $categoryHandler->extendForm(...));
-
-Extension::register('CAT_ADDED', $categoryHandler->extendForm(...), ExtensionLevel::Early);
-Extension::register('CAT_UPDATED', $categoryHandler->extendForm(...), ExtensionLevel::Early);
-
-Extension::register('CAT_FORM_BUTTONS', $categoryHandler->renderToggleButton(...));

--- a/src/MetaInfo/Handler/LanguageHandler.php
+++ b/src/MetaInfo/Handler/LanguageHandler.php
@@ -4,7 +4,7 @@ namespace Redaxo\Core\MetaInfo\Handler;
 
 use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
-use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\AsExtension;
 use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Http\Request;
@@ -17,6 +17,7 @@ final class LanguageHandler extends AbstractHandler
     public const PREFIX = 'clang_';
     public const CONTAINER = 'rex-clang-metainfo';
 
+    #[AsExtension('CLANG_FORM_BUTTONS')]
     public function renderToggleButton(ExtensionPoint $ep): string
     {
         $fields = parent::getSqlFields(self::PREFIX);
@@ -66,6 +67,10 @@ final class LanguageHandler extends AbstractHandler
         return $field;
     }
 
+    #[AsExtension('CLANG_FORM_ADD')]
+    #[AsExtension('CLANG_FORM_EDIT')]
+    #[AsExtension('CLANG_ADDED', ExtensionLevel::Early)]
+    #[AsExtension('CLANG_UPDATED', ExtensionLevel::Early)]
     public function extendForm(ExtensionPoint $ep): string
     {
         $params = $ep->getParams();
@@ -90,13 +95,3 @@ final class LanguageHandler extends AbstractHandler
         return $ep->subject . $result;
     }
 }
-
-$languageHandler = new LanguageHandler();
-
-Extension::register('CLANG_FORM_ADD', $languageHandler->extendForm(...));
-Extension::register('CLANG_FORM_EDIT', $languageHandler->extendForm(...));
-
-Extension::register('CLANG_ADDED', $languageHandler->extendForm(...), ExtensionLevel::Early);
-Extension::register('CLANG_UPDATED', $languageHandler->extendForm(...), ExtensionLevel::Early);
-
-Extension::register('CLANG_FORM_BUTTONS', $languageHandler->renderToggleButton(...));

--- a/src/MetaInfo/Handler/MediaHandler.php
+++ b/src/MetaInfo/Handler/MediaHandler.php
@@ -6,7 +6,7 @@ use Redaxo\Core\Core;
 use Redaxo\Core\Database\Sql;
 use Redaxo\Core\Exception\LogicException;
 use Redaxo\Core\Exception\RuntimeException;
-use Redaxo\Core\ExtensionPoint\Extension;
+use Redaxo\Core\ExtensionPoint\AsExtension;
 use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Filesystem\Url;
@@ -31,6 +31,7 @@ final class MediaHandler extends AbstractHandler
      *
      * @return list<string>
      */
+    #[AsExtension('MEDIA_IS_IN_USE')]
     public static function isMediaInUse(ExtensionPoint $ep): array
     {
         $params = $ep->getParams();
@@ -187,6 +188,10 @@ final class MediaHandler extends AbstractHandler
         return $field;
     }
 
+    #[AsExtension('MEDIA_FORM_EDIT')]
+    #[AsExtension('MEDIA_FORM_ADD')]
+    #[AsExtension('MEDIA_ADDED', ExtensionLevel::Early)]
+    #[AsExtension('MEDIA_UPDATED', ExtensionLevel::Early)]
     public function extendForm(ExtensionPoint $ep): string
     {
         $params = $ep->getParams();
@@ -211,13 +216,3 @@ final class MediaHandler extends AbstractHandler
         return $ep->subject . parent::renderFormAndSave(self::PREFIX, $params);
     }
 }
-
-$mediaHandler = new MediaHandler();
-
-Extension::register('MEDIA_FORM_EDIT', $mediaHandler->extendForm(...));
-Extension::register('MEDIA_FORM_ADD', $mediaHandler->extendForm(...));
-
-Extension::register('MEDIA_ADDED', $mediaHandler->extendForm(...), ExtensionLevel::Early);
-Extension::register('MEDIA_UPDATED', $mediaHandler->extendForm(...), ExtensionLevel::Early);
-
-Extension::register('MEDIA_IS_IN_USE', MediaHandler::isMediaInUse(...));

--- a/src/MetaInfo/MetaInfo.php
+++ b/src/MetaInfo/MetaInfo.php
@@ -9,14 +9,17 @@ use Redaxo\Core\Database\Table;
 use Redaxo\Core\Database\Util;
 use Redaxo\Core\Exception\InvalidArgumentException;
 use Redaxo\Core\ExtensionPoint\AsExtension;
+use Redaxo\Core\ExtensionPoint\Extension;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
 use Redaxo\Core\Filesystem\Url;
 use Redaxo\Core\MetaInfo\Database\Table as MetaInfoTable;
+use Redaxo\Core\MetaInfo\Handler\CategoryHandler;
+use Redaxo\Core\MetaInfo\Handler\LanguageHandler;
+use Redaxo\Core\MetaInfo\Handler\MediaHandler;
 use Redaxo\Core\Translation\I18n;
 use Redaxo\Core\Util\Type;
 use Redaxo\Core\View\Asset;
 
-use function dirname;
 use function in_array;
 use function is_int;
 
@@ -223,13 +226,13 @@ final class MetaInfo
             Asset::addJsFile(Url::coreAssets('js/metainfo.js'), [Asset::JS_IMMUTABLE => true]);
         }
 
-        // include extensions
+        // Register the handler instance backing the non-static #[AsExtension] methods for the current page.
         if ('structure' == $page) {
-            require_once dirname(__DIR__) . '/MetaInfo/Handler/CategoryHandler.php';
+            Extension::registerInstance(new CategoryHandler());
         } elseif ('mediapool' == $mainpage) {
-            require_once dirname(__DIR__) . '/MetaInfo/Handler/MediaHandler.php';
+            Extension::registerInstance(new MediaHandler());
         } elseif ('system/lang' == $page) {
-            require_once dirname(__DIR__) . '/MetaInfo/Handler/LanguageHandler.php';
+            Extension::registerInstance(new LanguageHandler());
         }
     }
 

--- a/tests/ExtensionPoint/ExtensionTest.php
+++ b/tests/ExtensionPoint/ExtensionTest.php
@@ -6,10 +6,14 @@ use PHPUnit\Framework\TestCase;
 use Redaxo\Core\ExtensionPoint\Extension;
 use Redaxo\Core\ExtensionPoint\ExtensionLevel;
 use Redaxo\Core\ExtensionPoint\ExtensionPoint;
+use Redaxo\Core\Tests\ExtensionPoint\Fixtures\InstanceExtensionFixture;
+use ReflectionProperty;
 
 /** @internal */
 final class ExtensionTest extends TestCase
 {
+    private const INSTANCE_EP = 'TEST_INSTANCE_EXTENSION_EP';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -17,6 +21,9 @@ final class ExtensionTest extends TestCase
 
     protected function tearDown(): void
     {
+        // Reset the static instance registry so instance-method tests don't leak into each other.
+        new ReflectionProperty(Extension::class, 'instances')->setValue(null, []);
+
         parent::tearDown();
     }
 
@@ -124,5 +131,37 @@ final class ExtensionTest extends TestCase
 
         self::assertSame('foo', Extension::dispatch(new ExtensionPoint($EP1, $subject)));
         self::assertSame('foo', Extension::dispatch(new ExtensionPoint($EP2, $subject)));
+    }
+
+    public function testInstanceExtensionNoInstanceIsNoop(): void
+    {
+        // The #[AsExtension] method is discovered and wired at boot, but with no registered instance it's a no-op.
+        self::assertSame('start', Extension::dispatch(new ExtensionPoint(self::INSTANCE_EP, 'start')));
+    }
+
+    public function testInstanceExtensionRunsForEachRegisteredInstance(): void
+    {
+        Extension::registerInstance(new InstanceExtensionFixture('A'));
+        Extension::registerInstance(new InstanceExtensionFixture('B'));
+
+        // The method runs once per instance, in registration order, chaining the subject between them.
+        self::assertSame('startAB', Extension::dispatch(new ExtensionPoint(self::INSTANCE_EP, 'start')));
+    }
+
+    public function testInstanceExtensionMatchesSubclassInstances(): void
+    {
+        // The attribute sits on the parent; a registered subclass instance must still serve it. Discovery only
+        // needs to find the parent, so an anonymous subclass created here is enough — it matches via instanceof.
+        Extension::registerInstance(new class('C') extends InstanceExtensionFixture {});
+
+        self::assertSame('startC', Extension::dispatch(new ExtensionPoint(self::INSTANCE_EP, 'start')));
+    }
+
+    public function testInstanceExtensionRespectsReadonly(): void
+    {
+        Extension::registerInstance(new InstanceExtensionFixture('A'));
+
+        // Readonly EP: the method still runs (no exception), but the subject is not changed.
+        self::assertSame('start', Extension::dispatch(new ExtensionPoint(self::INSTANCE_EP, 'start', [], true)));
     }
 }

--- a/tests/ExtensionPoint/Fixtures/InstanceExtensionFixture.php
+++ b/tests/ExtensionPoint/Fixtures/InstanceExtensionFixture.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Redaxo\Core\Tests\ExtensionPoint\Fixtures;
+
+use Redaxo\Core\ExtensionPoint\AsExtension;
+use Redaxo\Core\ExtensionPoint\ExtensionPoint;
+
+/**
+ * Fixture for non-static {@see AsExtension} methods backed by a registered instance.
+ * Carries a constructor argument on purpose, to mirror objects that cannot be created without parameters.
+ *
+ * @internal
+ */
+class InstanceExtensionFixture
+{
+    public function __construct(
+        private readonly string $marker,
+    ) {}
+
+    /** @param ExtensionPoint<string> $ep */
+    #[AsExtension('TEST_INSTANCE_EXTENSION_EP')]
+    public function append(ExtensionPoint $ep): string
+    {
+        return $ep->subject . $this->marker;
+    }
+}


### PR DESCRIPTION
## Summary

So far, class discovery only wired **static** `#[AsExtension]` methods, plus the special cases of the project object and addon objects. Non-static methods on any other class still required the old bottom-of-file `new X(); Extension::register(...)` pattern.

This adds **`Extension::registerInstance()`**: instances registered there back non-static `#[AsExtension]` methods, resolved **lazily on dispatch**.

- An attributed method runs **once per matching instance**, matched by `instanceof` — so a subclass instance also serves a method declared on its **parent**.
- Multiple instances may be registered; the subject is chained between them exactly like separately registered extensions.
- With no matching instance, it's simply a no-op.

Objects with constructor dependencies are supported (you control the `new`), so this also works for addon handlers that can't be created without parameters.

## Details

- Centralized the per-extension "call + apply result" logic (readonly flag and the *null means no change* convention) into `Extension::runExtension()`, shared by `dispatch()` and the instance-method wrapper.
- Converted the MetaInfo handlers (`Category`/`Language`/`Media`) to attributes and register their instances per page, dropping the executable file-bottom code. Note: `MediaHandler::isMediaInUse` is static and is now wired globally (previously only when on a mediapool page) — arguably a fix.
- Tests now run in **debug mode** so the class-discovery cache self-invalidates on file changes (e.g. newly added test fixtures), instead of relying on a warm cache.

## Tests

Added coverage in `ExtensionTest` for the new instance-method path: no-op without instances, run-once-per-instance with subject chaining, subclass matching via `instanceof`, and readonly handling.