### PR TITLE
docs: link security advisories to the repo instead of the global advisory database

### DIFF
--- a/redaxo/src/addons/mediapool/CHANGELOG.md
+++ b/redaxo/src/addons/mediapool/CHANGELOG.md
@@ -6,9 +6,9 @@ Version 2.18.4 – 03.08.2026
 
 ### Security
 
-* Beim Verschieben mehrerer Medien wurde nur die Berechtigung für die Ziel-Kategorie geprüft, nicht für die Quell-Kategorie der Dateien; zudem waren in der Liste auch Medien auswählbar, für deren Kategorie keine Berechtigung besteht ([GHSA-j9mx-x52f-48cw](https://github.com/advisories/GHSA-j9mx-x52f-48cw)) (gemeldet von @V-C-Williams) (@gharlan)
-* SVG-Uploads wurden erst in den Medienordner verschoben und dann bereinigt, wodurch der unbereinigte Inhalt kurzzeitig – und bei nicht abgeschlossener Bereinigung dauerhaft – öffentlich erreichbar war (Stored XSS) ([GHSA-2p3g-jr7p-qwwx](https://github.com/advisories/GHSA-2p3g-jr7p-qwwx)) (gemeldet von @alhamrizvi-cloud) (@gharlan)
-* Media- und Medialist-Widget: Werte werden escaped ausgegeben, vorher war Stored XSS möglich ([GHSA-5wmj-5x79-rr87](https://github.com/advisories/GHSA-5wmj-5x79-rr87)) (gemeldet von @V-C-Williams) (@gharlan)
+* Beim Verschieben mehrerer Medien wurde nur die Berechtigung für die Ziel-Kategorie geprüft, nicht für die Quell-Kategorie der Dateien; zudem waren in der Liste auch Medien auswählbar, für deren Kategorie keine Berechtigung besteht ([GHSA-j9mx-x52f-48cw](https://github.com/redaxo/core/security/advisories/GHSA-j9mx-x52f-48cw)) (gemeldet von @V-C-Williams) (@gharlan)
+* SVG-Uploads wurden erst in den Medienordner verschoben und dann bereinigt, wodurch der unbereinigte Inhalt kurzzeitig – und bei nicht abgeschlossener Bereinigung dauerhaft – öffentlich erreichbar war (Stored XSS) ([GHSA-2p3g-jr7p-qwwx](https://github.com/redaxo/core/security/advisories/GHSA-2p3g-jr7p-qwwx)) (gemeldet von @alhamrizvi-cloud) (@gharlan)
+* Media- und Medialist-Widget: Werte werden escaped ausgegeben, vorher war Stored XSS möglich ([GHSA-5wmj-5x79-rr87](https://github.com/redaxo/core/security/advisories/GHSA-5wmj-5x79-rr87)) (gemeldet von @V-C-Williams) (@gharlan)
 
 ### Bugfixes
 

--- a/redaxo/src/addons/structure/CHANGELOG.md
+++ b/redaxo/src/addons/structure/CHANGELOG.md
@@ -6,11 +6,11 @@ Version 2.20.4 – 03.08.2026
 
 ### Security
 
-* History: Der temporäre Frontend-Login konnte ohne vorherige Authentifizierung gefälscht werden, wodurch sich für jeden bekannten Login-Namen – auch für Administratoren – eine Backend-Session erlangen ließ ([GHSA-px8f-whj8-hrpq](https://github.com/advisories/GHSA-px8f-whj8-hrpq)) (gemeldet von @V-C-Williams) (@gharlan)
-* Content: Bei schreibenden Slice-Operationen (löschen, bearbeiten, verschieben, Status ändern) wurde nicht geprüft, ob der Slice zu dem Artikel gehört, für den die Kategorie-Berechtigung geprüft wurde; auf der Content-Seite fehlte zusätzlich die Prüfung der Sprach-Berechtigung ([GHSA-5m63-c3qx-wq8v](https://github.com/advisories/GHSA-5m63-c3qx-wq8v)) (gemeldet von @V-C-Williams) (@gharlan)
-* Version: Die Frontend-Vorschau der Arbeitsversion prüfte nur, ob eine Backend-Session existiert, aber weder Kategorie- noch Sprach-Berechtigung; außerdem wurden auch per `REX_ARTICLE[]` eingebundene Artikel in der Arbeitsversion ausgegeben ([GHSA-v4m9-jvvr-83cx](https://github.com/advisories/GHSA-v4m9-jvvr-83cx)) (@gharlan)
-* History: Das Auflisten und Wiederherstellen von Versionen sowie die Frontend-Vorschau prüften nicht die Berechtigung für den betroffenen Artikel und dessen Sprache ([GHSA-v4m9-jvvr-83cx](https://github.com/advisories/GHSA-v4m9-jvvr-83cx)) (@gharlan)
-* Link- und Linklist-Widget: Werte werden escaped ausgegeben, vorher war Stored XSS möglich ([GHSA-5wmj-5x79-rr87](https://github.com/advisories/GHSA-5wmj-5x79-rr87)) (gemeldet von @V-C-Williams) (@gharlan)
+* History: Der temporäre Frontend-Login konnte ohne vorherige Authentifizierung gefälscht werden, wodurch sich für jeden bekannten Login-Namen – auch für Administratoren – eine Backend-Session erlangen ließ ([GHSA-px8f-whj8-hrpq](https://github.com/redaxo/core/security/advisories/GHSA-px8f-whj8-hrpq)) (gemeldet von @V-C-Williams) (@gharlan)
+* Content: Bei schreibenden Slice-Operationen (löschen, bearbeiten, verschieben, Status ändern) wurde nicht geprüft, ob der Slice zu dem Artikel gehört, für den die Kategorie-Berechtigung geprüft wurde; auf der Content-Seite fehlte zusätzlich die Prüfung der Sprach-Berechtigung ([GHSA-5m63-c3qx-wq8v](https://github.com/redaxo/core/security/advisories/GHSA-5m63-c3qx-wq8v)) (gemeldet von @V-C-Williams) (@gharlan)
+* Version: Die Frontend-Vorschau der Arbeitsversion prüfte nur, ob eine Backend-Session existiert, aber weder Kategorie- noch Sprach-Berechtigung; außerdem wurden auch per `REX_ARTICLE[]` eingebundene Artikel in der Arbeitsversion ausgegeben ([GHSA-v4m9-jvvr-83cx](https://github.com/redaxo/core/security/advisories/GHSA-v4m9-jvvr-83cx)) (@gharlan)
+* History: Das Auflisten und Wiederherstellen von Versionen sowie die Frontend-Vorschau prüften nicht die Berechtigung für den betroffenen Artikel und dessen Sprache ([GHSA-v4m9-jvvr-83cx](https://github.com/redaxo/core/security/advisories/GHSA-v4m9-jvvr-83cx)) (@gharlan)
+* Link- und Linklist-Widget: Werte werden escaped ausgegeben, vorher war Stored XSS möglich ([GHSA-5wmj-5x79-rr87](https://github.com/redaxo/core/security/advisories/GHSA-5wmj-5x79-rr87)) (gemeldet von @V-C-Williams) (@gharlan)
 
 
 Version 2.20.3 – 31.07.2026

--- a/redaxo/src/core/CHANGELOG.md
+++ b/redaxo/src/core/CHANGELOG.md
@@ -8,7 +8,7 @@ Version 5.21.4 – 03.08.2026
 
 Dieses Release behebt Sicherheitslücken in den Addons `mediapool`, `metainfo` und `structure`. Ein Update wird allen Installationen empfohlen, Details stehen in den Changelogs der jeweiligen Addons.
 
-**Besonders dringend ist das Update für Installationen mit aktivem Plugin `structure/history`:** Dort war ohne Anmeldung eine Backend-Session für beliebige Accounts – auch für Administratoren – erlangbar ([GHSA-px8f-whj8-hrpq](https://github.com/advisories/GHSA-px8f-whj8-hrpq)). Ist ein sofortiges Update nicht möglich, sollte das Plugin deaktiviert werden.
+**Besonders dringend ist das Update für Installationen mit aktivem Plugin `structure/history`:** Dort war ohne Anmeldung eine Backend-Session für beliebige Accounts – auch für Administratoren – erlangbar ([GHSA-px8f-whj8-hrpq](https://github.com/redaxo/core/security/advisories/GHSA-px8f-whj8-hrpq)). Ist ein sofortiges Update nicht möglich, sollte das Plugin deaktiviert werden.
 
 
 Version 5.21.3 – 31.07.2026


### PR DESCRIPTION
Die Advisory-Links in den 5.21.4-Changelogs zeigen auf `github.com/advisories/GHSA-…` – die globale GitHub Advisory Database. Dort sind die Advisories (noch) nicht gelistet, alle sechs Links laufen daher in einen 404.

Die GHSA-IDs selbst stimmen, nur die URL-Form war falsch: Repo-Advisories sind unter `github.com/redaxo/core/security/advisories/GHSA-…` erreichbar.

Betroffen: core, mediapool, structure (9 Links, 6 unterschiedliche IDs). Der phpmailer-Eintrag bleibt unverändert – CVE-2020-13625 ist tatsächlich in der globalen DB.

Die Release Notes zu 5.21.4 sind bereits entsprechend korrigiert.