### PR TITLE
feat: add HtmlAttributes value object

### DIFF
--- a/src/View/HtmlAttributes.php
+++ b/src/View/HtmlAttributes.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Redaxo\Core\View;
+
+use BackedEnum;
+use Redaxo\Core\Util\Type;
+use Stringable;
+
+use function array_key_exists;
+use function is_array;
+use function is_string;
+
+/**
+ * Container for HTML attributes.
+ *
+ * ```php
+ * $attributes = new Attributes([
+ *     'attr1' => 'my_value', // string value
+ *     'attr2' => 5, // integer value
+ *     'attr3' => $myEnum, // BackedEnum values
+ *     'attr4' => null', // attributes with `null`/`false` value are omitted
+ *     'disabled' => true, // `true` value for boolean attributes without value
+ *     'class' => [ // arrays for space separated attributes
+ *         'cls1',
+ *         'cls2',
+ *         'cls3' => false, // conditional classes
+ *         'cls4' => true,  // conditional classes
+ *     ],
+ * ]);
+ * $attributes->toString();
+ * ```
+ *
+ * The example will result in this attributes string:
+ *    ` attr1="my_value" attr2="5" attr3="my_enum_value" disabled class="cls1 cls2 cls4"`
+ */
+final class HtmlAttributes implements Stringable
+{
+    public function __construct(
+        /** @var array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null> */
+        private array $attributes = [],
+    ) {}
+
+    /**
+     * @param literal-string $key
+     * @param bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null $value
+     */
+    public function set(string $key, bool|string|int|BackedEnum|array|null $value): void
+    {
+        $this->attributes[$key] = $value;
+    }
+
+    /** @param array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null> $attributes */
+    public function with(array $attributes): self
+    {
+        foreach ($this->attributes as $key => $value) {
+            if (!array_key_exists($key, $attributes)) {
+                $attributes[$key] = $value;
+                continue;
+            }
+
+            if (!is_array($attributes[$key])) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $value = self::normalizeArrayValue($value);
+            } elseif (is_string($value)) {
+                $value = self::normalizeArrayValue(explode(' ', $value));
+            } elseif ($value instanceof BackedEnum) {
+                $value = [Type::string($value->value) => true];
+            } else {
+                continue;
+            }
+
+            $normalized = self::normalizeArrayValue($attributes[$key]);
+
+            foreach ($value as $part => $enabled) {
+                if (!$enabled) {
+                    continue;
+                }
+                if (isset($normalized[$part])) {
+                    continue;
+                }
+
+                $attributes[$key][] = $part;
+            }
+        }
+
+        return new self($attributes);
+    }
+
+    public function toString(): string
+    {
+        $attr = '';
+
+        foreach ($this->attributes as $key => $value) {
+            if (true === $value) {
+                $attr .= ' ' . $key;
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $value = self::arrayValue($value);
+            }
+
+            if (null === $value || false === $value) {
+                continue;
+            }
+
+            if ($value instanceof BackedEnum) {
+                $value = $value->value;
+            } elseif (is_string($value)) {
+                $value = escape($value);
+            }
+
+            $attr .= ' ' . $key . '="' . $value . '"';
+        }
+
+        return ltrim($attr);
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    /** @param array<string|int, string|bool>|list<BackedEnum> $array */
+    private static function arrayValue(array $array): ?string
+    {
+        $array = self::normalizeArrayValue($array);
+
+        if (!$array) {
+            return null;
+        }
+
+        return implode(' ', array_keys(array_filter($array)));
+    }
+
+    /**
+     * @param array<string|int, string|bool>|list<BackedEnum> $array
+     * @return array<string, bool>
+     */
+    private static function normalizeArrayValue(array $array): array
+    {
+        $normalized = [];
+
+        foreach ($array as $key => $value) {
+            if (is_string($key)) {
+                $normalized[$key] = Type::bool($value);
+                continue;
+            }
+
+            $value = $value instanceof BackedEnum ? $value->value : $value;
+            $normalized[Type::string($value)] = true;
+        }
+
+        return $normalized;
+    }
+}

