### PR TITLE
feat: add config option to disable the directory protection check

### DIFF
--- a/redaxo/src/core/assets/standard.js
+++ b/redaxo/src/core/assets/standard.js
@@ -449,7 +449,7 @@ jQuery(function($){
         });
     $("[autofocus]").trigger("focus");
 
-    if ($('#rex-page-setup, #rex-page-login').length == 0 && getCookie('rex_htaccess_check') != '1')
+    if (false !== rex.directory_protection_check && $('#rex-page-setup, #rex-page-login').length == 0 && getCookie('rex_directory_protection_check') != '1')
     {
         // urls which are not expected to be accessible
         var urls = [
@@ -459,11 +459,11 @@ jQuery(function($){
             'cache/.redaxo'
         ];
 
-        // Only one folder is checked per day. All these folders are protected by identical .htaccess
-        // files, so a broken setup (e.g. nginx or "AllowOverride None") shows up on any of them.
-        // Checking a single folder keeps the number of denied requests low enough to not trip
-        // tools like fail2ban, which ban a client after a few denied requests.
-        var previousInsecureUrl = getCookie('rex_htaccess_check');
+        // Only one directory is checked per day. All of them are protected the same way, so a
+        // setup where that protection is missing (e.g. nginx or "AllowOverride None") shows up on
+        // any of them. Checking a single directory keeps the number of denied requests low enough
+        // to not trip tools like fail2ban, which ban a client after a few denied requests.
+        var previousInsecureUrl = getCookie('rex_directory_protection_check');
         var url = previousInsecureUrl !== '' ? previousInsecureUrl : urls[Math.floor(Math.random() * urls.length)];
 
         var setCheckCookie = function (value) {
@@ -471,7 +471,7 @@ jQuery(function($){
             time.setTime(time.getTime() + 1000 * 60 * 60 * 24);
 
             setCookie(
-                'rex_htaccess_check',
+                'rex_directory_protection_check',
                 value,
                 time.toGMTString(),
                 rex.cookie_params.path,
@@ -489,9 +489,9 @@ jQuery(function($){
             url: url + '?redaxo-security-self-test',
             cache: false,
             success: function (data) {
-                $('#rex-js-page-main').prepend('<div class="alert alert-danger" style="margin-top: 20px;">The folder <code>redaxo/' + url + '</code> is insecure. Make sure this folder is not publicly accessible.</div>');
+                $('#rex-js-page-main').prepend('<div class="alert alert-danger" style="margin-top: 20px;">The directory <code>redaxo/' + url + '</code> is insecure. Make sure this directory is not publicly accessible.</div>');
 
-                // keep checking this folder, so the warning stays visible. its request succeeds
+                // keep checking this directory, so the warning stays visible. its request succeeds
                 // anyway, so it does not produce denied requests.
                 setCheckCookie(url);
             }

--- a/redaxo/src/core/backend.php
+++ b/redaxo/src/core/backend.php
@@ -202,6 +202,7 @@ rex_view::addJsFile(rex_url::coreAssets('clipboard-copy-element.js'), [rex_view:
 
 rex_view::setJsProperty('backend', true);
 rex_view::setJsProperty('accesskeys', rex::getProperty('use_accesskeys'));
+rex_view::setJsProperty('directory_protection_check', rex::getProperty('use_directory_protection_check'));
 
 if (rex::getUser()) {
     rex_view::addJsFile(rex_url::coreAssets('session-timeout.js'), [rex_view::JS_IMMUTABLE => true]);

--- a/redaxo/src/core/default.config.yml
+++ b/redaxo/src/core/default.config.yml
@@ -63,6 +63,9 @@ hsts_max_age: 31536000 # 1 year
 use_gzip: false
 use_etag: true
 use_last_modified: false
+# the backend checks once a day whether directories like redaxo/data are publicly accessible.
+# disable it if the requests to those directories trigger tools like fail2ban.
+use_directory_protection_check: true
 start_page: structure
 timezone: Europe/Berlin
 socket_proxy: null

--- a/redaxo/src/core/lib/rex.php
+++ b/redaxo/src/core/lib/rex.php
@@ -152,6 +152,7 @@ class rex
      *     ($key is 'debug' ? array{enabled: bool, throw_always_exception: bool|int} :
      *     ($key is 'lang_fallback' ? string[] :
      *     ($key is 'use_accesskeys' ? bool :
+     *     ($key is 'use_directory_protection_check' ? bool :
      *     ($key is 'accesskeys' ? array<string, string> :
      *     ($key is 'editor' ? string|null :
      *     ($key is 'editor_basepath' ? string|null :
@@ -175,7 +176,7 @@ class rex
      *     ($key is 'system_addons' ? non-empty-string[] :
      *     ($key is 'setup_addons' ? non-empty-string[] :
      *     mixed|null
-     *     )))))))))))))))))))))))))))
+     *     ))))))))))))))))))))))))))))
      * ) The value for $key or $default if $key cannot be found
      */
     public static function getProperty($key, $default = null)

