### PR TITLE
refactor!: replace fileperm/dirperm config with umask-based permissions

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -961,9 +961,6 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$config['timezone']]]></code>
     </ArgumentTypeCoercion>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$value]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="pages/setup/step1.php">
     <MixedOperand>
@@ -1354,9 +1351,6 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$propertyKey]]></code>
     </ArgumentTypeCoercion>
-    <MixedArgument>
-      <code><![CDATA[$config]]></code>
-    </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$config]]></code>
@@ -1370,9 +1364,6 @@
       <code><![CDATA[$config[$pathPart]]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <PossiblyNullOperand>
-      <code><![CDATA[$value]]></code>
-    </PossiblyNullOperand>
   </file>
   <file src="src/Console/Command/CronjobRunCommand.php">
     <MixedArgument>

--- a/pages/setup/index.php
+++ b/pages/setup/index.php
@@ -210,9 +210,6 @@ if ($step > 3) {
         if (in_array($key, $check)) {
             continue;
         }
-        if (in_array($key, ['fileperm', 'dirperm'])) {
-            $value = octdec($value);
-        }
         Core::setProperty($key, $value);
     }
 

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -84,16 +84,6 @@
             "type": ["null", "string"],
             "format": "email"
         },
-        "fileperm": {
-            "description": "File permission (octal)",
-            "type": "string",
-            "pattern": "^0\\d{3}$"
-        },
-        "dirperm": {
-            "description": "Directory permission (octal)",
-            "type": "string",
-            "pattern": "^0\\d{3}$"
-        },
         "session_duration": {
             "description": "A Session will be closed when not activly used for this timespan (seconds)",
             "type": "integer"

--- a/setup/default.config.yml
+++ b/setup/default.config.yml
@@ -8,8 +8,6 @@ instname: null
 server: https://www.redaxo.org/
 servername: REDAXO
 error_email: null
-fileperm: '0664'
-dirperm: '0775'
 session_duration: 7200
 session_keep_alive: 21600
 session_max_overall_duration: 2419200 # 4 weeks

--- a/src/Console/Command/ConfigGetCommand.php
+++ b/src/Console/Command/ConfigGetCommand.php
@@ -24,7 +24,6 @@ final class ConfigGetCommand extends AbstractCommand implements StandaloneInterf
         SymfonyStyle $io,
         OutputInterface $output,
         #[Argument('config path separated by periods, e.g. "setup" or "db.1.host"')] string $key,
-        #[Option('php type of the returned value, e.g. "octal"', shortcut: 't')] string $type = 'string',
         #[Option('addon to inspect, defaults to redaxo-core', name: 'addon', shortcut: 'p')] string $package = 'core',
     ): int {
         if (!$key) {
@@ -59,12 +58,7 @@ final class ConfigGetCommand extends AbstractCommand implements StandaloneInterf
             $config = $config[$pathPart];
         }
 
-        if ('octal' === $type) {
-            // turn fileperm/dirperm into the expected values like e.g. 755
-            $output->writeln(decoct($config));
-        } else {
-            $output->writeln(json_encode($config));
-        }
+        $output->writeln(json_encode($config));
 
         return Command::SUCCESS;
     }

--- a/src/Console/Command/ConfigSetCommand.php
+++ b/src/Console/Command/ConfigSetCommand.php
@@ -41,7 +41,7 @@ final class ConfigSetCommand extends AbstractCommand implements StandaloneInterf
         SymfonyStyle $io,
         #[Argument('config path separated by periods, e.g. "setup" or "db.1.host"')] string $key,
         #[Argument('new value for config key, e.g. "somestring" or "1"')] ?string $value = null,
