### PR TITLE
fix: bind history plugin temp login to an active user session

### DIFF
--- a/.tools/phpstan/baseline/missingType.parameter.php
+++ b/.tools/phpstan/baseline/missingType.parameter.php
@@ -479,46 +479,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../redaxo/src/addons/structure/plugins/content/lib/event_select.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Method rex_history_login::checkTempSession() has parameter $historyLogin with no type specified.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../redaxo/src/addons/structure/plugins/history/lib/history_login.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method rex_history_login::checkTempSession() has parameter $historySession with no type specified.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../redaxo/src/addons/structure/plugins/history/lib/history_login.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method rex_history_login::checkTempSession() has parameter $historyValidtime with no type specified.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../redaxo/src/addons/structure/plugins/history/lib/history_login.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method rex_history_login::createSessionKey() has parameter $login with no type specified.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../redaxo/src/addons/structure/plugins/history/lib/history_login.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method rex_history_login::createSessionKey() has parameter $session with no type specified.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../redaxo/src/addons/structure/plugins/history/lib/history_login.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method rex_history_login::createSessionKey() has parameter $validtime with no type specified.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../redaxo/src/addons/structure/plugins/history/lib/history_login.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method rex_history_login::verifySessionKey() has parameter $key1 with no type specified.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../redaxo/src/addons/structure/plugins/history/lib/history_login.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method rex_history_login::verifySessionKey() has parameter $key2 with no type specified.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../redaxo/src/addons/structure/plugins/history/lib/history_login.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Method rex_form_container_element::addField() has parameter $value with no type specified.',
     'count' => 1,
     'path' => __DIR__ . '/../../../redaxo/src/core/lib/form/elements/container.php',

--- a/.tools/psalm/baseline.xml
+++ b/.tools/psalm/baseline.xml
@@ -2888,21 +2888,6 @@
       <code><![CDATA[$period]]></code>
     </MixedOperand>
   </file>
-  <file src="redaxo/src/addons/structure/plugins/history/lib/history_login.php">
-    <MixedArgument>
-      <code><![CDATA[$key1]]></code>
-      <code><![CDATA[$key2]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[[':login' => $historyLogin]]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedOperand>
-      <code><![CDATA[$historyLogin]]></code>
-      <code><![CDATA[$historyValidtime]]></code>
-      <code><![CDATA[$login]]></code>
-      <code><![CDATA[$validtime]]></code>
-    </MixedOperand>
-  </file>
   <file src="redaxo/src/addons/structure/plugins/version/lib/revision.php">
     <NoValue>
       <code><![CDATA[$fromRevisionId]]></code>

--- a/redaxo/src/addons/structure/plugins/history/boot.php
+++ b/redaxo/src/addons/structure/plugins/history/boot.php
@@ -198,7 +198,7 @@ if (rex::isBackend() && rex::getUser()?->hasPerm('history[article_rollback]')) {
                 $userLogin = $user->getLogin();
                 $historyValidTime = new DateTime();
                 $historyValidTime = $historyValidTime->modify('+10 Minutes')->format('YmdHis'); // 10 minutes valid key
-                $userHistorySession = rex_history_login::createSessionKey($userLogin, $user->getValue('session_id'), $historyValidTime);
+                $userHistorySession = rex_history_login::createSessionKey($userLogin, $historyValidTime);
                 $articleLink = rex_getUrl(rex_article::getCurrentId(), rex_clang::getCurrentId(), ['rex_history_login' => $userLogin, 'rex_history_session' => $userHistorySession, 'rex_history_validtime' => $historyValidTime], '&');
             }
 

--- a/redaxo/src/addons/structure/plugins/history/boot.php
+++ b/redaxo/src/addons/structure/plugins/history/boot.php
@@ -27,8 +27,12 @@ if ('' != $historyDate) {
             if ($login->checkTempSession($historyLogin, $historySession, $historyValidtime)) {
                 $user = $login->getUser();
                 rex::setProperty('user', $user);
-                rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) use ($login) {
+
+                // A shutdown function (not an OUTPUT_FILTER) so cleanup runs even when the request aborts
+                // before output — e.g. a bogus rex-api-call — which would otherwise leave a usable session.
+                register_shutdown_function(static function () use ($login) {
                     $login->deleteSession();
+                    rex_user_session::getInstance()->clearCurrentSession();
                 });
             }
         }

--- a/redaxo/src/addons/structure/plugins/history/lib/history_login.php
+++ b/redaxo/src/addons/structure/plugins/history/lib/history_login.php
@@ -10,13 +10,34 @@
 class rex_history_login extends rex_backend_login
 {
     /** @return bool */
-    public function checkTempSession($historyLogin, $historySession, $historyValidtime)
+    public function checkTempSession(string $historyLogin, string $historySession, string $historyValidtime)
     {
         $userSql = rex_sql::factory($this->DB);
         $userSql->setQuery($this->loginQuery, [':login' => $historyLogin]);
 
-        if (1 == $userSql->getRows()) {
-            if (self::verifySessionKey($historyLogin . $userSql->getValue('session_id') . $historyValidtime, $historySession)) {
+        if (1 != $userSql->getRows()) {
+            return false;
+        }
+
+        // Only non-expired sessions count (same rule as clearExpiredSessions, which runs on login only,
+        // so expired rows can linger). Otherwise a known but expired session id could still forge a token.
+        $sessionSql = rex_sql::factory($this->DB);
+        $sessionSql->setQuery(
+            'SELECT session_id FROM ' . rex::getTable('user_session') . '
+                WHERE user_id = ? AND UNIX_TIMESTAMP(last_activity) >= IF(cookie_key IS NULL, ?, ?)',
+            [
+                (int) $userSql->getValue($this->idColumn),
+                time() - (int) rex::getProperty('session_duration'),
+                strtotime('-' . rex_user_session::STAY_LOGGED_IN_DURATION . ' months'),
+            ],
+        );
+
+        // The session id is the shared secret — only its HMAC is in the URL. A matching row also proves
+        // the session is still alive: logout removes it and thereby invalidates the token.
+        foreach ($sessionSql as $session) {
+            $expected = self::hashSessionKey($historyLogin, $historyValidtime, (string) $session->getValue('session_id'));
+
+            if (hash_equals($expected, $historySession)) {
                 $this->user = $userSql;
                 $this->setSessionVar(rex_login::SESSION_LAST_ACTIVITY, time());
                 $this->setSessionVar(rex_login::SESSION_USER_ID, $this->user->getValue($this->idColumn));
@@ -28,15 +49,14 @@ class rex_history_login extends rex_backend_login
         return false;
     }
 
-    /** @return string|null */
-    public static function createSessionKey(#[SensitiveParameter] $login, $session, $validtime)
+    /** @return string */
+    public static function createSessionKey(string $login, string $validtime)
     {
-        return password_hash($login . $session . $validtime, PASSWORD_DEFAULT);
+        return self::hashSessionKey($login, $validtime, (string) session_id());
     }
 
-    /** @return bool */
-    public static function verifySessionKey($key1, $key2)
+    private static function hashSessionKey(string $login, string $validtime, #[SensitiveParameter] string $sessionId): string
     {
-        return password_verify($key1, $key2);
+        return hash_hmac('sha256', $login . '|' . $validtime, $sessionId);
     }
 }


### PR DESCRIPTION
The temporary login of the history plugin could be used without an active user session. This ties the token to a live session and makes sure the temp session is always cleaned up afterwards.