--- a/redaxo/src/core/pages/setup.step2.php
+++ b/redaxo/src/core/pages/setup.step2.php
@@ -23,10 +23,13 @@ if (count($errorArray) > 0) {
     $buttons = '<a class="btn btn-setup" href="' . $context->getUrl(['step' => 3]) . '">' . rex_i18n::msg('setup_210') . '</a>';
 }
 
-$security = '<div class="rex-js-setup-security-message" style="display:none">' . rex_view::error(rex_i18n::msg('setup_security_msg') . '<br />' . rex_i18n::msg('setup_no_js_security_msg')) . '</div>';
-$security .= '<noscript>' . rex_view::error(rex_i18n::msg('setup_no_js_security_msg')) . '</noscript>';
+$security = '';
 
-$security .= '<script nonce="' . rex_response::getNonce() . '">
+if (rex::getProperty('use_directory_protection_check')) {
+    $security .= '<div class="rex-js-setup-security-message" style="display:none">' . rex_view::error(rex_i18n::msg('setup_security_msg') . '<br />' . rex_i18n::msg('setup_no_js_security_msg')) . '</div>';
+    $security .= '<noscript>' . rex_view::error(rex_i18n::msg('setup_no_js_security_msg')) . '</noscript>';
+
+    $security .= '<script nonce="' . rex_response::getNonce() . '">
 
     jQuery(function($){
         // urls which are not expected to be accessible
@@ -52,6 +55,7 @@ $security .= '<script nonce="' . rex_response::getNonce() . '">
     })
 
 </script>';
+}
 
 foreach (rex_setup::checkPhpSecurity() as $warning) {
     $security .= rex_view::warning($warning);

--- a/redaxo/src/core/schemas/config.json
+++ b/redaxo/src/core/schemas/config.json
@@ -295,6 +295,10 @@
             "description": "Use Last-Modified header (not recommended)",
             "$ref": "#/definitions/bool-or-environment"
         },
