### PR TITLE
docs: extend AGENTS.md coding standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ All core classes use the `rex_` prefix (e.g., `rex_sql`, `rex_addon`, `rex_file`
 - In YAML files, prefer single quotes when quoting is needed
 - Comments and commit messages in English; commits use conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `style:`, `ci:`). The same rules (English + conventional commit prefix) apply to PR titles, since they become the commit message on squash merge
 - Don't write bare `@name` tokens in commit messages (e.g. annotations like `@internal`/`@deprecated`, or anything that looks like a username): GitHub autolinks them into user mentions and pings a random account. Wrap them in backticks (`` `@internal` ``) — GitHub renders code spans in commit messages and doesn't link mentions inside them
+- Don't put issue references (`Fixes #123`, `Closes #123`) in commit messages — they belong in the PR description instead
 
 ### Baselines
 The static analysis baselines exist to grandfather pre-existing issues. **New code must not add to the baselines** — fix the issue instead. Only regenerate baselines (`composer baseline`) when intentionally accepting new findings, and call that out in the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ All core classes use the `rex_` prefix (e.g., `rex_sql`, `rex_addon`, `rex_file`
 - Code style enforced by rector + php-cs-fixer (custom REDAXO config) — run `composer cs` after edits
 - PHPStan level 6 + Psalm level 1, both with baselines in `.tools/phpstan/` and `.tools/psalm/`
 - PHPUnit strict mode: warnings, notices, deprecations all fail the build
+- In tests, prefer data providers over repeating similar test methods; name providers with a `provide` prefix and place each one directly after its test method
 - In YAML files, prefer single quotes when quoting is needed
 - Comments and commit messages in English; commits use conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `style:`, `ci:`). The same rules (English + conventional commit prefix) apply to PR titles, since they become the commit message on squash merge
 - Don't write bare `@name` tokens in commit messages (e.g. annotations like `@internal`/`@deprecated`, or anything that looks like a username): GitHub autolinks them into user mentions and pings a random account. Wrap them in backticks (`` `@internal` ``) — GitHub renders code spans in commit messages and doesn't link mentions inside them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,13 @@ All core classes use the `rex_` prefix (e.g., `rex_sql`, `rex_addon`, `rex_file`
 - Don't write bare `@name` tokens in commit messages (e.g. annotations like `@internal`/`@deprecated`, or anything that looks like a username): GitHub autolinks them into user mentions and pings a random account. Wrap them in backticks (`` `@internal` ``) — GitHub renders code spans in commit messages and doesn't link mentions inside them
 - Don't put issue references (`Fixes #123`, `Closes #123`) in commit messages — they belong in the PR description instead
 
+### Comments
+The measure for a code comment is whether it helps someone looking at this code in a year — not whether it explains the change being made right now.
+
+- Don't comment the diff ("this used to be X") — that belongs in the commit message or PR description.
+- Leave out what the code already says, e.g. restating a method or variable name.
+- Keep what stays compact — one precise sentence beats three explanatory ones.
+
 ### Baselines
 The static analysis baselines exist to grandfather pre-existing issues. **New code must not add to the baselines** — fix the issue instead. Only regenerate baselines (`composer baseline`) when intentionally accepting new findings, and call that out in the PR.
 


### PR DESCRIPTION
A few additions to `AGENTS.md`, based on things that came up repeatedly in reviews:

- **Comments** — new subsection: the measure is whether a comment still helps someone reading the code in a year. Don't comment the diff, don't restate what the code already says, keep it compact.
- **Tests** — prefer data providers over near-duplicate test methods; name them with a `provide` prefix and put each one directly after its test method.
- **Commit messages** — issue references (`Fixes #123`) belong in the PR description, not in the commit message.

Docs only, no code changes.