--- a/src/View/HtmlAttributes.php
+++ b/src/View/HtmlAttributes.php
@@ -11,14 +11,14 @@ use function is_array;
 use function is_string;
 
 /**
- * Container for HTML attributes.
+ * Immutable container for HTML attributes.
  *
  * ```php
- * $attributes = new Attributes([
+ * $attributes = new HtmlAttributes([
  *     'attr1' => 'my_value', // string value
  *     'attr2' => 5, // integer value
  *     'attr3' => $myEnum, // BackedEnum values
- *     'attr4' => null', // attributes with `null`/`false` value are omitted
+ *     'attr4' => null, // attributes with `null`/`false` value are omitted
  *     'disabled' => true, // `true` value for boolean attributes without value
  *     'class' => [ // arrays for space separated attributes
  *         'cls1',
@@ -32,8 +32,12 @@ use function is_string;
  *
  * The example will result in this attributes string:
  *    ` attr1="my_value" attr2="5" attr3="my_enum_value" disabled class="cls1 cls2 cls4"`
+ *
+ * The object is immutable: {@see with()} returns a new instance. Build attributes up by collecting
+ * them in a plain `array` (mutable, conditional logic is cheap) and passing it once to the
+ * constructor or {@see with()}, instead of mutating the object step by step.
  */
