### PR TITLE
fix: validate rex_list sort column against sortable whitelist

### DIFF
--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -976,7 +976,10 @@ class rex_list implements rex_url_provider_interface
     public function getSortColumn($default = null)
     {
         if (rex_request('list', 'string') == $this->getName()) {
-            return rex_request('sort', 'string', $default);
+            $sortColumn = rex_request('sort', 'string', $default);
+            if ($this->hasColumnOption($sortColumn, REX_LIST_OPT_SORT)) {
+                return $sortColumn;
+            }
         }
         return $default;
     }

--- a/redaxo/src/core/tests/list_test.php
+++ b/redaxo/src/core/tests/list_test.php
@@ -14,4 +14,54 @@ final class rex_list_test extends TestCase
 
         self::assertSame($expected, $method->invoke(null, $query));
     }
+
+    public function testGetSortColumnOnlyAllowsSortableColumns(): void
+    {
+        $list = $this->createListWithSortableColumn('mylist', 'name');
+
+        $_REQUEST['list'] = 'mylist';
+
+        // sortable column is accepted
+        $_REQUEST['sort'] = 'name';
+        self::assertSame('name', $list->getSortColumn());
+
+        // non-sortable / unselected column is rejected and falls back to default
+        $_REQUEST['sort'] = 'password';
+        self::assertNull($list->getSortColumn());
+        self::assertSame('id', $list->getSortColumn('id'));
+
+        // non-existent column (error-based enumeration attempt) is rejected
+        $_REQUEST['sort'] = 'nonexistent_col';
+        self::assertNull($list->getSortColumn());
+
+        unset($_REQUEST['list'], $_REQUEST['sort']);
+    }
+
+    public function testGetSortColumnIgnoredForOtherList(): void
+    {
+        $list = $this->createListWithSortableColumn('mylist', 'name');
+
+        $_REQUEST['list'] = 'otherlist';
+        $_REQUEST['sort'] = 'name';
+
+        self::assertNull($list->getSortColumn());
+        self::assertSame('id', $list->getSortColumn('id'));
+
+        unset($_REQUEST['list'], $_REQUEST['sort']);
+    }
+
+    private function createListWithSortableColumn(string $name, string $sortableColumn): rex_list
+    {
+        $list = (new ReflectionClass(rex_list::class))->newInstanceWithoutConstructor();
+
+        $nameProp = new ReflectionProperty(rex_list::class, 'name');
+        $nameProp->setValue($list, $name);
+
+        $optionsProp = new ReflectionProperty(rex_list::class, 'columnOptions');
+        $optionsProp->setValue($list, []);
+
+        $list->setColumnSortable($sortableColumn);
+
+        return $list;
+    }
 }


### PR DESCRIPTION
`rex_list::getSortColumn()` returned the raw `sort` request parameter without checking it against the columns registered via `setColumnSortable()`. The value was backtick-escaped (no classical SQL injection), but an authenticated backend user could still `ORDER BY` any column of the query's FROM tables — including unselected sensitive columns like `rex_user.password` — and enumerate column names via error messages.

Now only columns flagged `REX_LIST_OPT_SORT` are accepted; anything else falls back to the default. The backend UI only emits sort links for sortable columns, so this is BC-safe for the normal flow.
