### PR TITLE
fix: add CSP nonce to dump() output

### DIFF
--- a/src/Util/VarDumper.php
+++ b/src/Util/VarDumper.php
@@ -4,6 +4,7 @@ namespace Redaxo\Core\Util;
 
 use Redaxo\Core\Core;
 use Redaxo\Core\Filesystem\Path;
+use Redaxo\Core\Http\Response;
 use Redaxo\Core\Security\BackendLogin;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
@@ -48,6 +49,7 @@ final class VarDumper
             } else {
                 $styleAll = 'font-family: "Fira Code", Menlo, Monaco, Consolas, monospace; font-size: 14px; line-height: 1.4 !important;';
                 $dumper = new HtmlDumper();
+                $dumper->setNonce(static fn () => Response::getNonce());
                 $dumper->setDumpBoundaries('<pre class="rex-var-dumper sf-dump" id="%s" data-indent-pad="%s">', '</pre><script>Sfdump(%s)</script>');
                 $dumper->setIndentPad('    ');
                 $dumper->setStyles([


### PR DESCRIPTION
Symfony 8.1 added `HtmlDumper::setNonce()`, which lets us forward our existing CSP nonce (`Response::getNonce()`) to the `<script>` and `<style>` tags the dumper emits. So `dump()` no longer triggers CSP violations under a strict `script-src`/`style-src` policy without `unsafe-inline`.

The nonce is passed as a closure so it resolves lazily — correct even though the dumper instance is cached statically.

Tested locally in the backend with a strict report-only CSP (`script-src 'nonce-X'; style-src 'nonce-X'`): the dump's script and style tags now carry the matching nonce, dropping the script-src and style-src violations from the dump to zero.

Closes #5503