-final class HtmlAttributes implements Stringable
+final readonly class HtmlAttributes implements Stringable
 {
     public function __construct(
         /** @var array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null> */
@@ -41,15 +45,20 @@ final class HtmlAttributes implements Stringable
     ) {}
 
     /**
-     * @param literal-string $key
-     * @param bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null $value
+     * Returns a new instance in which the given attributes take precedence over the existing ones.
+     *
+     * The attributes passed here win: a scalar value replaces whatever the existing side held for
+     * that key and cannot be overridden from there. An array value (e.g. `class`) is merged instead
+     * — existing parts are appended while the on/off state declared here is kept. This serves two
+     * purposes: setting/overriding values while building up attributes, and declaring component
+     * defaults in a view that callers must not override.
+     *
+     * Note: merging only happens when the value passed here is an array. A string like
+     * `'class' => 'foo'` is treated as a fixed, non-extendable value — write `'class' => ['foo']`
+     * if the other side should be able to add further classes.
+     *
+     * @param array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null> $attributes
      */
-    public function set(string $key, bool|string|int|BackedEnum|array|null $value): void
-    {
-        $this->attributes[$key] = $value;
-    }
-
-    /** @param array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null> $attributes */
     public function with(array $attributes): self
     {
         foreach ($this->attributes as $key => $value) {
@@ -59,6 +68,8 @@ final class HtmlAttributes implements Stringable
             }
 
             if (!is_array($attributes[$key])) {
+                // A scalar value passed to with() wins and stays fixed: the existing value for this
+                // key is dropped and cannot override it. Only array values (e.g. `class`) are merged.
                 continue;
             }
 
@@ -110,7 +121,9 @@ final class HtmlAttributes implements Stringable
 
             if ($value instanceof BackedEnum) {
                 $value = $value->value;
-            } elseif (is_string($value)) {
+            }
+
+            if (is_string($value)) {
                 $value = escape($value);
             }
 

--- a/tests/View/HtmlAttributesTest.php
+++ b/tests/View/HtmlAttributesTest.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace Redaxo\Core\Tests\Fragment;
+namespace Redaxo\Core\Tests\View;
 
 use BackedEnum;
-use http\Env;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redaxo\Core\Environment;
@@ -63,7 +62,7 @@ final class HtmlAttributesTest extends TestCase
         self::assertSame($expected, $with->toString());
     }
 
-    /** @return list<array{string, array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|null>, array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null>}> */
+    /** @return list<array{string, array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null>, array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null>}> */
     public static function dataWith(): array
     {
         return [

--- a/tests/View/HtmlAttributesTest.php
+++ b/tests/View/HtmlAttributesTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Redaxo\Core\Tests\Fragment;
+
+use BackedEnum;
+use http\Env;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Redaxo\Core\Environment;
+use Redaxo\Core\View\HtmlAttributes;
+
+/**
+ * @internal
+ */
+final class HtmlAttributesTest extends TestCase
+{
+    /** @param array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null> $attributes */
+    #[DataProvider('dataConstruct')]
+    public function testConstruct(string $expected, array $attributes): void
+    {
+        $attributes = new HtmlAttributes($attributes);
+
+        self::assertSame($expected, $attributes->toString());
+    }
+
+    /** @return list<array{string, array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null>}> */
+    public static function dataConstruct(): array
+    {
+        return [
+            ['', []],
+            ['', ['foo' => null, 'bar' => false, 'baz' => []]],
+            [
+                'title="foo" maxlength="5" disabled data-environment="backend"',
+                ['title' => 'foo', 'maxlength' => 5, 'disabled' => true, 'data-environment' => Environment::Backend],
+            ],
+            [
+                'title="foo" class="cls1 cls3 cls4"',
+                ['title' => 'foo', 'value' => null, 'class' => [
+                    'cls1',
+                    'cls2' => false,
+                    'cls3',
+                    'cls4' => true,
+                ]],
+            ],
+            [
+                'data-environments="backend frontend"',
+                ['data-environments' => [Environment::Backend, Environment::Frontend]],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null> $initial
+     * @param array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null> $with
+     */
+    #[DataProvider('dataWith')]
+    public function testWith(string $expected, array $initial, array $with): void
+    {
+        $initial = new HtmlAttributes($initial);
+        $with = $initial->with($with);
+
+        self::assertNotSame($initial, $with);
+        self::assertSame($expected, $with->toString());
+    }
+
+    /** @return list<array{string, array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|null>, array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null>}> */
+    public static function dataWith(): array
+    {
+        return [
+            ['', [], []],
+            [
+                '',
+                ['foo' => 'bar', 'disabled' => true],
+                ['foo' => null, 'disabled' => false],
+            ],
+            [
+                'foo="bar" disabled',
+                ['foo' => null, 'disabled' => false],
+                ['foo' => 'bar', 'disabled' => true],
+            ],
+            [
+                'title="foo" value="5"',
+                ['value' => 5],
+                ['title' => 'foo'],
+            ],
+            [
+                'class="cls1 cls3" value="5"',
+                ['value' => 5],
+                ['class' => ['cls1', 'cls2' => false, 'cls3' => true]],
+            ],
+            [
+                'class="cls1 cls3 foo bar"',
+                ['class' => 'foo cls2 bar'],
+                ['class' => ['cls1', 'cls2' => false, 'cls3' => true]],
+            ],
+            [
+                'class="cls1 cls3 foo bar"',
+                ['class' => ['cls1' => false, 'cls2', 'foo', 'cls3', 'bar' => true, 'baz' => false]],
+                ['class' => ['cls1', 'cls2' => false, 'cls3' => true]],
+            ],
+            [
+                'class="cls1 cls2"',
+                ['class' => ['cls1' => false, 'foo', 'bar' => true]],
+                ['class' => 'cls1 cls2'],
+            ],
+            [
+                'class="cls1 cls2"',
+                ['class' => 'cls1 foo bar'],
+                ['class' => 'cls1 cls2'],
+            ],
+            [
+                'data-environments="frontend backend"',
+                ['data-environments' => Environment::Backend],
+                ['data-environments' => [Environment::Frontend]],
+            ],
+            [
+                'data-environments="backend frontend console"',
+                ['data-environments' => [Environment::Frontend, Environment::Backend]],
+                ['data-environments' => [Environment::Backend, Environment::Frontend, Environment::Console]],
+            ],
+        ];
+    }
+}

--- a/tests/View/HtmlAttributesTest.php
+++ b/tests/View/HtmlAttributesTest.php
@@ -13,6 +13,18 @@ use Redaxo\Core\View\HtmlAttributes;
  */
 final class HtmlAttributesTest extends TestCase
 {
+    public function testValuesAreEscaped(): void
+    {
+        // the security-critical bit: values (plain and inside arrays) are escaped, names are not
+        // touched because they are typed as literal-string and therefore never user input
+        $attributes = new HtmlAttributes([
+            'title' => '"><script>',
+            'class' => ['"><x'],
+        ]);
+
+        self::assertSame('title="&quot;&gt;&lt;script&gt;" class="&quot;&gt;&lt;x"', $attributes->toString());
+    }
+
     /** @param array<literal-string, bool|string|int|BackedEnum|array<string|int, string|bool>|list<BackedEnum>|null> $attributes */
     #[DataProvider('dataConstruct')]
     public function testConstruct(string $expected, array $attributes): void


### PR DESCRIPTION
## HtmlAttributes

An immutable value object for building HTML attribute strings, intended to be used together with the new view system. Values are escaped on output, so the result is safe to emit in a view.

Attribute **names** are typed as `literal-string` — they can never originate from user input, so only the **values** need escaping (which they get, using the `html` strategy / `ENT_QUOTES`).

### Basic usage

```php
$attributes = new HtmlAttributes([
    'title' => 'My title',          // string value
    'maxlength' => 5,               // int value
    'disabled' => true,             // boolean attribute, rendered without a value
    'value' => null,                // null/false values are omitted entirely
    'data-environment' => Environment::Backend, // BackedEnum -> its backing value
    'class' => [                    // arrays for space-separated attributes
        'card',
        'card--muted' => false,     // conditional class
        'card--lg' => true,         // conditional class
    ],
]);

echo $attributes; // or ->toString()
// title="My title" maxlength="5" disabled data-environment="backend" class="card card--lg"
```

Because `null`/`false` values are dropped, you rarely need `if` blocks – just compute the value:

```php
$attributes = new HtmlAttributes([
    'fetchpriority' => $this->fetchPriority?->value,        // null -> omitted
    'data-transparent' => $this->source->hasTransparency(), // false -> omitted, true -> bare attribute
]);
```

### Defaults / merging with `with()`

`HtmlAttributes` is immutable. `with()` returns a new instance in which the **passed attributes take precedence** over the existing ones:

- a **scalar** value replaces the existing one and cannot be overridden from the other side;
- an **array** value (e.g. `class`) is **merged** – existing parts are appended, the on/off state declared in `with()` is kept.

This is the natural fit for a component that declares its own attributes in a view while letting callers add to them. The component owns what it declares; callers may contribute additional attributes.

```php
final class Card implements Renderable
{
    use RendersView;

    public function __construct(
        public string $title,
        public HtmlAttributes $attributes = new HtmlAttributes(),
    ) {}
}
```

```php
// Card.view.php
return static function (Card $card): void { ?>
    <div <?= $card->attributes->with([
        'class' => ['card'],   // array -> callers can add further classes
        'role' => 'group',     // scalar -> fixed, not overridable by the caller
    ]) ?>>
        <h2><?= escape($card->title) ?></h2>
        <!-- ... -->
    </div>
<?php };
```

```php
// caller
new Card(
    title: 'Hello',
    attributes: new HtmlAttributes(['class' => ['card--featured'], 'id' => 'intro']),
);
// -> <div class="card card--featured" role="group" id="intro">
```

> Note: merging only happens when the value passed to `with()` is an array. A string like
> `'class' => 'card'` is treated as a fixed, non-extendable value – use `'class' => ['card']`
> if the other side should be able to add further classes.

### Building imperatively

Since the object is immutable, build attributes up in a plain `array` (where conditional logic is cheap) and pass it once:

```php
$attributes = [
    'src' => $this->source->getUrl(),
    'alt' => $this->source->getAlt(),
    'loading' => $this->loading->value,
];

if (ImageLoading::Lazy === $this->loading) {
    $attributes['class'] = ['image--placeholder'];
}

$this->imageAttributes = $this->imageAttributes->with($attributes);
```

---

In https://github.com/redaxo/core/pull/5645 hatten wir das Klasse schon mal sehr ähnlich eingefügt, den Components-Branch hatten wir aber in der Form abgebrochen.