### PR TITLE
fix: add missing CSRF protection to package update API

### DIFF
--- a/redaxo/src/addons/install/lib/api/api_package_update.php
+++ b/redaxo/src/addons/install/lib/api/api_package_update.php
@@ -37,4 +37,9 @@ class rex_api_install_package_update extends rex_api_function
         }
         return new rex_api_result($success, $message);
     }
+
+    protected function requiresCsrfProtection()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Adds missing CSRF protection to the package update API for consistency with the other install API functions (`package_add`, `package_delete`, `package_upload`), which already opt in via `requiresCsrfProtection()`.