### PR TITLE
fix: handle non-x custom headers in MS Graph transport

### DIFF
--- a/redaxo/src/addons/phpmailer/lib/mailer.php
+++ b/redaxo/src/addons/phpmailer/lib/mailer.php
@@ -382,12 +382,31 @@ class rex_mailer extends PHPMailer
         }
 
         $customHeaders = [];
+        $extendedProperties = [];
         /** @var array{string, string} $header */
         foreach ($this->getCustomHeaders() as $header) {
-            $customHeaders[] = [
-                'name' => $header[0],
-                'value' => $this->encodeHeader(trim($header[1])),
-            ];
+            $name = trim($header[0]);
+            $value = trim($header[1]);
+
+            if (str_starts_with(strtolower($name), 'x-')) {
+                $customHeaders[] = [
+                    'name' => $name,
+                    'value' => $this->encodeHeader($value),
+                ];
+                continue;
+            }
+
+            if ('list-unsubscribe' === strtolower($name)) {
+                // MAPI property PidTagListUnsubscribe; Exchange emits it as List-Unsubscribe header
+                $extendedProperties[] = [
+                    'id' => 'String 0x1045',
+                    'value' => $value,
+                ];
+                continue;
+            }
+
+            // The Graph API rejects the whole request for custom headers without "x-" prefix,
+            // so headers without a MAPI mapping (e.g. Auto-Submitted) have to be dropped
         }
 
         // Attachments für Graph API aufbereiten
@@ -469,6 +488,9 @@ class rex_mailer extends PHPMailer
         }
         if (!empty($customHeaders)) {
             $mailData['message']['internetMessageHeaders'] = $customHeaders;
+        }
+        if (!empty($extendedProperties)) {
+            $mailData['message']['singleValueExtendedProperties'] = $extendedProperties;
         }
         if ('' !== $this->ConfirmReadingTo) {
             // MS Graph API unterstützt keine Read-Receipts an beliebige Empfänger


### PR DESCRIPTION
Fixes #6588

The Graph API only accepts custom headers whose name starts with `x-`/`X-` in `internetMessageHeaders` — any other header (e.g. `Auto-Submitted`, `List-Unsubscribe` as set by newsletter addons) makes the whole `sendMail` request fail with `InvalidInternetMessageHeader`, so no mail is sent at all.

This PR makes the MS Graph transport translate custom headers instead of passing them through blindly:

- Headers with `x-` prefix (case-insensitive, checked on the header *name*) are passed to `internetMessageHeaders` as before.
- `List-Unsubscribe` is mapped to the MAPI property `PidTagListUnsubscribe` (`String 0x1045`) via `singleValueExtendedProperties`, with the raw (non-MIME-encoded) value, since MAPI properties expect plain strings.
- All other headers are dropped instead of failing the send.

Compared to the suggestion in the issue, this handles *all* non-x headers generically (e.g. `Precedence`, `List-ID`) instead of special-casing two of them, and checks the prefix on the header name rather than the value.

`Auto-Submitted` cannot be transmitted at all: Exchange strips it even from raw MIME submissions ([msgraph-sdk-dotnet#2209](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2209), [Microsoft Q&A](https://learn.microsoft.com/en-us/answers/questions/325868/how-to-set-auto-submitted-email-header-sending-ema)). Callers who want to suppress auto-replies from Exchange recipients can set `X-Auto-Response-Suppress: All` instead. `List-Unsubscribe-Post` (RFC 8058 one-click) has no MAPI mapping either — full bulk-sender deliverability requirements can't be met via the Graph transport.

**Testing note:** I have no M365 tenant at hand — it would be great if someone with a Graph setup (e.g. the issue author) could verify that Exchange actually emits the `List-Unsubscribe` header on outbound mails sent this way.