### PR TITLE
fix: use original filename for mime type detection of uploaded files

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1268,9 +1268,6 @@
       <code><![CDATA[rex_escape($allowedExtensions)]]></code>
       <code><![CDATA[rex_escape(rex_mediapool::getBlockedExtensions())]]></code>
     </MixedArgumentTypeCoercion>
-    <NullOperand>
-      <code><![CDATA[rex_escape(rex_file::mimeType($data['file']['path']))]]></code>
-    </NullOperand>
     <PossiblyFalseArgument>
       <code><![CDATA[$content]]></code>
     </PossiblyFalseArgument>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ All core classes use the `rex_` prefix (e.g., `rex_sql`, `rex_addon`, `rex_file`
 
 - 4 spaces indentation, LF line endings, UTF-8
 - Soft line limit ~120 chars (applies to comments too — don't wrap at 80)
+- In multi-line phpdoc descriptions (e.g. for `@param`), indent continuation lines by 4 spaces — don't align them with the start of the description text
 - Code style enforced by rector + php-cs-fixer (custom REDAXO config) — run `composer cs` after edits
 - PHPStan level 6 + Psalm level 1, both with baselines in `.tools/phpstan/` and `.tools/psalm/`
 - PHPUnit strict mode: warnings, notices, deprecations all fail the build

--- a/redaxo/src/addons/mediapool/lib/mediapool.php
+++ b/redaxo/src/addons/mediapool/lib/mediapool.php
@@ -150,7 +150,7 @@ final class rex_mediapool
             return false;
         }
 
-        $mimeType = rex_file::mimeType($path);
+        $mimeType = rex_file::mimeType($path, $filename);
 
         return in_array($mimeType, $allowedMimetypes[$extension]);
     }

--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -49,7 +49,7 @@ final class rex_media_service
         }
 
         if (!rex_mediapool::isAllowedMimeType($data['file']['path'], $data['file']['name'])) {
-            $warning = rex_i18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . rex_escape(rex_file::extension($data['file']['name'])) . '</code> (<code>' . rex_escape(rex_file::mimeType($data['file']['path'])) . '</code>)';
+            $warning = rex_i18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . rex_escape(rex_file::extension($data['file']['name'])) . '</code> (<code>' . rex_escape(rex_file::mimeType($data['file']['path'], $data['file']['name']) ?? 'unknown mime type') . '</code>)';
             throw new rex_api_exception($warning);
         }
 
@@ -62,7 +62,7 @@ final class rex_media_service
         $srcFile = $data['file']['path'];
         $dstFile = rex_path::media($data['file']['name_new']);
 
-        $data['file']['type'] = rex_file::mimeType($srcFile);
+        $data['file']['type'] = rex_file::mimeType($srcFile, $data['file']['name']);
 
         // Bevor die Datei engueltig in den Medienpool uebernommen wird, koennen
         // Addons ueber einen Extension-Point ein Veto einlegen.
@@ -189,7 +189,7 @@ final class rex_media_service
                 throw new rex_api_exception(rex_i18n::msg('pool_file_not_found'));
             }
 
-            $filetype = rex_file::mimeType($file['path']);
+            $filetype = rex_file::mimeType($file['path'], $file['name']);
 
             $srcFile = $file['path'];
             $dstFile = rex_path::media($filename);

--- a/redaxo/src/core/lib/util/file.php
+++ b/redaxo/src/core/lib/util/file.php
@@ -268,10 +268,13 @@ class rex_file
      * Detects the mime type of the given file.
      *
      * @param string $file Path to the file
+     * @param string|null $filename Optional filename, will be used instead of `$file` for the extension-based
+     *     refinement of unspecific mime types (useful for uploaded files, whose temporary path does not contain
+     *     the original file extension)
      *
      * @return string|null Mime type or `null` if the type could not be detected
      */
-    public static function mimeType($file): ?string
+    public static function mimeType($file, ?string $filename = null): ?string
     {
         $mimeType = mime_content_type($file);
 
@@ -288,7 +291,7 @@ class rex_file
             };
         }
 
