### PR TITLE
fix: move debug addon translations back from core to the addon

### DIFF
--- a/addons/debug/lang/de_de.lang
+++ b/addons/debug/lang/de_de.lang
@@ -1,0 +1,3 @@
+debug = Debug
+debug_activate_debugmode = Aktiviere den Debug-Modus, um das Debug-Addon verwenden zu können.
+debug_error_unzip = Beim Entpacken der Assets aus dem Clockwork-Frontend-Archiv ist ein Fehler aufgetreten!

--- a/addons/debug/lang/en_gb.lang
+++ b/addons/debug/lang/en_gb.lang
@@ -1,0 +1,3 @@
+debug = Debug
+debug_activate_debugmode = Activate the debug mode to work with the debug addon.
+debug_error_unzip = An error occurred during unpacking the assets from the Clockwork frontend archive!

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -845,11 +845,6 @@ customizer_textarea = breite Textarea unter Template und Module
 customizer_liquid = Liquid Layout
 customizer_nav_flyout = Navigation mit Flyout
 
-# debug
-debug=Debug
-debug_activate_debugmode = Aktiviere den Debug-Modus, um das Debug-Addon verwenden zu können.
-debug_error_unzip = Beim Entpacken der Assets aus dem Clockwork-Frontend-Archiv ist ein Fehler aufgetreten!
-
 # mediapool
 pool_name = Medienpool
 pool_kats = Kategorien

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -811,11 +811,6 @@ customizer_textarea = Width of textarea in templates and modules
 customizer_liquid = Liquid layout
 customizer_nav_flyout = Navigation with flyout
 
-# debug
-debug=Debug
-debug_activate_debugmode = Activate the debug mode to work with the debug addon.
-debug_error_unzip = An error occurred during unpacking the assets from the Clockwork frontend archive!
-
 # mediapool
 pool_name = Mediapool
 pool_kats = Categories


### PR DESCRIPTION
#5900 moved all addon translations into the core lang files. That was correct for the addons being merged into core, but the debug addon was swept along even though it remains a standalone published addon (`redaxo/debug` via subtree split) — leaving the published package without its own translations.

This moves the three keys (`debug`, `debug_activate_debugmode`, `debug_error_unzip`) back to `addons/debug/lang/`. They are used exclusively by the debug addon, and the addon lang loading mechanism (`I18n::addDirectory()` on addon load) is still in place.

Only `de_de` and `en_gb` are restored, matching the languages shipped by core. Also normalized the key/value separator to ` = ` while at it.