### PR TITLE
refactor!: MetaInfo native DB types for date/time fields, unified multi-value storage

### DIFF
--- a/src/MetaInfo/Field/ArticleField.php
+++ b/src/MetaInfo/Field/ArticleField.php
@@ -3,15 +3,21 @@
 namespace Redaxo\Core\MetaInfo\Field;
 
 use Redaxo\Core\Database\Column;
+use Redaxo\Core\Http\Request;
 use Redaxo\Core\MetaInfo\MetaContext;
 use Redaxo\Core\MetaInfo\MetaEntity;
 use Redaxo\Core\RexVar\LinkListVar;
 use Redaxo\Core\RexVar\LinkVar;
 
+use function array_filter;
+use function array_map;
+use function array_values;
+use function explode;
+
 /**
  * Article/category picker (REX_LINK_WIDGET), stored as a text column.
  *
- * With `multiple: true` several articles may be selected (pipe-delimited article ids).
+ * With `multiple: true` several articles may be selected (comma-separated article ids).
  */
 class ArticleField extends MetaField
 {
@@ -32,7 +38,34 @@ class ArticleField extends MetaField
 
     public function column(MetaEntity $entity): ?Column
     {
-        return new Column($this->columnName($entity), 'text', nullable: true);
+        // A single article is just an id; multiple ids stay short enough for a varchar.
+        return $this->multiple
+            ? new Column($this->columnName($entity), 'varchar(255)', nullable: true)
+            : new Column($this->columnName($entity), 'int(11)', nullable: true);
+    }
+
+    public function parseRequest(MetaContext $context): int|string|null
+    {
+        $value = Request::post($this->columnName($context->entity), 'string', '');
+
+        if ($this->multiple) {
+            return $value;
+        }
+
+        return '' === $value ? null : (int) $value;
+    }
+
+    /** @return int|list<int>|null the article id, or the list of ids for `multiple` */
+    public function format(mixed $stored): int|array|null
+    {
+        if ($this->multiple) {
+            return array_values(array_map(
+                static fn (string $id): int => (int) $id,
+                array_filter(explode(',', (string) $stored), static fn (string $id): bool => '' !== $id),
+            ));
+        }
+
+        return null === $stored || '' === $stored ? null : (int) $stored;
     }
 
     public function renderInput(MetaContext $context): string

--- a/src/MetaInfo/Field/ChoiceField.php
+++ b/src/MetaInfo/Field/ChoiceField.php
@@ -17,7 +17,6 @@ use function is_array;
 use function preg_replace;
 use function Redaxo\Core\View\escape;
 use function sprintf;
-use function trim;
 
 /**
  * A choice among a fixed set of options, rendered as a select, multi-select, radio group or checkbox group
@@ -30,7 +29,8 @@ use function trim;
  * | true     | false    | radio buttons      |
  * | true     | true     | checkbox group     |
  *
- * Single values are stored as-is, multiple values pipe-delimited (`|a|b|`).
+ * Single values are stored as-is, multiple values comma-separated (`a,b,c`) so they stay queryable
+ * via SQL `FIND_IN_SET()`.
  *
  * Pass a static set via the `$choices` constructor argument, or override {@see self::choices()} to provide them
  * dynamically (#1480). Choices may be grouped by nesting: a value that is itself an array becomes an optgroup
@@ -71,7 +71,11 @@ class ChoiceField extends AbstractInputField
 
     public function column(MetaEntity $entity): ?Column
     {
-        return new Column($this->columnName($entity), 'varchar(255)', nullable: true, default: $this->default);
+        // Multiple values are comma-separated and can outgrow a varchar; a single value never does.
+        // `text` can not carry a default, so the default only applies to the single-value case.
+        return $this->multiple
+            ? new Column($this->columnName($entity), 'text', nullable: true)
+            : new Column($this->columnName($entity), 'varchar(255)', nullable: true, default: $this->default);
     }
 
     public function parseRequest(MetaContext $context): int|string|null
@@ -85,7 +89,7 @@ class ChoiceField extends AbstractInputField
         /** @var list<string> $values */
         $values = Request::post($name, 'array', []);
 
-        return [] === $values ? '' : '|' . implode('|', $values) . '|';
+        return implode(',', $values);
     }
 
     /** @return string|list<string> the single value, or the list of values for `multiple` */
