### PR TITLE
fix: prevent TypeError in DataList::getSortColumn() without sort parameter

### DIFF
--- a/src/View/DataList.php
+++ b/src/View/DataList.php
@@ -830,8 +830,11 @@ class DataList implements UrlProviderInterface
     public function getSortColumn(?string $default = null): ?string
     {
         if (Request::request('list', 'string') == $this->getName()) {
-            $sortColumn = Request::request('sort', 'string', $default);
-            if ($this->hasColumnOption($sortColumn, REX_LIST_OPT_SORT)) {
+            // Only a column the request actually asked for is validated here; $default is returned as-is
+            // below either way. Passing $default as cast default would let a null through to
+            // hasColumnOption(), which only accepts a string.
+            $sortColumn = Request::request('sort', 'string');
+            if ('' !== $sortColumn && $this->hasColumnOption($sortColumn, REX_LIST_OPT_SORT)) {
                 return $sortColumn;
             }
         }

--- a/tests/View/DataListTest.php
+++ b/tests/View/DataListTest.php
@@ -43,6 +43,20 @@ final class DataListTest extends TestCase
         unset($_REQUEST['list'], $_REQUEST['sort']);
     }
 
+    public function testGetSortColumnWithoutSortParameter(): void
+    {
+        $list = $this->createListWithSortableColumn('mylist', 'name');
+
+        // The list is addressed, but no sort column is requested. This is the shape of the row action
+        // urls a list generates itself ("?…&func=delete&id=…&list=mylist").
+        $_REQUEST['list'] = 'mylist';
+
+        self::assertNull($list->getSortColumn());
+        self::assertSame('id', $list->getSortColumn('id'));
+
+        unset($_REQUEST['list']);
+    }
+
     public function testGetSortColumnIgnoredForOtherList(): void
     {
         $list = $this->createListWithSortableColumn('mylist', 'name');


### PR DESCRIPTION
## Problem

`DataList::getSortColumn()` reads the `sort` request parameter with `$default` as the cast default and
passes the result into `hasColumnOption(string $columnName, …)`:

```php
$sortColumn = Request::request('sort', 'string', $default);
if ($this->hasColumnOption($sortColumn, REX_LIST_OPT_SORT)) {
```

`Request::request()` returns the default unchanged when the key is absent, so with the default `$default`
of `null` a request that addresses the list but carries no `sort` parameter ends in:

```
TypeError: Redaxo\Core\View\DataList::hasColumnOption(): Argument #1 ($columnName) must be of type string, null given
```

That is exactly the shape of the row action urls a list generates for itself, e.g.
`?page=users/roles&func=delete&id=1&_csrf_token=…&list=c13ea121` — `list` is present, `sort` is not.

**Every delete/edit link of a DataList therefore responds with a 500.** Core's own user roles page is
affected: deleting a role shows the error page. The `DELETE` query has already run at that point and only
re-rendering the list crashes, so it looks like a half-finished delete — the role is gone after a reload.

Reproduce on `6.x`: Users → Roles → create a role → click *löschen*.

In REDAXO 5 `rex_list::hasColumnOption()` had no parameter type, so the `null` passed through silently;
the native type declaration in REDAXO 6 turns it into a hard error.

## Fix

Only a column the request actually asked for needs validating — `$default` is returned unchanged by both
branches anyway, so it no longer needs to travel through `Request::request()`:

```php
$sortColumn = Request::request('sort', 'string');
if ('' !== $sortColumn && $this->hasColumnOption($sortColumn, REX_LIST_OPT_SORT)) {
    return $sortColumn;
}
```

No behaviour change beyond the missing crash:

| `sort` | before | after |
|---|---|---|
| sortable column | that column | that column |
| non-sortable / unknown column | `$default` | `$default` |
| absent | **TypeError** | `$default` |
| array (`sort[]=x`) | `$default` | `$default` |

## Tests

Added `testGetSortColumnWithoutSortParameter()` to `tests/View/DataListTest.php`, which covers the
previously untested "list addressed, no sort parameter" case. It reproduces the `TypeError` on `6.x` and
passes with the fix.

Checked locally: `phpunit tests/View/DataListTest.php` green, `phpstan` and `psalm` report no errors,
`php-cs-fixer` finds nothing to fix in the touched files. The full `phpunit` run has the same 116
errors / 11 failures before and after the change (they come from the missing database in my local setup).
