### PR TITLE
refactor: remove obsolete internal todo list from history plugin backend page

### DIFF
--- a/redaxo/src/addons/structure/plugins/history/lang/de_de.lang
+++ b/redaxo/src/addons/structure/plugins/history/lang/de_de.lang
@@ -5,8 +5,6 @@ structure_history_snapshot_reactivated = Version wurde übernommen
 structure_history_overview_versions = history_overview_versions
 structure_history_current_version = Aktuelle Version
 structure_history_info_content = <p>Ein History PlugIn mit welchem man Änderungen in den Artikelinhalten aufnehmen kann. Es wird jeweils ein Snapshot der Version erstellt und mit einem Datum versehen. Nachträglich können dann ältere Versionen wieder aktiviert werden.</p>
-structure_history_todos = Todos
-structure_history_todos_content = <ul><li>cronjob vorbereiten</li><li>History deaktivierbar machen</li><li>Einstellungen einbauen, um die Anzahl der Version einzuschränken. Z.B. nach einer Woche nur eine Version/Tag behalten. nach einem Monat nur noch eine Version/Monat behalten..</li><li>Skalierungswerte der Webseite setzen</li><li>Darstellung aufhübschen ala Time Machine ?</li></ul>
 
 perm_options_history[article_rollback] = Artikel wiederherstellen (Historie)
 

--- a/redaxo/src/addons/structure/plugins/history/lang/en_gb.lang
+++ b/redaxo/src/addons/structure/plugins/history/lang/en_gb.lang
@@ -5,8 +5,6 @@ structure_history_snapshot_reactivated = Version has been revertet
 structure_history_overview_versions = History overview
 structure_history_current_version = Current version
 structure_history_info_content = <p>The History PlugIn records all changes made to an article and creates snapshots which can later be used to restore a specific article to a previous state.</p>
-structure_history_todos = To do
-structure_history_todos_content = <ul><li>prepare cronjob</li><li>allow History to be turned off</li><li>Build settings, to reduce the number of version. Example: keep only one version after a month/week/day.</li><li>set scaling values for the website</li><li>make the visual appearance prettier similar to Time Machine?</li></ul>
 
 perm_options_history[article_rollback] = Restore article (History)
 

--- a/redaxo/src/addons/structure/plugins/history/lang/es_es.lang
+++ b/redaxo/src/addons/structure/plugins/history/lang/es_es.lang
@@ -5,8 +5,6 @@ structure_history_snapshot_reactivated = Se adoptó la versión
 structure_history_overview_versions = Versiones generales de la historia
 structure_history_current_version = Versión actual
 structure_history_info_content = <p>Un plug-in de la historia con la que puede registrar los cambios en el contenido del artículo. En cada caso, una versión instantánea y dado una fecha. Posteriormente versiones anteriores pueden entonces ser re-activados.</p>
-structure_history_todos = Todos
-structure_history_todos_content = <ul><li>cronjob preparar </li> <li> Historia hacer desactivado </li><li>Instalar las opciones para restringir el número de versiones. Por ejemplo, mantener sólo una versión / día después de una semana. retener meses después de un mes sólo una versión /.. </li><li> Los valores escalados el sitio web creado </li><li> representación aufhübschen ala máquina del tiempo? </li> </ul>
 
 perm_options_history[article_rollback] = Restablecimiento del artículo (Historia)
 

--- a/redaxo/src/addons/structure/plugins/history/lang/it_it.lang
+++ b/redaxo/src/addons/structure/plugins/history/lang/it_it.lang
@@ -5,8 +5,6 @@ structure_history_snapshot_reactivated =
 structure_history_overview_versions = 
 structure_history_current_version = 
 structure_history_info_content = 
-structure_history_todos = 
-structure_history_todos_content = 
 
 perm_options_history[article_rollback] = 
 

--- a/redaxo/src/addons/structure/plugins/history/lang/pt_br.lang
+++ b/redaxo/src/addons/structure/plugins/history/lang/pt_br.lang
@@ -5,8 +5,6 @@ structure_history_snapshot_reactivated = Versão foi revertida
 structure_history_overview_versions = Panorama da história
 structure_history_current_version = Versão atual
 structure_history_info_content = <p> O PlugIn história grava todas as alterações feitas em um produto e cria snapshots que podem ser utilizados posteriormente para restaurar um status anterior de produto específico. <p>
