### PR TITLE
fix: check only one folder per day in the htaccess check

### DIFF
--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -449,49 +449,52 @@ jQuery(function($){
         });
     $("[autofocus]").trigger("focus");
 
-    if ($('#rex-page-setup, #rex-page-login').length == 0 && getCookie('rex_htaccess_check') == '')
+    if ($('#rex-page-setup, #rex-page-login').length == 0 && getCookie('rex_htaccess_check') != '1')
     {
-        time = new Date();
-        time.setTime(time.getTime() + 1000 * 60 * 60 * 24);
-
-        setCookie(
-            'rex_htaccess_check',
-            '1',
-            time.toGMTString(),
-            rex.cookie_params.path,
-            rex.cookie_params.domain,
-            rex.cookie_params.secure,
-            rex.cookie_params.samesite.toLowerCase()
-        );
-
-        var allowedUrl = 'index.php';
-
-        // test urls, which is not expected to be accessible
-        // after each expected error, run a request which is expected to succeed.
-        // that way we try to make sure tools like fail2ban dont block the client
+        // urls which are not expected to be accessible
         var urls = [
             'bin/console',
-            allowedUrl,
             'data/.redaxo',
-            allowedUrl,
             'src/core/boot.php',
-            allowedUrl,
             'cache/.redaxo'
         ];
 
-        // NOTE: we have essentially a copy of this code in the setup process.
-        $.each(urls, function (i, url) {
-            $.ajax({
-                // add a human readable suffix so people get an idea what we are doing here
-                url: url + '?redaxo-security-self-test',
-                cache: false,
-                success: function (data) {
-                    if (i % 2 == 0) {
-                        $('#rex-js-page-main').prepend('<div class="alert alert-danger" style="margin-top: 20px;">The folder <code>redaxo/' + url + '</code> is insecure. Make sure this folder is not publicly accessible.</div>');
-                        setCookie('rex_htaccess_check', '');
-                    }
-                }
-            });
+        // Only one folder is checked per day. All these folders are protected by identical .htaccess
+        // files, so a broken setup (e.g. nginx or "AllowOverride None") shows up on any of them.
+        // Checking a single folder keeps the number of denied requests low enough to not trip
+        // tools like fail2ban, which ban a client after a few denied requests.
+        var previousInsecureUrl = getCookie('rex_htaccess_check');
+        var url = previousInsecureUrl !== '' ? previousInsecureUrl : urls[Math.floor(Math.random() * urls.length)];
+
+        var setCheckCookie = function (value) {
+            time = new Date();
+            time.setTime(time.getTime() + 1000 * 60 * 60 * 24);
+
+            setCookie(
+                'rex_htaccess_check',
+                value,
+                time.toGMTString(),
+                rex.cookie_params.path,
+                rex.cookie_params.domain,
+                rex.cookie_params.secure,
+                rex.cookie_params.samesite.toLowerCase()
+            );
+        };
+
+        setCheckCookie('1');
+
+        // NOTE: the setup process runs a similar check, see setup.step2.php
+        $.ajax({
+            // add a human readable suffix so people get an idea what we are doing here
+            url: url + '?redaxo-security-self-test',
+            cache: false,
+            success: function (data) {
+                $('#rex-js-page-main').prepend('<div class="alert alert-danger" style="margin-top: 20px;">The folder <code>redaxo/' + url + '</code> is insecure. Make sure this folder is not publicly accessible.</div>');
+
+                // keep checking this folder, so the warning stays visible. its request succeeds
+                // anyway, so it does not produce denied requests.
+                setCheckCookie(url);
+            }
         });
     }
 });

