### PR TITLE
fix: require valid csrf token for user update in users addon

### DIFF
--- a/redaxo/src/addons/users/pages/users.php
+++ b/redaxo/src/addons/users/pages/users.php
@@ -98,7 +98,7 @@ $adminchecked = '';
 
 $passwordPolicy = rex_backend_password_policy::factory();
 
-if ($save && ($fUNCADD || $fUNCUPDATE || $fUNCAPPLY)) {
+if ($fUNCUPDATE || $fUNCAPPLY || ($fUNCADD && $save)) {
     if (!rex_csrf_token::factory('user_edit')->isValid()) {
         $warnings[] = rex_i18n::msg('csrf_token_invalid');
     }


### PR DESCRIPTION
The csrf check ran only when `save` was set, while the update itself was triggered by `FUNC_UPDATE`/`FUNC_APPLY` alone. A request carrying `FUNC_UPDATE=1` without `save` therefore skipped the check completely and still wrote to the user record. Since the params are read from the whole request and the session cookie defaults to `SameSite=Lax`, a crafted link clicked by a logged-in admin was enough to grant admin rights to another account or to deactivate one.

The check now covers `FUNC_UPDATE`/`FUNC_APPLY` unconditionally. `FUNC_ADD` keeps its `save` condition, because it is also used to open the empty create form, which legitimately comes without a token.