### PR TITLE
fix: sanitize svg uploads before moving them into the media folder

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1268,9 +1268,6 @@
       <code><![CDATA[rex_escape($allowedExtensions)]]></code>
       <code><![CDATA[rex_escape(rex_mediapool::getBlockedExtensions())]]></code>
     </MixedArgumentTypeCoercion>
-    <PossiblyFalseArgument>
-      <code><![CDATA[$content]]></code>
-    </PossiblyFalseArgument>
     <PossiblyInvalidOperand>
       <code><![CDATA[$uses]]></code>
     </PossiblyInvalidOperand>

--- a/redaxo/src/addons/mediapool/lib/service_media.php
+++ b/redaxo/src/addons/mediapool/lib/service_media.php
@@ -85,9 +85,7 @@ final class rex_media_service
             throw new rex_api_exception($errorMessage);
         }
 
-        if (!rex_file::move($srcFile, $dstFile)) {
-            throw new rex_api_exception(rex_i18n::msg('pool_file_movefailed'));
-        }
+        self::moveMedia($srcFile, $dstFile, $data['file']['type']);
 
         @chmod($dstFile, rex::getFilePerm());
 
@@ -95,8 +93,6 @@ final class rex_media_service
         if ('' == $data['file']['type'] && isset($size['mime'])) {
             $data['file']['type'] = $size['mime'];
         }
-
-        self::sanitizeMedia($dstFile, $data['file']['type']);
 
         $saveObject = rex_sql::factory();
         $saveObject->setTable(rex::getTablePrefix() . 'media');
@@ -205,13 +201,9 @@ final class rex_media_service
                     $warning = rex_i18n::msg('pool_file_mediatype_not_allowed') . ' <code>' . rex_escape($extensionNew) . '</code> (<code>' . rex_escape($filetype ?? 'unknown mime type') . '</code>)';
                     throw new rex_api_exception($warning);
                 }
-                if (!rex_file::move($srcFile, $dstFile)) {
-                    throw new rex_api_exception(rex_i18n::msg('pool_file_movefailed'));
-                }
+                self::moveMedia($srcFile, $dstFile, $filetype);
 
                 @chmod($dstFile, rex::getFilePerm());
-
-                self::sanitizeMedia($dstFile, $filetype);
 
                 $saveObject->setValue('filetype', $filetype);
                 $saveObject->setValue('filesize', filesize($dstFile));
@@ -392,20 +384,64 @@ final class rex_media_service
         return $items;
     }
 
-    private static function sanitizeMedia(string $path, ?string $type): void
+    /**
+     * Sanitizes the file if necessary and moves it into the media folder.
+     *
+     * The file must never be moved before it has been sanitized, otherwise the unsanitized content would be publicly
+     * available for a short time (or permanently, if sanitizing fails).
+     *
+     * @throws rex_api_exception
+     */
+    private static function moveMedia(string $srcFile, string $dstFile, ?string $type): void
+    {
+        $sanitizedFile = self::sanitizeMedia($srcFile, $type, rex_path::basename($dstFile));
+
+        if (!rex_file::move($sanitizedFile ?? $srcFile, $dstFile)) {
+            if (null !== $sanitizedFile) {
+                rex_file::delete($sanitizedFile);
+            }
+
+            throw new rex_api_exception(rex_i18n::msg('pool_file_movefailed'));
+        }
+
+        // the source file is left behind when the sanitized copy has been moved instead
+        if (null !== $sanitizedFile && $srcFile !== $dstFile) {
+            rex_file::delete($srcFile);
+        }
+    }
+
+    /**
+     * Sanitizes the file into a temporary file, the source file is left untouched.
+     *
+     * @param string $filename Name of the target file, used to detect the file extension
+     *
+     * @throws rex_api_exception
+     *
+     * @return string|null Path of the sanitized temp file or `null` if the file does not need sanitization
+     */
+    private static function sanitizeMedia(string $path, ?string $type, string $filename): ?string
     {
         if (!rex_addon::require('mediapool')->getProperty('sanitize_svgs', true)) {
-            return;
+            return null;
         }
 
-        if ('image/svg+xml' !== $type && 'svg' !== strtolower(rex_file::extension($path))) {
-            return;
+        if ('image/svg+xml' !== $type && 'svg' !== strtolower(rex_file::extension($filename))) {
+            return null;
         }
 
-        $content = rex_type::notNull(rex_file::get($path));
+        $content = (new Sanitizer())->sanitize(rex_type::notNull(rex_file::get($path)));
 
-        $content = (new Sanitizer())->sanitize($content);
+        if (false === $content) {
+            throw new rex_api_exception(rex_i18n::msg('pool_file_upload_error'));
+        }
 
-        rex_file::put($path, $content);
+        // the temp file is placed inside the project to keep the final move to the media folder atomic
+        $sanitizedFile = rex_path::addonCache('mediapool', 'sanitize/' . bin2hex(random_bytes(16)) . '.svg');
+
+        if (!rex_file::put($sanitizedFile, $content)) {
+            throw new rex_api_exception(rex_i18n::msg('pool_file_movefailed'));
+        }
+
+        return $sanitizedFile;
     }
 }