+        "use_directory_protection_check": {
+            "description": "Whether the check for publicly accessible directories should be used",
+            "type": "boolean"
+        },
         "start_page": {
             "description": "Default start page for backend",
             "type": "string"


### PR DESCRIPTION
Ergänzung zu #6628: dort wurde der htaccess-Check auf einen Ordner pro Tag reduziert, damit
er keine fail2ban-Bans mehr auslöst. Für strenge Setups soll er sich zusätzlich ganz
abschalten lassen — ein Request pro Tag liegt weit unter den üblichen Schwellen, aber es
gibt Installationen, die auf Wege abgesichert sind, die der Check ohnehin nicht sehen kann.

## Änderung

```yaml
# the backend checks once a day whether directories like redaxo/data are publicly accessible.
# disable it if the requests to those directories trigger tools like fail2ban.
use_directory_protection_check: true
```

`false` schaltet den Check ab, im Backend wie im Setup. Umgesetzt analog zum bestehenden
`use_accesskeys`: Flag in der `default.config.yml`, per `rex_view::setJsProperty()` als
`rex.directory_protection_check` an die `standard.js`, dort eine Bedingung mehr. Dazu der Key im
`getProperty()`-Rückgabetyp und ein `if` um den Security-Block in `setup.step2.php`.

### Benennung

Der Check hängt nicht an Apache: die Ordner können genauso per nginx-Rules oder abweichendem
Docroot geschützt sein — die Setup-Meldung sagt das auch schon so („… oder der Schutz z.B.
für nginx-Server nicht erstellt wurde"). Nur die interne Benennung hing noch am
`.htaccess`. Da der Config-Key faktisch öffentliche API ist, heißt er hier von Anfang an
`use_directory_protection_check`; JS-Property (`rex.directory_protection_check`) und Cookie
(`rex_directory_protection_check`) wurden mitbenannt, ebenso der Wortlaut der Warnung.

„Directory" statt „folder", weil der Key im technischen Register liegt (bearbeitet wird er im
Texteditor, nicht in einer GUI): die englischen Sprachdateien nutzen „director(y|ies)" 9× gegen
3× „folder", die API heißt `rex_dir`, und die Webserver-Literatur sagt ebenfalls directory
(`<Directory>`, directory traversal).

Folge des Cookie-Namens: nach dem Update läuft der Check einmal zusätzlich, weil das alte
Cookie nicht mehr gelesen wird. Das ist ein Request, danach greift wieder der Tagesrhythmus.

Kein Update-Pfad nötig: die Config wird zur Laufzeit als
`array_merge(default.config.yml, config.yml)` geladen, das Flag wirkt also sofort auch für
bestehende Installationen, und `update.php` schreibt die gemergte Config beim Update
zurück, sodass der Schalter dort auch physisch auftaucht.

## Bewusst kein Schalter in den Einstellungen

- Es schaltet einen Sicherheitscheck ab. Das sollte nicht einen Klick von jedem Admin-User
  entfernt sein — wer es braucht, hat Dateisystem-Zugriff, denn dieselben Leute
  konfigurieren auch fail2ban.
- Der Check ist eine Stolperdraht-Funktion („merkt jemand, dass der Webserver `.htaccess`
  ignoriert?"). Eine Option, die man beim Durchklicken der Einstellungen versehentlich
  umlegt, entwertet ihn.
- UI plus Übersetzungen für einen Knopf, den kaum jemand anfasst, wäre unverhältnismäßig.

## Anmerkungen zur Umsetzung

- Name `use_directory_protection_check` wegen der bestehenden `use_*`-Booleans in der Datei; der
  JS-Property heißt entsprechend `rex.directory_protection_check` — dieselbe Asymmetrie wie
  `use_accesskeys` → `rex.accesskeys`.
- Das Setup gehorcht dem Flag ebenfalls. Das greift nur, wenn die `config.yml` vor dem
  Setup schon existiert (Deployment/Automatisierung), sonst gilt der Default `true`.
- In der `standard.js` steht `false !== rex.directory_protection_check` statt einer einfachen
  Truthiness-Prüfung: fehlt der JS-Property mal, bleibt der Check an statt still zu
  verschwinden. Bei einem Sicherheitscheck ist „im Zweifel an" die richtige Richtung.

## Getestet

An einer laufenden Installation, im Backend eingeloggt:

| Config | `rex.directory_protection_check` | Self-Test-Requests | Cookie |
| --- | --- | --- | --- |
| `use_directory_protection_check: false` | `false` | **0** | wird nicht gesetzt |
| Flag nicht gesetzt (Default) | `true` | 1 × `bin/console` → 403 | `1` |

Dass im abgeschalteten Fall auch das Cookie unangetastet bleibt, ist praktisch: das Flag
zurückzudrehen wirkt sofort beim nächsten Seitenaufruf und nicht erst nach 24 Stunden.

Zusätzlich mit altem und neuem Cookie gleichzeitig im Browser geprüft: die naive
`indexOf`-Suche in `getCookie()` verwechselt die beiden Namen nicht.

`composer cs` ohne Änderungen, Psalm und Taint grün, keine neuen Baseline-Einträge.
