### PR TITLE
refactor: drop PHP <8.4 PDO fallback in Sql

### DIFF
--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -35,7 +35,6 @@ use const FILTER_FLAG_HOSTNAME;
 use const FILTER_VALIDATE_DOMAIN;
 use const JSON_THROW_ON_ERROR;
 use const PHP_SAPI;
-use const PHP_VERSION_ID;
 
 /**
  * Connect and interact with the database.
@@ -101,7 +100,7 @@ class Sql implements Iterator
 
     protected ?PDOStatement $stmt = null;
 
-    /** @var array<positive-int, PDO> */
+    /** @var array<positive-int, Mysql> */
     protected static array $pdo = [];
 
     /** @param positive-int $db */
@@ -159,11 +158,11 @@ class Sql implements Iterator
     }
 
     /**
-     * return the PDO Instance, create database connection when not already created.
+     * Returns the `Pdo\Mysql` instance, creates the database connection when not already created.
      *
      * @throws SqlException
      */
-    public function getConnection(): PDO
+    public function getConnection(): Mysql
     {
         if (!isset(self::$pdo[$this->DBID])) {
             $this->selectDB($this->DBID);
@@ -180,7 +179,7 @@ class Sql implements Iterator
         #[SensitiveParameter] string $password,
         bool $persistent = false,
         array $options = [],
-    ): PDO {
+    ): Mysql {
         if (!$database) {
             throw new InvalidArgumentException('Database name can not be empty.');
         }
@@ -203,13 +202,7 @@ class Sql implements Iterator
             PDO::ATTR_FETCH_TABLE_NAMES => true,
         ];
 
-        if (PHP_VERSION_ID >= 8_04_00) {
-            $dbh = @new Mysql($dsn, $login, $password, $options);
-        } else {
-            $dbh = @new PDO($dsn, $login, $password, $options);
-        }
-
-        return $dbh;
+        return @new Mysql($dsn, $login, $password, $options);
     }
 
     /**

--- a/tests/Database/SqlTest.php
+++ b/tests/Database/SqlTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use DateTimeZone;
 use Override;
 use PDO;
+use Pdo\Mysql;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redaxo\Core\Core;
@@ -135,7 +136,7 @@ final class SqlTest extends TestCase
             {
                 parent::__construct($db);
 
-                self::$pdo[$db] = new class(Type::notNull($version)) extends PDO {
+                self::$pdo[$db] = new class(Type::notNull($version)) extends Mysql {
                     public function __construct(
                         private readonly string $version,
                     ) {}


### PR DESCRIPTION
Since PHP 8.5 is the minimum version, the `PHP_VERSION_ID >= 8_04_00` check in `Sql::createConnection()` is dead code — the connection can always be created via the `Pdo\Mysql` subclass.

This also allows narrowing the connection types from `PDO` to `Pdo\Mysql`:
- `createConnection(): Mysql`
- `getConnection(): Mysql`
- `Sql::$pdo` is now `array<positive-int, Mysql>`

The version mock in `SqlTest` now extends `Pdo\Mysql` accordingly.

Not touched (checked, but intentionally kept):
- The `defined(Mysql::class . '::ATTR_SSL_VERIFY_SERVER_CERT')` check — depends on mysqlnd, not on the PHP version.