### PR TITLE
fix: escape user-controlled values rendered as raw backend HTML (stored XSS)

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1923,7 +1923,6 @@
   <file src="redaxo/src/addons/phpmailer/pages/checkmail.php">
     <MixedArgument>
       <code><![CDATA[$addon->getConfig('test_address')]]></code>
-      <code><![CDATA[$str]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$securityMode]]></code>

--- a/redaxo/src/addons/media_manager/lib/media_manager.php
+++ b/redaxo/src/addons/media_manager/lib/media_manager.php
@@ -454,7 +454,7 @@ class rex_media_manager
         ', ['%' . $sql->escapeLikeWildcards(json_encode($filename)) . '%']);
 
         for ($i = 0; $i < $sql->getRows(); ++$i) {
-            $message = '<a href="javascript:openPage(\'' . rex_url::backendPage('media_manager/types', ['effects' => 1, 'type_id' => $sql->getValue('type_id'), 'effect_id' => $sql->getValue('effect_id'), 'func' => 'edit']) . '\')">' . rex_i18n::msg('media_manager') . ' ' . rex_i18n::msg('media_manager_effect_name') . ': ' . (string) $sql->getValue('name') . '</a>';
+            $message = '<a href="javascript:openPage(\'' . rex_url::backendPage('media_manager/types', ['effects' => 1, 'type_id' => $sql->getValue('type_id'), 'effect_id' => $sql->getValue('effect_id'), 'func' => 'edit']) . '\')">' . rex_i18n::msg('media_manager') . ' ' . rex_i18n::msg('media_manager_effect_name') . ': ' . rex_escape((string) $sql->getValue('name')) . '</a>';
 
             if (!in_array($message, $warning)) {
                 $warning[] = $message;

--- a/redaxo/src/addons/media_manager/pages/effects.php
+++ b/redaxo/src/addons/media_manager/pages/effects.php
@@ -85,7 +85,7 @@ if ('' == $func) {
     $list->setColumnLabel('effect', rex_i18n::msg('media_manager_type_name'));
     $list->setColumnFormat('effect', 'custom', static function ($params) use ($effects) {
         $shortName = $params['value'];
-        return isset($effects[$shortName]) ? $effects[$shortName]->getName() : $shortName;
+        return isset($effects[$shortName]) ? $effects[$shortName]->getName() : rex_escape((string) $shortName);
     });
 
     $list->setColumnLabel('priority', rex_i18n::msg('media_manager_type_priority'));

--- a/redaxo/src/addons/mediapool/lib/mediapool.php
+++ b/redaxo/src/addons/mediapool/lib/mediapool.php
@@ -83,7 +83,7 @@ final class rex_mediapool
                 $aid = (int) $artArr['article_id'];
                 $clang = (int) $artArr['clang_id'];
                 $ooa = rex_article::get($aid, $clang);
-                $name = ($ooa) ? $ooa->getName() : '';
+                $name = ($ooa) ? rex_escape($ooa->getName()) : '';
                 $warning[0] .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('content', ['article_id' => $aid, 'mode' => 'edit', 'clang' => $clang]) . '\')">' . $name . '</a></li>';
             }
             $warning[0] .= '</ul>';

--- a/redaxo/src/addons/mediapool/pages/sync.php
+++ b/redaxo/src/addons/mediapool/pages/sync.php
@@ -116,11 +116,11 @@ if ($diffCount > 0) {
     foreach ($diffFiles as $file) {
         if (is_writable(rex_path::media($file))) {
             $e = [];
-            $e['label'] = '<label>' . $file . '</label>';
-            $e['field'] = '<input type="checkbox" name="sync_files[]" value="' . $file . '" />';
+            $e['label'] = '<label>' . rex_escape($file) . '</label>';
+            $e['field'] = '<input type="checkbox" name="sync_files[]" value="' . rex_escape($file) . '" />';
             $writable[] = $e;
         } else {
-            $notWritable[] = $file;
+            $notWritable[] = rex_escape($file);
         }
     }
 

--- a/redaxo/src/addons/metainfo/lib/handler/media_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/media_handler.php
@@ -62,7 +62,7 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
                 $aid = (int) $artArr['id'];
                 $clang = (int) $artArr['clang_id'];
                 $parentId = (int) $artArr['parent_id'];
-                $articles .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('content', ['article_id' => $aid, 'mode' => 'meta', 'clang' => $clang]) . '\')">' . (string) $artArr['name'] . '</a></li>';
+                $articles .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('content', ['article_id' => $aid, 'mode' => 'meta', 'clang' => $clang]) . '\')">' . rex_escape((string) $artArr['name']) . '</a></li>';
             }
             if ('' != $articles) {
                 $warning[] = rex_i18n::msg('minfo_media_in_use_art') . '<br /><ul>' . $articles . '</ul>';
@@ -76,7 +76,7 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
                 $aid = (int) $artArr['id'];
                 $clang = (int) $artArr['clang_id'];
                 $parentId = (int) $artArr['parent_id'];
-                $categories .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('structure', ['edit_id' => $aid, 'function' => 'edit_cat', 'category_id' => $parentId, 'clang' => $clang]) . '\')">' . (string) $artArr['catname'] . '</a></li>';
+                $categories .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('structure', ['edit_id' => $aid, 'function' => 'edit_cat', 'category_id' => $parentId, 'clang' => $clang]) . '\')">' . rex_escape((string) $artArr['catname']) . '</a></li>';
             }
             if ('' != $categories) {
                 $warning[] = rex_i18n::msg('minfo_media_in_use_cat') . '<br /><ul>' . $categories . '</ul>';
@@ -88,7 +88,7 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
             $items = $sql->getArray('SELECT id, filename, category_id FROM ' . rex::getTablePrefix() . 'media WHERE ' . implode(' OR ', $where['media']));
             foreach ($items as $medArr) {
                 $id = (int) $medArr['id'];
-                $filename = (string) $medArr['filename'];
+                $filename = rex_escape((string) $medArr['filename']);
                 $catId = (int) $medArr['category_id'];
                 $media .= '<li><a href="' . rex_url::backendPage('mediapool/detail', ['file_id' => $id, 'rex_file_category' => $catId]) . '">' . $filename . '</a></li>';
             }
@@ -101,7 +101,7 @@ class rex_metainfo_media_handler extends rex_metainfo_handler
         if (!empty($where['clangs'])) {
             $items = $sql->getArray('SELECT id, name FROM ' . rex::getTablePrefix() . 'clang WHERE ' . implode(' OR ', $where['clangs']));
             foreach ($items as $clangArr) {
-                $name = (string) $clangArr['name'];
+                $name = rex_escape((string) $clangArr['name']);
                 if (rex::getUser()?->isAdmin()) {
                     $clangs .= '<li><a href="javascript:openPage(\'' . rex_url::backendPage('system/lang', ['clang_id' => $clangArr['id'], 'func' => 'editclang']) . '\')">' . $name . '</a></li>';
                 } else {

--- a/redaxo/src/addons/phpmailer/pages/checkmail.php
+++ b/redaxo/src/addons/phpmailer/pages/checkmail.php
@@ -35,12 +35,12 @@ if ('' == $addon->getConfig('from') || '' == $addon->getConfig('test_address')) 
     $mail->Body .= "\nMailer: " . $addon->getConfig('mailer') . $devider . $securityMode;
     $mail->Body .= "\n" . $addon->i18n('checkmail_domain_note') . "\n" . $devider;
     $mail->Debugoutput = static function ($str) use (&$mailerDebug) {
-        $mailerDebug .= date('Y-m-d H:i:s', time()) . ' ' . nl2br($str);
+        $mailerDebug .= date('Y-m-d H:i:s', time()) . ' ' . nl2br(rex_escape($str));
     };
 
     if (!$mail->send()) {
         $alert = '<h2>' . $addon->i18n('checkmail_error_headline') . '</h2><hr>';
-        $alert .= $addon->i18n('checkmail_error') . ': ' . $mail->ErrorInfo;
+        $alert .= $addon->i18n('checkmail_error') . ': ' . rex_escape($mail->ErrorInfo);
         $content .= rex_view::error($alert);
     } else {
         $success = '<h2>' . $addon->i18n('checkmail_send') . '</h2> ' . rex_escape($addon->getConfig('test_address')) . '<br>' . $addon->i18n('checkmail_info');

--- a/redaxo/src/addons/phpmailer/pages/checkmail.php
+++ b/redaxo/src/addons/phpmailer/pages/checkmail.php
@@ -34,7 +34,7 @@ if ('' == $addon->getConfig('from') || '' == $addon->getConfig('test_address')) 
 
     $mail->Body .= "\nMailer: " . $addon->getConfig('mailer') . $devider . $securityMode;
     $mail->Body .= "\n" . $addon->i18n('checkmail_domain_note') . "\n" . $devider;
-    $mail->Debugoutput = static function ($str) use (&$mailerDebug) {
+    $mail->Debugoutput = static function (string $str) use (&$mailerDebug) {
         $mailerDebug .= date('Y-m-d H:i:s', time()) . ' ' . nl2br(rex_escape($str));
     };
 


### PR DESCRIPTION
Several places concatenated database/filesystem values into backend HTML without rex_escape(), leading to stored XSS. Most of these flows are invisible to the Psalm taint analysis because they cross dynamic-dispatch boundaries (extension-point handlers invoked via call_user_func, a fragment var set with escaping disabled, and a rex_list 'custom' column formatter which is not auto-escaped), so the static taint graph is severed between source and sink.

Fixed sinks:

- media_manager: the MEDIA_IS_IN_USE handler rendered the effect type name unescaped.
- mediapool: the MEDIA_IS_IN_USE warning rendered the referencing article name unescaped.
- metainfo: the MEDIA_IS_IN_USE handler rendered article, category, media filename and clang names unescaped.
- mediapool sync page: on-disk filenames were rendered unescaped in the writable/not-writable lists.
- media_manager effects list: the 'custom' column formatter returned the raw effect short name from the DB when the effect class is no longer registered.
- phpmailer checkmail page: the SMTP server debug output and ErrorInfo were rendered unescaped (rex_escape applied before nl2br so line breaks are preserved).

All affected values are now passed through rex_escape() before being embedded into HTML.