### PR TITLE
fix: add missing csrf protection to several backend actions

### DIFF
--- a/redaxo/src/addons/be_style/plugins/customizer/pages/system.customizer.php
+++ b/redaxo/src/addons/be_style/plugins/customizer/pages/system.customizer.php
@@ -3,7 +3,11 @@
 $success = '';
 $error = '';
 
-if ('' != rex_post('btn_save', 'string')) {
+$csrfToken = rex_csrf_token::factory('be_style_customizer');
+
+if ('' != rex_post('btn_save', 'string') && !$csrfToken->isValid()) {
+    $error = rex_i18n::msg('csrf_token_invalid');
+} elseif ('' != rex_post('btn_save', 'string')) {
     // set config
 
     $newConfig = rex_post('settings', 'array');
@@ -255,6 +259,7 @@ $content = $fragment->parse('core/page/section.php');
 
 echo '
     <form action="' . rex_url::currentBackendPage() . '" method="post">
+        ' . $csrfToken->getHiddenField() . '
         ' . $content . '
     </form>
 ';

--- a/redaxo/src/addons/cronjob/pages/log.php
+++ b/redaxo/src/addons/cronjob/pages/log.php
@@ -12,7 +12,11 @@ $success = '';
 $message = '';
 $logFile = rex_path::log('cronjob.log');
 
-if ('cronjob_delLog' == $func) {
+$csrfToken = rex_csrf_token::factory('cronjob_log');
+
+if ('cronjob_delLog' == $func && !$csrfToken->isValid()) {
+    $error = rex_i18n::msg('csrf_token_invalid');
+} elseif ('cronjob_delLog' == $func) {
     if (rex_log_file::delete($logFile)) {
         $success = rex_i18n::msg('syslog_deleted');
     } else {
@@ -89,6 +93,7 @@ $content = $fragment->parse('core/page/section.php');
 
 $content = '
     <form action="' . rex_url::currentBackendPage() . '" method="post">
+        ' . $csrfToken->getHiddenField() . '
         <input type="hidden" name="func" value="cronjob_delLog" />
         ' . $content . '
     </form>';

--- a/redaxo/src/addons/install/pages/settings.php
+++ b/redaxo/src/addons/install/pages/settings.php
@@ -11,13 +11,17 @@ $config = array_merge([
     'api_key' => null,
 ], rex_file::getCache($configFile));
 
+$csrfToken = rex_csrf_token::factory('install_settings');
+
 $newConfig = rex_post('settings', [
     ['backups', 'bool', false],
     ['api_login', 'string'],
     ['api_key', 'string'],
 ], null);
 
-if (is_array($newConfig)) {
+if (is_array($newConfig) && !$csrfToken->isValid()) {
+    echo rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+} elseif (is_array($newConfig)) {
     $config = $newConfig;
     if (rex_file::putCache($configFile, $config)) {
         echo rex_view::success($addon->i18n('settings_saved'));
@@ -89,6 +93,7 @@ $content = $fragment->parse('core/page/section.php');
 
 $content = '
     <form action="' . rex_url::currentBackendPage() . '" method="post">
+        ' . $csrfToken->getHiddenField() . '
         ' . $content . '
     </form>';
 

--- a/redaxo/src/addons/media_manager/boot.php
+++ b/redaxo/src/addons/media_manager/boot.php
@@ -13,3 +13,11 @@ rex_extension::register('PACKAGES_INCLUDED', [rex_media_manager::class, 'init'],
 rex_extension::register('MEDIA_UPDATED', [rex_media_manager::class, 'mediaUpdated']);
 rex_extension::register('MEDIA_DELETED', [rex_media_manager::class, 'mediaUpdated']);
 rex_extension::register('MEDIA_IS_IN_USE', [rex_media_manager::class, 'mediaIsInUse']);
+
+// the href of the "clear cache" page is defined in package.yml, so the csrf token can only be added at runtime
+rex_extension::register('PAGES_PREPARED', static function (rex_extension_point $ep) {
+    /** @var array<string, rex_be_page> $pages */
+    $pages = $ep->getSubject();
+    $subpage = ($pages['media_manager'] ?? null)?->getSubpage('clear_cache');
+    $subpage?->setHref(['page' => 'media_manager/types', 'func' => 'clear_cache'] + rex_csrf_token::factory('media_manager')->getUrlParams());
+});

--- a/redaxo/src/addons/media_manager/pages/effects.php
+++ b/redaxo/src/addons/media_manager/pages/effects.php
@@ -18,6 +18,13 @@ $typeName = (string) $sql->getValue('name');
 $info = '';
 $warning = '';
 
+$csrfToken = rex_csrf_token::factory('media_manager_effect');
+
+if ('delete' == $func && !$csrfToken->isValid()) {
+    $warning = rex_i18n::msg('csrf_token_invalid');
+    $func = '';
+}
+
 // -------------- delete effect
 if ('delete' == $func && $effectId > 0) {
     $sql = rex_sql::factory();
@@ -104,7 +111,7 @@ if ('' == $func) {
 
     $delete = 'deleteCol';
     $list->addColumn($delete, '<i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('media_manager_effect_delete'), -1, ['', '<td class="rex-table-action">###VALUE###</td>']);
-    $list->setColumnParams($delete, ['type_id' => $typeId, 'effect_id' => '###id###', 'func' => 'delete']);
+    $list->setColumnParams($delete, ['type_id' => $typeId, 'effect_id' => '###id###', 'func' => 'delete'] + $csrfToken->getUrlParams());
     $list->addLinkAttribute($delete, 'data-confirm', rex_i18n::msg('delete') . ' ?');
 
     $content = $list->get();

--- a/redaxo/src/addons/media_manager/pages/index.php
+++ b/redaxo/src/addons/media_manager/pages/index.php
@@ -13,8 +13,12 @@ echo rex_view::title(rex_i18n::msg('media_manager'));
 
 $func = rex_request('func', 'string');
 if ('clear_cache' == $func) {
-    $c = rex_media_manager::deleteCache();
-    echo rex_view::info(rex_i18n::msg('media_manager_cache_files_removed', $c));
+    if (!rex_csrf_token::factory('media_manager')->isValid()) {
+        echo rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+    } else {
+        $c = rex_media_manager::deleteCache();
+        echo rex_view::info(rex_i18n::msg('media_manager_cache_files_removed', $c));
+    }
 }
 
 rex_be_controller::includeCurrentPageSubPath();

--- a/redaxo/src/addons/media_manager/pages/settings.php
+++ b/redaxo/src/addons/media_manager/pages/settings.php
@@ -11,7 +11,11 @@ $addon = rex_addon::get('media_manager');
 
 $func = rex_request('func', 'string');
 
-if ('update' == $func) {
+$csrfToken = rex_csrf_token::factory('media_manager_settings');
+
+if ('update' == $func && !$csrfToken->isValid()) {
+    echo rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+} elseif ('update' == $func) {
     $config = rex_post('settings', [
         ['jpg_quality', 'int'],
         ['png_compression', 'int'],
@@ -154,6 +158,7 @@ $content = $fragment->parse('core/page/section.php');
 
 $content = '
     <form action="' . rex_url::currentBackendPage() . '" method="post">
+        ' . $csrfToken->getHiddenField() . '
         <fieldset>
             <input type="hidden" name="func" value="update" />
             ' . $content . '

--- a/redaxo/src/addons/media_manager/pages/types.php
+++ b/redaxo/src/addons/media_manager/pages/types.php
@@ -13,6 +13,13 @@ if (rex_request('effects', 'boolean')) {
 $success = '';
 $error = '';
 
+$csrfToken = rex_csrf_token::factory('media_manager_type');
+
+if (in_array($func, ['delete', 'delete_cache', 'copy'], true) && !$csrfToken->isValid()) {
+    $error = rex_i18n::msg('csrf_token_invalid');
+    $func = '';
+}
+
 // -------------- delete type
 if ('delete' == $func && $typeId > 0) {
     // must be called before deletion, otherwise the method can not resolve the id to type name
@@ -118,7 +125,7 @@ if ('' == $func) {
     });
 
     $list->addColumn('deleteCache', '<i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('media_manager_type_cache_delete'), -1, ['', '<td class="rex-table-action">###VALUE###</td>']);
-    $list->setColumnParams('deleteCache', ['type_id' => '###id###', 'func' => 'delete_cache']);
+    $list->setColumnParams('deleteCache', ['type_id' => '###id###', 'func' => 'delete_cache'] + $csrfToken->getUrlParams());
     $list->addLinkAttribute('deleteCache', 'data-confirm', rex_i18n::msg('media_manager_type_cache_delete') . ' ?');
 
     $list->addColumn('editType', '', -1, ['', '<td class="rex-table-action">###VALUE###</td>']);
@@ -131,11 +138,11 @@ if ('' == $func) {
     });
 
     $list->addColumn('copyType', '<i class="rex-icon rex-icon-duplicate"></i> ' . rex_i18n::msg('media_manager_type_copy'), -1, ['', '<td class="rex-table-action">###VALUE###</td>']);
-    $list->setColumnParams('copyType', ['func' => 'copy', 'type_id' => '###id###']);
+    $list->setColumnParams('copyType', ['func' => 'copy', 'type_id' => '###id###'] + $csrfToken->getUrlParams());
 
     // override delete link on internal types
     $list->addColumn('deleteType', '', -1, ['', '<td class="rex-table-action">###VALUE###</td>']);
-    $list->setColumnParams('deleteType', ['type_id' => '###id###', 'func' => 'delete']);
+    $list->setColumnParams('deleteType', ['type_id' => '###id###', 'func' => 'delete'] + $csrfToken->getUrlParams());
     $list->addLinkAttribute('deleteType', 'data-confirm', rex_i18n::msg('delete') . ' ?');
     $list->setColumnFormat('deleteType', 'custom', static function () use ($list) {
         if (rex_media_manager::STATUS_SYSTEM_TYPE == $list->getValue('status')) {

--- a/redaxo/src/addons/metainfo/pages/field.php
+++ b/redaxo/src/addons/metainfo/pages/field.php
@@ -21,8 +21,13 @@ if (empty($metaTable) || !is_string($metaTable)) {
 $func = rex_request('func', 'string');
 $fieldId = rex_request('field_id', 'int');
 
+$csrfToken = rex_csrf_token::factory('metainfo_field');
+
 // ------------------------------> Feld loeschen
-if ('delete' == $func) {
+if ('delete' == $func && !$csrfToken->isValid()) {
+    echo rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+    $func = '';
+} elseif ('delete' == $func) {
     $fieldId = rex_request('field_id', 'int', 0);
     if (0 != $fieldId) {
         if (rex_metainfo_delete_field($fieldId)) {
@@ -69,7 +74,7 @@ if ('' == $func) {
 
     $list->addColumn('delete', '<i class="rex-icon rex-icon-delete"></i> ' . rex_i18n::msg('delete'));
     $list->setColumnLayout('delete', ['', '<td class="rex-table-action">###VALUE###</td>']);
-    $list->setColumnParams('delete', ['func' => 'delete', 'field_id' => '###id###']);
+    $list->setColumnParams('delete', ['func' => 'delete', 'field_id' => '###id###'] + $csrfToken->getUrlParams());
     $list->addLinkAttribute('delete', 'data-confirm', rex_i18n::msg('delete') . ' ?');
     $list->addLinkAttribute('delete', 'class', 'rex-delete');
 

--- a/redaxo/src/addons/phpmailer/pages/config.php
+++ b/redaxo/src/addons/phpmailer/pages/config.php
@@ -10,7 +10,12 @@ $addon = rex_addon::get('phpmailer');
 
 $message = '';
 
-if ('' != rex_post('btn_save', 'string') || '' != rex_post('btn_check', 'string')) {
+$csrfToken = rex_csrf_token::factory('phpmailer-config');
+$submitted = '' != rex_post('btn_save', 'string') || '' != rex_post('btn_check', 'string');
+
+if ($submitted && !$csrfToken->isValid()) {
+    echo rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+} elseif ($submitted) {
     $settings = rex_post('settings', [
         ['fromname', 'string'],
         ['from', 'string'],
@@ -402,6 +407,7 @@ $fragment->setVar('buttons', $buttons, false);
 $content = $fragment->parse('core/page/section.php');
 echo '
     <form action="' . rex_url::currentBackendPage() . '" method="post">
+        ' . $csrfToken->getHiddenField() . '
         ' . $content . '
     </form>';
 ?>

--- a/redaxo/src/addons/phpmailer/pages/log.php
+++ b/redaxo/src/addons/phpmailer/pages/log.php
@@ -5,7 +5,11 @@ $error = '';
 $success = '';
 $logFile = rex_mailer::logFile();
 
-if ('mailer_delLog' == $func) {
+$csrfToken = rex_csrf_token::factory('phpmailer-delete-log');
+
+if ('mailer_delLog' == $func && !$csrfToken->isValid()) {
+    $error = rex_i18n::msg('csrf_token_invalid');
+} elseif ('mailer_delLog' == $func) {
     if (rex_log_file::delete($logFile)) {
         $success = rex_i18n::msg('syslog_deleted');
     } else {
@@ -69,6 +73,7 @@ $fragment->setVar('buttons', $buttons, false);
 $content = $fragment->parse('core/page/section.php');
 $content = '
     <form action="' . rex_url::currentBackendPage() . '" method="post">
+        ' . $csrfToken->getHiddenField() . '
         <input type="hidden" name="func" value="mailer_delLog" />
         ' . $content . '
     </form>';

--- a/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/article_content_editor.php
@@ -171,7 +171,7 @@ class rex_article_content_editor extends rex_article_content
             // delete
             $item = [];
             $item['label'] = rex_i18n::msg('delete');
-            $item['url'] = $context->getUrl(['function' => 'delete', 'save' => 1]) . $fragment;
+            $item['url'] = $context->getUrl(['function' => 'delete', 'save' => 1] + rex_csrf_token::factory('structure_content_slice')->getUrlParams()) . $fragment;
             $item['attributes']['class'][] = 'btn-delete';
             $item['attributes']['title'] = rex_i18n::msg('delete');
             $item['attributes']['data-confirm'] = rex_i18n::msg('confirm_delete_block');
@@ -453,6 +453,7 @@ class rex_article_content_editor extends rex_article_content
         $panel = '
                 <fieldset>
                     <legend>' . rex_i18n::msg('add_block') . '</legend>
+                    ' . rex_csrf_token::factory('structure_content_slice')->getHiddenField() . '
                     <input type="hidden" name="function" value="add" />
                     <input type="hidden" name="module_id" value="' . $moduleId . '" />
                     <input type="hidden" name="save" value="1" />
@@ -521,6 +522,7 @@ class rex_article_content_editor extends rex_article_content
         $panel = '
                 <fieldset>
                     <legend>' . rex_i18n::msg('edit_block') . '</legend>
+                    ' . rex_csrf_token::factory('structure_content_slice')->getHiddenField() . '
                     <input type="hidden" name="module_id" value="' . $moduleId . '" />
                     <input type="hidden" name="save" value="1" />
                     <input type="hidden" name="update" value="0" />

--- a/redaxo/src/addons/structure/plugins/content/pages/content.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.php
@@ -101,6 +101,11 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
     // ----- hat rechte an diesem artikel
 
     // ------------------------------------------ Slice add/edit/delete
+    if (rex_request('save', 'boolean') && in_array($function, ['add', 'edit', 'delete']) && !rex_csrf_token::factory('structure_content_slice')->isValid()) {
+        $globalWarning = rex_i18n::msg('csrf_token_invalid');
+        $function = '';
+    }
+
     if (rex_request('save', 'boolean') && in_array($function, ['add', 'edit', 'delete'])) {
         // ----- check module
 

--- a/redaxo/src/addons/structure/plugins/history/assets/history.js
+++ b/redaxo/src/addons/structure/plugins/history/assets/history.js
@@ -440,7 +440,7 @@
          * @returns {*}
          */
         snapVersion: function (date) {
-            var url = 'index.php?rex_history_function=snap&history_article_id=' + this.articleId + '&history_clang_id=' + this.clangId + '&history_date=' + date;
+            var url = 'index.php?rex_history_function=snap&history_article_id=' + this.articleId + '&history_clang_id=' + this.clangId + '&history_date=' + date + '&_csrf_token=' + encodeURIComponent(history_csrf_token);
             debug.info('snap version: ' + url);
             return $.ajax({
                 url: url,

--- a/redaxo/src/addons/structure/plugins/history/boot.php
+++ b/redaxo/src/addons/structure/plugins/history/boot.php
@@ -113,6 +113,12 @@ if (rex::isBackend() && rex::getUser()?->hasPerm('history[article_rollback]')) {
 
     switch (rex_request('rex_history_function', 'string')) {
         case 'snap':
+            if (!rex_csrf_token::factory('structure_history')->isValid()) {
+                rex_response::setStatus(rex_response::HTTP_FORBIDDEN);
+                rex_response::sendContent(rex_i18n::msg('csrf_token_invalid'), 'text/plain');
+                exit;
+            }
+
             $articleId = rex_request('history_article_id', 'int');
             $clangId = rex_request('history_clang_id', 'int');
             $historyDate = rex_request('history_date', 'string');
@@ -174,6 +180,7 @@ if (rex::isBackend() && rex::getUser()?->hasPerm('history[article_rollback]')) {
                     var history_clang_id = ' . rex_clang::getCurrentId() . ';
                     var history_ctype_id = ' . rex_request('ctype', 'int', 0) . ';
                     var history_article_link = "' . rex_escape($articleLink, 'js') . '";
+                    var history_csrf_token = "' . rex_escape(rex_csrf_token::factory('structure_history')->getValue(), 'js') . '";
                     </script>';
         }
     },

--- a/redaxo/src/addons/structure/plugins/history/pages/system.history.php
+++ b/redaxo/src/addons/structure/plugins/history/pages/system.history.php
@@ -2,13 +2,19 @@
 
 $plugin = rex_plugin::get('structure', 'history');
 
+$csrfToken = rex_csrf_token::factory('structure_history');
+
 if ('clearall' == rex_request('func', 'string')) {
-    rex_article_slice_history::clearAllHistory();
-    echo rex_view::success($plugin->i18n('deleted'));
+    if (!$csrfToken->isValid()) {
+        echo rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+    } else {
+        rex_article_slice_history::clearAllHistory();
+        echo rex_view::success($plugin->i18n('deleted'));
+    }
 }
 
 $content = rex_i18n::rawMsg('structure_history_info_content');
-$content .= '<p><a href="' . rex_url::currentBackendPage(['func' => 'clearall']) . '" class="btn btn-setup">' . $plugin->i18n('button_delete_history') . '</a></p>';
+$content .= '<p><a href="' . rex_url::currentBackendPage(['func' => 'clearall'] + $csrfToken->getUrlParams()) . '" class="btn btn-setup" data-confirm="' . rex_i18n::msg('delete') . ' ?">' . $plugin->i18n('button_delete_history') . '</a></p>';
 
 $fragment = new rex_fragment();
 $fragment->setVar('title', $plugin->i18n('title_info'));

--- a/redaxo/src/addons/structure/plugins/version/boot.php
+++ b/redaxo/src/addons/structure/plugins/version/boot.php
@@ -77,7 +77,14 @@ rex_extension::register('STRUCTURE_CONTENT_BEFORE_SLICES', static function (rex_
         $workingVersionEmpty = false;
     }
 
+    $csrfToken = rex_csrf_token::factory('structure_version');
+
     $func = rex_request('rex_version_func', 'string');
+    if ('' !== $func && !$csrfToken->isValid()) {
+        $return .= rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+        $func = '';
+    }
+
     switch ($func) {
         case 'copy_work_to_live':
             if ($workingVersionEmpty) {
@@ -151,18 +158,18 @@ rex_extension::register('STRUCTURE_CONTENT_BEFORE_SLICES', static function (rex_
 
     if (!$user->hasPerm('version[live_version]')) {
         if ($revision > 0) {
-            $toolbar .= '<li><a href="' . $context->getUrl(['rex_version_func' => 'copy_live_to_work']) . '">' . rex_i18n::msg('version_copy_from_liveversion') . '</a></li>';
+            $toolbar .= '<li><a href="' . $context->getUrl(['rex_version_func' => 'copy_live_to_work'] + $csrfToken->getUrlParams()) . '">' . rex_i18n::msg('version_copy_from_liveversion') . '</a></li>';
             $toolbar .= '<li><a href="' . rex_getUrl($articleId, $clangId, ['rex_version' => rex_article_revision::WORK]) . '" rel="noopener noreferrer" target="_blank">' . rex_i18n::msg('version_preview') . '</a></li>';
         }
     } else {
         if ($revision > 0) {
             if (!$workingVersionEmpty) {
-                $toolbar .= '<li><a href="' . $context->getUrl(['rex_version_func' => 'clear_work']) . '" data-confirm="' . rex_i18n::msg('version_confirm_clear_workingversion') . '">' . rex_i18n::msg('version_clear_workingversion') . '</a></li>';
-                $toolbar .= '<li><a href="' . $context->getUrl(['rex_version_func' => 'copy_work_to_live']) . '">' . rex_i18n::msg('version_working_to_live') . '</a></li>';
+                $toolbar .= '<li><a href="' . $context->getUrl(['rex_version_func' => 'clear_work'] + $csrfToken->getUrlParams()) . '" data-confirm="' . rex_i18n::msg('version_confirm_clear_workingversion') . '">' . rex_i18n::msg('version_clear_workingversion') . '</a></li>';
+                $toolbar .= '<li><a href="' . $context->getUrl(['rex_version_func' => 'copy_work_to_live'] + $csrfToken->getUrlParams()) . '">' . rex_i18n::msg('version_working_to_live') . '</a></li>';
             }
             $toolbar .= '<li><a href="' . rex_getUrl($articleId, $clangId, ['rex_version' => rex_article_revision::WORK]) . '" rel="noopener noreferrer" target="_blank">' . rex_i18n::msg('version_preview') . '</a></li>';
         } else {
-            $toolbar .= '<li><a href="' . $context->getUrl(['rex_version_func' => 'copy_live_to_work']) . '" data-confirm="' . rex_i18n::msg('version_confirm_copy_live_to_workingversion') . '">' . rex_i18n::msg('version_copy_live_to_workingversion') . '</a></li>';
+            $toolbar .= '<li><a href="' . $context->getUrl(['rex_version_func' => 'copy_live_to_work'] + $csrfToken->getUrlParams()) . '" data-confirm="' . rex_i18n::msg('version_confirm_copy_live_to_workingversion') . '">' . rex_i18n::msg('version_copy_live_to_workingversion') . '</a></li>';
         }
     }
 


### PR DESCRIPTION
Several backend actions changed state without validating a csrf token. Most of them were reachable through plain GET links, so they could be triggered by a link click in an authenticated session.

Each commit covers one addon (or one pair of pages sharing the same change), so they can be reviewed and reverted independently.

## What was unprotected

**GET-triggered (link click is enough):**

| Action | Effect |
|---|---|
| `structure/version`: `rex_version_func` | publishes the working version to live, overwrites it with live, or clears it |
| `structure/history`: `func=clearall` | deletes the complete article history |
| `structure/history`: `rex_history_function=snap` | restores an old snapshot over the current article content (ajax) |
| `structure/content`: `save` + `function=add\|edit\|delete` | creates, overwrites or deletes content slices |
| `metainfo`: `func=delete` | deletes a field, which drops the column from the meta table |
| `media_manager`: `func=delete\|copy\|delete_cache` | deletes or copies a media type, clears its cache |
| `media_manager`: `func=delete` (effects) | deletes an effect |
| `media_manager`: `func=clear_cache` | clears the generated image cache |
| `cronjob` / `phpmailer`: log deletion | both submit via post, but read `func` from the whole request |

**Post-only, no token:** the settings forms of `install` (stores the myredaxo api credentials), `media_manager`, `phpmailer` and the be_style customizer. `SameSite=Lax` already covered the cross-site case here, but the token is the guarantee, not the cookie policy.

## Notes for review

- Adding the check was usually the small part — most of the work was adding the token to the places that build the links and forms (`rex_list` action columns, form fragments), otherwise the actions would just stop working.
- `media_manager/boot.php`: the href of the "clear cache" page is declared statically in `package.yml`, so the token can only be attached at runtime. It is set via `PAGES_PREPARED`.
- `structure/plugins/history`: the snapshot restore is an ajax call from `history.js`. The token is handed to js the same way the other history parameters already are, and an invalid token answers `403` instead of silently doing nothing.
- `structure/content`: the guard is placed before the existing block and resets `$function`, to avoid re-indenting ~200 lines.
- The "clear all history" link got a `data-confirm` — deleting the complete history without a prompt was unfortunate even without an attacker.

## Testing

Every action was checked manually in the backend: request without a token is rejected, the database is unchanged, the error message is shown and the page still renders — and the regular path through the ui still works.
