### PR TITLE
fix: add missing authorization to the history plugin and the working version preview

### DIFF
--- a/redaxo/src/addons/structure/plugins/history/boot.php
+++ b/redaxo/src/addons/structure/plugins/history/boot.php
@@ -52,11 +52,23 @@ if ('' != $historyDate) {
         $article->setEval(true);
     });
 
-    rex_extension::register('ART_SLICES_QUERY', static function (rex_extension_point $ep) {
+    // The article id is not known in ART_INIT yet (that extension point is fired in the constructor, before
+    // setArticleId()), so the article specific permissions can only be checked here, where the slices of the
+    // history are about to be fetched.
+    rex_extension::register('ART_SLICES_QUERY', static function (rex_extension_point $ep) use ($user) {
         $historyDate = rex_request('rex_history_date', 'string');
         $article = $ep->getParam('article');
 
         if ($article instanceof rex_article_content && $article->getArticleId() == rex_article::getCurrentId()) {
+            $historyArticle = rex_article::get($article->getArticleId(), $article->getClangId());
+            if (
+                !$historyArticle instanceof rex_article
+                || !$user->getComplexPerm('clang')->hasPerm($article->getClangId())
+                || !$user->getComplexPerm('structure')->hasCategoryPerm($historyArticle->getCategoryId())
+            ) {
+                throw new rex_http_exception(new rex_exception('no permission for the history of this article'), rex_response::HTTP_FORBIDDEN);
+            }
+
             $articleLimit = '';
             if (0 != $article->getArticleId()) {
                 $articleLimit = ' AND ' . rex::getTablePrefix() . 'article_slice.article_id=' . $article->getArticleId();
@@ -111,7 +123,26 @@ if (rex::isBackend() && rex::getUser()?->hasPerm('history[article_rollback]')) {
     rex_view::addCssFile($plugin->getAssetsUrl('history.css'));
     rex_view::addJsFile($plugin->getAssetsUrl('history.js'), [rex_view::JS_IMMUTABLE => true]);
 
-    switch (rex_request('rex_history_function', 'string')) {
+    $historyFunction = rex_request('rex_history_function', 'string');
+    $articleId = rex_request('history_article_id', 'int');
+    $clangId = rex_request('history_clang_id', 'int');
+
+    if (in_array($historyFunction, ['snap', 'layer'], true)) {
+        $historyArticle = rex_article::get($articleId, $clangId);
+        $user = rex::requireUser();
+
+        if (
+            !$historyArticle instanceof rex_article
+            || !$user->getComplexPerm('clang')->hasPerm($clangId)
+            || !$user->getComplexPerm('structure')->hasCategoryPerm($historyArticle->getCategoryId())
+        ) {
+            rex_response::setStatus(rex_response::HTTP_FORBIDDEN);
+            rex_response::sendContent(rex_i18n::msg('no_rights_to_this_function'), 'text/plain');
+            exit;
+        }
+    }
+
+    switch ($historyFunction) {
         case 'snap':
             if (!rex_csrf_token::factory('structure_history')->isValid()) {
                 rex_response::setStatus(rex_response::HTTP_FORBIDDEN);
@@ -119,15 +150,11 @@ if (rex::isBackend() && rex::getUser()?->hasPerm('history[article_rollback]')) {
                 exit;
             }
 
-            $articleId = rex_request('history_article_id', 'int');
-            $clangId = rex_request('history_clang_id', 'int');
             $historyDate = rex_request('history_date', 'string');
             rex_article_slice_history::restoreSnapshot($historyDate, $articleId, $clangId);
 
             // no break
         case 'layer':
-            $articleId = rex_request('history_article_id', 'int');
-            $clangId = rex_request('history_clang_id', 'int');
             $versions = rex_article_slice_history::getSnapshots($articleId, $clangId);
 
             $select1 = [];

--- a/redaxo/src/addons/structure/plugins/version/boot.php
+++ b/redaxo/src/addons/structure/plugins/version/boot.php
@@ -15,7 +15,9 @@ rex_extension::register('ART_INIT', static function (rex_extension_point $ep) {
         return;
     }
 
-    if (!rex_backend_login::hasSession()) {
+    // createUser() instead of hasSession(): it validates that the session is still valid and that the user
+    // still exists and is active
+    if (!rex_backend_login::createUser()) {
         $fragment = new rex_fragment([
             'content' => '<p>No permission for the working version. You need to be logged into the REDAXO backend at the same time.</p>',
         ]);
@@ -24,13 +26,51 @@ rex_extension::register('ART_INIT', static function (rex_extension_point $ep) {
         exit;
     }
 
-    /** @var rex_article_content_base $article */
+    // Plain rex_article_content_base instances are used by rex_content_service::generateArticleContent() to
+    // write the article cache. Switching those to the working version would persist unpublished content into
+    // the cache file, which is served to everybody afterwards.
     $article = $ep->getParam('article');
-    $article->setSliceRevision($version);
-    if ($article instanceof rex_article_content) {
-        $article->getContentAsQuery();
+    if (!$article instanceof rex_article_content) {
+        return;
     }
+
+    // the preview is limited to the requested article, articles embedded via REX_ARTICLE[] keep the live version
+    $articleId = rex_type::nullOrInt($ep->getParam('article_id'));
+    if (null !== $articleId && $articleId !== rex_article::getCurrentId()) {
+        return;
+    }
+
+    $article->setSliceRevision($version);
+    $article->getContentAsQuery();
     $article->setEval(true);
+});
+
+// The article id is not known in ART_INIT yet (that extension point is fired in the constructor, before
+// setArticleId()), so the article specific permissions can only be checked here, where the slices of the
+// working version are about to be fetched.
+rex_extension::register('ART_SLICES_QUERY', static function (rex_extension_point $ep) {
+    if (rex_article_revision::WORK != rex_request('rex_version', 'int')) {
+        return null;
+    }
+
+    $article = $ep->getParam('article');
+    if (!$article instanceof rex_article_content || $article->getArticleId() !== rex_article::getCurrentId()) {
+        return null;
+    }
+
+    $user = rex_backend_login::createUser();
+    $previewArticle = rex_article::get($article->getArticleId(), $article->getClangId());
+
+    if (
+        !$user
+        || !$previewArticle instanceof rex_article
+        || !$user->getComplexPerm('clang')->hasPerm($article->getClangId())
+        || !$user->getComplexPerm('structure')->hasCategoryPerm($previewArticle->getCategoryId())
+    ) {
+        throw new rex_http_exception(new rex_exception('no permission for the working version of this article'), rex_response::HTTP_FORBIDDEN);
+    }
+
+    return null;
 });
 
 rex_extension::register('STRUCTURE_CONTENT_HEADER', static function (rex_extension_point $ep) {


### PR DESCRIPTION
Both the history snapshots (backend and frontend preview) and the frontend preview of the working version were shown without checking whether the user may access the article and language at all.

Details are intentionally brief here — the relevant parts are only mentioned in the commit messages for now and will be described properly once released.