--- a/redaxo/src/addons/mediapool/tests/media_service_test.php
+++ b/redaxo/src/addons/mediapool/tests/media_service_test.php
@@ -1,0 +1,125 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+final class rex_media_service_test extends TestCase
+{
+    private const EVIL_SVG = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><circle r="1" onclick="alert(2)"/></svg>';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        rex_dir::create(self::getPath());
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        rex_dir::delete(self::getPath());
+        rex_dir::delete(self::getTempPath());
+    }
+
+    private static function getPath(string $file = ''): string
+    {
+        return rex_path::addonData('tests', 'rex_media_service_test/' . $file);
+    }
+
+    private static function getTempPath(): string
+    {
+        return rex_path::addonCache('mediapool', 'sanitize');
+    }
+
+    private static function moveMedia(string $srcFile, string $dstFile, ?string $type): void
+    {
+        (new ReflectionMethod(rex_media_service::class, 'moveMedia'))->invoke(null, $srcFile, $dstFile, $type);
+    }
+
+    private static function assertSanitized(string $file): void
+    {
+        $content = rex_file::get($file);
+
+        self::assertIsString($content);
+        self::assertStringNotContainsString('<script', $content);
+        self::assertStringNotContainsString('onclick', $content);
+        self::assertStringContainsString('<circle', $content);
+    }
+
+    public function testMoveSanitizesSvg(): void
+    {
+        $srcFile = self::getPath('source.svg');
+        $dstFile = self::getPath('target.svg');
+        rex_file::put($srcFile, self::EVIL_SVG);
+
+        self::moveMedia($srcFile, $dstFile, 'image/svg+xml');
+
+        self::assertSanitized($dstFile);
+        self::assertFileDoesNotExist($srcFile);
+    }
+
+    /**
+     * Uploads are sanitized before they are moved, so the source file is a php upload temp file without extension.
+     * The svg must be detected via the mime type or via the extension of the target file.
+     */
+    public function testMoveSanitizesSvgWithoutSourceExtension(): void
+    {
+        $srcFile = self::getPath('phpUpl04d');
+        $dstFile = self::getPath('target.svg');
+        rex_file::put($srcFile, self::EVIL_SVG);
+
+        self::moveMedia($srcFile, $dstFile, null);
+
+        self::assertSanitized($dstFile);
+    }
+
+    public function testMoveSanitizesSvgInPlace(): void
+    {
+        $file = self::getPath('inplace.svg');
+        rex_file::put($file, self::EVIL_SVG);
+
+        self::moveMedia($file, $file, 'image/svg+xml');
+
+        self::assertSanitized($file);
+    }
+
+    public function testMoveRejectsUnparsableSvg(): void
+    {
+        $srcFile = self::getPath('source.svg');
+        $dstFile = self::getPath('target.svg');
+        rex_file::put($srcFile, '<svg><unclosed &&&');
+
+        try {
+            self::moveMedia($srcFile, $dstFile, 'image/svg+xml');
+            self::fail('Expected a rex_api_exception');
+        } catch (rex_api_exception) {
+            // expected
+        }
+
+        self::assertFileDoesNotExist($dstFile);
+    }
+
+    public function testMoveKeepsOtherFilesUntouched(): void
+    {
+        $srcFile = self::getPath('source.txt');
+        $dstFile = self::getPath('target.txt');
+        rex_file::put($srcFile, self::EVIL_SVG);
+
+        self::moveMedia($srcFile, $dstFile, 'text/plain');
+
+        self::assertSame(self::EVIL_SVG, rex_file::get($dstFile));
+        self::assertFileDoesNotExist($srcFile);
+    }
+
+    public function testMoveRemovesTempFile(): void
+    {
+        $srcFile = self::getPath('source.svg');
+        $dstFile = self::getPath('target.svg');
+        rex_file::put($srcFile, self::EVIL_SVG);
+
+        self::moveMedia($srcFile, $dstFile, 'image/svg+xml');
+
+        self::assertSame([], glob(self::getTempPath() . '/*') ?: []);
+    }
+}


### PR DESCRIPTION
Uploaded svgs are now sanitized into a temp file and only the sanitized file is moved into the media folder.

Details are intentionally brief here — the relevant parts are only mentioned in the commit message for now and will be described properly once released.