### PR TITLE
fix: normalize column types and defaults consistently across MySQL and MariaDB

### DIFF
--- a/redaxo/src/core/lib/sql/column.php
+++ b/redaxo/src/core/lib/sql/column.php
@@ -183,13 +183,21 @@ class rex_sql_column
     }
 
     /**
-     * Normalizes the spelling of an extra clause (like `on update current_timestamp()`) to the form used by MySQL.
+     * Normalizes an extra clause (like `on update current_timestamp()`) to the form used by MySQL.
      *
      * @internal
      */
     public static function normalizeExtra(?string $extra): ?string
     {
-        return null === $extra ? null : self::normalizeCurrentTimestamp($extra);
+        if (null === $extra) {
+            return null;
+        }
+
+        // Since MySQL 8.0.13 an expression default value is reported as `DEFAULT_GENERATED`, which is
+        // not part of a column definition and would break the generated SQL.
+        $extra = preg_replace('/^DEFAULT_GENERATED\s*/i', '', $extra) ?? $extra;
+
+        return '' === $extra ? null : self::normalizeCurrentTimestamp($extra);
     }
 
     private static function isCurrentTimestamp(string $type, string $default): bool

--- a/redaxo/src/core/lib/sql/column.php
+++ b/redaxo/src/core/lib/sql/column.php
@@ -153,8 +153,58 @@ class rex_sql_column
             $this->name === $column->name
             && $this->type === $column->type
             && $this->nullable === $column->nullable
-            && $this->default === $column->default
-            && $this->extra === $column->extra
+            && self::normalizeDefault($this->type, $this->default) === self::normalizeDefault($column->type, $column->default)
+            && self::normalizeExtra($this->extra) === self::normalizeExtra($column->extra)
             && $this->comment === $column->comment;
+    }
+
+    /**
+     * Whether the default value is the current timestamp function instead of a literal value.
+     *
+     * @internal
+     */
+    public function hasCurrentTimestampDefault(): bool
+    {
+        return null !== $this->default && self::isCurrentTimestamp($this->type, $this->default);
+    }
+
+    /**
+     * Normalizes the spelling of a default value to the form used by MySQL.
+     *
+     * @internal
+     */
+    public static function normalizeDefault(string $type, ?string $default): ?string
+    {
+        if (null === $default || !self::isCurrentTimestamp($type, $default)) {
+            return $default;
+        }
+
+        return self::normalizeCurrentTimestamp($default);
+    }
+
+    /**
+     * Normalizes the spelling of an extra clause (like `on update current_timestamp()`) to the form used by MySQL.
+     *
+     * @internal
+     */
+    public static function normalizeExtra(?string $extra): ?string
+    {
+        return null === $extra ? null : self::normalizeCurrentTimestamp($extra);
+    }
+
+    private static function isCurrentTimestamp(string $type, string $default): bool
+    {
+        return 1 === preg_match('/^(?:timestamp|datetime)(?:\(\d+\))?$/i', $type)
+            && 1 === preg_match('/^current_timestamp(?:\(\s*\d*\s*\))?$/i', $default);
+    }
+
+    /** MySQL spells the function as `CURRENT_TIMESTAMP`, MariaDB as `current_timestamp()`. */
+    private static function normalizeCurrentTimestamp(string $value): string
+    {
+        return preg_replace_callback(
+            '/current_timestamp(?:\(\s*(\d*)\s*\))?/i',
+            static fn (array $match) => 'CURRENT_TIMESTAMP' . (('' === ($match[1] ?? '')) ? '' : '(' . $match[1] . ')'),
+            $value,
+        ) ?? $value;
     }
 }

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -96,8 +96,9 @@ class rex_sql_table
             // the max display width. `tinyint(1)` and zerofill columns still report their width.
             // https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html
             if (preg_match('/^(tinyint|smallint|mediumint|int|bigint)( unsigned)?$/', $type, $match)) {
-                [$signed, $unsigned] = self::INT_DISPLAY_WIDTHS[$match[1]];
-                $type = $match[1] . '(' . (isset($match[2]) ? $unsigned : $signed) . ')' . ($match[2] ?? '');
+                $unsigned = $match[2] ?? '';
+                [$signedWidth, $unsignedWidth] = self::INT_DISPLAY_WIDTHS[$match[1]];
+                $type = $match[1] . '(' . ('' === $unsigned ? $signedWidth : $unsignedWidth) . ')' . $unsigned;
             }
 
             $default = $column['default'];

