### PR TITLE
feat: add nosniff and referrer-policy headers to backend

### DIFF
--- a/boot/backend.php
+++ b/boot/backend.php
@@ -39,6 +39,8 @@ use function Redaxo\Core\View\escape;
 header('X-Robots-Tag: noindex, nofollow, noarchive');
 header('X-Frame-Options: SAMEORIGIN');
 header("Content-Security-Policy: frame-ancestors 'self'");
+header('X-Content-Type-Options: nosniff');
+header('Referrer-Policy: no-referrer');
 
 // assets which are passed with a cachebuster will be cached very long,
 // as we assume their url will change when the underlying content changes


### PR DESCRIPTION
Always set two additional security headers in the backend:

- `X-Content-Type-Options: nosniff` — prevents MIME-type sniffing.
- `Referrer-Policy: no-referrer` — the backend never needs to leak referrer information (neither internal paths nor the fact that a REDAXO backend is running) to external destinations.

The backend navigation does not rely on the `Referer` header, so `no-referrer` is safe and is hardcoded rather than made configurable.

The frontend is intentionally left untouched — security headers there depend heavily on the individual site and are better handled by the site admin (or on the server level).

Closes #2739
