### PR TITLE
fix: qualify and order the foreign key lookup in rex_sql_table

### DIFF
--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -141,12 +141,20 @@ class rex_sql_table
             $this->indexesExisting[$indexName] = $indexName;
         }
 
+        // Constraint names are only unique per schema, so the join must be qualified by schema and table.
+        // Otherwise same-named constraints in other databases on the same server are joined in as well.
+        // ORDER BY keeps the result deterministic: INFORMATION_SCHEMA gives no ordering guarantee, which
+        // otherwise leaves both the order of the foreign keys and the column order within a composite key to chance.
         /** @var list<array{CONSTRAINT_NAME: string, COLUMN_NAME: string, REFERENCED_TABLE_NAME: string, REFERENCED_COLUMN_NAME: string, UPDATE_RULE: rex_sql_foreign_key::*, DELETE_RULE: rex_sql_foreign_key::*}> $foreignKeyParts */
         $foreignKeyParts = $this->sql->getArray('
             SELECT c.CONSTRAINT_NAME, c.REFERENCED_TABLE_NAME, c.UPDATE_RULE, c.DELETE_RULE, k.COLUMN_NAME, k.REFERENCED_COLUMN_NAME
             FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS c
-            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE k ON c.CONSTRAINT_NAME = k.CONSTRAINT_NAME
-            WHERE c.CONSTRAINT_SCHEMA = DATABASE() AND c.TABLE_NAME = ?', [$name]);
+            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE k
+                ON c.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA
+                AND c.CONSTRAINT_NAME = k.CONSTRAINT_NAME
+                AND c.TABLE_NAME = k.TABLE_NAME
+            WHERE c.CONSTRAINT_SCHEMA = DATABASE() AND c.TABLE_NAME = ?
+            ORDER BY c.CONSTRAINT_NAME, k.ORDINAL_POSITION', [$name]);
         $foreignKeys = [];
         foreach ($foreignKeyParts as $part) {
             $foreignKeys[$part['CONSTRAINT_NAME']][] = $part;

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -141,10 +141,8 @@ class rex_sql_table
             $this->indexesExisting[$indexName] = $indexName;
         }
 
-        // Constraint names are only unique per schema, so the join must be qualified by schema and table.
-        // Otherwise same-named constraints in other databases on the same server are joined in as well.
-        // ORDER BY keeps the result deterministic: INFORMATION_SCHEMA gives no ordering guarantee, which
-        // otherwise leaves both the order of the foreign keys and the column order within a composite key to chance.
+        // KEY_COLUMN_USAGE spans all schemas and also lists unique/primary keys, so the join must be qualified.
+        // INFORMATION_SCHEMA gives no ordering guarantee, and the column order of a composite key ends up in the DDL.
         /** @var list<array{CONSTRAINT_NAME: string, COLUMN_NAME: string, REFERENCED_TABLE_NAME: string, REFERENCED_COLUMN_NAME: string, UPDATE_RULE: rex_sql_foreign_key::*, DELETE_RULE: rex_sql_foreign_key::*}> $foreignKeyParts */
         $foreignKeyParts = $this->sql->getArray('
             SELECT c.CONSTRAINT_NAME, c.REFERENCED_TABLE_NAME, c.UPDATE_RULE, c.DELETE_RULE, k.COLUMN_NAME, k.REFERENCED_COLUMN_NAME
@@ -153,6 +151,7 @@ class rex_sql_table
                 ON c.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA
                 AND c.CONSTRAINT_NAME = k.CONSTRAINT_NAME
                 AND c.TABLE_NAME = k.TABLE_NAME
+                AND k.POSITION_IN_UNIQUE_CONSTRAINT IS NOT NULL
             WHERE c.CONSTRAINT_SCHEMA = DATABASE() AND c.TABLE_NAME = ?
             ORDER BY c.CONSTRAINT_NAME, k.ORDINAL_POSITION', [$name]);
         $foreignKeys = [];

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -516,6 +516,12 @@ final class rex_sql_table_test extends TestCase
         $table = rex_sql_table::get(self::TABLE);
 
         self::assertEquals($fk, $table->getForeignKey('test1_fk_config'));
+
+        // assertEquals compares arrays order-insensitively, so the column order needs its own assertion.
+        self::assertSame(
+            ['config_namespace' => 'namespace', 'config_key' => 'key'],
+            $table->getForeignKey('test1_fk_config')?->getColumns(),
+        );
     }
 
     public function testEnsureForeignKey(): void


### PR DESCRIPTION
The INFORMATION_SCHEMA lookup joined REFERENTIAL_CONSTRAINTS to KEY_COLUMN_USAGE on the constraint name alone. Constraint names are only unique per schema, so on a server hosting several databases the join also picks up same-named constraints from other schemas. On a local setup with 39 REDAXO databases, reading the two foreign keys of rex_user_session returned 78 rows instead of 2.

The duplicates usually collapse again, because the columns are collected into a map keyed by column name. They stop being harmless as soon as a same-named constraint in another database covers different columns: the foreign key then carries columns that do not belong to it, and consumers comparing against a stored schema see a difference that is not there.

The query also had no ORDER BY. INFORMATION_SCHEMA gives no ordering guarantee, so both the order of the foreign keys and the column order within a composite key were left to chance. The latter matters, since that order ends up in the generated DDL.

Qualify the join by schema and table, and order by constraint name and ordinal position.