-structure_history_todos = A ser feito
-structure_history_todos_content = <ul><li>preparar cronjob</li><li>permite que o PlugIn "história" seja desligado</li><li>Criar configurações, para reduzir o número de versão. Exemplo: mantenha apenas uma versão após um mês / semana / diaLi> <li> definir valores de escala para o site </ li> <li>Tornar a aparência mais bonita, semelhante ao Time Machine? </ Li> </ ul>
 
 perm_options_history[article_rollback] = Restaurar produto (história)
 

--- a/redaxo/src/addons/structure/plugins/history/lang/ru_ru.lang
+++ b/redaxo/src/addons/structure/plugins/history/lang/ru_ru.lang
@@ -5,8 +5,6 @@ structure_history_snapshot_reactivated = Версия была изменена
 structure_history_overview_versions = Обзор истории
 structure_history_current_version = Текущая версия
 structure_history_info_content = <p>Плагин History PlugIn записывает все изменения, внесенные в статью, и создает снэпшоты, которые впоследствии можно использовать для восстановления предыдущего состояния конкретной статьи.</p>
-structure_history_todos = Сделать
-structure_history_todos_content = <ul><li>Подготовить cronjob</li><li>Разрешить отключение истории</li><li>Настройки сборки, позволяющие уменьшить количество версий. Пример: хранить только одну версию через месяц/неделю/день.</li><li>Установить значения масштабирования для сайта</li><li>Cделать визуальный вид более красивым, похожим на Time Machine?</li></ul>
 
 perm_options_history[article_rollback] = Восстановить статью (История)
 

--- a/redaxo/src/addons/structure/plugins/history/lang/sv_se.lang
+++ b/redaxo/src/addons/structure/plugins/history/lang/sv_se.lang
@@ -5,8 +5,6 @@ structure_history_snapshot_reactivated = Versionen har sparas
 structure_history_overview_versions = Historiköversikt
 structure_history_current_version = Aktuell version
 structure_history_info_content = <P> Historik PlugIn registrerar alla ändringar som gjorts i en artikel och skapar ögonblicksbilder som senare kan användas för att återställa en specifik artikel till ett tidigare tillstånd. </ P>
-structure_history_todos = Att göra
-structure_history_todos_content = <Ul> <li> Förbered cronjob </ li> <li> Tillåta historiken att stängas av </ li> <li> Gör inställningar för att minska antalet versioner. Exempel: Behåll bara en version efter en månad / vecka / dag. </ Li> <li> Ange skalvärden för webbplatsen </ li> <li> Gör det visuella utseendet snyggare som t.ex. Time Machine? </ Li> </ ul>
 
 perm_options_history[article_rollback] = återskapa artikeln fån historiken
 

--- a/redaxo/src/addons/structure/plugins/history/pages/system.history.php
+++ b/redaxo/src/addons/structure/plugins/history/pages/system.history.php
@@ -14,8 +14,3 @@ $fragment = new rex_fragment();
 $fragment->setVar('title', $plugin->i18n('title_info'));
 $fragment->setVar('body', $content, false);
 echo $fragment->parse('core/page/section.php');
-
-$fragment = new rex_fragment();
-$fragment->setVar('title', $plugin->i18n('todos'));
-$fragment->setVar('body', rex_i18n::rawMsg('structure_history_todos_content'), false);
-echo $fragment->parse('core/page/section.php');


### PR DESCRIPTION
## Was

Entfernt die alte interne Entwickler-Todo-Liste, die auf der Backend-Seite des History-Plugins (`structure/history`) ausgegeben wurde.

Die Liste enthielt längst überholte Wunschnotizen wie „cronjob vorbereiten", „History deaktivierbar machen" oder „Darstellung aufhübschen ala Time Machine?" — das hat im UI nichts verloren.

## Änderungen

- Den „Todos"-Section-Block aus `pages/system.history.php` entfernt (Kurzerklärung bleibt erhalten)
- Die Lang-Keys `structure_history_todos` und `structure_history_todos_content` aus allen 7 Sprachdateien gelöscht