-        return match (strtolower(self::extension($file))) {
+        return match (strtolower(self::extension($filename ?: $file))) {
             'css' => 'text/css',
             'csv' => 'text/csv',
             'html' => 'text/html',

--- a/redaxo/src/core/tests/util/file_test.php
+++ b/redaxo/src/core/tests/util/file_test.php
@@ -10,17 +10,17 @@ final class rex_file_test extends TestCase
     {
         parent::setUp();
 
-        rex_dir::create($this->getPath());
+        rex_dir::create(self::getPath());
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        rex_dir::delete($this->getPath());
+        rex_dir::delete(self::getPath());
     }
 
-    private function getPath(string $file = ''): string
+    private static function getPath(string $file = ''): string
     {
         return rex_path::addonData('tests', 'rex_file_test/' . $file);
     }
@@ -29,13 +29,13 @@ final class rex_file_test extends TestCase
     {
         $this->expectException(rex_exception::class);
 
-        $file = $this->getPath('non_existing.txt');
+        $file = self::getPath('non_existing.txt');
         rex_file::require($file);
     }
 
     public function testGetDefault(): void
     {
-        $file = $this->getPath('non_existing.txt');
+        $file = self::getPath('non_existing.txt');
         self::assertNull(rex_file::get($file), 'get() returns null for non-existing files');
         $myDefault = 'myDefault';
         self::assertEquals($myDefault, rex_file::get($file, $myDefault), 'get() returns given default value for non-existing files');
@@ -43,7 +43,7 @@ final class rex_file_test extends TestCase
 
     public function testGetConfigDefault(): void
     {
-        $file = $this->getPath('non_existing.txt');
+        $file = self::getPath('non_existing.txt');
         self::assertEquals([], rex_file::getConfig($file), 'getConfig() returns empty array for non-existing files');
         $myDefault = ['myDefault'];
         self::assertEquals($myDefault, rex_file::getConfig($file, $myDefault), 'getConfig() returns given default value for non-existing files');
@@ -51,7 +51,7 @@ final class rex_file_test extends TestCase
 
     public function testGetCacheDefault(): void
     {
-        $file = $this->getPath('non_existing.txt');
+        $file = self::getPath('non_existing.txt');
         self::assertEquals([], rex_file::getCache($file), 'getCache() returns empty array for non-existing files');
         $myDefault = ['myDefault'];
         self::assertEquals($myDefault, rex_file::getCache($file, $myDefault), 'getCache() returns given default value for non-existing files');
@@ -59,7 +59,7 @@ final class rex_file_test extends TestCase
 
     public function testPutGet(): void
     {
-        $file = $this->getPath('putget.txt');
+        $file = self::getPath('putget.txt');
         $content = 'test';
         self::assertTrue(rex_file::put($file, $content), 'put() returns true on success');
         self::assertEquals($content, rex_file::get($file), 'get() returns content of file');
@@ -67,7 +67,7 @@ final class rex_file_test extends TestCase
 
     public function testPutGetConfig(): void
     {
-        $file = $this->getPath('putgetcache.txt');
+        $file = self::getPath('putgetcache.txt');
         $content = ['test', 'key' => 'value'];
         self::assertTrue(rex_file::putConfig($file, $content), 'putConfig() returns true on success');
         self::assertEquals($content, rex_file::getConfig($file), 'getConfig() returns content of file');
@@ -75,7 +75,7 @@ final class rex_file_test extends TestCase
 
     public function testPutGetCache(): void
     {
-        $file = $this->getPath('putgetcache.txt');
+        $file = self::getPath('putgetcache.txt');
         $content = ['test', 'key' => 'value'];
         self::assertTrue(rex_file::putCache($file, $content), 'putCache() returns true on success');
         self::assertEquals($content, rex_file::getCache($file), 'getCache() returns content of file');
@@ -83,7 +83,7 @@ final class rex_file_test extends TestCase
 
     public function testPutInNewDir(): void
     {
-        $file = $this->getPath('subdir/test.txt');
+        $file = self::getPath('subdir/test.txt');
         $content = 'test';
         self::assertTrue(rex_file::put($file, $content), 'put() returns true on success');
         self::assertEquals($content, rex_file::get($file), 'get() returns content of file');
@@ -91,8 +91,8 @@ final class rex_file_test extends TestCase
 
     public function testCopyToFile(): void
     {
-        $orig = $this->getPath('orig.txt');
-        $copy = $this->getPath('sub/copy.txt');
+        $orig = self::getPath('orig.txt');
+        $copy = self::getPath('sub/copy.txt');
         $content = 'test';
         rex_file::put($orig, $content);
         self::assertTrue(rex_file::copy($orig, $copy), 'copy() returns true on success');
@@ -102,9 +102,9 @@ final class rex_file_test extends TestCase
 
     public function testCopyToDir(): void
     {
-        $orig = $this->getPath('file.txt');
-        $copyDir = $this->getPath('copy');
-        $copyFile = $this->getPath('copy/file.txt');
+        $orig = self::getPath('file.txt');
+        $copyDir = self::getPath('copy');
+        $copyFile = self::getPath('copy/file.txt');
         $content = 'test';
         rex_file::put($orig, $content);
         rex_dir::create($copyDir);
@@ -114,7 +114,7 @@ final class rex_file_test extends TestCase
 
     public function testDelete(): void
     {
-        $file = $this->getPath('delete.txt');
+        $file = self::getPath('delete.txt');
         rex_file::put($file, '');
         self::assertFileExists($file, 'file exists after put()');
         self::assertTrue(rex_file::delete($file), 'delete() returns true on success');
@@ -139,27 +139,38 @@ final class rex_file_test extends TestCase
         self::assertEquals($expectedExtension, rex_file::extension($file), 'extension() returns file extension');
     }
 
-    /** @return list<array{string, string}> */
-    public static function dataTestMimeType(): array
+    /** @return iterable<int, array{0: string, 1: string, 2?: string}> */
+    public static function dataTestMimeType(): iterable
     {
-        return [
-            ['image/png', rex_path::pluginAssets('be_style', 'redaxo', 'icons/apple-touch-icon.png')],
-            ['text/xml', rex_path::pluginAssets('be_style', 'redaxo', 'icons/browserconfig.xml')],
-            ['text/css', rex_path::pluginAssets('be_style', 'redaxo', 'css/styles.css')],
-            ['application/javascript', rex_path::pluginAssets('be_style', 'redaxo', 'javascripts/redaxo.js')],
-            ['image/svg+xml', rex_path::addonAssets('be_style', 'images/redaxo-logo.svg')],
-        ];
+        yield ['image/png', rex_path::pluginAssets('be_style', 'redaxo', 'icons/apple-touch-icon.png')];
+        yield ['text/xml', rex_path::pluginAssets('be_style', 'redaxo', 'icons/browserconfig.xml')];
+        yield ['text/css', rex_path::pluginAssets('be_style', 'redaxo', 'css/styles.css')];
+        yield ['application/javascript', rex_path::pluginAssets('be_style', 'redaxo', 'javascripts/redaxo.js')];
+        yield ['image/svg+xml', rex_path::addonAssets('be_style', 'images/redaxo-logo.svg')];
+
+        // simulates an uploaded file: extensionless tmp path, original name given separately
+        // (created on demand in testMimeType(), since data providers run before setUp()/tearDown())
+        $uploadTmpFile = self::getPath('upload_tmp_file');
+
+        yield ['text/plain', $uploadTmpFile];
+        yield ['text/vtt', $uploadTmpFile, 'test.vtt'];
+        yield ['text/markdown', $uploadTmpFile, 'test.md'];
+        yield ['text/plain', $uploadTmpFile, 'test.txt'];
     }
 
     #[DataProvider('dataTestMimeType')]
-    public function testMimeType(string $expectedMimeType, string $file): void
+    public function testMimeType(string $expectedMimeType, string $file, ?string $filename = null): void
     {
-        self::assertEquals($expectedMimeType, rex_file::mimeType($file));
+        if (self::getPath('upload_tmp_file') === $file) {
+            rex_file::put($file, 'Hallo Welt');
+        }
+
+        self::assertEquals($expectedMimeType, rex_file::mimeType($file, $filename));
     }
 
     public function testGetOutput(): void
     {
-        $file = $this->getPath('test.php');
+        $file = self::getPath('test.php');
         rex_file::put($file, 'a<?php echo "b";');
         self::assertEquals('ab', rex_file::getOutput($file), 'getOutput() returns the executed content');
     }


### PR DESCRIPTION
Closes #6591

## Problem

Uploading a `.vtt` file via the mediapool fails with **„Dateityp nicht zulässig: `vtt` (`text/plain`)"** on systems where libmagic detects the file content as `text/plain` (e.g. older libmagic versions without WebVTT magic).

The extension-based refinement of unspecific mime types in `rex_file::mimeType()` (added in #6312, `text/plain` → `text/vtt` etc.) uses the extension of the given file path. For uploads that path is the extensionless PHP tmp file (`/tmp/phpXXXXXX`), so the refinement never kicks in — it only works for files already stored with their extension (e.g. media sync).

The same applies to all other refined types whose mediapool whitelist doesn't include `text/plain` as fallback: `md`, `csv`, `ics`, `vcf`.

## Fix

- `rex_file::mimeType()` accepts a new optional `$filename` parameter that is used for the extension lookup instead of the file path (BC-safe)
- The mediapool passes the original filename through in `rex_mediapool::isAllowedMimeType()` and when determining the `filetype` stored in the database on add/update (previously also stored as `text/plain` for uploads)
- The error message in `rex_media_service::addMedia()` now shows the refined mime type and handles the (pre-existing) `null` case instead of relying on the psalm baseline

## Tests

`dataTestMimeType` now covers the upload scenario: an extensionless tmp file with `text/plain` content, checked with and without a separately given original filename (`vtt`, `md`, `txt`).

Verified end-to-end: a `.vtt` upload that was rejected before is accepted after the fix, and `rex_media.filetype` contains `text/vtt`.