### PR TITLE
fix: remove unescaped opener_link request param in mediapool (reflected XSS)

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1365,9 +1365,6 @@
     <MixedOperand>
       <code><![CDATA[$fileId]]></code>
       <code><![CDATA[$fileId]]></code>
-      <code><![CDATA[$openerLink]]></code>
-      <code><![CDATA[$openerLink]]></code>
-      <code><![CDATA[$openerLink]]></code>
     </MixedOperand>
     <NullOperand>
       <code><![CDATA[rex_escape($gf->getValue('createuser'))]]></code>

--- a/redaxo/src/addons/mediapool/pages/index.php
+++ b/redaxo/src/addons/mediapool/pages/index.php
@@ -21,7 +21,6 @@ foreach ($args as $argName => $argValue) {
 }
 
 // ----- opener_input_field setzen
-$openerLink = rex_request('opener_link', 'string');
 $openerInputField = rex_request('opener_input_field', 'string', '');
 
 if ('' != $openerInputField) {
@@ -101,4 +100,4 @@ if (!rex_request::isXmlHttpRequest()) {
 }
 
 // -------------- Include Page
-rex_be_controller::includeCurrentPageSubPath(compact('openerInputField', 'openerLink', 'argUrl', 'args', 'argFields', 'rexFileCategory', 'rexFileCategoryName', 'PERMALL', 'fileId', 'error', 'success'));
+rex_be_controller::includeCurrentPageSubPath(compact('openerInputField', 'argUrl', 'args', 'argFields', 'rexFileCategory', 'rexFileCategoryName', 'PERMALL', 'fileId', 'error', 'success'));

--- a/redaxo/src/addons/mediapool/pages/media.detail.php
+++ b/redaxo/src/addons/mediapool/pages/media.detail.php
@@ -13,9 +13,6 @@ if (!isset($success)) {
 if (!isset($error)) {
     $error = '';
 }
-if (!isset($openerLink)) {
-    $openerLink = '';
-}
 if (!isset($fileId)) {
     $fileId = 0;
 }
@@ -174,14 +171,13 @@ if ('' != $success) {
     $success = '';
 }
 
+$openerLink = '';
 if ('' != $openerInputField) {
     $openerLink = '<a class="btn btn-xs btn-select" onclick="selectMedia(\'' . $encodedFname . '\', \'' . rex_escape($gf->getValue('title'), 'js') . '\'); return false;">' . rex_i18n::msg('pool_file_get') . '</a>';
     if (str_starts_with($openerInputField, 'REX_MEDIALIST_')) {
         $openerLink = '<a class="btn btn-xs btn-select btn-highlight" onclick="selectMedialist(\'' . $encodedFname . '\'); return false;">' . rex_i18n::msg('pool_file_get') . '</a>';
     }
-}
 
-if ('' != $openerLink) {
     $openerLink = ' | ' . $openerLink;
 }
 


### PR DESCRIPTION
The `opener_link` GET/POST param was read raw from the request and appended to the media detail panel title, which is rendered unescaped. Without `opener_input_field` in the request the attacker-controlled value survived and arbitrary HTML/JS ended up in the backend DOM.

The param was never generated by the core and required raw HTML by design, so it is removed instead of escaped. The select link is still built server-side from `opener_input_field`, and `$openerLink` is now a purely local variable in the subpages instead of being taken over from the page context.