--- a/redaxo/src/core/pages/setup.step2.php
+++ b/redaxo/src/core/pages/setup.step2.php
@@ -29,31 +29,22 @@ $security .= '<noscript>' . rex_view::error(rex_i18n::msg('setup_no_js_security_
 $security .= '<script nonce="' . rex_response::getNonce() . '">
 
     jQuery(function($){
-        var allowedUrl = "' . rex_url::backend('index.php') . '";
-
-        // test url, which is not expected to be accessible
-        // after each expected error, run a request which is expected to succeed.
-        // that way we try to make sure tools like fail2ban dont block the client
+        // urls which are not expected to be accessible
         var urls = [
             "' . rex_url::backend('bin/console') . '",
-            allowedUrl,
             "' . rex_url::backend('data/.redaxo') . '",
-            allowedUrl,
             "' . rex_url::backend('src/core/boot.php') . '",
-            allowedUrl,
             "' . rex_url::backend('cache/.redaxo') . '"
         ];
 
-        // NOTE: we have essentially a copy of this code in checkHtaccess() - see standard.js
+        // NOTE: the backend runs a similar check, see standard.js
         $.each(urls, function (i, url) {
             $.ajax({
                 url: url,
                 cache: false,
                 success: function(data) {
-                    if (i % 2 == 0) {
-                        $(".rex-js-setup-security-message").show();
-                        $(".rex-js-setup-section").hide();
-                    }
+                    $(".rex-js-setup-security-message").show();
+                    $(".rex-js-setup-section").hide();
                 }
             });
         });


### PR DESCRIPTION
Es wurde berichtet, dass fail2ban wegen des htaccess-Checks Backend-Benutzer aussperrt.

## Warum der bisherige Schutz nicht funktioniert hat

Der Check ruft vier Ordner auf, die nicht erreichbar sein sollen, und schiebt zwischen
jeden davon einen Request auf `index.php`. Der Kommentar dazu:

> after each expected error, run a request which is expected to succeed.
> that way we try to make sure tools like fail2ban dont block the client

Das kann nicht funktionieren, aus zwei Gründen:

1. Die Requests laufen alle parallel per `$.ajax` — die gedachte Abwechslung existiert
   also gar nicht, alle sieben landen innerhalb von Millisekunden im Log.
2. Vor allem aber zählen die Filter nur *matchende* Logzeilen innerhalb ihrer `findtime`.
   Ein erfolgreicher Request setzt den Zähler nicht zurück, er landet in einem ganz
   anderen Log. Die eingestreuten `index.php`-Requests sind also wirkungslos.

Apache schreibt für jeden gesperrten Ordner eine Zeile ins Error-Log:

```
[Sat Aug 22 12:07:32 2026] [authz_core:error] [pid 573858:tid 573888] \
  [client 203.0.113.42:0] AH01630: client denied by server configuration: \
  /var/www/redaxo5/redaxo/data/.redaxo
```

Und der mitgelieferte Filter `apache-auth` matcht genau darauf:

```
^client (?:denied by server configuration|used wrong authentication scheme)\b
```

Jail-Defaults in fail2ban 1.1.0: `logpath = apache_error_log`, `findtime = 10m`,
`bantime = 10m`, `maxretry = 5`. Vier Zeilen pro Check liegen damit knapp unter der
Schwelle — bis der Check ein zweites Mal läuft.

Gegengeprüft mit `fail2ban-regex` gegen echte Logzeilen:

| Filter | Treffer |
| --- | --- |
| `apache-auth` | **3 von 3** |
| `apache-noscript` | 0 von 3 |
| `apache-botsearch` | 0 von 3 |
| `apache-overflows` | 0 von 3 |

Der Dateiname spielt übrigens keine Rolle — die Filter, die auf Endungen oder Dotfiles
schauen, wollen `File does not exist` bzw. `script not found`, was bei
`Require all denied` nie entsteht. Bei nginx oder einem globalen `<FilesMatch "^\.">`
sieht die Zeile anders aus und `apache-auth` greift nicht; dafür zählen Hoster-Setups
gern 403/404 im Access-Log. Dagegen hilft nur eins: weniger Requests.

### Der eigentliche Auslöser

Wird ein Ordner als unsicher erkannt, wurde das Cookie geleert, damit die Warnung auf
jeder Seite erscheint. Bei einer teilweise unsicheren Installation (drei Ordner dicht,
einer offen) feuerte der Check damit bei **jedem** Seitenaufruf drei Deny-Requests.
Zwei Klicks im Backend reichten für den Ban.

## Änderung

Es wird nur noch **ein zufällig gewählter Ordner pro Tag** geprüft. Die vier Ordner sind
durch identische, im Repo eingecheckte `.htaccess`-Dateien geschützt; der realistische
Fehlerfall ist nicht „data ist dicht, cache nicht", sondern global (nginx,
`AllowOverride None`). Ein Ordner ist damit fast so aussagekräftig wie alle vier.

Ein als unsicher erkannter Ordner wird im Cookie gemerkt und ab dann bei jedem
Seitenaufruf geprüft. Die Warnung bleibt sichtbar, aber dieser Request liefert 200 und
erzeugt damit gar keine Deny-Zeile mehr. Wird der Ordner abgesichert, fällt das Cookie
zurück und ab dem Folgetag wird wieder gelost.

Im Setup werden weiterhin alle vier Ordner geprüft — dort ist es ein einmaliger Aufruf
und vollständige Abdeckung ist genau das, was man in dem Moment will. Die wirkungslosen
`index.php`-Requests sind dort ebenfalls entfallen.

## Getestet

Im Backend, eingeloggt:

| Szenario | Requests | Ergebnis |
| --- | --- | --- |
| Cookie leer, alle Ordner dicht | 1 × `bin/console` → 403 (ausgelost) | keine Warnung, Cookie `1` |
| Cookie `1`, nächster Seitenaufruf | 0 | nichts |
| `data/.htaccess` entfernt, Cookie sticky | 1 × `data/.redaxo` → **200** | Warnung sichtbar, Cookie bleibt auf dem Ordner, **null** Deny-Requests |
| `.htaccess` wieder da | 1 × `data/.redaxo` → 403 | Warnung weg, Cookie fällt auf `1` zurück |

Zusätzlich geprüft: Cookie-Round-Trip mit Slashes im Wert durch `setCookie`/`getCookie`,
403 landet zuverlässig im `error`-Handler von `$.ajax` (`success` feuert also wirklich
nur bei einem erreichbaren Ordner), und die Gleichverteilung der Zufallsauswahl.

## Anmerkung zu v6

In v6 ist der Check mit der Ordnerstruktur samt `public`-Ordner ohnehin entfallen, daher
hier bewusst eine minimale Änderung ohne Umbau und ohne neue PHP-Logik.
