### PR TITLE
fix: check that slices belong to the permission checked article

### DIFF
--- a/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content.php
@@ -24,8 +24,10 @@ class rex_api_content_move_slice extends rex_api_function
             throw new rex_api_exception('Unable to find article with id "' . $articleId . '" and clang "' . $clang . '"!');
         }
 
+        // article_id must match: the permission check below is based on the requested article, so slices of
+        // other articles (possibly in categories the user has no permission for) must not be addressable here
         $CM = rex_sql::factory();
-        $CM->setQuery('select * from ' . rex::getTablePrefix() . 'article_slice left join ' . rex::getTablePrefix() . 'module on ' . rex::getTablePrefix() . 'article_slice.module_id=' . rex::getTablePrefix() . 'module.id where ' . rex::getTablePrefix() . 'article_slice.id=? and clang_id=?', [$sliceId, $clang]);
+        $CM->setQuery('select * from ' . rex::getTablePrefix() . 'article_slice left join ' . rex::getTablePrefix() . 'module on ' . rex::getTablePrefix() . 'article_slice.module_id=' . rex::getTablePrefix() . 'module.id where ' . rex::getTablePrefix() . 'article_slice.id=? and article_id=? and clang_id=?', [$sliceId, $articleId, $clang]);
         if (1 != $CM->getRows()) {
             throw new rex_api_exception(rex_i18n::msg('module_not_found'));
         }

--- a/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_slice_status.php
+++ b/redaxo/src/addons/structure/plugins/content/lib/api_functions/api_content_slice_status.php
@@ -32,6 +32,14 @@ class rex_api_content_slice_status extends rex_api_function
         $sliceId = rex_request('slice_id', 'int');
         $status = rex_request('status', 'int');
 
+        // the slice must belong to the article whose category permission was checked above, otherwise slices of
+        // categories the user has no permission for could be addressed
+        $slice = rex_sql::factory();
+        $slice->setQuery('SELECT id FROM ' . rex::getTable('article_slice') . ' WHERE id = ? AND article_id = ? AND clang_id = ?', [$sliceId, $articleId, $clang]);
+        if (1 !== $slice->getRows()) {
+            throw new rex_api_exception(rex_i18n::msg('no_rights_to_this_function'));
+        }
+
         rex_content_service::sliceStatus($sliceId, $status);
 
         return new rex_api_result(true);

--- a/redaxo/src/addons/structure/plugins/content/pages/content.php
+++ b/redaxo/src/addons/structure/plugins/content/pages/content.php
@@ -94,7 +94,10 @@ echo rex_extension::registerPoint(new rex_extension_point('STRUCTURE_CONTENT_HEA
 $user = rex::requireUser();
 
 // ----------------- HAT USER DIE RECHTE AN DIESEM ARTICLE ODER NICHT
-if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
+if (
+    !$user->getComplexPerm('clang')->hasPerm($clang)
+    || !$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)
+) {
     // ----- hat keine rechte an diesem artikel
     echo rex_view::warning(rex_i18n::msg('no_rights_to_edit'));
 } else {
@@ -113,7 +116,9 @@ if (!$user->getComplexPerm('structure')->hasCategoryPerm($categoryId)) {
         $moduleId = null;
         if ('edit' == $function || 'delete' == $function) {
             // edit/ delete
-            $CM->setQuery('SELECT * FROM ' . rex::getTablePrefix() . 'article_slice LEFT JOIN ' . rex::getTablePrefix() . 'module ON ' . rex::getTablePrefix() . 'article_slice.module_id=' . rex::getTablePrefix() . 'module.id WHERE ' . rex::getTablePrefix() . 'article_slice.id=? AND clang_id=?', [$sliceId, $clang]);
+            // article_id must match: the permission check above is based on the requested article, so slices of
+            // other articles (possibly in categories the user has no permission for) must not be addressable here
+            $CM->setQuery('SELECT * FROM ' . rex::getTablePrefix() . 'article_slice LEFT JOIN ' . rex::getTablePrefix() . 'module ON ' . rex::getTablePrefix() . 'article_slice.module_id=' . rex::getTablePrefix() . 'module.id WHERE ' . rex::getTablePrefix() . 'article_slice.id=? AND article_id=? AND clang_id=?', [$sliceId, $articleId, $clang]);
             if (1 == $CM->getRows()) {
                 $moduleId = $CM->getValue('' . rex::getTablePrefix() . 'article_slice.module_id');
             }


### PR DESCRIPTION
The writing slice operations checked the permission for the article given in the request, but acted on an independent slice reference from the same request. The content page also did not check the clang permission.

Details are intentionally brief here — the relevant parts are only mentioned in the commit message for now and will be described properly once released.