### PR TITLE
fix: add missing csrf protection to metainfo saves

### DIFF
--- a/redaxo/src/addons/metainfo/lib/handler/article_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/article_handler.php
@@ -18,6 +18,10 @@ class rex_metainfo_article_handler extends rex_metainfo_handler
             return $params;
         }
 
+        if (!self::getCsrfToken()->isValid()) {
+            return $params;
+        }
+
         $article = rex_sql::factory();
         // $article->setDebug();
         $article->setTable(rex::getTablePrefix() . 'article');

--- a/redaxo/src/addons/metainfo/lib/handler/category_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/category_handler.php
@@ -28,7 +28,8 @@ class rex_metainfo_category_handler extends rex_metainfo_handler
     /** @return array */
     public function handleSave(array $params, rex_sql $sqlFields)
     {
-        if ('post' != rex_request_method()) {
+        // Only save when the category itself is saved, as only that request is protected by a csrf token.
+        if (!$params['save'] || 'post' != rex_request_method()) {
             return $params;
         }
 
@@ -84,6 +85,8 @@ class rex_metainfo_category_handler extends rex_metainfo_handler
     public function extendForm(rex_extension_point $ep)
     {
         $params = $ep->getParams();
+        $params['save'] = in_array($ep->getName(), ['CAT_ADDED', 'CAT_UPDATED'], true);
+
         if (isset($params['category'])) {
             $params['activeItem'] = $params['category'];
 

--- a/redaxo/src/addons/metainfo/lib/handler/clang_handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/clang_handler.php
@@ -26,7 +26,8 @@ class rex_metainfo_clang_handler extends rex_metainfo_handler
     /** @return array */
     public function handleSave(array $params, rex_sql $sqlFields)
     {
-        if ('post' != rex_request_method() || !isset($params['id'])) {
+        // Only save when the clang itself is saved, as only that request is protected by a csrf token.
+        if (!$params['save'] || 'post' != rex_request_method() || !isset($params['id'])) {
             return $params;
         }
 
@@ -62,6 +63,8 @@ class rex_metainfo_clang_handler extends rex_metainfo_handler
     public function extendForm(rex_extension_point $ep)
     {
         $params = $ep->getParams();
+        $params['save'] = in_array($ep->getName(), ['CLANG_ADDED', 'CLANG_UPDATED'], true);
+
         if (isset($params['sql'])) {
             $params['activeItem'] = $params['sql'];
         }

--- a/redaxo/src/addons/metainfo/lib/handler/handler.php
+++ b/redaxo/src/addons/metainfo/lib/handler/handler.php
@@ -8,6 +8,16 @@
 abstract class rex_metainfo_handler
 {
     /**
+     * Csrf token for forms which are provided by metainfo itself.
+     *
+     * Metafields which are rendered into a form of another package are covered by the csrf token of that form.
+     */
+    public static function getCsrfToken(): rex_csrf_token
+    {
+        return rex_csrf_token::factory('metainfo');
+    }
+
+    /**
      * Erstellt den nötigen HTML Code um ein Formular zu erweitern.
      *
      * @param rex_sql $sqlFields rex_sql-objekt, dass die zu verarbeitenden Felder enthält

--- a/redaxo/src/addons/metainfo/pages/content.metainfo.php
+++ b/redaxo/src/addons/metainfo/pages/content.metainfo.php
@@ -113,13 +113,23 @@ if (1 == $article->getRows()) {
     $fragment->setVar('elements', $formElements, false);
     $form = $fragment->parse('core/form/form.php') . $form;
 
+    $csrfToken = rex_metainfo_handler::getCsrfToken();
+
+    $message = '';
+    if (rex_post('savemeta', 'boolean')) {
+        $message = $csrfToken->isValid()
+            ? rex_view::success(rex_i18n::msg('minfo_metadata_saved'))
+            : rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+    }
+
     $content[] = '
               <div id="rex-page-sidebar-metainfo" data-pjax-container="#rex-page-sidebar-metainfo">
                 <form class="metainfo-sidebar" action="' . $context->getUrl() . '" method="post" enctype="multipart/form-data">
-                    ' . (rex_post('savemeta', 'boolean') ? rex_view::success(rex_i18n::msg('minfo_metadata_saved')) : '') . '
+                    ' . $message . '
                     <fieldset>
                         <input type="hidden" name="save" value="1" />
                         <input type="hidden" name="ctype" value="' . $ctype . '" />
+                        ' . $csrfToken->getHiddenField() . '
                         ' . $form . '
                         <button class="btn btn-primary pull-left" type="submit" name="savemeta"' . rex::getAccesskey(rex_i18n::msg('update_metadata'), 'save') . ' value="1">' . rex_i18n::msg('update_metadata') . '</button>
                     </fieldset>


### PR DESCRIPTION
The metainfo handlers stored posted metafields without validating a csrf token.

- The sidebar on the content page posts without `function` and therefore bypassed the csrf check of the content page. This affected the article name as well as all article metafields.
- The category and clang handlers saved on every POST to the structure resp. language page, no matter whether the csrf check of that page had passed.

The sidebar is a form of metainfo itself, so it gets its own csrf token. Category and clang metafields are rendered into a form of another package, which already carries a csrf token of its own — a second token field cannot be added there, as both would use the same request param and overwrite each other. Instead those metafields are now only saved via the `CAT_ADDED`/`CAT_UPDATED` resp. `CLANG_ADDED`/`CLANG_UPDATED` extension points, which are only reached through the csrf protected save of the category resp. clang itself. The media handler already worked that way.

Manually tested in the backend: saving article name/metafields via the sidebar, category metafields on add and edit, clang metafields on add and edit.