-        #[Option('php type of new value, e.g. "bool", "octal" or "int"', shortcut: 't')] string $type = 'string',
+        #[Option('php type of new value, e.g. "bool" or "int"', shortcut: 't')] string $type = 'string',
         #[Option('sets the config key to null')] bool $unset = false,
     ): int {
         if (null === $value && false === $unset) {
@@ -53,10 +53,6 @@ final class ConfigSetCommand extends AbstractCommand implements StandaloneInterf
         } elseif ('bool' === $type || 'boolean' === $type) {
             $value = in_array($value, ['true', 'on', '1'], true) ? true : $value;
             $value = in_array($value, ['false', 'off', '0'], true) ? false : $value;
-        } elseif ('octal' === $type) {
-            // turns e.g. 755 into 0755
-            // a leading zero marks a octal-string
-            $value = '0' . $value;
         } else {
             $value = Type::cast($value, $type);
         }

--- a/src/Core.php
+++ b/src/Core.php
@@ -470,18 +470,6 @@ final class Core
         return ' title="' . $title . '"';
     }
 
-    /** Returns the file perm. */
-    public static function getFilePerm(): int
-    {
-        return (int) self::getProperty('fileperm', 0o664);
-    }
-
-    /** Returns the dir perm. */
-    public static function getDirPerm(): int
-    {
-        return (int) self::getProperty('dirperm', 0o775);
-    }
-
     /**
      * Returns the current backend theme.
      *
@@ -536,10 +524,6 @@ final class Core
         foreach ($config as $key => $value) {
             /** @psalm-suppress MixedAssignment */
             $value = self::convertEnvVariables($value);
-
-            if (in_array($key, ['fileperm', 'dirperm'])) {
-                $value = octdec((string) $value);
-            }
 
             self::setProperty($key, $value);
         }

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -2,7 +2,6 @@
 
 namespace Redaxo\Core\Filesystem;
 
-use Redaxo\Core\Core;
 use SplFileInfo;
 use Traversable;
 
@@ -43,15 +42,11 @@ final class Dir
             return false;
         }
 
-        // suppress "File exists" warning in case of concurrent processes
-        @mkdir($dir, Core::getDirPerm());
+        // suppress "File exists" warning in case of concurrent processes.
+        // the mode is masked by the process umask, so the actual perms follow the server policy.
+        @mkdir($dir, 0o777);
 
