### PR TITLE
fix: avoid database access in Config during setup

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -7,6 +7,7 @@ use Redaxo\Core\Exception\RuntimeException;
 use Redaxo\Core\Filesystem\Dir;
 use Redaxo\Core\Filesystem\File;
 use Redaxo\Core\Filesystem\Path;
+use Redaxo\Core\Setup\Setup;
 
 use function count;
 use function dirname;
@@ -238,12 +239,20 @@ final class Config
     private static function load(): void
     {
         // check if we can load the config from the filesystem
-        if (!self::loadFromFile()) {
-            // if not possible, fallback to load config from the db
-            self::loadFromDb();
-            // afterwards persist loaded data into file-cache
-            self::generateCache();
+        if (self::loadFromFile()) {
+            return;
         }
+
+        // during setup there may be no (working) database yet, so skip the db fallback
+        // and keep the config empty (consumers fall back to their defaults)
+        if (Setup::isEnabled()) {
+            return;
+        }
+
+        // fallback to load config from the db
+        self::loadFromDb();
+        // afterwards persist loaded data into file-cache
+        self::generateCache();
     }
 
     /**


### PR DESCRIPTION
## Problem

`boot/backend.php` calls `Core::getConfig()` several times unconditionally. During setup the database may not exist yet, so these calls bubble down into `Config::load()` → `loadFromDb()` → `Sql::factory()` and crash with a connection error.

## Fix

Guard the db fallback at its real choke point in `Config::load()`: try the file cache first, and only fall back to the database when setup is **not** enabled. During setup the config stays empty and consumers fall back to their defaults.

This covers all access methods uniformly (`get`/`has`/`set`/`remove`) instead of patching a single `Core::getConfig` wrapper, and it does not swallow genuine connection errors in normal operation. `Config::refresh()` (used by the setup backup importer) still loads from the db explicitly when it wants to.
