### PR TITLE
fix: apply sort request for columns marked sortable after list construction

### DIFF
--- a/redaxo/src/core/lib/list.php
+++ b/redaxo/src/core/lib/list.php
@@ -66,6 +66,11 @@ class rex_list implements rex_url_provider_interface
     // --------- List Attributes
     /** @var string */
     private $name;
+    private string $query;
+    /** @var array<string, 'asc'|'desc'> */
+    private array $defaultSort;
+    private string $executedQuery;
+    private bool $dataLoaded = false;
     /** @var array<string, string|int> */
     private array $params;
     private int $rows;
@@ -139,6 +144,8 @@ class rex_list implements rex_url_provider_interface
         $this->debug = $debug;
         $this->sql->setDebug($this->debug);
         $this->name = $listName;
+        $this->query = $query;
+        $this->defaultSort = $defaultSort;
         $this->caption = '';
         $this->rows = 0;
         $this->params = [];
@@ -186,9 +193,14 @@ class rex_list implements rex_url_provider_interface
         }
 
         // --------- Load Data
-        $this->sql->setQuery($this->prepareQuery($query, $defaultSort));
-        if (self::DISABLE_PAGINATION === $rowsPerPage) {
-            $this->rows = (int) $this->sql->getRows();
+        if (rex_request('list', 'string') == $this->getName() && '' !== rex_request('sort', 'string', '')) {
+            // The requested sort column can not be validated yet since the sortable columns are registered
+            // after construction (getSortColumn() checks against them). Fetch only the field names here,
+            // the data is loaded in get() after the sortable columns are known.
+            $this->executedQuery = 'SELECT * FROM (' . $query . ') t LIMIT 0';
+            $this->sql->setQuery($this->executedQuery);
+        } else {
+            $this->loadData();
         }
 
         foreach ($this->sql->getFieldnames() as $columnName) {
@@ -934,12 +946,36 @@ class rex_list implements rex_url_provider_interface
     }
 
     /**
+     * Executes the query unless it already ran and the effective query is still the same
+     * (it changes when columns are marked as sortable after construction).
+     */
+    private function loadData(): void
+    {
+        $query = $this->prepareQuery($this->query, $this->defaultSort);
+        if ($this->dataLoaded && $query === $this->executedQuery) {
+            return;
+        }
+
+        $this->dataLoaded = true;
+        $this->executedQuery = $query;
+        $this->sql->setQuery($query);
+
+        if (null === $this->pager) {
+            $this->rows = (int) $this->sql->getRows();
+        }
+    }
+
+    /**
      * Gibt die Anzahl der Zeilen zurück, welche vom ursprüngliche SQL Statement betroffen werden.
      *
      * @return int
      */
     public function getRows()
     {
+        if (!$this->dataLoaded) {
+            $this->loadData();
+        }
+
         return $this->rows;
     }
 
@@ -1184,6 +1220,12 @@ class rex_list implements rex_url_provider_interface
      */
     public function getValue($column)
     {
+        // only initial loading here, no unconditional loadData(): the query (and with it the
+        // result pointer) must not change anymore while the rows are iterated in get()
+        if (!$this->dataLoaded) {
+            $this->loadData();
+        }
+
         return $this->customColumns[$column] ?? $this->sql->getValue($column);
     }
 
@@ -1204,6 +1246,10 @@ class rex_list implements rex_url_provider_interface
     public function get()
     {
         rex_extension::registerPoint(new rex_extension_point('REX_LIST_GET', $this, [], true));
+
+        // By now the sortable columns are registered (including via the extension point above),
+        // so the deferred data query can run with the validated ORDER BY
+        $this->loadData();
 
         $s = "\n";
 

--- a/redaxo/src/core/tests/list_test.php
+++ b/redaxo/src/core/tests/list_test.php
@@ -50,6 +50,78 @@ final class rex_list_test extends TestCase
         unset($_REQUEST['list'], $_REQUEST['sort']);
     }
 
+    public function testSortableColumnRegisteredAfterConstructionIsApplied(): void
+    {
+        $table = 'rex_tests_list';
+
+        $sql = rex_sql::factory();
+        $sql->setQuery('DROP TABLE IF EXISTS `' . $table . '`');
+        $sql->setQuery('CREATE TABLE `' . $table . '` (
+                `id` INT NOT NULL AUTO_INCREMENT,
+                `name` VARCHAR(255) NOT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE = InnoDB');
+        $sql->setQuery('INSERT INTO `' . $table . '` (`name`) VALUES ("aaa"), ("zzz")');
+
+        $_REQUEST['list'] = 'sortlist';
+        $_REQUEST['sort'] = 'name';
+        $_REQUEST['sorttype'] = 'desc';
+
+        try {
+            // setColumnSortable() is called after the constructor already executed the query,
+            // the requested sort order must still be applied (https://github.com/redaxo/core/issues/6585)
+            $list = rex_list::factory('SELECT id, name FROM ' . $table, rex_list::DISABLE_PAGINATION, 'sortlist');
+            $list->setColumnSortable('name');
+
+            $html = $list->get();
+
+            $posZzz = strpos($html, 'zzz');
+            $posAaa = strpos($html, 'aaa');
+            self::assertNotFalse($posZzz);
+            self::assertNotFalse($posAaa);
+            self::assertLessThan($posAaa, $posZzz, 'rows must be sorted desc by name');
+            self::assertSame(2, $list->getRows());
+            self::assertSame(['id', 'name'], $list->getColumnNames());
+        } finally {
+            unset($_REQUEST['list'], $_REQUEST['sort'], $_REQUEST['sorttype']);
+            $sql->setQuery('DROP TABLE `' . $table . '`');
+        }
+    }
+
+    public function testNonSortableSortParamFallsBackToDefaultOrder(): void
+    {
+        $table = 'rex_tests_list';
+
+        $sql = rex_sql::factory();
+        $sql->setQuery('DROP TABLE IF EXISTS `' . $table . '`');
+        $sql->setQuery('CREATE TABLE `' . $table . '` (
+                `id` INT NOT NULL AUTO_INCREMENT,
+                `name` VARCHAR(255) NOT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE = InnoDB');
+        $sql->setQuery('INSERT INTO `' . $table . '` (`name`) VALUES ("aaa"), ("zzz")');
+
+        $_REQUEST['list'] = 'sortlist';
+        $_REQUEST['sort'] = 'name';
+        $_REQUEST['sorttype'] = 'desc';
+
+        try {
+            // "name" is never marked as sortable, so the requested sort must be ignored
+            $list = rex_list::factory('SELECT id, name FROM ' . $table, rex_list::DISABLE_PAGINATION, 'sortlist', defaultSort: ['id' => 'asc']);
+
+            $html = $list->get();
+
+            $posZzz = strpos($html, 'zzz');
+            $posAaa = strpos($html, 'aaa');
+            self::assertNotFalse($posZzz);
+            self::assertNotFalse($posAaa);
+            self::assertLessThan($posZzz, $posAaa, 'rows must keep the default sort order');
+        } finally {
+            unset($_REQUEST['list'], $_REQUEST['sort'], $_REQUEST['sorttype']);
+            $sql->setQuery('DROP TABLE `' . $table . '`');
+        }
+    }
+
     private function createListWithSortableColumn(string $name, string $sortableColumn): rex_list
     {
         $list = (new ReflectionClass(rex_list::class))->newInstanceWithoutConstructor();


### PR DESCRIPTION
Fixes #6585

## Problem

Since the sort column is validated against the sortable columns (GHSA-4f5f-j737-pm58, #6580), sorting via column headers stopped working: the query runs in the `rex_list` constructor, but `setColumnSortable()` is called afterwards, so the whitelist was always empty at the time `prepareQuery()` built the `ORDER BY`.

## Solution

When a sort request is pending (`list` param matches and `sort` param present), the constructor no longer loads the data. It fetches only the field names via a `LIMIT 0` metadata query (optimized away by MySQL, needed for `getColumnNames()`/`addColumn()` etc.) and defers the data query to `get()` — at that point all sortable columns are registered, including those added via the `REX_LIST_GET` extension point.

- Requests without a sort param behave exactly as before (no additional query).
- Sorted views: count + `LIMIT 0` metadata + one data query with the validated `ORDER BY`.
- Non-whitelisted sort params still fall back to the default order (security fix stays intact, covered by a new test).
- `getRows()`/`getValue()` lazily trigger the initial data load in case they are used before `get()`; `get()` re-executes only if the effective query changed in the meantime.

Note: existing `rex_list` behavior is unchanged in that a query with a hardcoded `ORDER BY` (and no `$defaultSort`) still ignores sort requests — use the `$defaultSort` factory parameter instead.

Verified end-to-end in the backend (users list, cronjobs list with temporarily enabled sortable columns): default sort, asc/desc via column headers, and rejected non-sortable columns.