-        if (is_dir($dir)) {
-            @chmod($dir, Core::getDirPerm());
-            return true;
-        }
-
-        return false;
+        return is_dir($dir);
     }
 
     /**

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -2,7 +2,6 @@
 
 namespace Redaxo\Core\Filesystem;
 
-use Redaxo\Core\Core;
 use Redaxo\Core\Exception\RuntimeException;
 use Redaxo\Core\Util\Exception\YamlParseException;
 use Redaxo\Core\Util\Formatter;
@@ -107,10 +106,14 @@ final class File
                 return false;
             }
 
+            // preserve the perms of an existing file, otherwise use the umask-derived default
+            $perm = is_file($file) ? fileperms($file) : false;
+
             // mimic a atomic write
             $tmpFile = @tempnam(dirname($file), Path::basename($file));
             if (false !== file_put_contents($tmpFile, $content) && self::move($tmpFile, $file)) {
-                @chmod($file, Core::getFilePerm());
+                // tempnam() creates the file with 0600, restore the preserved or umask-derived perms
+                @chmod($file, $perm ?: 0o666 & ~umask());
                 return true;
             }
             @unlink($tmpFile);
@@ -144,14 +147,9 @@ final class File
             if ($hasContent) {
                 $content = $delimiter . $content;
             }
-
-            // Append the content to the file with FILE_APPEND and LOCK_EX flags
-            if (false !== file_put_contents($file, $content, FILE_APPEND | LOCK_EX)) {
-                @chmod($file, Core::getFilePerm());
-                return true;
-            }
-
-            return false;
+            // Append the content to the file with FILE_APPEND and LOCK_EX flags.
+            // No chmod needed: file_put_contents() applies the umask-derived perms on creation.
+            return false !== file_put_contents($file, $content, FILE_APPEND | LOCK_EX);
         });
     }
 
@@ -210,7 +208,7 @@ final class File
                 }
 
                 if (Dir::isWritable($dstdir) && (!is_file($dstfile) || is_writable($dstfile)) && copy($srcfile, $dstfile)) {
-                    @chmod($dstfile, Core::getFilePerm());
+                    // copy() applies the umask-derived perms on a new file and keeps them on an existing one
                     @touch($dstfile, filemtime($srcfile), fileatime($srcfile));
                     return true;
                 }

--- a/src/MediaPool/MediaHandler.php
+++ b/src/MediaPool/MediaHandler.php
@@ -111,11 +111,15 @@ final class MediaHandler
             throw new ApiFunctionException($errorMessage);
         }
 
+        // preserve the perms of an existing file, otherwise use the umask-derived default
+        $perm = is_file($dstFile) ? fileperms($dstFile) : false;
+
         if (!File::move($srcFile, $dstFile)) {
             throw new ApiFunctionException(I18n::msg('pool_file_movefailed'));
         }
 
-        @chmod($dstFile, Core::getFilePerm());
+        // the uploaded temp file may carry restrictive perms (e.g. 0600), restore the preserved or umask-derived perms
+        @chmod($dstFile, $perm ?: 0o666 & ~umask());
 
         $size = @getimagesize($dstFile);
         if ('' == $data['file']['type'] && isset($size['mime'])) {
@@ -231,11 +235,15 @@ final class MediaHandler
                     $warning = I18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . escape($extensionNew) . '</code> (<code>' . escape($filetype ?? 'unknown mime type') . '</code>)';
                     throw new ApiFunctionException($warning);
                 }
+                // preserve the perms of an existing file, otherwise use the umask-derived default
+                $perm = is_file($dstFile) ? fileperms($dstFile) : false;
+
                 if (!File::move($srcFile, $dstFile)) {
                     throw new ApiFunctionException(I18n::msg('pool_file_movefailed'));
                 }
 
-                @chmod($dstFile, Core::getFilePerm());
+                // the uploaded temp file may carry restrictive perms (e.g. 0600), restore the preserved or umask-derived perms
+                @chmod($dstFile, $perm ?: 0o666 & ~umask());
 
                 self::sanitizeMedia($dstFile, $filetype);
 
@@ -247,7 +255,6 @@ final class MediaHandler
                     $saveObject->setValue('width', $size[0]);
                     $saveObject->setValue('height', $size[1]);
                 }
-                @chmod($dstFile, Core::getFilePerm());
             } else {
                 throw new ApiFunctionException(I18n::msg('pool_file_upload_errortype'));
             }


### PR DESCRIPTION
## What

Replaces the explicit `fileperm` / `dirperm` configuration and the hard `chmod` to fixed permissions after every file/directory operation with **umask-based permissions**. The resulting permissions now follow the process umask (i.e. the server policy) instead of overriding it.

## Why

The fixed `0664` / `0775` chmod is a leftover from REDAXO 5's shared-hosting era. It ignores the server's umask and overwrites deliberately set policies. Letting the umask govern the permissions is the idiomatic approach and brings `File::put` in line with Symfony's `Filesystem::dumpFile` (same `tempnam` → `chmod(fileperms() ?: 0666 & ~umask())` pattern).

## Changes

| Location | Before | After |
|---|---|---|
| `Dir::create` | `mkdir(0775)` + `chmod(0775)` | `mkdir(0o777)`, no chmod — umask applies |
| `File::put` | `chmod(0664)` | preserve an existing file's perms, otherwise `0o666 & ~umask()` (chmod still required because `tempnam` creates `0600`) |
| `File::append` / `File::copy` | `chmod(0664)` | chmod dropped — the native calls already apply umask |
| `MediaHandler` | `chmod(0664)` (once duplicated) | preserve existing perms, otherwise `0o666 & ~umask()` |

Also removed:
- `Core::getFilePerm()` / `getDirPerm()`, the `octdec` handling and the `fileperm` / `dirperm` keys from `default.config.yml` and setup
- The now-unused `octal` type handling from `config:get` / `config:set` (it only ever served `fileperm` / `dirperm`)

## BC break

Setups relying on the enforced `0664` / `0775` need to set their umask instead, e.g. `umask(0002)` in the project `boot()` — that reproduces the old default exactly. Upgrade notes to follow separately.
