### PR TITLE
fix: escape values in media and link widgets

### DIFF
--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -1306,7 +1306,6 @@
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$name]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedOperand>
   </file>
   <file src="redaxo/src/addons/mediapool/lib/var_medialist.php">
@@ -1324,7 +1323,6 @@
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$name]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedOperand>
   </file>
   <file src="redaxo/src/addons/mediapool/pages/index.php">
@@ -2053,7 +2051,6 @@
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$name]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedOperand>
     <PossiblyNullReference>
       <code><![CDATA[getId]]></code>
@@ -2072,7 +2069,6 @@
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$name]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedOperand>
     <PossiblyNullReference>
       <code><![CDATA[getId]]></code>

--- a/redaxo/src/addons/mediapool/lib/var_media.php
+++ b/redaxo/src/addons/mediapool/lib/var_media.php
@@ -90,7 +90,7 @@ class rex_var_media extends rex_var
 
         $e = [];
         $e['before'] = '<div class="rex-js-widget' . $wdgtClass . '">';
-        $e['field'] = '<input class="form-control" type="text" name="' . $name . '" value="' . $value . '" id="REX_MEDIA_' . $id . '" readonly />';
+        $e['field'] = '<input class="form-control" type="text" name="' . $name . '" value="' . rex_escape((string) $value) . '" id="REX_MEDIA_' . $id . '" readonly />';
         $e['functionButtons'] = '
                 <a href="#" class="btn btn-popup" onclick="' . $openFunc . 'return false;" title="' . rex_i18n::msg('var_media_open') . '"' . $disabled . '><i class="rex-icon rex-icon-open-mediapool"></i></a>
                 <a href="#" class="btn btn-popup" onclick="' . $addFunc . 'return false;" title="' . rex_i18n::msg('var_media_new') . '"' . $disabled . '><i class="rex-icon rex-icon-add-media"></i></a>

--- a/redaxo/src/addons/mediapool/lib/var_medialist.php
+++ b/redaxo/src/addons/mediapool/lib/var_medialist.php
@@ -68,7 +68,7 @@ class rex_var_medialist extends rex_var
         $medialistarray = null === $value ? [] : explode(',', $value);
         foreach ($medialistarray as $file) {
             if ('' != $file) {
-                $options .= '<option value="' . $file . '">' . $file . '</option>';
+                $options .= '<option value="' . rex_escape($file) . '">' . rex_escape($file) . '</option>';
             }
         }
 
@@ -88,7 +88,7 @@ class rex_var_medialist extends rex_var
 
         $e = [];
         $e['before'] = '<div class="rex-js-widget' . $wdgtClass . '">';
-        $e['field'] = '<select class="form-control" name="REX_MEDIALIST_SELECT[' . $id . ']" id="REX_MEDIALIST_SELECT_' . $id . '" size="10">' . $options . '</select><input type="hidden" name="' . $name . '" id="REX_MEDIALIST_' . $id . '" value="' . $value . '" />';
+        $e['field'] = '<select class="form-control" name="REX_MEDIALIST_SELECT[' . $id . ']" id="REX_MEDIALIST_SELECT_' . $id . '" size="10">' . $options . '</select><input type="hidden" name="' . $name . '" id="REX_MEDIALIST_' . $id . '" value="' . rex_escape((string) $value) . '" />';
         $e['moveButtons'] = '
                 <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $quotedId . ',\'top\');return false;" title="' . rex_i18n::msg('var_medialist_move_top') . '"><i class="rex-icon rex-icon-top"></i></a>
                 <a href="#" class="btn btn-popup" onclick="moveREXMedialist(' . $quotedId . ',\'up\');return false;" title="' . rex_i18n::msg('var_medialist_move_up') . '"><i class="rex-icon rex-icon-up"></i></a>

--- a/redaxo/src/addons/structure/lib/linkmap/var_link.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_link.php
@@ -77,7 +77,7 @@ class rex_var_link extends rex_var
         }
 
         $e = [];
-        $e['field'] = '<input class="form-control" type="text" name="REX_LINK_NAME[' . $id . ']" value="' . rex_escape($artName) . '" id="REX_LINK_' . $id . '_NAME" readonly="readonly" /><input type="hidden" name="' . $name . '" id="REX_LINK_' . $id . '" value="' . $value . '" />';
+        $e['field'] = '<input class="form-control" type="text" name="REX_LINK_NAME[' . $id . ']" value="' . rex_escape($artName) . '" id="REX_LINK_' . $id . '_NAME" readonly="readonly" /><input type="hidden" name="' . $name . '" id="REX_LINK_' . $id . '" value="' . rex_escape((string) $value) . '" />';
         $e['functionButtons'] = '
                         <a href="#" class="btn btn-popup' . $class . '" onclick="' . $openFunc . 'return false;" title="' . rex_i18n::msg('var_link_open') . '"><i class="rex-icon rex-icon-open-linkmap"></i></a>
                         <a href="#" class="btn btn-popup' . $class . '" onclick="' . $deleteFunc . 'return false;" title="' . rex_i18n::msg('var_link_delete') . '"><i class="rex-icon rex-icon-delete-link"></i></a>';

--- a/redaxo/src/addons/structure/lib/linkmap/var_linklist.php
+++ b/redaxo/src/addons/structure/lib/linkmap/var_linklist.php
@@ -61,7 +61,7 @@ class rex_var_linklist extends rex_var
                 continue;
             }
             if ($article = rex_article::get((int) $link)) {
-                $options .= '<option value="' . $link . '">' . rex_escape(trim(sprintf('%s [%s]', $article->getName(), $article->getId()))) . '</option>';
+                $options .= '<option value="' . $article->getId() . '">' . rex_escape(trim(sprintf('%s [%s]', $article->getName(), $article->getId()))) . '</option>';
             }
         }
 
@@ -80,7 +80,7 @@ class rex_var_linklist extends rex_var
                 <select class="form-control" name="REX_LINKLIST_SELECT[' . $id . ']" id="REX_LINKLIST_SELECT_' . $id . '" size="10">
                     ' . $options . '
                 </select>
-                <input type="hidden" name="' . $name . '" id="REX_LINKLIST_' . $id . '" value="' . $value . '" />';
+                <input type="hidden" name="' . $name . '" id="REX_LINKLIST_' . $id . '" value="' . rex_escape((string) $value) . '" />';
         $e['moveButtons'] = '
                     <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $quotedId . ',\'top\');return false;" title="' . rex_i18n::msg('var_linklist_move_top') . '"><i class="rex-icon rex-icon-top"></i></a>
                     <a href="#" class="btn btn-popup" onclick="moveREXLinklist(' . $quotedId . ',\'up\');return false;" title="' . rex_i18n::msg('var_linklist_move_up') . '"><i class="rex-icon rex-icon-up"></i></a>


### PR DESCRIPTION
The media, medialist, link and linklist widgets rendered their value unescaped into the `value` attribute of their input fields, and the list widgets did the same for their option entries.

Escaping happens at the sink, so all callers are covered — the slice editor, the metainfo fields and the `rex_form` elements.

The linklist option value now uses the resolved article id instead of the raw list entry.