--- a/redaxo/src/core/lib/sql/table.php
+++ b/redaxo/src/core/lib/sql/table.php
@@ -19,6 +19,15 @@ class rex_sql_table
 
     public const FIRST = 'FIRST '; // The space is intended: column names cannot end with space
 
+    /** @var array<string, array{int, int}> Default display width of integer types, signed and unsigned */
+    private const INT_DISPLAY_WIDTHS = [
+        'tinyint' => [4, 3],
+        'smallint' => [6, 5],
+        'mediumint' => [9, 8],
+        'int' => [11, 10],
+        'bigint' => [20, 20],
+    ];
+
     private int $db;
     private rex_sql $sql;
     private bool $new;
@@ -82,13 +91,13 @@ class rex_sql_table
         foreach ($columns as $column) {
             $type = $column['type'];
 
-            // Since MySQL 8.0.17 the display width for integer columns is deprecated.
-            // To be compatible with our code for MySQL 5 and MariaDB we simulate the max display width.
+            // Since MySQL 8.0.17 the display width for integer columns is deprecated and it is not
+            // reported anymore. To be compatible with our code for MySQL 5 and MariaDB we simulate
+            // the max display width. `tinyint(1)` and zerofill columns still report their width.
             // https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html
-            if ('int' === $type) {
-                $type = 'int(11)';
-            } elseif ('int unsigned' === $type) {
-                $type = 'int(10) unsigned';
+            if (preg_match('/^(tinyint|smallint|mediumint|int|bigint)( unsigned)?$/', $type, $match)) {
+                [$signed, $unsigned] = self::INT_DISPLAY_WIDTHS[$match[1]];
+                $type = $match[1] . '(' . (isset($match[2]) ? $unsigned : $signed) . ')' . ($match[2] ?? '');
             }
 
             $default = $column['default'];
@@ -100,8 +109,8 @@ class rex_sql_table
                 $column['name'],
                 $type,
                 'YES' === $column['null'],
-                $default,
-                $column['extra'] ?: null,
+                rex_sql_column::normalizeDefault($type, $default),
+                rex_sql_column::normalizeExtra($column['extra'] ?: null),
                 $column['comment'] ?: null,
             );
 
@@ -932,10 +941,7 @@ class rex_sql_table
         $default = $column->getDefault();
         if (null === $default) {
             $default = '';
-        } elseif (
-            in_array(strtolower($column->getType()), ['timestamp', 'datetime'], true)
-            && in_array(strtolower($default), ['current_timestamp', 'current_timestamp()'], true)
-        ) {
+        } elseif ($column->hasCurrentTimestampDefault()) {
             $default = 'DEFAULT ' . $default;
         } else {
             $default = 'DEFAULT ' . $this->sql->escape($default);

--- a/redaxo/src/core/tests/sql/sql_column_test.php
+++ b/redaxo/src/core/tests/sql/sql_column_test.php
@@ -1,0 +1,44 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+final class rex_sql_column_test extends TestCase
+{
+    #[DataProvider('provideDefaults')]
+    public function testNormalizeDefault(?string $expected, string $type, ?string $default): void
+    {
+        self::assertSame($expected, rex_sql_column::normalizeDefault($type, $default));
+    }
+
+    /** @return iterable<string, array{string|null, string, string|null}> */
+    public static function provideDefaults(): iterable
+    {
+        yield 'null' => [null, 'datetime', null];
+        yield 'literal value' => ['2026-01-01 00:00:00', 'datetime', '2026-01-01 00:00:00'];
+        yield 'mysql spelling' => ['CURRENT_TIMESTAMP', 'datetime', 'CURRENT_TIMESTAMP'];
+        yield 'mariadb spelling' => ['CURRENT_TIMESTAMP', 'datetime', 'current_timestamp()'];
+        yield 'timestamp' => ['CURRENT_TIMESTAMP', 'timestamp', 'current_timestamp()'];
+        yield 'with precision' => ['CURRENT_TIMESTAMP(3)', 'datetime(3)', 'current_timestamp(3)'];
+        yield 'non temporal type' => ['current_timestamp()', 'varchar(255)', 'current_timestamp()'];
+    }
+
+    #[DataProvider('provideExtras')]
+    public function testNormalizeExtra(?string $expected, ?string $extra): void
+    {
+        self::assertSame($expected, rex_sql_column::normalizeExtra($extra));
+    }
+
+    /** @return iterable<string, array{string|null, string|null}> */
+    public static function provideExtras(): iterable
+    {
+        yield 'null' => [null, null];
+        yield 'auto increment' => ['auto_increment', 'auto_increment'];
+        yield 'mysql spelling' => ['on update CURRENT_TIMESTAMP', 'on update CURRENT_TIMESTAMP'];
+        yield 'mariadb spelling' => ['on update CURRENT_TIMESTAMP', 'on update current_timestamp()'];
+        yield 'with precision' => ['on update CURRENT_TIMESTAMP(3)', 'on update current_timestamp(3)'];
+        yield 'generated default' => [null, 'DEFAULT_GENERATED'];
+        yield 'generated default on update' => ['on update CURRENT_TIMESTAMP', 'DEFAULT_GENERATED on update CURRENT_TIMESTAMP'];
+    }
+}

--- a/redaxo/src/core/tests/sql/sql_table_test.php
+++ b/redaxo/src/core/tests/sql/sql_table_test.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 
@@ -680,6 +681,80 @@ final class rex_sql_table_test extends TestCase
                 ->ensureColumn(new rex_sql_column('title', 'varchar(255)'))
                 ->ensure();
         }
+    }
+
+    #[DataProvider('provideIntegerTypes')]
+    public function testEnsureIntegerColumn(string $type): void
+    {
+        $column = new rex_sql_column('foo', $type, true);
+
+        rex_sql_table::get(self::TABLE)
+            ->ensurePrimaryIdColumn()
+            ->ensureColumn($column)
+            ->ensure();
+
+        rex_sql_table::clearInstance(self::TABLE);
+
+        self::assertEquals($column, rex_sql_table::get(self::TABLE)->getColumn('foo'));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function provideIntegerTypes(): iterable
+    {
+        $types = [
+            'tinyint(4)', 'tinyint(3) unsigned', 'tinyint(1)',
+            'smallint(6)', 'smallint(5) unsigned',
+            'mediumint(9)', 'mediumint(8) unsigned',
+            'int(11)', 'int(10) unsigned',
+            'bigint(20)', 'bigint(20) unsigned',
+        ];
+
+        foreach ($types as $type) {
+            yield $type => [$type];
+        }
+    }
+
+    #[DataProvider('provideCurrentTimestampColumns')]
+    public function testEnsureCurrentTimestampColumn(rex_sql_column $column, string $expectedDefault, ?string $expectedExtra): void
+    {
+        rex_sql_table::get(self::TABLE)
+            ->ensurePrimaryIdColumn()
+            ->ensureColumn($column)
+            ->ensure();
+
+        rex_sql_table::clearInstance(self::TABLE);
+
+        $readColumn = rex_sql_table::get(self::TABLE)->getColumn('foo');
+        self::assertInstanceOf(rex_sql_column::class, $readColumn);
+
+        self::assertSame($expectedDefault, $readColumn->getDefault());
+        self::assertSame($expectedExtra, $readColumn->getExtra());
+        self::assertTrue($column->equals($readColumn));
+    }
+
+    /** @return iterable<string, array{rex_sql_column, string, string|null}> */
+    public static function provideCurrentTimestampColumns(): iterable
+    {
+        yield 'datetime' => [
+            new rex_sql_column('foo', 'datetime', false, 'CURRENT_TIMESTAMP'),
+            'CURRENT_TIMESTAMP', null,
+        ];
+        yield 'datetime, function spelling' => [
+            new rex_sql_column('foo', 'datetime', false, 'current_timestamp()'),
+            'CURRENT_TIMESTAMP', null,
+        ];
+        yield 'datetime with precision' => [
+            new rex_sql_column('foo', 'datetime(3)', false, 'current_timestamp(3)'),
+            'CURRENT_TIMESTAMP(3)', null,
+        ];
+        yield 'timestamp, on update' => [
+            new rex_sql_column('foo', 'timestamp', false, 'CURRENT_TIMESTAMP', 'on update CURRENT_TIMESTAMP'),
+            'CURRENT_TIMESTAMP', 'on update CURRENT_TIMESTAMP',
+        ];
+        yield 'timestamp, on update function spelling' => [
+            new rex_sql_column('foo', 'timestamp', false, 'current_timestamp()', 'on update current_timestamp()'),
+            'CURRENT_TIMESTAMP', 'on update CURRENT_TIMESTAMP',
+        ];
     }
 
     public function testEnsureWithEnsureGlobalColumns(): void


### PR DESCRIPTION
When reading a table, `rex_sql_table` normalizes the column type to make definitions written for one database engine match the columns reported by another. Two gaps in that normalization made `ensure()` alter columns over and over, and made generated schema code depend on the engine it was generated on.

## Integer display width

Since MySQL 8.0.17 the display width for integer columns is deprecated and no longer reported by `SHOW COLUMNS`, so `rex_sql_table` simulates the default width — but only for `int` and `int unsigned`. Every other integer type fell through, so a definition like `bigint(20)` never matched the existing column on MySQL 8, and each `ensure()` emitted another ALTER.

Now all five integer types are covered:

| MariaDB / MySQL 5 | MySQL 8 |
| --- | --- |
| `tinyint(4)` / `tinyint(3) unsigned` | `tinyint` / `tinyint unsigned` |
| `smallint(6)` / `smallint(5) unsigned` | `smallint` / `smallint unsigned` |
| `mediumint(9)` / `mediumint(8) unsigned` | `mediumint` / `mediumint unsigned` |
| `int(11)` / `int(10) unsigned` | `int` / `int unsigned` (already handled) |
| `bigint(20)` / `bigint(20) unsigned` | `bigint` / `bigint unsigned` |

`tinyint(1)` and zerofill columns keep their width in MySQL's output and are therefore left alone.

A non-default width like `int(4)` still cannot be preserved on MySQL 8 — the information is gone from the output, so it is normalized to `int(11)`. That is unchanged behaviour and already covered by an existing test.

## Current timestamp function

MySQL reports the function as `CURRENT_TIMESTAMP`, MariaDB as `current_timestamp()` — both as default value and inside the `on update` clause. Comparing columns was a plain string comparison, so a column declared with `'CURRENT_TIMESTAMP'` never matched itself on MariaDB and was altered on every `ensure()`.

Both spellings are now normalized to the MySQL form when a column is read, next to the type normalization. That also fixes `rex_sql_schema_dumper`, which writes the raw values into the generated code — for the same table it now emits the same code on both engines:

~~~php
// before, on MariaDB
->ensureColumn(new rex_sql_column('created', 'datetime', false, 'current_timestamp()'))
->ensureColumn(new rex_sql_column('updated', 'timestamp', false, 'current_timestamp()', 'on update current_timestamp()'))

// after, on MariaDB and MySQL
->ensureColumn(new rex_sql_column('created', 'datetime', false, 'CURRENT_TIMESTAMP'))
->ensureColumn(new rex_sql_column('updated', 'timestamp', false, 'CURRENT_TIMESTAMP', 'on update CURRENT_TIMESTAMP'))
~~~

`rex_sql_column::equals()` additionally accepts both spellings, since existing addon definitions use either of them and only the value read from the database is normalized.

**Behaviour change to be aware of:** on MariaDB `getDefault()` now returns `CURRENT_TIMESTAMP` where it returned `current_timestamp()` before. Code comparing against the MariaDB spelling needs adjusting; code written against MySQL starts working on MariaDB.

## Fractional seconds precision

The check whether a default is the current timestamp function moves from `rex_sql_table` into `rex_sql_column::hasCurrentTimestampDefault()` and now matches types with a precision, too. Before, `datetime(3)` missed the check, its default was escaped as a string literal, and creating the column failed with *Invalid default value*.

## Tests

Two data-driven tests in `rex_sql_table_test`, both running against the real database so the CI matrix covers all engines:

- `testEnsureIntegerColumn` ensures a column per integer type and asserts the column read back matches the definition. Verified locally by patching the constructor to strip the widths from MariaDB's output, simulating MySQL 8: with the fix 11/11 pass, with the previous `int`-only logic exactly the eight uncovered cases fail.
- `testEnsureCurrentTimestampColumn` asserts both the normalized value (`CURRENT_TIMESTAMP`, `on update CURRENT_TIMESTAMP`, `CURRENT_TIMESTAMP(3)`) and that the definition still compares equal, for either spelling.

## Open question

MySQL adds `DEFAULT_GENERATED` to the `Extra` field for expression defaults. I could not check whether that also happens for a plain `DEFAULT CURRENT_TIMESTAMP` on datetime/timestamp — I have no MySQL 8 at hand and did not want to code against a guess. If it does, the extra comparison still mismatches there; the new tests run on the mysql 8.0/8.4/latest matrix entries and will say so.