@@ -184,6 +188,6 @@ class ChoiceField extends AbstractInputField
     /** @return list<string> */
     private static function splitMultiple(string $stored): array
     {
-        return array_values(array_filter(explode('|', trim($stored, '|')), static fn (string $v): bool => '' !== $v));
+        return array_values(array_filter(explode(',', $stored), static fn (string $v): bool => '' !== $v));
     }
 }

--- a/src/MetaInfo/Field/DateField.php
+++ b/src/MetaInfo/Field/DateField.php
@@ -11,25 +11,33 @@ use function date;
 use function sprintf;
 use function strtotime;
 
-/** Date picker (HTML5), stored as a Unix timestamp (local midnight). */
+/** Date picker (HTML5), stored as a SQL `date` (`Y-m-d`). */
 class DateField extends AbstractInputField
 {
     public function column(MetaEntity $entity): ?Column
     {
-        return new Column($this->columnName($entity), 'int(11)', nullable: true);
+        return new Column($this->columnName($entity), 'date', nullable: true);
     }
 
     public function parseRequest(MetaContext $context): int|string|null
     {
         $value = Request::post($this->columnName($context->entity), 'string', '');
+        $time = '' === $value ? false : strtotime($value);
 
-        return '' === $value ? null : (strtotime($value) ?: null);
+        return false === $time ? null : date('Y-m-d', $time);
+    }
+
+    public function format(mixed $stored): ?int
+    {
+        // Expose a Unix timestamp (local midnight), consistent with Sql::getDateTimeValue().
+        return null === $stored || '' === $stored ? null : (strtotime((string) $stored) ?: null);
     }
 
     public function renderInput(MetaContext $context): string
     {
         $stored = $context->value($this);
-        $value = null === $stored || '' === $stored ? '' : date('Y-m-d', (int) $stored);
+        // The stored value is already `Y-m-d`, exactly what the date input expects.
+        $value = null === $stored || '' === $stored ? '' : (string) $stored;
         $name = $this->columnName($context->entity);
 
         $attributes = $this->attributes->with([

--- a/src/MetaInfo/Field/DateTimeField.php
+++ b/src/MetaInfo/Field/DateTimeField.php
@@ -12,26 +12,35 @@ use function sprintf;
 use function str_replace;
 use function strtotime;
 
-/** Date+time picker (HTML5), stored as a Unix timestamp. */
+/** Date+time picker (HTML5), stored as a SQL `datetime` (`Y-m-d H:i:s`). */
 class DateTimeField extends AbstractInputField
 {
     public function column(MetaEntity $entity): ?Column
     {
-        return new Column($this->columnName($entity), 'int(11)', nullable: true);
+        return new Column($this->columnName($entity), 'datetime', nullable: true);
     }
 
     public function parseRequest(MetaContext $context): int|string|null
     {
         // HTML datetime-local uses a "T" separator.
         $value = Request::post($this->columnName($context->entity), 'string', '');
+        $time = '' === $value ? false : strtotime(str_replace('T', ' ', $value));
 
-        return '' === $value ? null : (strtotime(str_replace('T', ' ', $value)) ?: null);
+        return false === $time ? null : date('Y-m-d H:i:s', $time);
+    }
+
+    public function format(mixed $stored): ?int
+    {
+        // Expose a Unix timestamp, consistent with Sql::getDateTimeValue().
+        return null === $stored || '' === $stored ? null : (strtotime((string) $stored) ?: null);
     }
 
     public function renderInput(MetaContext $context): string
     {
         $stored = $context->value($this);
-        $value = null === $stored || '' === $stored ? '' : date('Y-m-d\TH:i', (int) $stored);
+        $time = null === $stored || '' === $stored ? false : strtotime((string) $stored);
+        // The datetime-local input wants `Y-m-dTH:i`, without seconds.
+        $value = false === $time ? '' : date('Y-m-d\TH:i', $time);
         $name = $this->columnName($context->entity);
 
         $attributes = $this->attributes->with([

--- a/src/MetaInfo/Field/MediaField.php
+++ b/src/MetaInfo/Field/MediaField.php
@@ -8,12 +8,15 @@ use Redaxo\Core\MetaInfo\MetaEntity;
 use Redaxo\Core\RexVar\MediaListVar;
 use Redaxo\Core\RexVar\MediaVar;
 
+use function array_filter;
+use function array_values;
+use function explode;
 use function implode;
 
 /**
  * Media picker (REX_MEDIA_WIDGET), stored as a text column.
  *
- * With `multiple: true` several media may be selected (pipe-delimited filenames).
+ * With `multiple: true` several media may be selected (comma-separated filenames).
  */
 class MediaField extends MetaField
 {
@@ -37,7 +40,20 @@ class MediaField extends MetaField
 
     public function column(MetaEntity $entity): ?Column
     {
-        return new Column($this->columnName($entity), 'text', nullable: true);
+        // A single filename fits a varchar; multiple filenames are pipe-delimited and need a text column.
+        return $this->multiple
+            ? new Column($this->columnName($entity), 'text', nullable: true)
+            : new Column($this->columnName($entity), 'varchar(255)', nullable: true);
+    }
+
+    /** @return string|list<string> the filename, or the list of filenames for `multiple` */
+    public function format(mixed $stored): string|array
+    {
+        if ($this->multiple) {
+            return array_values(array_filter(explode(',', (string) $stored), static fn (string $f): bool => '' !== $f));
+        }
+
+        return (string) $stored;
     }
 
     public function renderInput(MetaContext $context): string

--- a/src/MetaInfo/Field/TimeField.php
+++ b/src/MetaInfo/Field/TimeField.php
@@ -7,35 +7,45 @@ use Redaxo\Core\Http\Request;
 use Redaxo\Core\MetaInfo\MetaContext;
 use Redaxo\Core\MetaInfo\MetaEntity;
 
+use function date;
 use function explode;
-use function gmdate;
 use function sprintf;
+use function strtotime;
+use function substr;
 
-/** Time picker (HTML5), stored as seconds since midnight. */
+/** Time picker (HTML5), stored as a SQL `time` (`H:i:s`). */
 class TimeField extends AbstractInputField
 {
     public function column(MetaEntity $entity): ?Column
     {
-        return new Column($this->columnName($entity), 'int(11)', nullable: true);
+        return new Column($this->columnName($entity), 'time', nullable: true);
     }
 
     public function parseRequest(MetaContext $context): int|string|null
     {
         $value = Request::post($this->columnName($context->entity), 'string', '');
+        $time = '' === $value ? false : strtotime($value);
 
-        if ('' === $value) {
+        return false === $time ? null : date('H:i:s', $time);
+    }
+
+    public function format(mixed $stored): ?int
+    {
+        if (null === $stored || '' === $stored) {
             return null;
         }
 
-        $parts = explode(':', $value);
+        // A `time` column has no date part, so the natural int is seconds since midnight.
+        $parts = explode(':', (string) $stored);
 
-        return ((int) ($parts[0] ?? 0) * 3600) + ((int) ($parts[1] ?? 0) * 60);
+        return ((int) ($parts[0] ?? 0) * 3600) + ((int) ($parts[1] ?? 0) * 60) + (int) ($parts[2] ?? 0);
     }
 
     public function renderInput(MetaContext $context): string
     {
         $stored = $context->value($this);
-        $value = null === $stored || '' === $stored ? '' : gmdate('H:i', (int) $stored);
+        // The stored value is `H:i:s`; the time input shows `H:i`.
+        $value = null === $stored || '' === $stored ? '' : substr((string) $stored, 0, 5);
         $name = $this->columnName($context->entity);
 
         $attributes = $this->attributes->with([


### PR DESCRIPTION
Reviews the column definitions of the MetaInfo fields and tightens them up.

## Date / time fields → native DB types
`DateField`, `DateTimeField` and `TimeField` were stored as `int(11)` Unix timestamps. They now use native `date` / `datetime` / `time` columns (sortable and filterable in SQL). The PHP-facing API is unchanged: `format()` still returns a Unix timestamp (seconds since midnight for `time`), consistent with `Sql::getDateTimeValue()`.

## Per-field column types
- `ChoiceField`: single → `varchar(255)`, multiple → `text`
- `ArticleField`: single → `int(11)`, multiple → `varchar(255)` (ids stay short)
- `MediaField`: single → `varchar(255)`, multiple → `text` (filenames can be long)

## Unified multi-value storage
Multi-value fields are now stored consistently **comma-separated** (`ChoiceField` previously used pipe-wrapped `|a|b|`), so they stay queryable via SQL `FIND_IN_SET()`. This also matches what the link/media list widgets already emit, so no conversion glue is needed.

`format()` now returns a typed list for every multi-value field (`list<int>` for articles, `list<string>` for choices/media) instead of the raw delimited string.

## Notes
- Breaking change to storage format & column types — fine while 6.x has no stable release yet.
- No data migration: the affected fields are part of the new, not-yet-shipped MetaSchema design.